### PR TITLE
Universal filters Phase 2: shared filter bar on Browse

### DIFF
--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -1,0 +1,148 @@
+"""E2E: universal filter bar on Browse (Phase 2).
+
+Ports the interaction checks from the design prototype's verify suite
+(docs/plans/2026-07-19-photo-filter-prototype/verify_features.py) against
+the real page: chip semantics, quick-filter multi-select, single
+replaceable quick-search clause, pause/resume, typeahead counts,
+persistence, and select-all consistency with the filtered grid.
+
+Seed data (conftest): 3 hawk photos in /photos/park, 2 robins in
+/photos/yard; hawk1 has rating 4 and the Red-tailed Hawk species keyword.
+"""
+
+
+def _total(page):
+    return int(page.inner_text(".vf-total strong").replace(",", ""))
+
+
+def _wait_total(page, expected, timeout=8000):
+    page.wait_for_function(
+        "expected => document.querySelector('.vf-total strong')"
+        f".textContent.replace(/,/g, '') === String({expected})",
+        timeout=timeout,
+    )
+
+
+def _open_browse(page, live_server):
+    page.goto(live_server["url"] + "/browse")
+    page.wait_for_selector("#grid .grid-card", timeout=15000)
+    page.wait_for_selector("#vireoFilterBar", timeout=15000)
+    page.wait_for_function(
+        "document.querySelector('.vf-total strong').textContent !== '–'",
+        timeout=15000,
+    )
+
+
+def test_quick_rating_filter_and_chip_semantics(live_server, page):
+    _open_browse(page, live_server)
+    assert _total(page) == 5
+
+    page.click(".vf-filters-btn")
+    page.click('.vf-quick-rating .vf-star[data-rating="4"]')
+    _wait_total(page, 1)
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent")
+    assert "Rating is at least 4 stars" in chips
+    # Toggling the same star clears the rule.
+    page.click('.vf-quick-rating .vf-star[data-rating="4"]')
+    _wait_total(page, 5)
+
+
+def test_quick_flags_multi_select_combines(live_server, page):
+    _open_browse(page, live_server)
+    page.click(".vf-filters-btn")
+    page.click('.vf-quick-flags [data-flag="flagged"]')
+    page.wait_for_timeout(300)
+    page.click('.vf-quick-flags [data-flag="none"]')
+    # Seed photos have NULL flags — all 5 must count as Unflagged.
+    _wait_total(page, 5)
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent")
+    assert "Flag is one of Picked, Unflagged" in chips
+
+
+def test_quick_search_is_single_replaceable_clause(live_server, page):
+    _open_browse(page, live_server)
+    search = page.locator(".vf-search input")
+    search.fill("hawk")
+    search.press("Enter")
+    _wait_total(page, 3)
+    search.fill("robin")
+    search.press("Enter")
+    _wait_total(page, 2)
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent")
+    assert "robin" in chips and "hawk" not in chips
+
+
+def test_pause_resume_with_backslash(live_server, page):
+    _open_browse(page, live_server)
+    page.click(".vf-filters-btn")
+    page.click('.vf-quick-rating .vf-star[data-rating="4"]')
+    _wait_total(page, 1)
+    page.click(".vf-done")
+
+    page.keyboard.press("\\")
+    _wait_total(page, 5)
+    note = page.inner_text(".vf-paused-note")
+    assert "Filters paused" in note
+    page.wait_for_function(
+        "document.querySelector('.vf-paused-note').textContent.includes('1 would match')",
+        timeout=8000,
+    )
+    chips_row_class = page.get_attribute(".vf-chip-row", "class")
+    assert "muted" in chips_row_class
+
+    page.keyboard.press("\\")
+    _wait_total(page, 1)
+    assert page.locator(".vf-paused-note").is_hidden()
+
+
+def test_rule_builder_typeahead_counts_and_pick(live_server, page):
+    _open_browse(page, live_server)
+    page.click(".vf-filters-btn")
+    page.click(".vf-add-filter")
+    page.fill(".vf-field-search", "species")
+    page.click('[data-add-field="species"]')
+    page.wait_for_timeout(400)
+    value_input = page.locator('.vf-rule-tree [data-suggest="1"]')
+    value_input.click()
+    page.wait_for_selector(".vf-suggest .vf-value-option", timeout=8000)
+    options = page.locator(".vf-suggest .vf-value-option")
+    texts = [options.nth(i).inner_text() for i in range(options.count())]
+    assert any("Red-tailed Hawk" in t for t in texts)
+    assert all(any(ch.isdigit() for ch in t) for t in texts), texts
+    # Pick the hawk option (typeahead narrows first).
+    value_input.type("red", delay=30)
+    page.wait_for_timeout(600)
+    page.locator(".vf-suggest .vf-value-option").first.click()
+    _wait_total(page, 1)
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent")
+    assert "Species contains Red-tailed Hawk" in chips
+
+
+def test_filter_state_persists_across_reload(live_server, page):
+    _open_browse(page, live_server)
+    search = page.locator(".vf-search input")
+    search.fill("hawk")
+    search.press("Enter")
+    _wait_total(page, 3)
+    page.wait_for_timeout(1200)  # persist debounce
+
+    page.reload()
+    page.wait_for_selector("#vireoFilterBar", timeout=15000)
+    _wait_total(page, 3, timeout=15000)
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent")
+    assert "hawk" in chips
+
+
+def test_select_all_matches_filtered_grid(live_server, page):
+    """Select-all must resolve exactly the photos the filtered grid shows
+    (hard requirement: no surface may disagree with the visible result)."""
+    _open_browse(page, live_server)
+    search = page.locator(".vf-search input")
+    search.fill("hawk")
+    search.press("Enter")
+    _wait_total(page, 3)
+    search.press("Escape")  # blur: select-all is a grid shortcut, not an input one
+    page.keyboard.press("ControlOrMeta+a")
+    page.wait_for_function(
+        "window.selectedPhotos && selectedPhotos.size === 3", timeout=8000,
+    )

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -9,27 +9,21 @@ def test_keyword_search_empty_state_and_clear(live_server, page):
     cards = page.locator(".grid-card")
     cards.first.wait_for(state="visible")
 
-    search = page.locator("#searchInput")
+    search = page.locator(".vf-search input")
     expect(search).to_have_attribute("autocomplete", "off")
-    expect(search).to_have_attribute("autocorrect", "off")
-    expect(search).to_have_attribute("autocapitalize", "none")
     expect(search).to_have_attribute("spellcheck", "false")
 
-    with page.expect_response(
-        lambda response: "/api/photos?" in response.url
-        and "keyword=definitely-no-such-photo" in response.url
-    ):
+    with page.expect_response(lambda response: "/api/photos/query" in response.url):
         search.fill("definitely-no-such-photo")
+        search.press("Enter")
 
     expect(page.locator("#emptyState")).to_be_visible()
     expect(page.locator("#welcomeState")).to_be_hidden()
     expect(page.locator("#emptyState")).to_contain_text("No photos match")
 
-    with page.expect_response(
-        lambda response: "/api/photos?" in response.url
-        and "keyword=" not in response.url
-    ):
+    with page.expect_response(lambda response: "/api/photos/query" in response.url):
         search.fill("")
+        search.press("Enter")
 
     cards.first.wait_for(state="visible")
     expect(page.locator("#emptyState")).to_be_hidden()
@@ -45,18 +39,7 @@ def test_clearing_keyword_search_keeps_selected_photo_in_place(live_server, page
     page.locator(".grid-card").first.wait_for(state="visible")
     page.evaluate("updateThumbSize(400)")
 
-    search = page.locator("#searchInput")
-    # A different filter can apply the text before its debounce fires. The
-    # applied-search tracker must still learn about that active query so the
-    # later clear takes the anchor-preserving path.
-    page.evaluate(
-        """() => {
-          const input = document.getElementById('searchInput');
-          input.value = 'American Robin';
-          input.dispatchEvent(new Event('input', { bubbles: true }));
-          applyFilters();
-        }"""
-    )
+    page.evaluate("VireoFilter.quickSearch('American Robin')")
     page.wait_for_function("() => photos.length === 1")
     selected = page.locator(f'.grid-card[data-id="{selected_id}"]')
     selected.wait_for(state="visible")
@@ -71,16 +54,7 @@ def test_clearing_keyword_search_keeps_selected_photo_in_place(live_server, page
         selected_id,
     )
 
-    # Clearing can likewise be applied by another filter before the debounce.
-    # That reset must infer that the search was cleared and preserve the anchor.
-    page.evaluate(
-        """() => {
-          const input = document.getElementById('searchInput');
-          input.value = '';
-          input.dispatchEvent(new Event('input', { bubbles: true }));
-          applyFilters();
-        }"""
-    )
+    page.evaluate("VireoFilter.quickSearch('')")
     page.wait_for_function(
         "(id) => photos.length === 5 && selectedPhotoId === id",
         arg=selected_id,
@@ -113,22 +87,25 @@ def test_flag_quick_filters_show_picks_and_rejects(live_server, page):
     page.goto(f"{url}/browse")
     page.locator(".grid-card").first.wait_for(state="visible")
 
-    pick_btn = page.locator("#pickFilterBtn")
-    reject_btn = page.locator("#rejectFilterBtn")
+    page.click(".vf-filters-btn")
+    pick_btn = page.locator('.vf-quick-flags [data-flag="flagged"]')
+    reject_btn = page.locator('.vf-quick-flags [data-flag="rejected"]')
     expect(pick_btn).to_be_visible()
     expect(reject_btn).to_be_visible()
 
     pick_btn.click()
-    expect(pick_btn).to_have_class("flag-filter-btn active-pick")
+    expect(pick_btn).to_have_class("active")
     expect(page.locator(".grid-card")).to_have_count(1)
     assert page.locator(".grid-card").first.get_attribute("data-id") == str(pick_id)
 
+    # Flags multi-select now: adding Rejected combines into "is one of".
     reject_btn.click()
-    expect(pick_btn).to_have_class("flag-filter-btn")
-    expect(reject_btn).to_have_class("flag-filter-btn active-reject")
+    expect(page.locator(".grid-card")).to_have_count(2)
+
+    pick_btn.click()
+    expect(pick_btn).not_to_have_class("active")
     expect(page.locator(".grid-card")).to_have_count(1)
     assert page.locator(".grid-card").first.get_attribute("data-id") == str(reject_id)
 
     reject_btn.click()
-    expect(reject_btn).to_have_class("flag-filter-btn")
     expect(page.locator(".grid-card")).to_have_count(5)

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -52,9 +52,9 @@ def test_large_library_uses_bounded_placeholder_runway(live_server, page):
           var nextId = 100000;
           var calls = 0;
           safeFetch = function(url, options, fetchOptions) {
-            if (url.indexOf('/api/photos?') === 0) {
+            if (url === '/api/photos/query') {
               calls++;
-              var perPage = parseInt(new URL(url, location.origin).searchParams.get('per_page'), 10);
+              var perPage = JSON.parse(options.body).per_page;
               if (calls >= 10) return Promise.resolve({photos: [], total: totalPhotos});
               var batch = [];
               for (var i = 0; i < perPage; i++) {
@@ -1161,7 +1161,9 @@ def test_filterByCollection_cancels_pending_search_debounce(live_server, page):
     page.goto(f"{url}/browse")
     page.locator(".grid-card").first.wait_for(state="visible")
 
-    page.locator("#searchInput").fill("hum")
+    # Text sitting in the quick-search box (no Enter yet) must not apply
+    # later and kick the user out of collection mode.
+    page.locator(".vf-search input").fill("hum")
     page.evaluate(f"filterByCollection({collection_id})")
     page.wait_for_function(
         f"activeCollectionId === {collection_id}", timeout=2000

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -163,9 +163,17 @@ def test_browse_coordinate_filter_deep_link(live_server, page):
         )
 
     page.goto(f"{live_server['url']}/browse?location_status=none")
-    expect(page.locator("#locationStatusFilter")).to_have_value("none")
+    # The legacy deep-link param compiles to a "Has GPS is No" filter rule.
+    page.wait_for_function(
+        "document.querySelector('.vf-chips') && "
+        "document.querySelector('.vf-chips').textContent.includes('Has GPS is No')",
+        timeout=15000,
+    )
     page.locator(".grid-card").first.wait_for(state="visible")
-    assert page.locator(f".grid-card[data-id='{exif_id}']").count() == 0
+    page.wait_for_function(
+        f"!document.querySelector(\".grid-card[data-id='{exif_id}']\")",
+        timeout=15000,
+    )
     assert page.locator(".grid-location-status.none").count() > 0
 
 

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -163,10 +163,14 @@ def test_browse_coordinate_filter_deep_link(live_server, page):
         )
 
     page.goto(f"{live_server['url']}/browse?location_status=none")
-    # The legacy deep-link param compiles to a "Has GPS is No" filter rule.
+    # ?location_status=none historically means "no EXIF coords AND no assigned
+    # map location", so the legacy deep-link compiles to two rules — Has GPS is
+    # No AND Has named location is No — not Has GPS alone, which would still
+    # include photos with an assigned location.
     page.wait_for_function(
         "document.querySelector('.vf-chips') && "
-        "document.querySelector('.vf-chips').textContent.includes('Has GPS is No')",
+        "document.querySelector('.vf-chips').textContent.includes('Has GPS is No') && "
+        "document.querySelector('.vf-chips').textContent.includes('Has named location is No')",
         timeout=15000,
     )
     page.locator(".grid-card").first.wait_for(state="visible")

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -163,14 +163,16 @@ def test_browse_coordinate_filter_deep_link(live_server, page):
         )
 
     page.goto(f"{live_server['url']}/browse?location_status=none")
-    # ?location_status=none historically means "no EXIF coords AND no assigned
-    # map location", so the legacy deep-link compiles to two rules — Has GPS is
-    # No AND Has named location is No — not Has GPS alone, which would still
-    # include photos with an assigned location.
+    # ?location_status=none historically means "no EXIF coords AND no
+    # coordinate-bearing location keyword" (a free-text location without
+    # lat/lng still leaves the photo unplaceable on the map). The legacy
+    # deep-link compiles to two rules — Has GPS is No AND
+    # Has location keyword with coordinates is No.
     page.wait_for_function(
         "document.querySelector('.vf-chips') && "
         "document.querySelector('.vf-chips').textContent.includes('Has GPS is No') && "
-        "document.querySelector('.vf-chips').textContent.includes('Has named location is No')",
+        "document.querySelector('.vf-chips').textContent.includes("
+        "'Has location keyword with coordinates is No')",
         timeout=15000,
     )
     page.locator(".grid-card").first.wait_for(state="visible")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5524,19 +5524,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not isinstance(sort, str):
             return json_error("sort must be a string", 400)
         per_page = min(per_page, _MAX_PER_PAGE)
+        collection_id = payload.get("collection_id")
+        if collection_id is not None and (
+            not isinstance(collection_id, int) or isinstance(collection_id, bool)
+        ):
+            return json_error("collection_id must be an integer", 400)
+        folder_id = payload.get("folder_id")
+        if folder_id is not None and (
+            not isinstance(folder_id, int) or isinstance(folder_id, bool)
+        ):
+            return json_error("folder_id must be an integer", 400)
         rules = _inject_active_visual_model(rules)
         if payload.get("ids_only"):
             # Select-all and other bulk flows need the complete matching id
             # set; it must resolve exactly the photos the filtered grid
             # shows, so it shares this endpoint rather than a legacy path.
             try:
-                ids = db.query_photo_ids(rules, sort=sort)
+                ids = db.query_photo_ids(rules, sort=sort, collection_id=collection_id,
+                                         folder_id=folder_id)
             except ValueError as exc:
                 return json_error(str(exc), 400)
             return jsonify({"ids": ids, "total": len(ids)})
         try:
-            photos = db.query_photos(rules, sort=sort, page=page, per_page=per_page)
-            total = db.count_photos_for_rules(rules)
+            photos = db.query_photos(rules, sort=sort, page=page, per_page=per_page,
+                                     collection_id=collection_id, folder_id=folder_id)
+            total = db.count_photos_for_rules(rules, collection_id=collection_id,
+                                              folder_id=folder_id)
         except ValueError as exc:
             return json_error(str(exc), 400)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5662,6 +5662,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         keyword = request.args.get("keyword", None)
         keyword_match_case = _request_bool_arg("keyword_match_case")
         keyword_whole_word = _request_bool_arg("keyword_whole_word")
+        collection_id = request.args.get("collection_id", None, type=int)
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
@@ -5674,6 +5675,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 year=year, folder_id=folder_id, rating_min=rating_min, keyword=keyword,
                 keyword_match_case=keyword_match_case,
                 keyword_whole_word=keyword_whole_word,
+                collection_id=collection_id,
                 color_label=color_label, flag=flag,
                 location_status=location_status,
                 rules=rules,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5583,6 +5583,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ``rules`` (JSON, optional) is the active expression minus the rule
         being edited, so counts answer "how many results would I get" under
         the user's other selections — never a global COUNT(*).
+        ``folder_id``/``collection_id`` (optional) narrow the count set to
+        the page-scope restriction Browse applies to ``/api/photos/query``,
+        so a folder- or dashboard-collection-scoped Browse view shows
+        typeahead counts that match its visible grid instead of the whole
+        workspace.
         """
         db = _get_db()
         field = request.args.get("field", "")
@@ -5596,6 +5601,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except ValueError:
                 return json_error("rules must be valid JSON", 400)
         q = request.args.get("q") or None
+        folder_id = request.args.get("folder_id", None, type=int)
+        collection_id = request.args.get("collection_id", None, type=int)
         # Clamp ``limit`` to a positive bounded range. Werkzeug's ``type=int``
         # cheerfully parses ``?limit=0``/``?limit=-5`` (SQLite treats a
         # negative ``LIMIT`` as "no limit" and returns everything), and
@@ -5607,7 +5614,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         limit = max(1, min(limit_raw, 500))
         rules = _inject_active_visual_model(rules)
         try:
-            values = db.get_filter_field_values(field, rules=rules, q=q, limit=limit)
+            values = db.get_filter_field_values(
+                field, rules=rules, q=q, limit=limit,
+                folder_id=folder_id, collection_id=collection_id,
+            )
         except ValueError as exc:
             return json_error(str(exc), 400)
         return jsonify({"field": field, "values": values})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -26853,7 +26853,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         candidate_photo_ids = None
         if scope_rules is not None:
             try:
-                candidate_photo_ids = db.query_photo_ids(scope_rules)
+                candidate_photo_ids = db.query_photo_ids(
+                    scope_rules,
+                    collection_id=collection_id,
+                    folder_id=folder_id,
+                )
             except ValueError as e:
                 return json_error(str(e), 400)
         elif collection_id is not None:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3876,6 +3876,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         raw = request.args.get(name, "")
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
+    def _request_rules_arg():
+        """Parse the optional ``rules`` query param (a JSON universal-filter
+        rule tree). Returns None when absent; raises ValueError on invalid
+        JSON so callers surface a 400. The active visual model is injected
+        exactly as /api/photos/query does, keeping every rules-accepting
+        endpoint's notion of "has a visual index" consistent.
+        """
+        raw = request.args.get("rules")
+        if not raw:
+            return None
+        try:
+            rules = json.loads(raw)
+        except ValueError as exc:
+            raise ValueError("rules must be valid JSON") from exc
+        return _inject_active_visual_model(rules)
+
     def _request_location_status_filter():
         value = (request.args.get("location_status") or "").strip().lower()
         if not value:
@@ -5509,6 +5525,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("sort must be a string", 400)
         per_page = min(per_page, _MAX_PER_PAGE)
         rules = _inject_active_visual_model(rules)
+        if payload.get("ids_only"):
+            # Select-all and other bulk flows need the complete matching id
+            # set; it must resolve exactly the photos the filtered grid
+            # shows, so it shares this endpoint rather than a legacy path.
+            try:
+                ids = db.query_photo_ids(rules, sort=sort)
+            except ValueError as exc:
+                return json_error(str(exc), 400)
+            return jsonify({"ids": ids, "total": len(ids)})
         try:
             photos = db.query_photos(rules, sort=sort, page=page, per_page=per_page)
             total = db.count_photos_for_rules(rules)
@@ -5628,15 +5653,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             flag = _request_flag_filter()
             location_status = _request_location_status_filter()
+            rules = _request_rules_arg()
         except ValueError as e:
             return json_error(str(e), 400)
-        data = db.get_calendar_data(
-            year=year, folder_id=folder_id, rating_min=rating_min, keyword=keyword,
-            keyword_match_case=keyword_match_case,
-            keyword_whole_word=keyword_whole_word,
-            color_label=color_label, flag=flag,
-            location_status=location_status,
-        )
+        try:
+            data = db.get_calendar_data(
+                year=year, folder_id=folder_id, rating_min=rating_min, keyword=keyword,
+                keyword_match_case=keyword_match_case,
+                keyword_whole_word=keyword_whole_word,
+                color_label=color_label, flag=flag,
+                location_status=location_status,
+                rules=rules,
+            )
+        except ValueError as e:
+            return json_error(str(e), 400)
         return jsonify(data)
 
     @app.route("/api/browse/summary")
@@ -5654,10 +5684,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             flag = _request_flag_filter()
             location_status = _request_location_status_filter()
+            rules = _request_rules_arg()
         except ValueError as e:
             return json_error(str(e), 400)
-        return jsonify(
-            db.get_browse_summary(
+        try:
+            summary = db.get_browse_summary(
                 folder_id=folder_id,
                 rating_min=rating_min,
                 date_from=date_from,
@@ -5669,8 +5700,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 color_label=color_label,
                 flag=flag,
                 location_status=location_status,
+                rules=rules,
             )
-        )
+        except ValueError as e:
+            return json_error(str(e), 400)
+        return jsonify(summary)
 
     @app.route("/api/photos/<int:photo_id>")
     def api_photo_detail(photo_id):
@@ -26798,8 +26832,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return jsonify({"results": [], "total_matches": 0, "model_used": model_name,
                             "reason": "model_no_text_search"})
 
+        try:
+            scope_rules = _request_rules_arg()
+        except ValueError as e:
+            return json_error(str(e), 400)
+
         candidate_photo_ids = None
-        if collection_id is not None:
+        if scope_rules is not None:
+            try:
+                candidate_photo_ids = db.query_photo_ids(scope_rules)
+            except ValueError as e:
+                return json_error(str(e), 400)
+        elif collection_id is not None:
             candidate_photo_ids = db.get_collection_photo_ids(collection_id)
         elif any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag, location_status]):
             candidate_photo_ids = db.get_photo_ids(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7157,6 +7157,7 @@ class Database:
         keyword=None,
         keyword_match_case=False,
         keyword_whole_word=False,
+        collection_id=None,
         color_label=None,
         flag=None,
         location_status=None,
@@ -7177,6 +7178,21 @@ class Database:
                 f"{r_folder_join} {r_join_clause} {r_where})"
             )
             where_params.extend(r_params)
+
+        # Dashboard-scoped collection Browse composes the collection with the
+        # active rules/folder — the calendar must match the grid, so restrict
+        # counts to photos in the collection (same subquery shape as
+        # get_browse_summary).
+        if collection_id is not None:
+            parts = self._build_collection_query(collection_id)
+            if parts is not None:
+                coll_folder_join, coll_join_clause, coll_where, coll_params = parts
+                coll_subquery = (
+                    f"SELECT DISTINCT p.id FROM photos p "
+                    f"{coll_folder_join} {coll_join_clause} {coll_where}"
+                )
+                conditions.append(f"p.id IN ({coll_subquery})")
+                where_params.extend(coll_params)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -18349,6 +18365,19 @@ class Database:
                     "EXISTS (SELECT 1 FROM photo_keywords pk "
                     "JOIN keywords k ON k.id = pk.keyword_id "
                     "WHERE pk.photo_id = p.id AND k.type = 'location')"
+                )
+                return _boolean_predicate(has, op, value)
+            if field == "has_coord_location_keyword":
+                # A structured location supplies coordinates the map can
+                # place. Matches the ``assigned`` branch of
+                # ``_append_location_status_filter`` — the deep-link path
+                # depends on this being distinct from ``has_location_keyword``
+                # (which also matches free-text locations without lat/lng).
+                has = (
+                    "EXISTS (SELECT 1 FROM photo_keywords pk "
+                    "JOIN keywords k ON k.id = pk.keyword_id "
+                    "WHERE pk.photo_id = p.id AND k.type = 'location' "
+                    "AND k.latitude IS NOT NULL AND k.longitude IS NOT NULL)"
                 )
                 return _boolean_predicate(has, op, value)
             if field == "location_keyword_missing":

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -18645,14 +18645,17 @@ class Database:
             return False
         return True
 
-    def count_photos_for_rules(self, rules):
+    def count_photos_for_rules(self, rules, collection_id=None, folder_id=None):
         """Return the number of photos in the active workspace that match
-        an unsaved rules list. Used by the smart-collection modal preview.
+        an unsaved rules list. Used by the smart-collection modal preview
+        and /api/photos/query totals.
 
         Raises ValueError on malformed input (propagated from
         ``_build_query_from_rules``).
         """
         folder_join, join_clause, where, params = self._build_query_from_rules(rules)
+        where, params = self._append_collection_restriction(collection_id, where, params)
+        where, params = self._append_folder_restriction(folder_id, where, params)
         query = f"""
             SELECT COUNT(DISTINCT p.id) FROM photos p
             {folder_join}
@@ -18661,7 +18664,41 @@ class Database:
         """
         return self.conn.execute(query, params).fetchone()[0]
 
-    def query_photos(self, rules, sort="date", page=1, per_page=50):
+    def _append_folder_restriction(self, folder_id, where, params):
+        """AND a folder-subtree restriction onto built rule clauses, matching
+        get_photos' folder_id semantics (the folder and its descendants)."""
+        if folder_id is None:
+            return where, params
+        subtree = self.get_folder_subtree_ids(folder_id)
+        placeholders = ",".join("?" for _ in subtree)
+        clause = f"p.folder_id IN ({placeholders})"
+        where = f"{where} AND {clause}" if where else f"WHERE {clause}"
+        return where, list(params) + list(subtree)
+
+    def _append_collection_restriction(self, collection_id, where, params):
+        """AND a collection-membership subquery onto built rule clauses.
+
+        Lets /api/photos/query serve Browse's dashboard-scoped collection
+        view (collection as a restriction on the filtered grid) without the
+        rule tree needing to reference collections. Raises ValueError for a
+        collection missing from the active workspace.
+        """
+        if collection_id is None:
+            return where, params
+        parts = self._build_collection_query(collection_id)
+        if parts is None:
+            raise ValueError("collection not found in active workspace")
+        c_folder_join, c_join, c_where, c_params = parts
+        sub = (
+            f"SELECT DISTINCT p.id FROM photos p {c_folder_join} "
+            f"{c_join} {c_where}"
+        )
+        clause = f"p.id IN ({sub})"
+        where = f"{where} AND {clause}" if where else f"WHERE {clause}"
+        return where, list(params) + list(c_params)
+
+    def query_photos(self, rules, sort="date", page=1, per_page=50,
+                     collection_id=None, folder_id=None):
         """Return paginated photos matching a universal-filter rule tree.
 
         The rules format is the smart-collection tree (see
@@ -18669,6 +18706,8 @@ class Database:
         matching total. Raises ValueError on malformed rules.
         """
         folder_join, join_clause, where, params = self._build_query_from_rules(rules)
+        where, params = self._append_collection_restriction(collection_id, where, params)
+        where, params = self._append_folder_restriction(folder_id, where, params)
         sort_map = {
             "date": _PHOTO_DATE_ASC_ORDER,
             "date_desc": _PHOTO_DATE_DESC_ORDER,
@@ -18701,12 +18740,15 @@ class Database:
     # match both photos. ``display_expr`` is what the picker shows; using
     # ``MIN(col)`` picks a stable representative spelling within each
     # case-insensitive bucket instead of always lower-casing the label.
-    def query_photo_ids(self, rules, sort="date"):
+    def query_photo_ids(self, rules, sort="date", collection_id=None,
+                        folder_id=None):
         """Return every photo id matching a universal-filter rule tree, in
         display order — the rules analog of ``get_photo_ids`` (select-all,
         visual-search candidate scope). Raises ValueError on malformed rules.
         """
         folder_join, join_clause, where, params = self._build_query_from_rules(rules)
+        where, params = self._append_collection_restriction(collection_id, where, params)
+        where, params = self._append_folder_restriction(folder_id, where, params)
         order = {
             "date": _PHOTO_DATE_ASC_ORDER,
             "date_desc": _PHOTO_DATE_DESC_ORDER,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7160,6 +7160,7 @@ class Database:
         color_label=None,
         flag=None,
         location_status=None,
+        rules=None,
     ):
         """Return daily photo counts for a given year, scoped to active workspace."""
         ws = self._ws_id()
@@ -7167,6 +7168,15 @@ class Database:
                       "substr(p.timestamp, 1, 4) = ?"]
         join_params = []
         where_params = [ws, str(year)]
+        if rules is not None:
+            r_folder_join, r_join_clause, r_where, r_params = (
+                self._build_query_from_rules(rules)
+            )
+            conditions.append(
+                "p.id IN (SELECT DISTINCT p.id FROM photos p "
+                f"{r_folder_join} {r_join_clause} {r_where})"
+            )
+            where_params.extend(r_params)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -7516,8 +7526,15 @@ class Database:
         color_label=None,
         flag=None,
         location_status=None,
+        rules=None,
     ):
-        """Return summary stats for the browse panel, scoped to active workspace and filters."""
+        """Return summary stats for the browse panel, scoped to active workspace and filters.
+
+        ``rules`` (a universal-filter rule tree) restricts every aggregate to
+        the matching photo set, exactly like the collection_id subquery path —
+        the summary panel must describe the same photos the filtered grid
+        shows. Raises ValueError on malformed rules.
+        """
         ws = self._ws_id()
 
         # Build shared filter conditions
@@ -7559,6 +7576,17 @@ class Database:
                 )
                 conditions.append(f"p.id IN ({coll_subquery})")
                 where_params.extend(coll_params)
+
+        if rules is not None:
+            r_folder_join, r_join_clause, r_where, r_params = (
+                self._build_query_from_rules(rules)
+            )
+            rules_subquery = (
+                f"SELECT DISTINCT p.id FROM photos p "
+                f"{r_folder_join} {r_join_clause} {r_where}"
+            )
+            conditions.append(f"p.id IN ({rules_subquery})")
+            where_params.extend(r_params)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -18673,6 +18701,31 @@ class Database:
     # match both photos. ``display_expr`` is what the picker shows; using
     # ``MIN(col)`` picks a stable representative spelling within each
     # case-insensitive bucket instead of always lower-casing the label.
+    def query_photo_ids(self, rules, sort="date"):
+        """Return every photo id matching a universal-filter rule tree, in
+        display order — the rules analog of ``get_photo_ids`` (select-all,
+        visual-search candidate scope). Raises ValueError on malformed rules.
+        """
+        folder_join, join_clause, where, params = self._build_query_from_rules(rules)
+        order = {
+            "date": _PHOTO_DATE_ASC_ORDER,
+            "date_desc": _PHOTO_DATE_DESC_ORDER,
+            "name": "p.filename ASC, p.id ASC",
+            "name_desc": "p.filename DESC, p.id ASC",
+            "rating": "p.rating DESC, p.filename ASC, p.id ASC",
+            "sharpness": "p.sharpness DESC, p.filename ASC, p.id ASC",
+            "sharpness_asc": "p.sharpness ASC, p.filename ASC, p.id ASC",
+            "quality": "p.quality_score DESC, p.filename ASC, p.id ASC",
+        }.get(sort, _PHOTO_DATE_ASC_ORDER)
+        query = f"""
+            SELECT DISTINCT p.id FROM photos p
+            {folder_join}
+            {join_clause}
+            {where}
+            ORDER BY {order}
+        """
+        return [row["id"] for row in self.conn.execute(query, params).fetchall()]
+
     _SUGGEST_VALUE_EXPRS = {
         "camera_make": ("MIN(p.camera_make)", "LOWER(p.camera_make)"),
         "camera_model": ("MIN(p.camera_model)", "LOWER(p.camera_model)"),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -18804,18 +18804,26 @@ class Database:
         "extension": ("LOWER(p.extension)", "LOWER(p.extension)"),
     }
 
-    def get_filter_field_values(self, field, rules=None, q=None, limit=20):
+    def get_filter_field_values(self, field, rules=None, q=None, limit=20,
+                                 folder_id=None, collection_id=None):
         """Distinct values (with photo counts) for a suggest-capable field.
 
         Counts respect the supplied rule tree, so the caller can pass the
         active expression minus the rule being edited and get live facet
         counts (design requirement: counts answer "how many results would I
-        get", never a global COUNT(*)). Raises ValueError for fields without
-        value suggestions or malformed rules.
+        get", never a global COUNT(*)). ``folder_id``/``collection_id`` AND
+        the same page-scope restrictions Browse applies to
+        ``/api/photos/query``; without them the typeahead advertises counts
+        computed over the whole workspace while the visible grid is
+        folder/collection-scoped, so picking a suggestion can yield fewer
+        (or zero) grid results than the badge promised. Raises ValueError
+        for fields without value suggestions or malformed rules.
         """
         folder_join, join_clause, where, params = self._build_query_from_rules(
             rules if rules is not None else []
         )
+        where, params = self._append_collection_restriction(collection_id, where, params)
+        where, params = self._append_folder_restriction(folder_id, where, params)
         limit = max(1, min(int(limit or 20), 50))
         if field == "folder":
             return self._folder_filter_values(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7182,17 +7182,21 @@ class Database:
         # Dashboard-scoped collection Browse composes the collection with the
         # active rules/folder — the calendar must match the grid, so restrict
         # counts to photos in the collection (same subquery shape as
-        # get_browse_summary).
+        # get_browse_summary). Match get_photos / _append_collection_restriction:
+        # raise on a missing/invalid collection instead of silently returning
+        # unfiltered workspace data (which would mislead users into thinking
+        # the collection contains those photos).
         if collection_id is not None:
             parts = self._build_collection_query(collection_id)
-            if parts is not None:
-                coll_folder_join, coll_join_clause, coll_where, coll_params = parts
-                coll_subquery = (
-                    f"SELECT DISTINCT p.id FROM photos p "
-                    f"{coll_folder_join} {coll_join_clause} {coll_where}"
-                )
-                conditions.append(f"p.id IN ({coll_subquery})")
-                where_params.extend(coll_params)
+            if parts is None:
+                raise ValueError("collection not found in active workspace")
+            coll_folder_join, coll_join_clause, coll_where, coll_params = parts
+            coll_subquery = (
+                f"SELECT DISTINCT p.id FROM photos p "
+                f"{coll_folder_join} {coll_join_clause} {coll_where}"
+            )
+            conditions.append(f"p.id IN ({coll_subquery})")
+            where_params.extend(coll_params)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -7578,20 +7582,25 @@ class Database:
 
         # When browsing a collection, restrict photos to those matching the
         # collection's rules by using a subquery from _build_collection_query.
+        # Match get_photos / _append_collection_restriction: raise on a
+        # missing/invalid collection instead of silently returning unfiltered
+        # workspace numbers (which would mislead users into thinking the
+        # collection contains those photos).
         if collection_id is not None:
             parts = self._build_collection_query(collection_id)
-            if parts is not None:
-                coll_folder_join, coll_join_clause, coll_where, coll_params = parts
-                # Build a subquery that returns the photo IDs in this collection.
-                # Use alias "p" to match the alias expected by _build_collection_query;
-                # the subquery is wrapped in parentheses so "p" is scoped to it and
-                # does not conflict with the outer query's "p" alias.
-                coll_subquery = (
-                    f"SELECT DISTINCT p.id FROM photos p "
-                    f"{coll_folder_join} {coll_join_clause} {coll_where}"
-                )
-                conditions.append(f"p.id IN ({coll_subquery})")
-                where_params.extend(coll_params)
+            if parts is None:
+                raise ValueError("collection not found in active workspace")
+            coll_folder_join, coll_join_clause, coll_where, coll_params = parts
+            # Build a subquery that returns the photo IDs in this collection.
+            # Use alias "p" to match the alias expected by _build_collection_query;
+            # the subquery is wrapped in parentheses so "p" is scoped to it and
+            # does not conflict with the outer query's "p" alias.
+            coll_subquery = (
+                f"SELECT DISTINCT p.id FROM photos p "
+                f"{coll_folder_join} {coll_join_clause} {coll_where}"
+            )
+            conditions.append(f"p.id IN ({coll_subquery})")
+            where_params.extend(coll_params)
 
         if rules is not None:
             r_folder_join, r_join_clause, r_where, r_params = (

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -18704,13 +18704,24 @@ class Database:
 
     def _append_folder_restriction(self, folder_id, where, params):
         """AND a folder-subtree restriction onto built rule clauses, matching
-        get_photos' folder_id semantics (the folder and its descendants)."""
+        get_photos' folder_id semantics (the folder and its descendants).
+
+        Wraps the existing WHERE body in parentheses before ANDing so a
+        top-level ``any`` rule tree (``WHERE (A) OR (B)``) doesn't have the
+        folder restriction bind only to the last OR branch — AND binds
+        tighter than OR in SQL, and without wrapping photos outside the
+        selected folder would leak through the earlier branches.
+        """
         if folder_id is None:
             return where, params
         subtree = self.get_folder_subtree_ids(folder_id)
         placeholders = ",".join("?" for _ in subtree)
         clause = f"p.folder_id IN ({placeholders})"
-        where = f"{where} AND {clause}" if where else f"WHERE {clause}"
+        if where:
+            body = where[len("WHERE "):]
+            where = f"WHERE ({body}) AND {clause}"
+        else:
+            where = f"WHERE {clause}"
         return where, list(params) + list(subtree)
 
     def _append_collection_restriction(self, collection_id, where, params):
@@ -18719,7 +18730,9 @@ class Database:
         Lets /api/photos/query serve Browse's dashboard-scoped collection
         view (collection as a restriction on the filtered grid) without the
         rule tree needing to reference collections. Raises ValueError for a
-        collection missing from the active workspace.
+        collection missing from the active workspace. Wraps the existing
+        WHERE body in parentheses before ANDing for the same OR-precedence
+        reason as ``_append_folder_restriction``.
         """
         if collection_id is None:
             return where, params
@@ -18732,7 +18745,11 @@ class Database:
             f"{c_join} {c_where}"
         )
         clause = f"p.id IN ({sub})"
-        where = f"{where} AND {clause}" if where else f"WHERE {clause}"
+        if where:
+            body = where[len("WHERE "):]
+            where = f"WHERE ({body}) AND {clause}"
+        else:
+            where = f"WHERE {clause}"
         return where, list(params) + list(c_params)
 
     def query_photos(self, rules, sort="date", page=1, per_page=50,

--- a/vireo/filter_fields.py
+++ b/vireo/filter_fields.py
@@ -74,6 +74,14 @@ FILTER_FIELDS = {
     "has_gps": _field("Has GPS", "Location", "boolean", BOOLEAN_OPS),
     "has_location_keyword": _field("Has named location", "Location", "boolean",
                                    BOOLEAN_OPS),
+    # Distinct from ``has_location_keyword``: a free-text location keyword
+    # (no lat/lng) counts as "has named location" but cannot place the photo
+    # on the map. Legacy Browse ``?location_status=assigned``/``none`` deep
+    # links depend on this coordinate-bearing check to round-trip correctly.
+    "has_coord_location_keyword": _field(
+        "Has location keyword with coordinates", "Location", "boolean",
+        BOOLEAN_OPS,
+    ),
     "gps_lat": _field("GPS latitude", "Location", "number", NUMBER_OPS),
     "gps_lng": _field("GPS longitude", "Location", "number", NUMBER_OPS),
     # Quality & AI

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1,0 +1,1031 @@
+/* Universal photo filter bar — shared across Browse/Map/Review/Duplicates.
+ *
+ * Owns the filter expression (a smart-collection rule tree, the same JSON
+ * collections store), its UI (quick search, chips, popover with quick
+ * filters + rule builder), pause state, and per-workspace persistence.
+ * All evaluation is server-side: pages call VireoFilter.getRules() and
+ * fetch /api/photos/query themselves; the module fires onChange when the
+ * effective expression changes.
+ *
+ * Design + hard UI requirements (chip text = exact semantics, counts =
+ * "how many results would I get", pause never loses filters, Advanced
+ * toggle never rewrites the tree):
+ * docs/plans/2026-07-19-universal-filters-design.md
+ */
+(function () {
+  'use strict';
+
+  const OP_LABELS = {
+    'contains': 'contains',
+    'not_contains': "doesn't contain",
+    'is': 'is',
+    'is not': 'is not',
+    'starts_with': 'starts with',
+    'ends_with': 'ends with',
+    '>=': 'is at least',
+    '<=': 'is at most',
+    '>': 'is more than',
+    '<': 'is less than',
+    'between': 'is between',
+    'in': 'is one of',
+    'not_in': 'is not one of',
+    'under': 'is under',
+    'not_under': 'is not under',
+    'recent': 'is in the last',
+  };
+  const RECENT_UNITS = [
+    ['days', 'day', 'days'],
+    ['weeks', 'week', 'weeks'],
+    ['months', 'month', 'months'],
+    ['years', 'year', 'years'],
+  ];
+  // Quick search fans out over these fields as one replaceable any-group.
+  const QUICK_SEARCH_FIELDS = ['filename', 'keyword', 'species', 'camera_make', 'camera_model', 'lens'];
+
+  const state = {
+    page: 'browse',
+    root: { mode: 'all', rules: [] },
+    muted: false,
+    scopeLabel: '',
+    scopeLocked: true,
+    fields: null,          // registry from /api/filters/fields (key -> spec)
+    fieldOrder: [],
+    onChange: null,
+    getContextRules: null, // page-supplied rules ANDed outside the user tree
+    workspaceId: null,
+    resultTotal: null,
+    wouldMatch: null,      // count while paused
+    advanced: false,
+    ready: false,
+  };
+
+  let rootEl = null;
+  let snapshots = [];
+  let persistTimer = null;
+  let suggestTimer = null;
+  let toastTimer = null;
+  let wouldMatchEpoch = 0;
+
+  const $ = (sel) => rootEl.querySelector(sel);
+  const $$ = (sel) => Array.from(rootEl.querySelectorAll(sel));
+  const clone = (v) => JSON.parse(JSON.stringify(v));
+
+  function fetchJson(url, options) {
+    return fetch(url, options).then((r) => {
+      if (!r.ok) return r.json().catch(() => ({})).then((body) => {
+        throw new Error(body.error || body.message || `HTTP ${r.status}`);
+      });
+      return r.json();
+    });
+  }
+
+  function loadRegistry() {
+    if (state.fields) return Promise.resolve(state.fields);
+    return fetchJson('/api/filters/fields').then((data) => {
+      state.fields = {};
+      state.fieldOrder = [];
+      data.fields.forEach((f) => {
+        state.fields[f.key] = f;
+        state.fieldOrder.push(f.key);
+      });
+      return state.fields;
+    });
+  }
+
+  // ---- rule model -------------------------------------------------------
+
+  function isGroup(node) {
+    return node && typeof node === 'object' && Array.isArray(node.rules) && !('field' in node);
+  }
+
+  function allLeaves(node, out) {
+    const target = out || [];
+    if (!node) return target;
+    if (isGroup(node)) node.rules.forEach((child) => allLeaves(child, target));
+    else target.push(node);
+    return target;
+  }
+
+  function defaultOp(spec) {
+    if (!spec) return 'is';
+    if (spec.type === 'text') return 'contains';
+    if (spec.type === 'date') return 'recent';
+    if (spec.type === 'enum') return 'in';
+    if (spec.type === 'rating') return '>=';
+    if (spec.type === 'folder') return 'under';
+    return spec.ops[0];
+  }
+
+  function defaultValue(spec, op) {
+    if (op === 'recent') return { n: 12, unit: 'months' };
+    if (op === 'between') {
+      if (spec.type === 'date') return ['2025-01-01', new Date().toISOString().slice(0, 10)];
+      return [0, 100];
+    }
+    if (op === 'in' || op === 'not_in') return spec.values ? [spec.values[0]] : [];
+    if (spec.type === 'boolean') return 1;
+    if (spec.type === 'enum') return (spec.values || [''])[0];
+    if (spec.type === 'rating') return 3;
+    if (spec.type === 'number') return 0;
+    if (spec.type === 'date') return new Date().toISOString().slice(0, 10);
+    return '';
+  }
+
+  function coerceValue(spec, op, prev) {
+    if (op === 'recent') {
+      return prev && typeof prev === 'object' && !Array.isArray(prev) && prev.n ? prev : defaultValue(spec, op);
+    }
+    if (op === 'between') {
+      if (Array.isArray(prev) && prev.length === 2) return prev;
+      return defaultValue(spec, op);
+    }
+    if (op === 'in' || op === 'not_in') {
+      if (Array.isArray(prev)) return prev.length ? prev : defaultValue(spec, op);
+      if (prev != null && prev !== '' && (!spec.values || spec.values.includes(prev))) return [prev];
+      return defaultValue(spec, op);
+    }
+    if (Array.isArray(prev)) return prev.length ? prev[0] : defaultValue(spec, op);
+    if (prev && typeof prev === 'object') return defaultValue(spec, op);
+    if (spec.type === 'enum' && spec.values && !spec.values.includes(prev)) return spec.values[0];
+    if (prev == null || prev === '') return defaultValue(spec, op);
+    return prev;
+  }
+
+  function makeRule(field, op, value) {
+    const spec = state.fields[field];
+    const resolvedOp = op || defaultOp(spec);
+    return { field, op: resolvedOp, value: value == null ? defaultValue(spec, resolvedOp) : value };
+  }
+
+  function getNodeAtPath(path) {
+    if (path === 'root' || path === '') return state.root;
+    let node = state.root;
+    String(path).split('.').forEach((idx) => {
+      node = node && node.rules ? node.rules[Number(idx)] : undefined;
+    });
+    return node;
+  }
+
+  function getParentAtPath(path) {
+    const parts = String(path).split('.');
+    const index = Number(parts.pop());
+    let parent = state.root;
+    parts.forEach((idx) => { parent = parent.rules[Number(idx)]; });
+    return { parent, index };
+  }
+
+  function removeByReference(node, target) {
+    if (!isGroup(node)) return false;
+    const idx = node.rules.indexOf(target);
+    if (idx >= 0) { node.rules.splice(idx, 1); return true; }
+    return node.rules.some((child) => removeByReference(child, target));
+  }
+
+  // Clone the tree with one leaf dropped from its group — never substitute
+  // "true", which inverts any/none groups (prototype review finding).
+  function rulesWithout(target) {
+    function walk(node) {
+      if (!isGroup(node)) return node === target ? null : clone(node);
+      const kept = node.rules.map(walk).filter((c) => c !== null);
+      return { ...clone({ ...node, rules: [] }), rules: kept };
+    }
+    return walk(state.root);
+  }
+
+  // ---- labels -----------------------------------------------------------
+
+  function valueLabel(spec, rule) {
+    const labels = spec.labels || {};
+    if (rule.op === 'in' || rule.op === 'not_in') {
+      const values = Array.isArray(rule.value) ? rule.value : [rule.value];
+      return values.map((v) => labels[v] || v).join(', ') || '(none)';
+    }
+    if (rule.op === 'recent') {
+      const spec2 = rule.value || {};
+      const unit = RECENT_UNITS.find(([k]) => k === spec2.unit) || RECENT_UNITS[0];
+      return `${spec2.n} ${Number(spec2.n) === 1 ? unit[1] : unit[2]}`;
+    }
+    if (rule.op === 'between') {
+      const pair = Array.isArray(rule.value) ? rule.value : ['', ''];
+      return `${pair[0]} and ${pair[1]}`;
+    }
+    if (spec.type === 'boolean') return rule.value ? 'Yes' : 'No';
+    if (spec.type === 'rating') {
+      return `${rule.value} ${Number(rule.value) === 1 ? 'star' : 'stars'}`;
+    }
+    return labels[rule.value] != null ? labels[rule.value] : rule.value;
+  }
+
+  function ruleLabel(rule) {
+    const spec = state.fields[rule.field] || { label: rule.field, type: 'text' };
+    const opLabel = OP_LABELS[rule.op] || rule.op;
+    return `${spec.label} ${opLabel} ${valueLabel(spec, rule)}`;
+  }
+
+  function quickSearchGroup() {
+    return state.root.rules.find((n) => isGroup(n) && n._qs);
+  }
+
+  function chipEntries() {
+    const entries = [];
+    state.root.rules.forEach((node) => {
+      if (isGroup(node) && node._qs) {
+        entries.push({ node, label: `Search: “${node._qs_text}”`, qs: true });
+      } else {
+        allLeaves(node).forEach((leaf) => entries.push({ node: leaf, label: ruleLabel(leaf) }));
+      }
+    });
+    return entries;
+  }
+
+  // ---- public expression ------------------------------------------------
+
+  function userRules() {
+    return state.root.rules.length ? clone(state.root) : { mode: 'all', rules: [] };
+  }
+
+  function effectiveRules() {
+    const context = state.getContextRules ? state.getContextRules() : [];
+    const user = state.muted ? [] : state.root.rules;
+    if (!context.length && !user.length) return [];
+    return { mode: 'all', rules: clone(context).concat(clone(user)) };
+  }
+
+  function hasUserFilters() {
+    return state.root.rules.length > 0;
+  }
+
+  // ---- mutation + change plumbing --------------------------------------
+
+  function snapshot() {
+    snapshots.push(clone({ root: state.root, muted: state.muted }));
+    if (snapshots.length > 20) snapshots.shift();
+  }
+
+  function mutate(fn, opts) {
+    const options = opts || {};
+    // A pending debounced edit would replay stale input against the
+    // re-rendered tree (e.g. overwrite a just-picked suggestion with the
+    // half-typed text). Nothing survives across a mutate.
+    clearTimeout(editDebounce);
+    editDebounce = null;
+    if (!options.noSnapshot) snapshot();
+    fn();
+    // lightRender: state committed from a live input — refresh chips and
+    // counters but leave the rule tree DOM (and the focused input + its
+    // open suggest dropdown) untouched. Full re-renders mid-typing were
+    // the root of a whole class of prototype-review bugs.
+    if (options.lightRender) renderLight();
+    else render();
+    schedulePersist();
+    if (state.onChange && !options.silent) state.onChange();
+    if (state.muted) refreshWouldMatch();
+  }
+
+  function undo() {
+    const prev = snapshots.pop();
+    if (!prev) return;
+    state.root = prev.root;
+    state.muted = prev.muted;
+    render();
+    schedulePersist();
+    if (state.onChange) state.onChange();
+  }
+
+  function toast(text, withUndo) {
+    const el = $('.vf-toast');
+    if (!el) return;
+    el.querySelector('span').textContent = text;
+    el.querySelector('button').hidden = !withUndo;
+    el.hidden = false;
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { el.hidden = true; }, 4200);
+  }
+
+  function refreshWouldMatch() {
+    const epoch = ++wouldMatchEpoch;
+    const context = state.getContextRules ? state.getContextRules() : [];
+    const rules = { mode: 'all', rules: clone(context).concat(clone(state.root.rules)) };
+    fetchJson('/api/photos/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rules, per_page: 1 }),
+    }).then((data) => {
+      if (epoch !== wouldMatchEpoch || !state.muted) return;
+      state.wouldMatch = data.total;
+      renderMuteState();
+    }).catch(() => {});
+  }
+
+  // ---- persistence ------------------------------------------------------
+
+  function schedulePersist() {
+    if (!state.workspaceId) return;
+    clearTimeout(persistTimer);
+    persistTimer = setTimeout(persistNow, 800);
+  }
+
+  function persistNow() {
+    if (!state.workspaceId) return;
+    // Read-modify-write ui_state so other keys survive.
+    fetchJson('/api/workspaces/active').then((ws) => {
+      if (ws.id !== state.workspaceId) return;
+      const uiState = parseUiState(ws.ui_state);
+      if (!uiState.universal_filters) uiState.universal_filters = {};
+      uiState.universal_filters[state.page] = { root: state.root, muted: state.muted };
+      // The server JSON-encodes ui_state itself — send the object, or the
+      // stored value ends up double-encoded and unreadable on restore.
+      return fetch(`/api/workspaces/${state.workspaceId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ui_state: uiState }),
+      });
+    }).catch(() => {});
+  }
+
+  function parseUiState(raw) {
+    if (raw == null) return {};
+    let value = raw;
+    try {
+      // Tolerate one level of legacy double-encoding.
+      if (typeof value === 'string') value = JSON.parse(value);
+      if (typeof value === 'string') value = JSON.parse(value);
+    } catch (e) { return {}; }
+    return value && typeof value === 'object' ? value : {};
+  }
+
+  function restorePersisted() {
+    return fetchJson('/api/workspaces/active').then((ws) => {
+      state.workspaceId = ws.id;
+      const uiState = parseUiState(ws.ui_state);
+      const saved = uiState.universal_filters && uiState.universal_filters[state.page];
+      if (saved && saved.root && Array.isArray(saved.root.rules)) {
+        state.root = saved.root;
+        state.muted = Boolean(saved.muted);
+        return true;
+      }
+      return false;
+    }).catch(() => false);
+  }
+
+  // ---- deep links -------------------------------------------------------
+
+  function applyLegacyParams(params) {
+    const rules = [];
+    const ratingMin = params.get('rating_min');
+    if (ratingMin) rules.push(makeRule('rating', '>=', Number(ratingMin)));
+    const flag = params.get('flag');
+    if (flag) rules.push(makeRule('flag', 'is', flag));
+    const color = params.get('color_label');
+    if (color) rules.push(makeRule('color_label', 'in', [color]));
+    const dateFrom = params.get('date_from');
+    if (dateFrom) rules.push(makeRule('timestamp', '>=', dateFrom));
+    const dateTo = params.get('date_to');
+    if (dateTo) rules.push(makeRule('timestamp', '<=', dateTo));
+    const locationStatus = params.get('location_status');
+    if (locationStatus === 'has_gps') rules.push(makeRule('has_gps', 'is', 1));
+    else if (locationStatus === 'none') rules.push(makeRule('has_gps', 'is', 0));
+    const keyword = params.get('keyword');
+    if (keyword) rules.push(buildQuickSearchGroup(keyword));
+    if (!rules.length) return false;
+    state.root = { mode: 'all', rules };
+    state.muted = false;
+    return true;
+  }
+
+  // ---- quick search -----------------------------------------------------
+
+  function buildQuickSearchGroup(text) {
+    return {
+      mode: 'any',
+      _qs: true,
+      _qs_text: text,
+      rules: QUICK_SEARCH_FIELDS.map((field) => ({ field, op: 'contains', value: text })),
+    };
+  }
+
+  function applyQuickSearch(text) {
+    const value = String(text || '').trim();
+    mutate(() => {
+      state.root.rules = state.root.rules.filter((n) => !(isGroup(n) && n._qs));
+      if (value) state.root.rules.unshift(buildQuickSearchGroup(value));
+    });
+  }
+
+  function syncQuickSearchInput() {
+    const input = $('.vf-search input');
+    if (!input || document.activeElement === input) return;
+    const group = quickSearchGroup();
+    input.value = group ? group._qs_text : '';
+  }
+
+  // ---- rendering --------------------------------------------------------
+
+  function render() {
+    if (!state.ready) return;
+    syncQuickSearchInput();
+    renderRules();
+    renderLight();
+  }
+
+  function renderLight() {
+    if (!state.ready) return;
+    renderChips();
+    renderQuick();
+    renderMuteState();
+    const count = chipEntries().length;
+    const badge = $('.vf-filters-btn .vf-count');
+    badge.textContent = count;
+    badge.hidden = count === 0;
+    $('.vf-clear').hidden = !hasUserFilters();
+    $('.vf-mute').hidden = !hasUserFilters() && !state.muted;
+    requestAnimationFrame(updateChipOverflow);
+  }
+
+  function renderMuteState() {
+    const btn = $('.vf-mute');
+    btn.textContent = state.muted ? '▶ Resume' : '⏸ Pause';
+    btn.classList.toggle('active', state.muted);
+    btn.title = 'Temporarily disable filters without losing them (\\)';
+    $('.vf-chip-row').classList.toggle('muted', state.muted);
+    const note = $('.vf-paused-note');
+    if (state.muted) {
+      const n = state.wouldMatch;
+      note.textContent = n == null
+        ? 'Filters paused — showing everything in scope · press \\ to resume'
+        : `Filters paused — showing everything in scope · ${n} would match · press \\ to resume`;
+      note.hidden = false;
+    } else {
+      note.hidden = true;
+    }
+  }
+
+  function esc(value) {
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function renderChips() {
+    const list = $('.vf-chips');
+    $('.vf-scope-chip span').textContent = state.scopeLabel;
+    list.innerHTML = chipEntries().map((entry, idx) =>
+      `<button class="vf-chip" data-chip="${idx}" type="button" title="Edit filters">
+        <span>${esc(entry.label)}</span>
+        <span class="vf-chip-x" data-chip-x="${idx}" role="button" aria-label="Remove ${esc(entry.label)}">×</span>
+      </button>`).join('');
+  }
+
+  function updateChipOverflow() {
+    const viewport = $('.vf-chip-viewport');
+    const overflow = $('.vf-overflow');
+    if (!viewport) return;
+    const chips = $$('.vf-chips .vf-chip');
+    chips.forEach((c) => { c.style.display = 'inline-flex'; });
+    overflow.hidden = true;
+    if (!chips.length || viewport.clientWidth <= 0) return;
+    let used = 0;
+    let hidden = 0;
+    chips.forEach((chip) => {
+      const w = chip.getBoundingClientRect().width + 6;
+      if (used + w > Math.max(20, viewport.clientWidth - 44)) {
+        chip.style.display = 'none';
+        hidden += 1;
+      } else used += w;
+    });
+    if (hidden) {
+      overflow.textContent = `+${hidden}`;
+      overflow.hidden = false;
+    }
+  }
+
+  function findRootRule(field) {
+    return state.root.rules.find((n) => !isGroup(n) && n.field === field);
+  }
+
+  function quickEnumValues(field) {
+    const rule = findRootRule(field);
+    if (!rule) return [];
+    if (rule.op === 'in' && Array.isArray(rule.value)) return rule.value;
+    if (rule.op === 'is') return [rule.value];
+    return [];
+  }
+
+  function toggleQuickEnum(field, value) {
+    mutate(() => {
+      const idx = state.root.rules.findIndex((n) => !isGroup(n) && n.field === field);
+      if (idx < 0) { state.root.rules.unshift(makeRule(field, 'in', [value])); return; }
+      const rule = state.root.rules[idx];
+      let values;
+      if (rule.op === 'in' && Array.isArray(rule.value)) values = rule.value.slice();
+      else if (rule.op === 'is') values = [rule.value];
+      else { state.root.rules[idx] = makeRule(field, 'in', [value]); return; }
+      if (values.includes(value)) values = values.filter((v) => v !== value);
+      else values.push(value);
+      if (!values.length) state.root.rules.splice(idx, 1);
+      else state.root.rules[idx] = makeRule(field, 'in', values);
+    });
+  }
+
+  function renderQuick() {
+    const rating = findRootRule('rating');
+    const opSel = $('.vf-quick-rating select');
+    if (rating && ['>=', 'is', '<='].includes(rating.op)) opSel.value = rating.op;
+    $$('.vf-quick-rating .vf-star').forEach((btn) => {
+      btn.classList.toggle('active', Boolean(rating && Number(rating.value) >= Number(btn.dataset.rating)));
+    });
+    const flags = quickEnumValues('flag');
+    $$('.vf-quick-flags button').forEach((btn) => btn.classList.toggle('active', flags.includes(btn.dataset.flag)));
+    const colors = quickEnumValues('color_label');
+    $$('.vf-quick-colors button').forEach((btn) => btn.classList.toggle('active', colors.includes(btn.dataset.color)));
+  }
+
+  function renderRules() {
+    const tree = $('.vf-rule-tree');
+    $('.vf-advanced input').checked = state.advanced;
+    $('.vf-add-group').hidden = !state.advanced;
+    const active = document.activeElement;
+    const restore = active && tree.contains(active) && active.dataset && active.dataset.path != null
+      ? {
+          action: active.dataset.action,
+          path: active.dataset.path,
+          start: active.selectionStart,
+          end: active.selectionEnd,
+          suggest: Boolean(active.dataset.suggest),
+        }
+      : null;
+    tree.innerHTML = state.root.rules.length
+      ? state.root.rules.map((node, i) => renderNode(node, String(i), 0)).join('')
+      : '<div class="vf-empty-rules">No rules yet. Use a quick filter or add any metadata field.</div>';
+    if (restore) {
+      const el = tree.querySelector(`[data-action="${restore.action}"][data-path="${restore.path}"]`);
+      if (el) {
+        el.focus({ preventScroll: true });
+        if (restore.start != null) {
+          try { el.setSelectionRange(restore.start, restore.end); } catch (e) { /* selects */ }
+        }
+        if (restore.suggest) showValueSuggest(el);
+      }
+    }
+  }
+
+  function renderNode(node, path, depth) {
+    if (isGroup(node)) {
+      if (node._qs) {
+        return `<div class="vf-rule-row vf-qs-row">
+          <span class="vf-qs-label">Search all text contains “${esc(node._qs_text)}”</span>
+          <button class="vf-remove" data-action="remove" data-path="${path}" type="button" aria-label="Remove search">×</button>
+        </div>`;
+      }
+      return `<div class="vf-group" data-depth="${depth}">
+        <div class="vf-group-mode"><span>Match</span>
+          <select data-action="mode" data-path="${path}" aria-label="Group logic">
+            <option value="all" ${node.mode === 'all' ? 'selected' : ''}>all</option>
+            <option value="any" ${node.mode === 'any' ? 'selected' : ''}>any</option>
+            <option value="none" ${node.mode === 'none' ? 'selected' : ''}>none</option>
+          </select><span>in this group</span>
+          <button class="vf-remove" data-action="remove" data-path="${path}" type="button" aria-label="Remove group">×</button>
+        </div>
+        <div class="vf-group-children">${node.rules.map((c, i) => renderNode(c, `${path}.${i}`, depth + 1)).join('')}</div>
+        <div class="vf-group-actions">
+          <button class="vf-text-btn" data-action="add-child" data-path="${path}" type="button">＋ Rule</button>
+          <button class="vf-text-btn" data-action="add-subgroup" data-path="${path}" type="button">＋ Group</button>
+        </div>
+      </div>`;
+    }
+    const spec = state.fields[node.field] || { label: node.field, type: 'text', ops: ['is'] };
+    const fieldOptions = state.fieldOrder.map((key) =>
+      `<option value="${key}" ${key === node.field ? 'selected' : ''}>${esc(state.fields[key].label)}</option>`).join('');
+    const opOptions = spec.ops.map((op) =>
+      `<option value="${esc(op)}" ${op === node.op ? 'selected' : ''}>${esc(OP_LABELS[op] || op)}</option>`).join('');
+    return `<div class="vf-rule-row">
+      <select data-action="field" data-path="${path}" aria-label="Filter field">${fieldOptions}</select>
+      <select data-action="op" data-path="${path}" aria-label="Filter operator">${opOptions}</select>
+      ${renderValueInput(node, spec, path)}
+      <button class="vf-remove" data-action="remove" data-path="${path}" type="button" aria-label="Remove rule">×</button>
+      ${spec.case_toggle ? `<div class="vf-rule-opts"><label><input data-action="case" data-path="${path}" type="checkbox" ${node.case ? 'checked' : ''}> Match case</label></div>` : ''}
+    </div>`;
+  }
+
+  function renderValueInput(node, spec, path) {
+    if ((node.op === 'in' || node.op === 'not_in') && spec.values) {
+      const selected = Array.isArray(node.value) ? node.value : [node.value];
+      const labels = spec.labels || {};
+      return `<div class="vf-enum-multi" role="group">${spec.values.map((v) =>
+        `<button type="button" class="vf-enum-pill ${selected.includes(v) ? 'active' : ''}" data-action="multi" data-path="${path}" data-value="${esc(v)}" aria-pressed="${selected.includes(v)}">${esc(labels[v] || v)}</button>`).join('')}</div>`;
+    }
+    if ((node.op === 'in' || node.op === 'not_in') && !spec.values) {
+      // Suggest-backed enum (extension): free-entry list via typeahead.
+      const selected = Array.isArray(node.value) ? node.value : [];
+      return `<span class="vf-value-wrap"><input data-action="multi-text" data-path="${path}" data-suggest="${spec.suggest ? '1' : ''}" type="text" autocomplete="off" spellcheck="false" value="${esc(selected.join(', '))}" placeholder="Comma-separated values" aria-label="Filter values"><div class="vf-suggest" hidden></div></span>`;
+    }
+    if (node.op === 'recent') {
+      const v = node.value || {};
+      return `<div class="vf-value-pair"><input data-action="recent-n" data-path="${path}" type="number" min="1" step="1" value="${esc(v.n)}" aria-label="Number"><select data-action="recent-unit" data-path="${path}" aria-label="Unit">${RECENT_UNITS.map(([k, , plural]) => `<option value="${k}" ${v.unit === k ? 'selected' : ''}>${plural}</option>`).join('')}</select></div>`;
+    }
+    if (node.op === 'between') {
+      const pair = Array.isArray(node.value) ? node.value : ['', ''];
+      const type = spec.type === 'date' ? 'date' : 'number';
+      return `<div class="vf-value-pair"><input data-action="between-lo" data-path="${path}" type="${type}" value="${esc(pair[0])}" aria-label="Lower bound"><span>and</span><input data-action="between-hi" data-path="${path}" type="${type}" value="${esc(pair[1])}" aria-label="Upper bound"></div>`;
+    }
+    if (spec.type === 'boolean') {
+      return `<select data-action="value-bool" data-path="${path}" aria-label="Filter value"><option value="1" ${node.value ? 'selected' : ''}>Yes</option><option value="0" ${!node.value ? 'selected' : ''}>No</option></select>`;
+    }
+    if (spec.type === 'enum' && spec.values) {
+      const labels = spec.labels || {};
+      return `<select data-action="value-select" data-path="${path}" aria-label="Filter value">${spec.values.map((v) => `<option value="${esc(v)}" ${v === node.value ? 'selected' : ''}>${esc(labels[v] || v)}</option>`).join('')}</select>`;
+    }
+    const inputType = spec.type === 'number' || spec.type === 'rating' ? 'number' : (spec.type === 'date' ? 'date' : 'text');
+    const extras = spec.type === 'rating' ? 'min="0" max="5" step="1"' : (inputType === 'number' ? 'step="any"' : '');
+    if (spec.suggest && inputType === 'text') {
+      return `<span class="vf-value-wrap"><input data-action="value-input" data-path="${path}" data-suggest="1" type="text" autocomplete="off" spellcheck="false" value="${esc(node.value)}" placeholder="Type or pick a value…" aria-label="Filter value"><div class="vf-suggest" hidden></div></span>`;
+    }
+    return `<input data-action="value-input" data-path="${path}" type="${inputType}" ${extras} value="${esc(node.value)}" aria-label="Filter value">`;
+  }
+
+  // ---- typeahead --------------------------------------------------------
+
+  function showValueSuggest(input) {
+    const wrap = input.closest('.vf-value-wrap');
+    if (!wrap) return;
+    const drop = wrap.querySelector('.vf-suggest');
+    const node = getNodeAtPath(input.dataset.path);
+    if (!node || isGroup(node)) { drop.hidden = true; return; }
+    const spec = state.fields[node.field];
+    if (!spec || !spec.suggest) { drop.hidden = true; return; }
+    const raw = input.dataset.action === 'multi-text'
+      ? String(input.value).split(',').pop() : input.value;
+    const q = String(raw || '').trim();
+    // Counts respect everything except the rule being edited, plus the
+    // page's context rules — "how many results would I get".
+    const context = state.getContextRules ? state.getContextRules() : [];
+    const others = rulesWithout(node);
+    const rules = { mode: 'all', rules: clone(context).concat(others.rules) };
+    const params = new URLSearchParams({ field: node.field, limit: '8' });
+    if (q) params.set('q', q);
+    params.set('rules', JSON.stringify(rules));
+    fetchJson(`/api/filters/values?${params}`).then((data) => {
+      if (!document.contains(input)) return;
+      if (!data.values.length) { drop.hidden = true; return; }
+      drop.innerHTML = `<div class="vf-suggest-hint">In your photos · counts respect other filters</div>` +
+        data.values.map((entry) =>
+          `<button class="vf-value-option" data-suggest-value="${esc(entry.value)}" data-path="${input.dataset.path}" type="button"><span>${esc(entry.value)}</span><em>${entry.count}</em></button>`).join('');
+      drop.hidden = false;
+    }).catch(() => { drop.hidden = true; });
+  }
+
+  function hideSuggests() {
+    $$('.vf-suggest').forEach((d) => { d.hidden = true; });
+  }
+
+  // ---- popover ----------------------------------------------------------
+
+  function openPopover(open) {
+    const pop = $('.vf-popover');
+    const shouldOpen = open == null ? pop.hidden : Boolean(open);
+    pop.hidden = !shouldOpen;
+    $('.vf-filters-btn').classList.toggle('open', shouldOpen);
+    $('.vf-filters-btn').setAttribute('aria-expanded', String(shouldOpen));
+    if (shouldOpen) renderRules();
+  }
+
+  function renderFieldPicker(query) {
+    const needle = String(query || '').trim().toLowerCase();
+    const byCategory = new Map();
+    state.fieldOrder.forEach((key) => {
+      const spec = state.fields[key];
+      if (needle && !`${spec.label} ${spec.category}`.toLowerCase().includes(needle)) return;
+      if (!byCategory.has(spec.category)) byCategory.set(spec.category, []);
+      byCategory.get(spec.category).push([key, spec]);
+    });
+    $('.vf-field-options').innerHTML = Array.from(byCategory.entries()).map(([category, fields]) =>
+      `<div class="vf-field-category">${esc(category)}</div>` + fields.map(([key, spec]) =>
+        `<button class="vf-field-option" data-add-field="${key}" type="button"><span>${esc(spec.label)}</span><span>${esc(spec.type)}</span></button>`).join('')).join('')
+      || '<div class="vf-empty-rules">No fields found</div>';
+  }
+
+  // ---- events -----------------------------------------------------------
+
+  let editDebounce = null;
+
+  function handleRuleEdit(target, fromTyping) {
+    const action = target.dataset.action;
+    const path = target.dataset.path;
+    if (!action || path == null) return;
+    mutate(() => {
+      const node = getNodeAtPath(path);
+      if (!node) return;
+      if (isGroup(node)) {
+        if (action === 'mode') node.mode = target.value;
+        return;
+      }
+      const spec = state.fields[node.field];
+      if (action === 'field') {
+        node.field = target.value;
+        const next = state.fields[node.field];
+        node.op = defaultOp(next);
+        node.value = defaultValue(next, node.op);
+        delete node.case;
+      } else if (action === 'op') {
+        node.op = target.value;
+        node.value = coerceValue(spec, node.op, node.value);
+      } else if (action === 'value-input') {
+        node.value = ['number', 'rating'].includes(spec.type) ? Number(target.value) : target.value;
+      } else if (action === 'value-select') {
+        node.value = target.value;
+      } else if (action === 'value-bool') {
+        node.value = target.value === '1' ? 1 : 0;
+      } else if (action === 'between-lo' || action === 'between-hi') {
+        const pair = Array.isArray(node.value) ? node.value.slice() : ['', ''];
+        const parsed = spec.type === 'date' ? target.value : Number(target.value);
+        pair[action === 'between-lo' ? 0 : 1] = parsed;
+        node.value = pair;
+      } else if (action === 'recent-n') {
+        node.value = { ...(node.value || {}), n: Math.max(1, Number(target.value) || 1) };
+      } else if (action === 'recent-unit') {
+        node.value = { ...(node.value || {}), unit: target.value };
+      } else if (action === 'multi-text') {
+        node.value = String(target.value).split(',').map((s) => s.trim()).filter(Boolean);
+      } else if (action === 'case') {
+        if (target.checked) node.case = true;
+        else delete node.case;
+      }
+    }, {
+      noSnapshot: ['value-input', 'between-lo', 'between-hi', 'recent-n', 'multi-text'].includes(action),
+      // change-event edits (selects, checkboxes) re-render the row; live
+      // typing must not destroy the input under the caret.
+      lightRender: ['value-input', 'between-lo', 'between-hi', 'recent-n', 'multi-text'].includes(action) && fromTyping,
+    });
+  }
+
+  function installEvents() {
+    const searchInput = $('.vf-search input');
+    searchInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); applyQuickSearch(searchInput.value); }
+      else if (e.key === 'Escape') { searchInput.blur(); }
+    });
+    searchInput.addEventListener('blur', () => {
+      // Blur with a cleared box removes the quick-search clause.
+      if (!searchInput.value.trim() && quickSearchGroup()) applyQuickSearch('');
+      else syncQuickSearchInput();
+    });
+
+    $('.vf-filters-btn').addEventListener('click', () => openPopover());
+    $('.vf-popover-close').addEventListener('click', () => openPopover(false));
+    $('.vf-done').addEventListener('click', () => openPopover(false));
+    $('.vf-overflow').addEventListener('click', () => openPopover(true));
+    $('.vf-mute').addEventListener('click', toggleMute);
+    $('.vf-clear').addEventListener('click', () => {
+      mutate(() => { state.root = { mode: 'all', rules: [] }; state.muted = false; });
+      toast('Filters cleared', true);
+    });
+    $('.vf-clear-rules').addEventListener('click', () => {
+      mutate(() => { state.root = { mode: 'all', rules: [] }; state.muted = false; });
+      toast('Filters cleared', true);
+    });
+    $('.vf-toast button').addEventListener('click', () => { undo(); $('.vf-toast').hidden = true; });
+
+    $('.vf-chip-row').addEventListener('click', (e) => {
+      const x = e.target.closest('[data-chip-x]');
+      if (x) {
+        e.stopPropagation();
+        const entry = chipEntries()[Number(x.dataset.chipX)];
+        if (entry) {
+          mutate(() => {
+            if (isGroup(entry.node)) {
+              state.root.rules = state.root.rules.filter((n) => n !== entry.node);
+            } else removeByReference(state.root, entry.node);
+          });
+          toast('Filter removed', true);
+        }
+        return;
+      }
+      if (e.target.closest('[data-chip]')) openPopover(true);
+    });
+
+    // Quick filters
+    $('.vf-quick-rating').addEventListener('click', (e) => {
+      const btn = e.target.closest('.vf-star');
+      if (!btn) return;
+      const op = $('.vf-quick-rating select').value;
+      const value = Number(btn.dataset.rating);
+      mutate(() => {
+        const idx = state.root.rules.findIndex((n) => !isGroup(n) && n.field === 'rating');
+        if (idx >= 0 && state.root.rules[idx].op === op && Number(state.root.rules[idx].value) === value) {
+          state.root.rules.splice(idx, 1);
+        } else if (idx >= 0) state.root.rules[idx] = makeRule('rating', op, value);
+        else state.root.rules.unshift(makeRule('rating', op, value));
+      });
+    });
+    $('.vf-quick-rating select').addEventListener('change', (e) => {
+      const rating = findRootRule('rating');
+      if (rating) mutate(() => { rating.op = e.target.value; });
+    });
+    $('.vf-quick-flags').addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-flag]');
+      if (btn) toggleQuickEnum('flag', btn.dataset.flag);
+    });
+    $('.vf-quick-colors').addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-color]');
+      if (btn) toggleQuickEnum('color_label', btn.dataset.color);
+    });
+
+    $('.vf-advanced input').addEventListener('change', (e) => {
+      // Only controls whether group tooling is offered — never rewrites
+      // the rule tree (hard requirement from the prototype review).
+      state.advanced = e.target.checked;
+      renderRules();
+    });
+    $('.vf-add-group').addEventListener('click', () => {
+      mutate(() => state.root.rules.push({ mode: 'any', rules: [makeRule('flag', 'is', 'flagged'), makeRule('rating', 'is', 5)] }));
+    });
+    $('.vf-add-filter').addEventListener('click', () => {
+      const picker = $('.vf-field-picker');
+      picker.hidden = !picker.hidden;
+      if (!picker.hidden) {
+        renderFieldPicker('');
+        const search = $('.vf-field-search');
+        search.value = '';
+        setTimeout(() => search.focus(), 0);
+      }
+    });
+    $('.vf-field-search').addEventListener('input', (e) => renderFieldPicker(e.target.value));
+    $('.vf-field-options').addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-add-field]');
+      if (!btn) return;
+      mutate(() => state.root.rules.push(makeRule(btn.dataset.addField)));
+      $('.vf-field-picker').hidden = true;
+    });
+
+    const tree = $('.vf-rule-tree');
+    tree.addEventListener('change', (e) => {
+      // Typed inputs commit through the debounced input path; their blur
+      // 'change' would re-render mid-click and destroy a suggest option
+      // before its pick lands (blur fires before click).
+      const action = e.target.dataset.action;
+      if (['value-input', 'between-lo', 'between-hi', 'recent-n', 'multi-text'].includes(action)) return;
+      handleRuleEdit(e.target);
+    });
+    tree.addEventListener('input', (e) => {
+      const action = e.target.dataset.action;
+      if (['value-input', 'between-lo', 'between-hi', 'recent-n', 'multi-text'].includes(action)) {
+        clearTimeout(editDebounce);
+        const target = e.target;
+        editDebounce = setTimeout(() => {
+          editDebounce = null;
+          if (document.contains(target)) handleRuleEdit(target, true);
+        }, 250);
+      }
+      if (e.target.dataset.suggest) showValueSuggest(e.target);
+    });
+    tree.addEventListener('focusin', (e) => {
+      if (e.target.dataset && e.target.dataset.suggest) showValueSuggest(e.target);
+    });
+    tree.addEventListener('click', (e) => {
+      const suggestion = e.target.closest('[data-suggest-value]');
+      if (suggestion) {
+        mutate(() => {
+          const node = getNodeAtPath(suggestion.dataset.path);
+          if (!node || isGroup(node)) return;
+          if (node.op === 'in' || node.op === 'not_in') {
+            const values = Array.isArray(node.value) ? node.value.slice() : [];
+            if (!values.includes(suggestion.dataset.suggestValue)) values.push(suggestion.dataset.suggestValue);
+            node.value = values;
+          } else node.value = suggestion.dataset.suggestValue;
+        });
+        hideSuggests();
+        return;
+      }
+      const target = e.target.closest('[data-action]');
+      if (!target) return;
+      const action = target.dataset.action;
+      const path = target.dataset.path;
+      if (action === 'multi') {
+        mutate(() => {
+          const node = getNodeAtPath(path);
+          if (!node || isGroup(node)) return;
+          let values = Array.isArray(node.value) ? node.value.slice() : [node.value];
+          if (values.includes(target.dataset.value)) values = values.filter((v) => v !== target.dataset.value);
+          else values.push(target.dataset.value);
+          node.value = values;
+        });
+        return;
+      }
+      if (action === 'remove') {
+        clearTimeout(editDebounce);
+        mutate(() => {
+          const ref = getParentAtPath(path);
+          const container = ref.parent === state.root ? state.root.rules : ref.parent.rules;
+          container.splice(ref.index, 1);
+        });
+        toast('Rule removed', true);
+      } else if (action === 'add-child') {
+        mutate(() => getNodeAtPath(path).rules.push(makeRule('keyword')));
+      } else if (action === 'add-subgroup') {
+        mutate(() => getNodeAtPath(path).rules.push({ mode: 'all', rules: [makeRule('rating', '>=', 3)] }));
+      }
+    });
+
+    document.addEventListener('keydown', (e) => {
+      const typing = ['INPUT', 'SELECT', 'TEXTAREA'].includes(e.target.tagName) || e.target.isContentEditable;
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f' && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        searchInput.focus();
+        searchInput.select();
+      }
+      if (e.key === '\\' && !typing && !e.metaKey && !e.ctrlKey) { e.preventDefault(); toggleMute(); }
+      if (e.key === 'Escape') {
+        hideSuggests();
+        $('.vf-field-picker').hidden = true;
+        if (!$('.vf-popover').hidden) openPopover(false);
+      }
+    });
+    document.addEventListener('click', (e) => {
+      // A click that triggered a re-render leaves a detached target by the
+      // time this bubbles; treating it as an outside click would close the
+      // popover after every suggestion pick.
+      if (!document.contains(e.target)) return;
+      if (!rootEl.contains(e.target)) {
+        hideSuggests();
+        $('.vf-field-picker').hidden = true;
+        if (!$('.vf-popover').hidden && !e.target.closest('.vf-popover')) openPopover(false);
+      } else {
+        if (!e.target.closest('.vf-value-wrap')) hideSuggests();
+        if (!e.target.closest('.vf-add-wrap')) $('.vf-field-picker').hidden = true;
+      }
+    });
+    window.addEventListener('resize', updateChipOverflow);
+  }
+
+  function toggleMute() {
+    if (!hasUserFilters() && !state.muted) { toast('No filters to pause'); return; }
+    mutate(() => { state.muted = !state.muted; });
+    toast(state.muted ? 'Filters paused — press \\ to resume' : 'Filters resumed');
+  }
+
+  // ---- public API -------------------------------------------------------
+
+  window.VireoFilter = {
+    init(options) {
+      state.page = options.page || 'browse';
+      state.scopeLabel = options.scopeLabel || '';
+      state.onChange = options.onChange || null;
+      state.getContextRules = options.getContextRules || null;
+      rootEl = typeof options.root === 'string' ? document.querySelector(options.root) : options.root;
+      if (!rootEl) return Promise.reject(new Error('VireoFilter: missing root element'));
+      return loadRegistry().then(() => {
+        installEvents();
+        const urlParams = new URLSearchParams(window.location.search);
+        const fromUrl = applyLegacyParams(urlParams);
+        const finish = () => {
+          state.ready = true;
+          render();
+          if (state.muted) refreshWouldMatch();
+          return true;
+        };
+        if (fromUrl) {
+          // Deep-link params win; still resolve the workspace for saves.
+          return fetchJson('/api/workspaces/active')
+            .then((ws) => { state.workspaceId = ws.id; })
+            .catch(() => {})
+            .then(finish);
+        }
+        return restorePersisted().then(finish);
+      });
+    },
+    getRules() { return effectiveRules(); },
+    getUserRules() { return userRules(); },
+    addRule(field, op, value) {
+      mutate(() => {
+        // Same-field root rule is replaced (sidebar keyword clicks toggle).
+        const idx = state.root.rules.findIndex((n) => !isGroup(n) && n.field === field);
+        const rule = makeRule(field, op, value);
+        if (idx >= 0 && JSON.stringify(state.root.rules[idx]) === JSON.stringify(rule)) {
+          state.root.rules.splice(idx, 1);
+        } else if (idx >= 0) state.root.rules[idx] = rule;
+        else state.root.rules.unshift(rule);
+      });
+    },
+    quickSearch(text) { applyQuickSearch(text); },
+    removeField(field) {
+      const idx = state.root.rules.findIndex((n) => !isGroup(n) && n.field === field);
+      if (idx < 0) return;
+      mutate(() => { state.root.rules.splice(idx, 1); });
+    },
+    hasFilters() { return hasUserFilters(); },
+    isMuted() { return state.muted; },
+    setScopeLabel(label) {
+      state.scopeLabel = label;
+      if (state.ready) renderChips();
+    },
+    setResultTotal(total) {
+      state.resultTotal = total;
+      if (!state.ready) return;
+      const el = $('.vf-total strong');
+      if (el) el.textContent = total == null ? '–' : Number(total).toLocaleString();
+      const matchEl = $('.vf-match-count');
+      if (matchEl) matchEl.textContent = total == null ? '' : `${Number(total).toLocaleString()} matching ${total === 1 ? 'photo' : 'photos'}`;
+    },
+    refresh() { if (state.ready) render(); },
+  };
+})();

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -413,11 +413,27 @@
   // ---- quick search -----------------------------------------------------
 
   function buildQuickSearchGroup(text) {
+    // Whitespace tokenizes: "red bill" matches (any field contains "red")
+    // AND (any field contains "bill"), so a filename token plus a keyword
+    // token still hit — pre-Phase 2 Browse search behavior. Single-token
+    // input keeps the original flat any-group shape.
+    const tokens = String(text).trim().split(/\s+/).filter(Boolean);
+    if (tokens.length <= 1) {
+      return {
+        mode: 'any',
+        _qs: true,
+        _qs_text: text,
+        rules: QUICK_SEARCH_FIELDS.map((field) => ({ field, op: 'contains', value: text })),
+      };
+    }
     return {
-      mode: 'any',
+      mode: 'all',
       _qs: true,
       _qs_text: text,
-      rules: QUICK_SEARCH_FIELDS.map((field) => ({ field, op: 'contains', value: text })),
+      rules: tokens.map((tok) => ({
+        mode: 'any',
+        rules: QUICK_SEARCH_FIELDS.map((field) => ({ field, op: 'contains', value: tok })),
+      })),
     };
   }
 

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -52,6 +52,7 @@
     fieldOrder: [],
     onChange: null,
     getContextRules: null, // page-supplied rules ANDed outside the user tree
+    getScope: null,        // page-supplied {folder_id, collection_id} for /api/filters/values
     workspaceId: null,
     resultTotal: null,
     wouldMatch: null,      // count while paused
@@ -680,6 +681,16 @@
     const params = new URLSearchParams({ field: node.field, limit: '8' });
     if (q) params.set('q', q);
     params.set('rules', JSON.stringify(rules));
+    // Page scope (folder / dashboard-scoped collection) is passed as
+    // separate params to /api/photos/query, so the visible grid is
+    // restricted to that scope. Mirror it here or the counts advertised
+    // beside each suggestion are computed over the whole workspace and a
+    // pick can produce fewer (or zero) grid rows than the badge promised.
+    const scope = state.getScope ? state.getScope() : null;
+    if (scope) {
+      if (scope.folder_id != null) params.set('folder_id', scope.folder_id);
+      if (scope.collection_id != null) params.set('collection_id', scope.collection_id);
+    }
     fetchJson(`/api/filters/values?${params}`).then((data) => {
       if (!document.contains(input)) return;
       if (!data.values.length) { drop.hidden = true; return; }
@@ -987,6 +998,7 @@
       state.scopeLabel = options.scopeLabel || '';
       state.onChange = options.onChange || null;
       state.getContextRules = options.getContextRules || null;
+      state.getScope = options.getScope || null;
       rootEl = typeof options.root === 'string' ? document.querySelector(options.root) : options.root;
       if (!rootEl) return Promise.reject(new Error('VireoFilter: missing root element'));
       return loadRegistry().then(() => {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -279,7 +279,12 @@
     if (options.lightRender) renderLight();
     else render();
     schedulePersist();
-    if (state.onChange && !options.silent) state.onChange();
+    // `reason` (optional string) is forwarded to onChange so pages can
+    // pick per-cause reload behavior — e.g. Browse preserving the
+    // selected-photo anchor when a quick search is cleared but not for
+    // every filter change (arbitrary edits usually exclude the anchor,
+    // and loadUntilPhotoRendered would then page through the whole set).
+    if (state.onChange && !options.silent) state.onChange({ reason: options.reason || null });
     if (state.muted) refreshWouldMatch();
   }
 
@@ -290,7 +295,7 @@
     state.muted = prev.muted;
     render();
     schedulePersist();
-    if (state.onChange) state.onChange();
+    if (state.onChange) state.onChange({ reason: null });
   }
 
   function toast(text, withUndo) {
@@ -439,10 +444,15 @@
 
   function applyQuickSearch(text) {
     const value = String(text || '').trim();
+    // A cleared quick search is the one filter edit where the previously
+    // selected/open photo is expected to reappear in the wider result set.
+    // Flag it so the page can preserve the anchor for this case without
+    // reintroducing preservation for every filter change.
+    const cleared = !value && !!quickSearchGroup();
     mutate(() => {
       state.root.rules = state.root.rules.filter((n) => !(isGroup(n) && n._qs));
       if (value) state.root.rules.unshift(buildQuickSearchGroup(value));
-    });
+    }, cleared ? { reason: 'quickSearchCleared' } : undefined);
   }
 
   function syncQuickSearchInput() {
@@ -1057,6 +1067,24 @@
       mutate(() => { state.root.rules.splice(idx, 1); });
     },
     hasFilters() { return hasUserFilters(); },
+    // Wipe restored/current filters without firing onChange. Used when the
+    // page detects a deep-link (e.g. plain collection view) that must
+    // ignore whatever was persisted — the alternative (applying then
+    // dropping them on the first filter interaction) briefly paints the
+    // wrong photo set and desyncs chips from the visible grid.
+    clearAll(silent) {
+      if (silent) {
+        state.root = { mode: 'all', rules: [] };
+        state.muted = false;
+        schedulePersist();
+        if (state.ready) render();
+        return;
+      }
+      mutate(() => {
+        state.root = { mode: 'all', rules: [] };
+        state.muted = false;
+      });
+    },
     isReady() { return !!state.ready && !!state.fields; },
     isMuted() { return state.muted; },
     setScopeLabel(label) {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1051,20 +1051,34 @@
     getUserRules() { return userRules(); },
     addRule(field, op, value) {
       mutate(() => {
-        // Same-field root rule is replaced (sidebar keyword clicks toggle).
-        const idx = state.root.rules.findIndex((n) => !isGroup(n) && n.field === field);
         const rule = makeRule(field, op, value);
-        if (idx >= 0 && JSON.stringify(state.root.rules[idx]) === JSON.stringify(rule)) {
-          state.root.rules.splice(idx, 1);
-        } else if (idx >= 0) state.root.rules[idx] = rule;
-        else state.root.rules.unshift(rule);
+        const existing = state.root.rules.filter((n) => !isGroup(n) && n.field === field);
+        // Toggle off when the sole existing rule of this field is
+        // identical (sidebar keyword clicks re-toggle to clear).
+        if (existing.length === 1 && JSON.stringify(existing[0]) === JSON.stringify(rule)) {
+          state.root.rules = state.root.rules.filter((n) => n !== existing[0]);
+          return;
+        }
+        // Otherwise replace ALL same-field root leaves. Legacy deep
+        // links can install more than one rule per field (e.g.
+        // ?date_from=…&date_to=… → two `timestamp` rules), and
+        // replacing only the first would leave the stale bound behind
+        // — a calendar day pick would then compose "day X" with the
+        // leftover ">= date_from" and silently show wrong results.
+        state.root.rules = state.root.rules.filter((n) => isGroup(n) || n.field !== field);
+        state.root.rules.unshift(rule);
       });
     },
     quickSearch(text) { applyQuickSearch(text); },
     removeField(field) {
-      const idx = state.root.rules.findIndex((n) => !isGroup(n) && n.field === field);
-      if (idx < 0) return;
-      mutate(() => { state.root.rules.splice(idx, 1); });
+      // Remove ALL matching root leaves — legacy `?date_from=…&date_to=…`
+      // and other multi-rule param combinations can install more than
+      // one leaf per field.
+      const hasMatch = state.root.rules.some((n) => !isGroup(n) && n.field === field);
+      if (!hasMatch) return;
+      mutate(() => {
+        state.root.rules = state.root.rules.filter((n) => isGroup(n) || n.field !== field);
+      });
     },
     hasFilters() { return hasUserFilters(); },
     // Wipe restored/current filters without firing onChange. Used when the

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -386,19 +386,20 @@
     // three coordinate sources: `exif` = photo has EXIF GPS; `assigned` = no
     // EXIF GPS but a location keyword supplies coordinates; `none` = neither.
     // `has_gps` was a JS-side alias for `exif`, and `?missing_gps=1` a legacy
-    // alias for `?location_status=none`. Mapping only to `has_gps` would break
-    // `assigned`/`none` links (photos with an assigned location still have
-    // has_gps=false, so they would leak into a `none` grid).
+    // alias for `?location_status=none`. `assigned`/`none` require the
+    // coordinate-bearing keyword check (`has_coord_location_keyword`) — the
+    // plain `has_location_keyword` field also matches free-text locations
+    // without lat/lng, so it would misclassify photos the map cannot place.
     let locationStatus = params.get('location_status');
     if (!locationStatus && params.get('missing_gps') === '1') locationStatus = 'none';
     if (locationStatus === 'has_gps' || locationStatus === 'exif') {
       rules.push(makeRule('has_gps', 'is', 1));
     } else if (locationStatus === 'assigned') {
       rules.push(makeRule('has_gps', 'is', 0));
-      rules.push(makeRule('has_location_keyword', 'is', 1));
+      rules.push(makeRule('has_coord_location_keyword', 'is', 1));
     } else if (locationStatus === 'none') {
       rules.push(makeRule('has_gps', 'is', 0));
-      rules.push(makeRule('has_location_keyword', 'is', 0));
+      rules.push(makeRule('has_coord_location_keyword', 'is', 0));
     }
     const keyword = params.get('keyword');
     if (keyword) rules.push(buildQuickSearchGroup(keyword));

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1029,6 +1029,7 @@
       mutate(() => { state.root.rules.splice(idx, 1); });
     },
     hasFilters() { return hasUserFilters(); },
+    isReady() { return !!state.ready && !!state.fields; },
     isMuted() { return state.muted; },
     setScopeLabel(label) {
       state.scopeLabel = label;

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -382,9 +382,24 @@
     if (dateFrom) rules.push(makeRule('timestamp', '>=', dateFrom));
     const dateTo = params.get('date_to');
     if (dateTo) rules.push(makeRule('timestamp', '<=', dateTo));
-    const locationStatus = params.get('location_status');
-    if (locationStatus === 'has_gps') rules.push(makeRule('has_gps', 'is', 1));
-    else if (locationStatus === 'none') rules.push(makeRule('has_gps', 'is', 0));
+    // Preserve legacy Browse deep-link semantics. The old backend distinguished
+    // three coordinate sources: `exif` = photo has EXIF GPS; `assigned` = no
+    // EXIF GPS but a location keyword supplies coordinates; `none` = neither.
+    // `has_gps` was a JS-side alias for `exif`, and `?missing_gps=1` a legacy
+    // alias for `?location_status=none`. Mapping only to `has_gps` would break
+    // `assigned`/`none` links (photos with an assigned location still have
+    // has_gps=false, so they would leak into a `none` grid).
+    let locationStatus = params.get('location_status');
+    if (!locationStatus && params.get('missing_gps') === '1') locationStatus = 'none';
+    if (locationStatus === 'has_gps' || locationStatus === 'exif') {
+      rules.push(makeRule('has_gps', 'is', 1));
+    } else if (locationStatus === 'assigned') {
+      rules.push(makeRule('has_gps', 'is', 0));
+      rules.push(makeRule('has_location_keyword', 'is', 1));
+    } else if (locationStatus === 'none') {
+      rules.push(makeRule('has_gps', 'is', 0));
+      rules.push(makeRule('has_location_keyword', 'is', 0));
+    }
     const keyword = params.get('keyword');
     if (keyword) rules.push(buildQuickSearchGroup(keyword));
     if (!rules.length) return false;

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1073,12 +1073,17 @@
     removeField(field) {
       // Remove ALL matching root leaves — legacy `?date_from=…&date_to=…`
       // and other multi-rule param combinations can install more than
-      // one leaf per field.
+      // one leaf per field. Returns true when a rule was actually
+      // removed (and onChange fired) so callers that were relying on the
+      // reload — e.g. filterByFolder handing off after dropping a
+      // sidebar-installed keyword rule — can fall back to their own
+      // reload when this is a no-op.
       const hasMatch = state.root.rules.some((n) => !isGroup(n) && n.field === field);
-      if (!hasMatch) return;
+      if (!hasMatch) return false;
       mutate(() => {
         state.root.rules = state.root.rules.filter((n) => isGroup(n) || n.field !== field);
       });
+      return true;
     },
     hasFilters() { return hasUserFilters(); },
     // Wipe restored/current filters without firing onChange. Used when the

--- a/vireo/templates/_filterbar.html
+++ b/vireo/templates/_filterbar.html
@@ -1,0 +1,218 @@
+<!-- Universal photo filter bar (shared: Browse now, Map/Review/Duplicates in
+     Phase 4). Markup + scoped styles; behavior in /static/vireo-filter.js.
+     Pages include this, then call VireoFilter.init({...}).
+     Design: docs/plans/2026-07-19-universal-filters-design.md -->
+<div id="vireoFilterBar" class="vf-bar">
+  <div class="vf-primary">
+    <div class="vf-search">
+      <span class="vf-search-icon" aria-hidden="true">⌕</span>
+      <input type="search" autocomplete="off" spellcheck="false"
+             placeholder="Search photos…" aria-label="Search photos">
+      <kbd>⌘F</kbd>
+    </div>
+    <button class="vf-filters-btn" type="button" aria-expanded="false">
+      <span aria-hidden="true">≡</span> Filters <span class="vf-count" hidden>0</span>
+    </button>
+    <div class="vf-total" aria-live="polite"><strong>–</strong> <span>photos</span></div>
+    <button class="vf-mute" type="button" hidden>⏸ Pause</button>
+    <button class="vf-clear" type="button" hidden>Clear</button>
+  </div>
+
+  <div class="vf-chip-row">
+    <div class="vf-scope-chip" title="This page always applies this scope">
+      <span></span><em aria-hidden="true">⌁</em>
+    </div>
+    <div class="vf-chip-viewport"><div class="vf-chips" aria-label="Active filters"></div></div>
+    <button class="vf-overflow" type="button" hidden>+0</button>
+  </div>
+
+  <div class="vf-paused-note" hidden></div>
+
+  <div class="vf-popover" role="dialog" aria-label="Edit photo filters" hidden>
+    <div class="vf-popover-header">
+      <div><h2>Filter photos</h2><p>Changes update the page immediately.</p></div>
+      <button class="vf-popover-close" type="button" aria-label="Close">×</button>
+    </div>
+
+    <section class="vf-quick">
+      <div class="vf-section-heading"><h3>Quick filters</h3><span>Click again to clear · flags and colors combine</span></div>
+      <div class="vf-quick-grid">
+        <div class="vf-quick-group vf-quick-rating">
+          <span>Rating</span>
+          <div class="vf-quick-control">
+            <select aria-label="Rating comparison">
+              <option value=">=">At least (≥)</option>
+              <option value="is">Exactly (=)</option>
+              <option value="<=">At most (≤)</option>
+            </select>
+            <div class="vf-stars" aria-label="Rating value">
+              <button type="button" class="vf-star" data-rating="1" aria-label="1 star">★</button>
+              <button type="button" class="vf-star" data-rating="2" aria-label="2 stars">★</button>
+              <button type="button" class="vf-star" data-rating="3" aria-label="3 stars">★</button>
+              <button type="button" class="vf-star" data-rating="4" aria-label="4 stars">★</button>
+              <button type="button" class="vf-star" data-rating="5" aria-label="5 stars">★</button>
+            </div>
+          </div>
+        </div>
+        <div class="vf-quick-group">
+          <span>Flag</span>
+          <div class="vf-segmented vf-quick-flags">
+            <button type="button" data-flag="flagged">⚑ Picked</button>
+            <button type="button" data-flag="none">– Unflagged</button>
+            <button type="button" data-flag="rejected">× Rejected</button>
+          </div>
+        </div>
+        <div class="vf-quick-group">
+          <span>Color</span>
+          <div class="vf-quick-colors" aria-label="Color label">
+            <button type="button" data-color="red" aria-label="Red label"></button>
+            <button type="button" data-color="yellow" aria-label="Yellow label"></button>
+            <button type="button" data-color="green" aria-label="Green label"></button>
+            <button type="button" data-color="blue" aria-label="Blue label"></button>
+            <button type="button" data-color="purple" aria-label="Purple label"></button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="vf-rules">
+      <div class="vf-section-heading">
+        <div class="vf-heading-toggle">
+          <h3>Rules</h3>
+          <label class="vf-advanced"><input type="checkbox"> Advanced logic</label>
+        </div>
+        <button class="vf-text-btn vf-clear-rules" type="button">Clear rules</button>
+      </div>
+      <div class="vf-rule-tree"></div>
+      <div class="vf-add-row">
+        <div class="vf-add-wrap">
+          <button class="vf-add-filter" type="button">＋ Add filter</button>
+          <div class="vf-field-picker" hidden>
+            <input class="vf-field-search" type="search" placeholder="Find a field…" aria-label="Find a filter field">
+            <div class="vf-field-options"></div>
+          </div>
+        </div>
+        <button class="vf-text-btn vf-add-group" type="button" hidden>＋ Add group</button>
+      </div>
+    </section>
+
+    <footer class="vf-popover-footer">
+      <span class="vf-match-count"></span>
+      <button class="vf-done" type="button">Done</button>
+    </footer>
+  </div>
+
+  <div class="vf-toast" role="status" aria-live="polite" hidden><span></span><button type="button">Undo</button></div>
+</div>
+
+<style>
+.vf-bar { position: relative; z-index: 30; }
+.vf-primary { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.vf-search { position: relative; flex: 1 1 420px; min-width: 160px; }
+.vf-search input { width: 100%; height: 34px; padding: 0 46px 0 30px; border: 1px solid var(--border-secondary); border-radius: 8px; background: var(--bg-input); color: var(--text-primary); }
+.vf-search input:focus { border-color: var(--accent); outline: none; }
+.vf-search-icon { position: absolute; left: 9px; top: 6px; color: var(--text-muted); font-size: 17px; }
+.vf-search kbd { position: absolute; right: 8px; top: 8px; padding: 1px 5px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-tertiary); color: var(--text-dim); font-size: 10px; }
+.vf-filters-btn, .vf-mute, .vf-clear { height: 34px; display: inline-flex; align-items: center; gap: 6px; padding: 0 11px; border: 1px solid var(--border-secondary); border-radius: 8px; background: var(--bg-input); color: var(--text-secondary); cursor: pointer; white-space: nowrap; }
+.vf-filters-btn:hover, .vf-mute:hover, .vf-clear:hover { border-color: var(--accent); color: var(--text-primary); }
+.vf-filters-btn.open { border-color: var(--accent); color: var(--accent); }
+.vf-count { min-width: 17px; padding: 1px 5px; border-radius: 9px; background: var(--accent); color: var(--accent-text); font-size: 11px; font-weight: 700; text-align: center; }
+.vf-mute.active { color: var(--warning); border-color: color-mix(in srgb, var(--warning) 55%, transparent); background: color-mix(in srgb, var(--warning) 10%, transparent); }
+.vf-total { min-width: 70px; text-align: right; white-space: nowrap; color: var(--text-dim); }
+.vf-total strong { color: var(--text-primary); font-variant-numeric: tabular-nums; }
+.vf-chip-row { display: flex; align-items: center; gap: 6px; min-width: 0; height: 32px; margin-top: 6px; }
+.vf-scope-chip, .vf-chip, .vf-overflow { height: 26px; display: inline-flex; align-items: center; gap: 6px; padding: 0 9px; border: 1px solid var(--border-secondary); border-radius: 13px; background: var(--bg-secondary); color: var(--text-secondary); font-size: 12px; white-space: nowrap; }
+.vf-scope-chip { border-style: dashed; color: var(--text-muted); flex: none; }
+.vf-scope-chip em { font-style: normal; color: var(--text-faint); }
+.vf-chip-viewport { min-width: 0; flex: 1; overflow: hidden; }
+.vf-chips { display: flex; gap: 6px; }
+.vf-chip { cursor: pointer; border-color: color-mix(in srgb, var(--accent) 45%, var(--border-secondary)); background: color-mix(in srgb, var(--accent) 8%, var(--bg-primary)); }
+.vf-chip:hover { border-color: var(--accent); }
+.vf-chip-row.muted .vf-chip { opacity: .45; border-style: dashed; }
+.vf-chip-x { width: 16px; height: 16px; display: grid; place-items: center; margin-right: -4px; border-radius: 50%; color: var(--text-dim); cursor: pointer; }
+.vf-chip-x:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.vf-overflow { cursor: pointer; flex: none; }
+.vf-paused-note { margin-top: 6px; padding: 5px 9px; border-radius: 6px; background: color-mix(in srgb, var(--warning) 12%, var(--bg-tertiary)); color: var(--warning); font-size: 12px; }
+.vf-popover { position: absolute; top: calc(100% + 8px); left: 0; z-index: 5000; width: min(680px, 100%); max-height: min(72vh, 640px); overflow-y: auto; border: 1px solid var(--border-secondary); border-radius: 11px; background: var(--bg-panel); box-shadow: 0 18px 50px rgba(0,0,0,.34); }
+.vf-popover-header { position: sticky; top: 0; z-index: 2; display: flex; justify-content: space-between; align-items: flex-start; padding: 13px 16px 10px; background: var(--bg-panel); border-bottom: 1px solid var(--border-primary); }
+.vf-popover-header h2 { margin: 0; font-size: 15px; color: var(--text-primary); }
+.vf-popover-header p { margin: 3px 0 0; color: var(--text-dim); font-size: 11px; }
+.vf-popover-close { width: 26px; height: 26px; border: 0; border-radius: 6px; background: transparent; color: var(--text-dim); cursor: pointer; font-size: 17px; }
+.vf-popover-close:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.vf-quick, .vf-rules { padding: 12px 16px; }
+.vf-quick { border-bottom: 1px solid var(--border-primary); }
+.vf-section-heading { display: flex; justify-content: space-between; align-items: center; margin-bottom: 9px; }
+.vf-section-heading h3 { margin: 0; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); }
+.vf-section-heading > span { color: var(--text-faint); font-size: 10px; }
+.vf-heading-toggle { display: flex; align-items: center; gap: 12px; }
+.vf-advanced { display: inline-flex; align-items: center; gap: 5px; color: var(--text-dim); font-size: 11px; cursor: pointer; }
+.vf-quick-grid { display: flex; flex-wrap: wrap; gap: 18px; }
+.vf-quick-group { display: grid; gap: 5px; }
+.vf-quick-group > span { color: var(--text-dim); font-size: 10px; }
+.vf-quick-control { display: flex; align-items: center; gap: 8px; }
+.vf-quick-control select, .vf-group-mode select { height: 27px; padding: 0 7px; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-input); color: var(--text-secondary); font-size: 11px; }
+.vf-stars { display: flex; }
+.vf-star { padding: 0 2px; border: 0; background: transparent; color: var(--text-faint); cursor: pointer; font-size: 18px; }
+.vf-star.active { color: var(--warning); }
+.vf-segmented { display: flex; width: max-content; padding: 2px; border-radius: 7px; background: var(--bg-secondary); }
+.vf-segmented button { padding: 5px 8px; border: 0; border-radius: 5px; background: transparent; color: var(--text-muted); cursor: pointer; font-size: 11px; }
+.vf-segmented button.active { background: var(--bg-tertiary); color: var(--accent); }
+.vf-quick-colors { display: flex; align-items: center; gap: 7px; padding-top: 3px; }
+.vf-quick-colors button { width: 20px; height: 20px; border: 2px solid transparent; border-radius: 50%; cursor: pointer; box-shadow: 0 0 0 1px var(--border-secondary); }
+.vf-quick-colors button.active { border-color: var(--text-primary); box-shadow: 0 0 0 2px var(--accent); }
+.vf-quick-colors [data-color="red"] { background: #ef635b; }
+.vf-quick-colors [data-color="yellow"] { background: #f6c945; }
+.vf-quick-colors [data-color="green"] { background: #6fcf75; }
+.vf-quick-colors [data-color="blue"] { background: #4aa9e9; }
+.vf-quick-colors [data-color="purple"] { background: #a782ff; }
+.vf-rule-tree { display: grid; gap: 7px; }
+.vf-rule-row { display: grid; grid-template-columns: minmax(120px, 1fr) minmax(110px, .9fr) minmax(140px, 1.3fr) 25px; gap: 6px; align-items: center; }
+.vf-rule-row select, .vf-rule-row input, .vf-value-pair input, .vf-value-pair select { min-width: 0; height: 30px; padding: 0 8px; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-input); color: var(--text-primary); font-size: 12px; }
+.vf-rule-row select:focus, .vf-rule-row input:focus { border-color: var(--accent); outline: none; }
+.vf-qs-row { grid-template-columns: 1fr 25px; }
+.vf-qs-label { color: var(--text-secondary); font-size: 12px; padding-left: 2px; }
+.vf-remove { width: 25px; height: 25px; border: 0; border-radius: 5px; background: transparent; color: var(--text-dim); cursor: pointer; font-size: 16px; }
+.vf-remove:hover { color: var(--danger); background: color-mix(in srgb, var(--danger) 10%, transparent); }
+.vf-rule-opts { grid-column: 1 / -1; display: flex; justify-content: flex-end; margin-top: -4px; }
+.vf-rule-opts label { color: var(--text-dim); font-size: 10px; cursor: pointer; }
+.vf-value-pair { min-width: 0; display: flex; align-items: center; gap: 5px; }
+.vf-value-pair input, .vf-value-pair select { flex: 1; }
+.vf-value-pair > span { color: var(--text-dim); font-size: 11px; }
+.vf-enum-multi { min-width: 0; display: flex; flex-wrap: wrap; gap: 4px; }
+.vf-enum-pill { padding: 5px 8px; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-input); color: var(--text-muted); cursor: pointer; font-size: 11px; }
+.vf-enum-pill:hover { border-color: var(--border-secondary); color: var(--text-primary); }
+.vf-enum-pill.active { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, var(--bg-input)); color: var(--text-primary); }
+.vf-value-wrap { position: relative; min-width: 0; display: block; }
+.vf-value-wrap input { width: 100%; }
+.vf-suggest { position: absolute; top: 33px; left: 0; right: 0; z-index: 5010; overflow: hidden; padding: 4px; border: 1px solid var(--border-secondary); border-radius: 7px; background: var(--bg-panel); box-shadow: 0 12px 32px rgba(0,0,0,.3); }
+.vf-suggest-hint { padding: 4px 7px 5px; color: var(--text-faint); font-size: 9px; text-transform: uppercase; letter-spacing: .07em; }
+.vf-value-option { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 7px; border: 0; border-radius: 5px; background: transparent; color: var(--text-secondary); text-align: left; cursor: pointer; font-size: 12px; }
+.vf-value-option:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.vf-value-option span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.vf-value-option em { color: var(--accent); font-size: 11px; font-style: normal; font-variant-numeric: tabular-nums; }
+.vf-group { padding: 8px; border: 1px solid var(--border-primary); border-radius: 8px; background: color-mix(in srgb, var(--bg-secondary) 65%, transparent); }
+.vf-group-mode { display: flex; align-items: center; gap: 6px; margin-bottom: 7px; color: var(--text-dim); font-size: 11px; }
+.vf-group-mode .vf-remove { margin-left: auto; }
+.vf-group-children { display: grid; gap: 7px; padding-left: 11px; border-left: 2px solid var(--border-primary); }
+.vf-group-actions { display: flex; gap: 8px; margin: 8px 0 0 12px; }
+.vf-text-btn { border: 0; background: transparent; color: var(--text-muted); cursor: pointer; font-size: 11px; }
+.vf-text-btn:hover { color: var(--accent); }
+.vf-add-row { display: flex; align-items: center; gap: 7px; margin-top: 10px; }
+.vf-add-wrap { position: relative; }
+.vf-add-filter { height: 30px; padding: 0 10px; border: 1px dashed var(--border-secondary); border-radius: 7px; background: transparent; color: var(--text-secondary); cursor: pointer; }
+.vf-add-filter:hover { color: var(--accent); border-color: var(--accent); }
+.vf-field-picker { position: absolute; left: 0; top: 36px; z-index: 5010; width: 300px; max-height: 340px; overflow: hidden; padding: 7px; border: 1px solid var(--border-secondary); border-radius: 8px; background: var(--bg-panel); box-shadow: 0 12px 32px rgba(0,0,0,.3); }
+.vf-field-picker input { width: 100%; height: 30px; padding: 0 8px; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-input); color: var(--text-primary); }
+.vf-field-options { max-height: 280px; overflow-y: auto; margin-top: 6px; }
+.vf-field-category { padding: 7px 8px 3px; color: var(--text-dim); font-size: 9px; text-transform: uppercase; letter-spacing: .09em; }
+.vf-field-option { width: 100%; display: flex; align-items: center; justify-content: space-between; padding: 7px 8px; border: 0; border-radius: 5px; background: transparent; color: var(--text-secondary); text-align: left; cursor: pointer; font-size: 12px; }
+.vf-field-option:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.vf-field-option span:last-child { color: var(--text-faint); font-size: 10px; }
+.vf-empty-rules { padding: 12px; border: 1px dashed var(--border-primary); border-radius: 7px; color: var(--text-dim); font-size: 11px; text-align: center; }
+.vf-popover-footer { position: sticky; bottom: 0; display: flex; align-items: center; justify-content: space-between; padding: 10px 16px; border-top: 1px solid var(--border-primary); background: var(--bg-panel); }
+.vf-match-count { color: var(--text-muted); font-size: 11px; }
+.vf-done { height: 30px; padding: 0 14px; border: 0; border-radius: 7px; background: var(--accent); color: var(--accent-text); cursor: pointer; font-weight: 700; }
+.vf-toast { position: fixed; z-index: 100; left: 50%; bottom: 22px; display: flex; align-items: center; gap: 14px; transform: translateX(-50%); padding: 9px 12px; border: 1px solid var(--border-secondary); border-radius: 8px; background: var(--bg-panel); box-shadow: 0 12px 32px rgba(0,0,0,.3); color: var(--text-secondary); font-size: 12px; }
+.vf-toast button { border: 0; background: transparent; color: var(--accent); cursor: pointer; font-weight: 700; }
+</style>
+<script src="/static/vireo-filter.js"></script>

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2924,18 +2924,29 @@ async function bootstrapBrowse() {
       },
     }).then(function() {
       VireoFilter.setResultTotal(totalPhotos);
-      // Plain collection deep-link (?collection_id=... with no
-      // ?dashboard_scope=1) must show exactly that collection. A saved
-      // workspace filter restored from ui_state makes hasFilters() true,
-      // and the resetAndLoad() below would then clear activeCollectionId
-      // via the resetAndLoad path (see line ~3901 \u2014 non-dashboard scopes),
-      // silently switching from the requested collection to the saved
-      // filter. Drop the persisted state so the deep link is honored.
+      // Collection deep links must open showing exactly that collection \u2014
+      // whether plain (?collection_id=..., historical endpoint behavior) or
+      // dashboard-scoped (?dashboard_scope=1&collection_id=..., composable).
+      // A restored persisted Browse filter overrides both: for plain links
+      // the resetAndLoad below clears activeCollectionId (see line ~3901
+      // \u2014 non-dashboard scopes); for dashboard links it silently
+      // intersects the drill-down collection with unrelated saved
+      // rules. If the URL itself didn't supply any legacy filter params,
+      // treat the collection link as URL-scoped and drop the persisted
+      // state so the link is honored.
       var urlParams = new URLSearchParams(window.location.search);
-      var plainCollectionLink = !!urlParams.get('collection_id') &&
-        urlParams.get('dashboard_scope') !== '1';
-      if (plainCollectionLink && VireoFilter.hasFilters()) {
+      var LEGACY_FILTER_PARAMS = ['rating_min', 'flag', 'color_label',
+        'date_from', 'date_to', 'location_status', 'missing_gps', 'keyword'];
+      var hasExplicitFilterParams = LEGACY_FILTER_PARAMS.some(function(p) {
+        return urlParams.has(p);
+      });
+      var collectionLink = !!urlParams.get('collection_id');
+      if (collectionLink && !hasExplicitFilterParams && VireoFilter.hasFilters()) {
         VireoFilter.clearAll(true);
+        // Plain collection: /api/browse/init already painted the collection
+        // and there are no filters left to apply, so skip the reload
+        // entirely. Dashboard-scoped: same story \u2014 the init call included
+        // collection_id, so the just-painted grid already matches.
         return;
       }
       if (VireoFilter.hasFilters()) {
@@ -3059,14 +3070,26 @@ function filterByFolder(folderId) {
   } else {
     activeFolderId = folderId;
   }
+  // If the current keyword highlight came from a sidebar click,
+  // filterByKeyword also installed a VireoFilter 'keyword' rule — that
+  // rule is now the sidebar's stored state, not activeKeyword. Clearing
+  // just activeKeyword drops the highlight but leaves the rule in place,
+  // so the folder reload silently applies folder ∩ keyword. Drop the
+  // rule before the reload; VireoFilter.removeField fires onChange,
+  // which runs the reload path (including timelineMode + summary), so
+  // skip the plain reloadBrowseResults() branch when we take that route.
+  var hadSidebarKeyword = activeKeyword !== null;
   activeKeyword = null;
   activeCollectionId = null;
-  if (timelineMode) loadCalendarData();
-  reloadBrowseResults();
-  // Update active state
   document.querySelectorAll('#folderTree .tree-item').forEach(function(el) {
     el.classList.toggle('active', parseInt(el.dataset.folderId) === activeFolderId);
   });
+  if (hadSidebarKeyword && window.VireoFilter && VireoFilter.isReady()) {
+    VireoFilter.removeField('keyword');
+    return;
+  }
+  if (timelineMode) loadCalendarData();
+  reloadBrowseResults();
 }
 
 /* ---------- Keyword Tree ---------- */

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4073,6 +4073,12 @@ async function loadCalendarData() {
   var params = new URLSearchParams();
   params.set('year', calendarYear);
   if (activeFolderId) params.set('folder_id', activeFolderId);
+  // Dashboard-scoped Browse composes the collection with active filters —
+  // without this the calendar shows counts from the whole workspace/folder
+  // and a day-click applies a date chip based on photos not in the collection.
+  if (activeCollectionId && dashboardCollectionScope) {
+    params.set('collection_id', activeCollectionId);
+  }
   var rules = getBrowseRules();
   if (rules) params.set('rules', JSON.stringify(rules));
 
@@ -4242,7 +4248,13 @@ function getClipSearchQuery() {
 function appendClipSearchScopeParams(params) {
   if (activeCollectionId) {
     params.set('collection_id', activeCollectionId);
-    return;
+    // Dashboard-scoped collection Browse composes the collection with the
+    // active rules/folder in the grid — CLIP/select-all search must match
+    // that scope. Backend intersects collection_id with rules/folder_id.
+    // Legacy collection view (activeCollectionId && !dashboardCollectionScope)
+    // clears activeCollectionId as soon as a filter is applied (see
+    // VireoFilter.init.onChange), so composing here is a no-op in that path.
+    if (!dashboardCollectionScope) return;
   }
   if (activeFolderId) params.set('folder_id', activeFolderId);
   var rules = getBrowseRules();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -185,6 +185,11 @@ body.sidebar-resizing {
 }
 
 /* ---------- Filter Bar ---------- */
+.browse-filter-shell { display: block; }
+.browse-filter-shell .vf-bar { width: 100%; }
+.browse-view-controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-top: 8px; }
+.browse-view-controls input[type=text] { background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border-secondary); border-radius: 4px; padding: 5px 10px; font-size: 12px; flex: 1; min-width: 200px; }
+.browse-view-controls select { background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border-secondary); border-radius: 4px; padding: 5px 8px; font-size: 12px; }
 .filter-bar {
   background: var(--bg-primary);
   padding: 10px 20px;
@@ -1522,80 +1527,45 @@ body.sidebar-resizing {
   <!-- Content -->
   <div class="content-area">
 
-    <!-- Filter Bar -->
-    <div class="filter-bar">
-      <div class="search-control">
-        <input type="text" id="searchInput" placeholder="Search keywords or filenames..."
-               autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"
-               onkeydown="if(event.key==='Enter')applySearchFilterNow()" oninput="scheduleSearchFilter()">
-        <button id="keywordMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleKeywordSearchOption('match_case')" title="Match case">Aa</button>
-        <button id="keywordWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleKeywordSearchOption('whole_word')" title="Match whole word">ab</button>
+    <!-- Universal filter bar (shared module) + Browse view controls -->
+    <div class="filter-bar browse-filter-shell">
+      {% include '_filterbar.html' %}
+      <div class="browse-view-controls">
+        <input type="text" id="clipSearchInput" placeholder="CLIP search: describe what you see..."
+               onkeydown="if(event.key==='Enter')runClipSearch()">
+        <button id="clipSearchBtn" onclick="runClipSearch()"
+                style="background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;white-space:nowrap;">
+          Search
+        </button>
+        <button id="clipClearBtn" onclick="clearClipSearch()" style="display:none;background:none;color:var(--text-faint);border:none;padding:4px 8px;font-size:12px;cursor:pointer;">
+          Clear
+        </button>
+        <select id="sortSelect" onchange="applyFilters()" title="Sort order">
+          <option value="date">Capture date (oldest)</option>
+          <option value="date_desc">Capture date (newest)</option>
+          <option value="name">Filename (A-Z)</option>
+          <option value="name_desc">Filename (Z-A)</option>
+          <option value="rating">Rating (highest)</option>
+          <option value="quality">Quality (best)</option>
+          <option value="sharpness">Sharpness (sharpest)</option>
+          <option value="sharpness_asc">Sharpness (softest)</option>
+        </select>
+        <label style="display:flex;align-items:center;gap:4px;" title="Thumbnail size">
+          <input type="range" id="thumbSizeSlider" min="120" max="400" step="20" value="220"
+                 style="width:80px;accent-color:var(--accent);"
+                 oninput="updateThumbSize(this.value)">
+          <span style="font-size:10px;color:var(--text-faint);">&#9638;</span>
+        </label>
+        <button id="detBoxToggle" onclick="toggleDetectionBoxes()" title="Show/hide detection boxes"
+                style="background:var(--bg-tertiary);color:var(--text-muted);border:1px solid var(--border-secondary);border-radius:4px;padding:3px 8px;font-size:11px;cursor:pointer;">
+          &#9634; Boxes
+        </button>
+        <button id="calToggle" onclick="toggleTimelineMode()" title="Calendar heatmap"
+                style="background:var(--bg-tertiary);color:var(--text-muted);border:1px solid var(--border-secondary);border-radius:4px;padding:3px 8px;font-size:11px;cursor:pointer;">
+          &#128197; Calendar
+        </button>
+        <span class="filter-summary" id="filterSummary"></span>
       </div>
-      <input type="text" id="clipSearchInput" placeholder="CLIP search: describe what you see..."
-             style="flex:1;min-width:200px;"
-             onkeydown="if(event.key==='Enter')runClipSearch()">
-      <button id="clipSearchBtn" onclick="runClipSearch()"
-              style="background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;white-space:nowrap;">
-        Search
-      </button>
-      <button id="clipClearBtn" onclick="clearClipSearch()" style="display:none;background:none;color:var(--text-faint);border:none;padding:4px 8px;font-size:12px;cursor:pointer;">
-        Clear
-      </button>
-      <label title="EXIF capture date (DateTimeOriginal)">Captured from</label>
-      <input type="date" id="dateFrom" onchange="applyFilters()" title="Filter by EXIF capture date (DateTimeOriginal)">
-      <label>to</label>
-      <input type="date" id="dateTo" onchange="applyFilters()" title="Filter by EXIF capture date (DateTimeOriginal)">
-      <div class="rating-filter">
-        <label title="Minimum star rating">Min:</label>
-        <span class="rating-star" data-val="1" onclick="setFilterRating(1)">&#9733;</span>
-        <span class="rating-star" data-val="2" onclick="setFilterRating(2)">&#9733;</span>
-        <span class="rating-star" data-val="3" onclick="setFilterRating(3)">&#9733;</span>
-        <span class="rating-star" data-val="4" onclick="setFilterRating(4)">&#9733;</span>
-        <span class="rating-star" data-val="5" onclick="setFilterRating(5)">&#9733;</span>
-      </div>
-      <div class="flag-filter" aria-label="Flag filters">
-        <button id="pickFilterBtn" class="flag-filter-btn" type="button" onclick="setFlagFilter('flagged')" title="Show only picks">P Picks</button>
-        <button id="rejectFilterBtn" class="flag-filter-btn" type="button" onclick="setFlagFilter('rejected')" title="Show only rejects">X Rejects</button>
-      </div>
-      <select id="colorFilter" onchange="applyFilters()" title="Filter by color label" style="font-size:12px;">
-        <option value="">Color: Any</option>
-        <option value="red">Red</option>
-        <option value="yellow">Yellow</option>
-        <option value="green">Green</option>
-        <option value="blue">Blue</option>
-        <option value="purple">Purple</option>
-      </select>
-      <select id="locationStatusFilter" onchange="applyFilters()" title="Filter by coordinate source" style="font-size:12px;">
-        <option value="">Coordinates: Any</option>
-        <option value="exif">EXIF GPS</option>
-        <option value="assigned">Assigned map location</option>
-        <option value="none">No coordinates</option>
-      </select>
-      <select id="sortSelect" onchange="applyFilters()" title="Sort order">
-        <option value="date">Capture date (oldest)</option>
-        <option value="date_desc">Capture date (newest)</option>
-        <option value="name">Filename (A-Z)</option>
-        <option value="name_desc">Filename (Z-A)</option>
-        <option value="rating">Rating (highest)</option>
-        <option value="quality">Quality (best)</option>
-        <option value="sharpness">Sharpness (sharpest)</option>
-        <option value="sharpness_asc">Sharpness (softest)</option>
-      </select>
-      <label style="display:flex;align-items:center;gap:4px;" title="Thumbnail size">
-        <input type="range" id="thumbSizeSlider" min="120" max="400" step="20" value="220"
-               style="width:80px;accent-color:var(--accent);"
-               oninput="updateThumbSize(this.value)">
-        <span style="font-size:10px;color:var(--text-faint);">&#9638;</span>
-      </label>
-      <button id="detBoxToggle" onclick="toggleDetectionBoxes()" title="Show/hide detection boxes"
-              style="background:var(--bg-tertiary);color:var(--text-muted);border:1px solid var(--border-secondary);border-radius:4px;padding:3px 8px;font-size:11px;cursor:pointer;">
-        &#9634; Boxes
-      </button>
-      <button id="calToggle" onclick="toggleTimelineMode()" title="Calendar heatmap"
-              style="background:var(--bg-tertiary);color:var(--text-muted);border:1px solid var(--border-secondary);border-radius:4px;padding:3px 8px;font-size:11px;cursor:pointer;">
-        &#128197; Calendar
-      </button>
-      <span class="filter-summary" id="filterSummary"></span>
     </div>
 
     <!-- Calendar Heatmap (Timeline Mode) -->
@@ -2023,24 +1993,22 @@ var colorLabelsFetched = new Set();
 var colorLabelGen = 0;   // bumped on local edits; guards against stale fetch responses
 var loadEpoch = 0;       // bumped on any grid reset; guards against stale loadPhotos responses
 var selectAllRequestSeq = 0; // bumped to ignore stale async select-all responses
-var filterRating = 0;
-var flagFilter = '';
+// rating/flag/color/date/keyword filter state now lives in VireoFilter
+// (the universal filter bar); Browse keeps only page-scope state.
 var activeFolderId = null;
 var activeKeyword = null;
 var activeCollectionId = null;
 // A Dashboard deep link can combine a collection with date/keyword filters.
 // Normal collection clicks keep the historical collection-only behavior.
 var dashboardCollectionScope = false;
-var keywordSearchMatchCase = false;
-var keywordSearchWholeWord = false;
+
 var timelineMode = false;
 var calendarYear = new Date().getFullYear();
 var selectedDay = null;
 var calendarData = null;
 var clipSearchActive = false;
 var clipSearchSeq = 0;
-var searchFilterTimer = null;
-var appliedKeywordSearch = '';
+
 var bestBatchData = null;
 var keywordAutocompleteCache = null;
 var keywordAutocompletePromise = null;
@@ -2456,23 +2424,12 @@ function bindKeywordAutocomplete(inputId, dropdownId, submitFn) {
 }
 
 function hasActiveBrowseFilter() {
-  var searchInput = document.getElementById('searchInput');
-  var colorFilter = document.getElementById('colorFilter');
-  var locationStatusFilter = document.getElementById('locationStatusFilter');
-  var dateFrom = document.getElementById('dateFrom');
-  var dateTo = document.getElementById('dateTo');
   return !!(
     activeFolderId ||
     activeKeyword ||
     activeCollectionId ||
     clipSearchActive ||
-    filterRating > 0 ||
-    flagFilter ||
-    (searchInput && searchInput.value.trim()) ||
-    (colorFilter && colorFilter.value) ||
-    (locationStatusFilter && locationStatusFilter.value) ||
-    (dateFrom && dateFrom.value) ||
-    (dateTo && dateTo.value)
+    (window.VireoFilter && VireoFilter.hasFilters())
   );
 }
 
@@ -2895,33 +2852,11 @@ async function bootstrapBrowse() {
       activeCollectionId = initialCollectionId;
       dashboardCollectionScope = pageParams.get('dashboard_scope') === '1';
     }
-    document.getElementById('dateFrom').value = pageParams.get('date_from') || '';
-    document.getElementById('dateTo').value = pageParams.get('date_to') || '';
-    var initialKeyword = pageParams.get('keyword') || '';
-    if (initialKeyword) {
-      document.getElementById('searchInput').value = initialKeyword;
-      appliedKeywordSearch = initialKeyword;
-    }
-    var initialRating = parseInt(pageParams.get('rating_min'), 10);
-    if (!isNaN(initialRating) && initialRating >= 1 && initialRating <= 5) {
-      filterRating = initialRating;
-      document.querySelectorAll('.rating-filter .rating-star').forEach(function(el) {
-        el.classList.toggle('active', parseInt(el.dataset.val, 10) <= filterRating);
-      });
-    }
-    var initialFlag = pageParams.get('flag') || '';
-    if (['none', 'flagged', 'rejected'].indexOf(initialFlag) !== -1) {
-      flagFilter = initialFlag;
-      updateFlagFilterButtons();
-    }
-    var initialLocationStatus = pageParams.get('location_status') || '';
-    if (!initialLocationStatus && pageParams.get('missing_gps') === '1') {
-      initialLocationStatus = 'none';
-    }
-    if (['exif', 'assigned', 'none'].indexOf(initialLocationStatus) !== -1) {
-      document.getElementById('locationStatusFilter').value = initialLocationStatus;
-    }
-    var initParams = buildCurrentBrowseParams();
+    // Legacy filter deep-link params (rating_min/flag/keyword/dates/…) are
+    // compiled into an initial rule tree by VireoFilter.init below.
+    var initParams = new URLSearchParams();
+    initParams.set('sort', document.getElementById('sortSelect').value);
+    if (activeFolderId) initParams.set('folder_id', activeFolderId);
     // Collection-only deep links keep their historical endpoint behavior,
     // while Dashboard links opt into composable filters via dashboard_scope.
     // The combined init endpoint still needs the collection id for first paint
@@ -2949,6 +2884,23 @@ async function bootstrapBrowse() {
     // Lazy-load collection photo counts to avoid N+1 on init
     loadCollectionCounts();
     bootstrapSucceeded = true;
+
+    // Universal filter bar: registry + persisted/deep-linked state load
+    // async; when it comes up with active filters the unfiltered first
+    // paint above is stale, so reload through the rules path.
+    VireoFilter.init({
+      page: 'browse',
+      root: document.getElementById('vireoFilterBar'),
+      scopeLabel: 'Workspace \u00b7 All available photos',
+      onChange: function() {
+        if (timelineMode) loadCalendarData();
+        if (activeCollectionId && !dashboardCollectionScope) activeCollectionId = null;
+        resetAndLoad({ preserveAnchor: true });
+      },
+    }).then(function() {
+      VireoFilter.setResultTotal(totalPhotos);
+      if (VireoFilter.hasFilters()) resetAndLoad();
+    }).catch(function() {});
   } catch(e) {
     document.getElementById('loadingState').textContent = 'Error loading.';
   }
@@ -3060,17 +3012,12 @@ function toggleTree(e, el) {
 }
 
 function filterByFolder(folderId) {
-  var previousKeyword = activeKeyword;
   if (activeFolderId === folderId) {
     activeFolderId = null;
   } else {
     activeFolderId = folderId;
   }
   activeKeyword = null;
-  var searchInput = document.getElementById('searchInput');
-  if (previousKeyword && searchInput && searchInput.value.trim() === previousKeyword) {
-    searchInput.value = '';
-  }
   activeCollectionId = null;
   if (timelineMode) loadCalendarData();
   reloadBrowseResults();
@@ -3137,9 +3084,9 @@ function filterByKeyword(name) {
   }
   activeFolderId = null;
   activeCollectionId = null;
-  document.getElementById('searchInput').value = activeKeyword || '';
-  if (timelineMode) loadCalendarData();
-  reloadBrowseResults();
+  // The rule toggles: adding an identical keyword rule removes it. The
+  // filter bar's onChange handles the reload.
+  VireoFilter.addRule('keyword', 'is', name);
   document.querySelectorAll('#keywordTree .tree-item').forEach(function(el) {
     el.classList.toggle('active', el.dataset.keyword === activeKeyword);
   });
@@ -3239,25 +3186,14 @@ function refreshActiveKeywordAfterRemoval(removedName) {
   // `resetAndLoad`, which clears `activeCollectionId` and drops the user
   // into the global keyword search.
   if (activeCollectionId) return;
-  var searchInput = document.getElementById('searchInput');
-  var query = searchInput ? searchInput.value.trim() : '';
-  if (!query) return;
-  // The backend keyword filter tokenizes `keyword=<query>` and satisfies
-  // each token independently — a token can match via a different keyword
-  // or the filename. So a photo can appear in the grid because
-  // `removedName` satisfied one token while other tokens matched
-  // elsewhere. Reload whenever any query token still matches the removed
-  // keyword name; requiring the whole query to match would miss those
-  // multi-token cases.
-  var opts = {
-    matchCase: keywordSearchMatchCase,
-    wholeWord: keywordSearchWholeWord,
-  };
-  var tokens = query.split(/\s+/);
-  var anyTokenMatches = tokens.some(function(token) {
-    return token && VireoTextSearch.tokenMatches(removedName, token, opts);
-  });
-  if (anyTokenMatches) {
+  // The universal filter expression may reference the removed keyword via
+  // keyword/species rules or the quick-search group; a name substring test
+  // over the serialized expression over-reloads at worst (reloading is
+  // safe), never under-reloads.
+  var rules = getBrowseRules();
+  if (!rules) return;
+  var needle = String(removedName).toLowerCase();
+  if (JSON.stringify(rules).toLowerCase().indexOf(needle) !== -1) {
     reloadBrowseResults();
   }
 }
@@ -3286,7 +3222,6 @@ async function filterByCollection(id, options) {
     }
     return;
   }
-  cancelScheduledSearchFilter();
   var preserveAnchor = !(options && options.preserveAnchor === false);
   var anchor = preserveAnchor ? captureSelectedPhotoAnchor() : null;
   var restoreEpoch = anchor ? ++anchorRestoreEpoch : null;
@@ -3907,17 +3842,9 @@ async function saveCollection() {
 
 /* ---------- Photo Loading ---------- */
 async function resetAndLoad(options) {
-  cancelScheduledSearchFilter();
-  var searchInput = document.getElementById('searchInput');
-  var currentSearch = searchInput ? searchInput.value.trim() : '';
-  var searchWasCleared = appliedKeywordSearch !== '' && currentSearch === '';
-  var preserveAnchor = !!(options && options.preserveAnchor) || searchWasCleared;
+  var preserveAnchor = !!(options && options.preserveAnchor);
   var anchor = preserveAnchor ? captureSelectedPhotoAnchor() : null;
   var restoreEpoch = anchor ? ++anchorRestoreEpoch : null;
-  // Any non-collection reload also applies the current text box through
-  // buildCurrentBrowseParams(). Keep the tracker aligned when another control
-  // (sort/date/color/etc.) beats the search debounce to this reset.
-  appliedKeywordSearch = currentSearch;
   if (clipSearchActive) {
     clipSearchActive = false;
     document.getElementById('clipSearchInput').value = '';
@@ -3938,14 +3865,18 @@ async function resetAndLoad(options) {
   selectedIndex = -1;
   // Leaving collection mode when applying non-collection filters (sort, rating,
   // date, keyword, folder) so the summary stays in sync with the visible grid.
-  activeCollectionId = null;
+  // Dashboard-scoped collections are the exception: there the collection is an
+  // explicit composable restriction that filters combine WITH, so it must
+  // survive filter-driven reloads (dashboard drill-down deep links).
+  if (!dashboardCollectionScope) activeCollectionId = null;
   if (anchor) hideDetailPanel();
   else closeDetail();
   document.getElementById('grid').innerHTML = '';
   document.getElementById('gridContainer').scrollTop = 0;
 
   function resetRequestIsCurrent() {
-    return resetLoadEpoch === loadEpoch && activeCollectionId == null;
+    return resetLoadEpoch === loadEpoch &&
+      (activeCollectionId == null || dashboardCollectionScope);
   }
   function anchorScanShouldContinue() {
     return resetRequestIsCurrent() && anchorRestoreEpoch === restoreEpoch;
@@ -3986,59 +3917,23 @@ async function resetAndLoad(options) {
   }
 }
 
+function getBrowseRules() {
+  if (!window.VireoFilter || !VireoFilter.getRules) return null;
+  var rules = VireoFilter.getRules();
+  var count = Array.isArray(rules) ? rules.length : (rules.rules || []).length;
+  return count ? rules : null;
+}
+
 function buildCurrentBrowseParams() {
   var params = new URLSearchParams();
   params.set('sort', document.getElementById('sortSelect').value);
-
   if (activeFolderId) params.set('folder_id', activeFolderId);
   if (activeCollectionId && dashboardCollectionScope) {
     params.set('collection_id', activeCollectionId);
   }
-  if (filterRating > 0) params.set('rating_min', filterRating);
-  if (flagFilter) params.set('flag', flagFilter);
-
-  var colorFilter = document.getElementById('colorFilter').value;
-  if (colorFilter) params.set('color_label', colorFilter);
-
-  var locationStatus = document.getElementById('locationStatusFilter').value;
-  if (locationStatus) params.set('location_status', locationStatus);
-
-  var dateFrom = document.getElementById('dateFrom').value;
-  var dateTo = document.getElementById('dateTo').value;
-  if (dateFrom) params.set('date_from', dateFrom);
-  if (dateTo) params.set('date_to', dateTo);
-
-  appendKeywordSearchParams(params);
+  var rules = getBrowseRules();
+  if (rules) params.set('rules', JSON.stringify(rules));
   return params;
-}
-
-function appendKeywordSearchParams(params) {
-  var search = document.getElementById('searchInput').value.trim();
-  if (search) params.set('keyword', search);
-  if (activeKeyword) params.set('keyword', activeKeyword);
-  if (params.has('keyword')) {
-    VireoTextSearch.appendParams(
-      params,
-      { matchCase: keywordSearchMatchCase, wholeWord: keywordSearchWholeWord },
-      'keyword_match_case',
-      'keyword_whole_word'
-    );
-  }
-}
-
-function renderKeywordSearchOptions() {
-  VireoTextSearch.renderOptions('keyword', {
-    matchCase: keywordSearchMatchCase,
-    wholeWord: keywordSearchWholeWord,
-  });
-}
-
-function toggleKeywordSearchOption(option) {
-  VireoTextSearch.toggle('keyword', option, function(options) {
-    keywordSearchMatchCase = options.matchCase;
-    keywordSearchWholeWord = options.wholeWord;
-    applySearchFilterNow();
-  });
 }
 
 async function loadPhotos(options) {
@@ -4071,22 +3966,34 @@ async function loadPhotos(options) {
   var reqPerPage = perPage * chunk;
 
   var url;
+  var fetchOptions = {};
   if (activeCollectionId && !dashboardCollectionScope) {
     var cparams = new URLSearchParams();
     cparams.set('page', reqPage);
     cparams.set('per_page', reqPerPage);
     url = '/api/collections/' + activeCollectionId + '/photos?' + cparams.toString();
   } else {
-    var params = buildCurrentBrowseParams();
-    params.set('page', reqPage);
-    params.set('per_page', reqPerPage);
-    url = '/api/photos?' + params.toString();
+    url = '/api/photos/query';
+    var body = {
+      rules: getBrowseRules() || [],
+      sort: document.getElementById('sortSelect').value,
+      page: reqPage,
+      per_page: reqPerPage,
+    };
+    if (activeFolderId) body.folder_id = activeFolderId;
+    if (activeCollectionId && dashboardCollectionScope) body.collection_id = activeCollectionId;
+    fetchOptions = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    };
   }
 
   try {
-    var data = await safeFetch(url);
+    var data = await safeFetch(url, fetchOptions);
     if (epoch !== loadEpoch) return;  // grid was reset mid-flight; drop stale response
     totalPhotos = data.total;
+    if (window.VireoFilter && VireoFilter.setResultTotal) VireoFilter.setResultTotal(totalPhotos);
     var firstNewIdx = photos.length;
 
     if (data.photos.length === 0) {
@@ -4159,13 +4066,8 @@ async function loadCalendarData() {
   var params = new URLSearchParams();
   params.set('year', calendarYear);
   if (activeFolderId) params.set('folder_id', activeFolderId);
-  if (filterRating > 0) params.set('rating_min', filterRating);
-  if (flagFilter) params.set('flag', flagFilter);
-  var colorFilter = document.getElementById('colorFilter').value;
-  if (colorFilter) params.set('color_label', colorFilter);
-  var locationStatus = document.getElementById('locationStatusFilter').value;
-  if (locationStatus) params.set('location_status', locationStatus);
-  appendKeywordSearchParams(params);
+  var rules = getBrowseRules();
+  if (rules) params.set('rules', JSON.stringify(rules));
 
   calendarData = await safeFetch('/api/photos/calendar?' + params.toString());
   renderCalendar();
@@ -4276,24 +4178,18 @@ function selectCalendarDay(dateStr, count) {
   document.getElementById('calSelectionText').textContent = formatted + ' \u00b7 ' + count + ' photo' + (count !== 1 ? 's' : '');
   document.getElementById('calSelection').classList.add('active');
 
-  // Update date inputs and reload. #dateTo is <input type="date">, which
-  // rejects datetime strings (the value would silently blank and the filter
-  // would lose its upper bound). A bare date is correct: the backend pads
-  // date_to to end-of-day (_inclusive_date_to in db.py).
-  document.getElementById('dateFrom').value = dateStr;
-  document.getElementById('dateTo').value = dateStr;
+  // Day selection is a capture-date rule in the filter bar (single-day
+  // between; the backend pads the upper bound to end-of-day).
+  VireoFilter.addRule('timestamp', 'between', [dateStr, dateStr]);
   activeCollectionId = null;
-  reloadBrowseResults();
   renderCalendar(); // update selected state
 }
 
 function clearCalendarSelection() {
   selectedDay = null;
   document.getElementById('calSelection').classList.remove('active');
-  document.getElementById('dateFrom').value = '';
-  document.getElementById('dateTo').value = '';
+  if (window.VireoFilter) VireoFilter.removeField('timestamp');
   activeCollectionId = null;
-  reloadBrowseResults();
   if (calendarData) renderCalendar();
 }
 
@@ -4303,81 +4199,15 @@ function calendarChangeYear(delta) {
   calendarYear += delta;
   selectedDay = null;
   document.getElementById('calSelection').classList.remove('active');
-  document.getElementById('dateFrom').value = '';
-  document.getElementById('dateTo').value = '';
+  if (window.VireoFilter) VireoFilter.removeField('timestamp');
   loadCalendarData();
   activeCollectionId = null;
-  reloadBrowseResults();
 }
 
 function applyFilters() {
-  var locationStatus = document.getElementById('locationStatusFilter').value;
-  var url = new URL(window.location.href);
-  if (locationStatus) url.searchParams.set('location_status', locationStatus);
-  else url.searchParams.delete('location_status');
-  url.searchParams.delete('missing_gps');
-  window.history.replaceState({}, '', url.pathname + url.search);
   if (timelineMode) loadCalendarData();
   activeCollectionId = null;
   reloadBrowseResults();
-}
-
-function scheduleSearchFilter() {
-  cancelScheduledSearchFilter();
-  searchFilterTimer = setTimeout(function() {
-    searchFilterTimer = null;
-    applySearchFilters();
-  }, 250);
-}
-
-function cancelScheduledSearchFilter() {
-  if (searchFilterTimer) {
-    clearTimeout(searchFilterTimer);
-    searchFilterTimer = null;
-  }
-}
-
-function applySearchFilterNow() {
-  cancelScheduledSearchFilter();
-  applySearchFilters();
-}
-
-function applySearchFilters() {
-  var input = document.getElementById('searchInput');
-  var nextSearch = input ? input.value.trim() : '';
-  var preserveAnchor = appliedKeywordSearch !== '' && nextSearch === '';
-  appliedKeywordSearch = nextSearch;
-  if (timelineMode) loadCalendarData();
-  activeCollectionId = null;
-  reloadBrowseResults({ preserveAnchor: preserveAnchor });
-}
-
-function setFilterRating(val) {
-  if (filterRating === val) {
-    filterRating = 0;
-  } else {
-    filterRating = val;
-  }
-  document.querySelectorAll('.rating-filter .rating-star').forEach(function(el) {
-    el.classList.toggle('active', parseInt(el.dataset.val) <= filterRating);
-  });
-  activeCollectionId = null;
-  reloadBrowseResults();
-}
-
-function setFlagFilter(flag) {
-  flagFilter = flagFilter === flag ? '' : flag;
-  updateFlagFilterButtons();
-  if (timelineMode) loadCalendarData();
-  activeCollectionId = null;
-  reloadBrowseResults();
-}
-
-function updateFlagFilterButtons() {
-  var pick = document.getElementById('pickFilterBtn');
-  var reject = document.getElementById('rejectFilterBtn');
-  if (pick) pick.classList.toggle('active-pick', flagFilter === 'flagged');
-  if (reject) reject.classList.toggle('active-reject', flagFilter === 'rejected');
 }
 
 function updateFilterSummary() {
@@ -4408,20 +4238,8 @@ function appendClipSearchScopeParams(params) {
     return;
   }
   if (activeFolderId) params.set('folder_id', activeFolderId);
-  if (filterRating > 0) params.set('rating_min', filterRating);
-  if (flagFilter) params.set('flag', flagFilter);
-
-  var colorFilter = document.getElementById('colorFilter').value;
-  if (colorFilter) params.set('color_label', colorFilter);
-  var locationStatus = document.getElementById('locationStatusFilter').value;
-  if (locationStatus) params.set('location_status', locationStatus);
-
-  var dateFrom = document.getElementById('dateFrom').value;
-  var dateTo = document.getElementById('dateTo').value;
-  if (dateFrom) params.set('date_from', dateFrom);
-  if (dateTo) params.set('date_to', dateTo);
-
-  appendKeywordSearchParams(params);
+  var rules = getBrowseRules();
+  if (rules) params.set('rules', JSON.stringify(rules));
 }
 
 function reloadBrowseResults(options) {
@@ -4842,18 +4660,31 @@ async function selectAllMatchingPhotos() {
   }
 
   var url;
+  var fetchOpts = {};
   if (activeCollectionId && !dashboardCollectionScope) {
     url = '/api/collections/' + activeCollectionId + '/photo-ids';
   } else {
-    url = '/api/photos/ids?' + buildCurrentBrowseParams().toString();
+    url = '/api/photos/query';
+    var idsBody = {
+      rules: getBrowseRules() || [],
+      sort: document.getElementById('sortSelect').value,
+      ids_only: true,
+    };
+    if (activeFolderId) idsBody.folder_id = activeFolderId;
+    if (activeCollectionId && dashboardCollectionScope) idsBody.collection_id = activeCollectionId;
+    fetchOpts = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(idsBody),
+    };
   }
 
   showToast('Selecting all matching photos...');
   try {
-    var data = await safeFetch(url, {}, { toast: false });
+    var data = await safeFetch(url, fetchOpts, { toast: false });
     if (requestSeq !== selectAllRequestSeq || requestEpoch !== loadEpoch) return;
     selectedPhotos.clear();
-    (data.photo_ids || []).forEach(function(id) { selectedPhotos.add(id); });
+    (data.photo_ids || data.ids || []).forEach(function(id) { selectedPhotos.add(id); });
     renderGrid();
     updateBatchBar();
     showToast('Selected ' + selectedPhotos.size.toLocaleString() + ' photo' + (selectedPhotos.size === 1 ? '' : 's'));
@@ -6628,17 +6459,8 @@ function closeDetail() {
 async function loadSummary() {
   var params = new URLSearchParams();
   if (activeFolderId) params.set('folder_id', activeFolderId);
-  if (filterRating > 0) params.set('rating_min', filterRating);
-  if (flagFilter) params.set('flag', flagFilter);
-  var colorFilter = document.getElementById('colorFilter').value;
-  if (colorFilter) params.set('color_label', colorFilter);
-  var locationStatus = document.getElementById('locationStatusFilter').value;
-  if (locationStatus) params.set('location_status', locationStatus);
-  var dateFrom = document.getElementById('dateFrom').value;
-  var dateTo = document.getElementById('dateTo').value;
-  if (dateFrom) params.set('date_from', dateFrom);
-  if (dateTo) params.set('date_to', dateTo);
-  appendKeywordSearchParams(params);
+  var rules = getBrowseRules();
+  if (rules) params.set('rules', JSON.stringify(rules));
   if (activeCollectionId) params.set('collection_id', activeCollectionId);
 
   try {
@@ -7170,7 +6992,7 @@ async function _afterLocationMutation(photoIds, detailPhotoId) {
     await filterByCollection(activeCollectionId);
     return;
   }
-  if (document.getElementById('locationStatusFilter').value) {
+  if (window.VireoFilter && VireoFilter.hasFilters()) {
     resetAndLoad();
     return;
   }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3077,7 +3077,11 @@ function filterByFolder(folderId) {
   // so the folder reload silently applies folder ∩ keyword. Drop the
   // rule before the reload; VireoFilter.removeField fires onChange,
   // which runs the reload path (including timelineMode + summary), so
-  // skip the plain reloadBrowseResults() branch when we take that route.
+  // skip the plain reloadBrowseResults() branch only when removeField
+  // actually removed something. If the user already dropped the rule
+  // via the filter chip, activeKeyword lingers but there's no keyword
+  // rule left to remove — removeField returns false and we still need
+  // to run our own reload for the folder change.
   var hadSidebarKeyword = activeKeyword !== null;
   activeKeyword = null;
   activeCollectionId = null;
@@ -3085,8 +3089,7 @@ function filterByFolder(folderId) {
     el.classList.toggle('active', parseInt(el.dataset.folderId) === activeFolderId);
   });
   if (hadSidebarKeyword && window.VireoFilter && VireoFilter.isReady()) {
-    VireoFilter.removeField('keyword');
-    return;
+    if (VireoFilter.removeField('keyword')) return;
   }
   if (timelineMode) loadCalendarData();
   reloadBrowseResults();
@@ -4266,6 +4269,14 @@ function renderCalendar() {
 }
 
 function selectCalendarDay(dateStr, count) {
+  // /api/photos/calendar can resolve before VireoFilter.init() has
+  // loaded /api/filters/fields, so a click that lands in that window
+  // would reach addRule -> makeRule with state.fields still null and
+  // throw \u2014 silently swallowing the day pick and leaving the calendar
+  // in a half-selected state (chip up, no filter applied). Bail out
+  // until the filter registry is ready; the click will succeed on the
+  // next attempt once the field payload lands.
+  if (!window.VireoFilter || !VireoFilter.isReady()) return;
   selectedDay = dateStr;
   var dateObj = new Date(dateStr + 'T12:00:00');
   var formatted = dateObj.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2895,7 +2895,11 @@ async function bootstrapBrowse() {
       onChange: function() {
         if (timelineMode) loadCalendarData();
         if (activeCollectionId && !dashboardCollectionScope) activeCollectionId = null;
-        resetAndLoad({ preserveAnchor: true });
+        // Don't preserveAnchor: a filter change usually excludes the previously
+        // selected photo, and loadUntilPhotoRendered would then keep paging
+        // through the whole matching set (potentially many /api/photos/query
+        // requests) just to prove the anchor is gone.
+        resetAndLoad();
         // Summary panel (photo count, classified, top species) is a separate
         // endpoint from the grid; without this the filter changes the grid
         // but leaves the summary showing pre-filter numbers.
@@ -3084,6 +3088,12 @@ function renderKeywordTree(keywords) {
 }
 
 function filterByKeyword(name) {
+  // The sidebar tree is rendered from the /photos init payload, so a
+  // slow /api/filters/fields (or workspace) round-trip leaves clickable
+  // keywords in the DOM before VireoFilter.init resolves. Without this
+  // guard, addRule -> makeRule dereferences state.fields (still null)
+  // and throws, leaving activeKeyword toggled but no rule/reload applied.
+  if (!VireoFilter.isReady()) return;
   if (activeKeyword === name) {
     activeKeyword = null;
   } else {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4120,11 +4120,28 @@ async function loadCalendarData() {
   if (activeCollectionId && dashboardCollectionScope) {
     params.set('collection_id', activeCollectionId);
   }
-  var rules = getBrowseRules();
+  // Strip any root-level `timestamp` rule from the calendar's own request.
+  // selectCalendarDay adds/replaces exactly such a rule, and the filter
+  // bar's onChange calls loadCalendarData() synchronously — feeding the
+  // just-selected day back into the heatmap zeros out every other day and
+  // makes it impossible to click through to another one. The heatmap is a
+  // date picker: it should always show all days matching the non-date
+  // filters (the visible grid still applies the date rule).
+  var rules = getBrowseRulesWithoutTimestamp();
   if (rules) params.set('rules', JSON.stringify(rules));
 
   calendarData = await safeFetch('/api/photos/calendar?' + params.toString());
   renderCalendar();
+}
+
+function getBrowseRulesWithoutTimestamp() {
+  var rules = getBrowseRules();
+  if (!rules || !rules.rules) return rules;
+  var kept = rules.rules.filter(function(r) {
+    return !(r && !Array.isArray(r.rules) && r.field === 'timestamp');
+  });
+  if (!kept.length) return null;
+  return { mode: rules.mode || 'all', rules: kept };
 }
 
 function renderCalendar() {
@@ -8298,6 +8315,38 @@ document.addEventListener('contextmenu', function(e) {
         el.style.outline = '';
         el.style.outlineOffset = '';
       }, 2000);
+    }
+
+    // bootstrapBrowse (which owns VireoFilter.init) short-circuits when
+    // ?photo_id=... is present, so without this the filter bar renders but
+    // has no event handlers: quick-search does nothing, chips can't be
+    // added, and the total stays at "–". Initialize here so the bar is
+    // live once the deep-link has finished loading. Drop any persisted
+    // workspace filter — the explicit ?photo_id link should not be
+    // silently overridden by whatever the user had saved on Browse.
+    if (window.VireoFilter && !VireoFilter.isReady()) {
+      VireoFilter.init({
+        page: 'browse',
+        root: document.getElementById('vireoFilterBar'),
+        scopeLabel: 'Workspace · All available photos',
+        onChange: function(info) {
+          if (timelineMode) loadCalendarData();
+          if (activeCollectionId && !dashboardCollectionScope) activeCollectionId = null;
+          var preserveAnchor = info && info.reason === 'quickSearchCleared';
+          resetAndLoad(preserveAnchor ? { preserveAnchor: true } : undefined);
+          loadSummary();
+        },
+        getScope: function() {
+          return {
+            folder_id: activeFolderId,
+            collection_id: (activeCollectionId && dashboardCollectionScope)
+              ? activeCollectionId : null,
+          };
+        },
+      }).then(function() {
+        VireoFilter.setResultTotal(totalPhotos);
+        if (VireoFilter.hasFilters()) VireoFilter.clearAll(true);
+      }).catch(function() {});
     }
   } catch(e) { /* ignore deep-link errors silently */ }
   loading = false;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4227,9 +4227,18 @@ function selectCalendarDay(dateStr, count) {
 }
 
 function clearCalendarSelection() {
+  // Only drop collection scope when a day was actually selected — that
+  // scope is what selectCalendarDay cleared, and its removal here pairs
+  // with the removeField('timestamp') reload. Toggling the calendar off
+  // (or clearing selection twice) with no day picked hits this path with
+  // nothing to remove: removeField would return early without firing
+  // onChange, so a silent activeCollectionId=null would leave the grid
+  // showing the collection while infinite-scroll/summary/select-all
+  // silently widened to the whole workspace.
+  var hadSelection = selectedDay !== null;
   selectedDay = null;
   document.getElementById('calSelection').classList.remove('active');
-  if (!dashboardCollectionScope) activeCollectionId = null;
+  if (hadSelection && !dashboardCollectionScope) activeCollectionId = null;
   if (window.VireoFilter) VireoFilter.removeField('timestamp');
   if (calendarData) renderCalendar();
 }
@@ -4238,9 +4247,14 @@ function calendarChangeYear(delta) {
   if (delta < 0 && calendarData && calendarYear <= calendarData.min_year) return;
   if (delta > 0 && calendarData && calendarYear >= calendarData.max_year) return;
   calendarYear += delta;
+  // Same guard as clearCalendarSelection: only touch collection scope
+  // when a day was actually picked (that day-pick is what dropped it).
+  // Without this, switching year in a collection view before ever
+  // selecting a day silently widens later requests to the workspace.
+  var hadSelection = selectedDay !== null;
   selectedDay = null;
   document.getElementById('calSelection').classList.remove('active');
-  if (!dashboardCollectionScope) activeCollectionId = null;
+  if (hadSelection && !dashboardCollectionScope) activeCollectionId = null;
   if (window.VireoFilter) VireoFilter.removeField('timestamp');
   loadCalendarData();
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2896,10 +2896,17 @@ async function bootstrapBrowse() {
         if (timelineMode) loadCalendarData();
         if (activeCollectionId && !dashboardCollectionScope) activeCollectionId = null;
         resetAndLoad({ preserveAnchor: true });
+        // Summary panel (photo count, classified, top species) is a separate
+        // endpoint from the grid; without this the filter changes the grid
+        // but leaves the summary showing pre-filter numbers.
+        loadSummary();
       },
     }).then(function() {
       VireoFilter.setResultTotal(totalPhotos);
-      if (VireoFilter.hasFilters()) resetAndLoad();
+      if (VireoFilter.hasFilters()) {
+        resetAndLoad();
+        loadSummary();
+      }
     }).catch(function() {});
   } catch(e) {
     document.getElementById('loadingState').textContent = 'Error loading.';

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2905,6 +2905,19 @@ async function bootstrapBrowse() {
         // but leaves the summary showing pre-filter numbers.
         loadSummary();
       },
+      // Typeahead counts otherwise ignore the folder/collection restriction
+      // the grid uses via /api/photos/query, so picking a suggestion inside
+      // a folder or dashboard-scoped collection can yield fewer visible
+      // grid results than the advertised count. Dashboard-scoped collection
+      // Browse composes collection + rules; the legacy collection view
+      // clears activeCollectionId on filter apply, so this is a no-op there.
+      getScope: function() {
+        return {
+          folder_id: activeFolderId,
+          collection_id: (activeCollectionId && dashboardCollectionScope)
+            ? activeCollectionId : null,
+        };
+      },
     }).then(function() {
       VireoFilter.setResultTotal(totalPhotos);
       if (VireoFilter.hasFilters()) {
@@ -4203,16 +4216,21 @@ function selectCalendarDay(dateStr, count) {
 
   // Day selection is a capture-date rule in the filter bar (single-day
   // between; the backend pads the upper bound to end-of-day).
+  // Clear the collection scope BEFORE addRule() — its onChange fires the
+  // reload synchronously, so mutating scope after would only take effect
+  // for later requests (infinite scroll, select-all, summary, calendar).
+  // Dashboard-scoped collection Browse composes collection + rules and
+  // must keep activeCollectionId.
+  if (!dashboardCollectionScope) activeCollectionId = null;
   VireoFilter.addRule('timestamp', 'between', [dateStr, dateStr]);
-  activeCollectionId = null;
   renderCalendar(); // update selected state
 }
 
 function clearCalendarSelection() {
   selectedDay = null;
   document.getElementById('calSelection').classList.remove('active');
+  if (!dashboardCollectionScope) activeCollectionId = null;
   if (window.VireoFilter) VireoFilter.removeField('timestamp');
-  activeCollectionId = null;
   if (calendarData) renderCalendar();
 }
 
@@ -4222,14 +4240,14 @@ function calendarChangeYear(delta) {
   calendarYear += delta;
   selectedDay = null;
   document.getElementById('calSelection').classList.remove('active');
+  if (!dashboardCollectionScope) activeCollectionId = null;
   if (window.VireoFilter) VireoFilter.removeField('timestamp');
   loadCalendarData();
-  activeCollectionId = null;
 }
 
 function applyFilters() {
   if (timelineMode) loadCalendarData();
-  activeCollectionId = null;
+  if (!dashboardCollectionScope) activeCollectionId = null;
   reloadBrowseResults();
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2892,14 +2892,18 @@ async function bootstrapBrowse() {
       page: 'browse',
       root: document.getElementById('vireoFilterBar'),
       scopeLabel: 'Workspace \u00b7 All available photos',
-      onChange: function() {
+      onChange: function(info) {
         if (timelineMode) loadCalendarData();
         if (activeCollectionId && !dashboardCollectionScope) activeCollectionId = null;
-        // Don't preserveAnchor: a filter change usually excludes the previously
+        // A cleared quick search is the one filter edit where the previously
+        // selected photo is expected to reappear in the wider result set \u2014
+        // preserve the anchor so the detail panel and scroll position don't
+        // reset. Every other filter change usually excludes the previously
         // selected photo, and loadUntilPhotoRendered would then keep paging
         // through the whole matching set (potentially many /api/photos/query
         // requests) just to prove the anchor is gone.
-        resetAndLoad();
+        var preserveAnchor = info && info.reason === 'quickSearchCleared';
+        resetAndLoad(preserveAnchor ? { preserveAnchor: true } : undefined);
         // Summary panel (photo count, classified, top species) is a separate
         // endpoint from the grid; without this the filter changes the grid
         // but leaves the summary showing pre-filter numbers.
@@ -2920,6 +2924,20 @@ async function bootstrapBrowse() {
       },
     }).then(function() {
       VireoFilter.setResultTotal(totalPhotos);
+      // Plain collection deep-link (?collection_id=... with no
+      // ?dashboard_scope=1) must show exactly that collection. A saved
+      // workspace filter restored from ui_state makes hasFilters() true,
+      // and the resetAndLoad() below would then clear activeCollectionId
+      // via the resetAndLoad path (see line ~3901 \u2014 non-dashboard scopes),
+      // silently switching from the requested collection to the saved
+      // filter. Drop the persisted state so the deep link is honored.
+      var urlParams = new URLSearchParams(window.location.search);
+      var plainCollectionLink = !!urlParams.get('collection_id') &&
+        urlParams.get('dashboard_scope') !== '1';
+      if (plainCollectionLink && VireoFilter.hasFilters()) {
+        VireoFilter.clearAll(true);
+        return;
+      }
       if (VireoFilter.hasFilters()) {
         resetAndLoad();
         loadSummary();
@@ -4235,11 +4253,16 @@ function clearCalendarSelection() {
   // onChange, so a silent activeCollectionId=null would leave the grid
   // showing the collection while infinite-scroll/summary/select-all
   // silently widened to the whole workspace.
+  //
+  // The removeField('timestamp') is also gated on hadSelection: a user
+  // with a manual capture-date rule from a deep link or the filter
+  // popover (never entered via the calendar) toggling the calendar on
+  // and back off would otherwise silently clear their date filter.
   var hadSelection = selectedDay !== null;
   selectedDay = null;
   document.getElementById('calSelection').classList.remove('active');
   if (hadSelection && !dashboardCollectionScope) activeCollectionId = null;
-  if (window.VireoFilter) VireoFilter.removeField('timestamp');
+  if (hadSelection && window.VireoFilter) VireoFilter.removeField('timestamp');
   if (calendarData) renderCalendar();
 }
 
@@ -4247,15 +4270,18 @@ function calendarChangeYear(delta) {
   if (delta < 0 && calendarData && calendarYear <= calendarData.min_year) return;
   if (delta > 0 && calendarData && calendarYear >= calendarData.max_year) return;
   calendarYear += delta;
-  // Same guard as clearCalendarSelection: only touch collection scope
-  // when a day was actually picked (that day-pick is what dropped it).
-  // Without this, switching year in a collection view before ever
-  // selecting a day silently widens later requests to the workspace.
+  // Same guards as clearCalendarSelection: only touch collection scope
+  // and only removeField('timestamp') when a day was actually picked
+  // (that day-pick is what dropped scope and set the timestamp rule).
+  // Without them, switching year in a collection view before ever
+  // selecting a day silently widens later requests to the workspace,
+  // and stepping through years with a manual timestamp rule active
+  // would silently clear the user's date filter.
   var hadSelection = selectedDay !== null;
   selectedDay = null;
   document.getElementById('calSelection').classList.remove('active');
   if (hadSelection && !dashboardCollectionScope) activeCollectionId = null;
-  if (window.VireoFilter) VireoFilter.removeField('timestamp');
+  if (hadSelection && window.VireoFilter) VireoFilter.removeField('timestamp');
   loadCalendarData();
 }
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -9899,3 +9899,44 @@ def test_api_filter_values_clamps_limit(app_and_db):
     resp = client.get('/api/filters/values?field=camera_model&limit=999999')
     assert resp.status_code == 200
     assert len(resp.get_json()["values"]) <= 500
+
+
+def test_api_photos_query_ids_only(app_and_db):
+    """ids_only returns the complete matching id set in display order —
+    select-all must resolve exactly what the filtered grid shows."""
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.post('/api/photos/query', json={
+        "rules": [{"field": "rating", "op": ">=", "value": 3}],
+        "ids_only": True,
+        "sort": "name",
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    photos = {p["filename"]: p["id"] for p in db.get_photos()}
+    assert data["ids"] == [photos["bird1.jpg"], photos["bird3.jpg"]]
+    assert data["total"] == 2
+
+
+def test_api_browse_summary_accepts_rules(app_and_db):
+    import json as _json
+    app, _ = app_and_db
+    client = app.test_client()
+    rules = _json.dumps([{"field": "rating", "op": ">=", "value": 4}])
+    resp = client.get(f'/api/browse/summary?rules={rules}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["filtered_total"] == 1
+    assert client.get('/api/browse/summary?rules=notjson').status_code == 400
+
+
+def test_api_photos_calendar_accepts_rules(app_and_db):
+    import json as _json
+    app, _ = app_and_db
+    client = app.test_client()
+    rules = _json.dumps([{"field": "rating", "op": ">=", "value": 4}])
+    resp = client.get(f'/api/photos/calendar?year=2024&rules={rules}')
+    assert resp.status_code == 200
+    # bird3.jpg (rating 5, 2024-06-10) is the only match in 2024
+    assert resp.get_json()["days"] == {"2024-06-10": 1}
+    assert client.get('/api/photos/calendar?rules=notjson').status_code == 400

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -9901,6 +9901,50 @@ def test_api_filter_values_clamps_limit(app_and_db):
     assert len(resp.get_json()["values"]) <= 500
 
 
+def test_api_filter_values_respects_scope(app_and_db):
+    """Typeahead counts must respect the folder / dashboard-collection scope
+    Browse passes to /api/photos/query; without this the badge beside each
+    suggestion counts photos over the whole workspace while the grid is
+    folder- or collection-restricted, and a pick can produce fewer visible
+    grid rows than the count promised."""
+    app, db = app_and_db
+    photos = {p["filename"]: p["id"] for p in db.get_photos()}
+    folders = db.get_folder_tree()
+    jan = [f for f in folders if f["name"] == "January"][0]
+    db.conn.execute(
+        "UPDATE photos SET camera_model='Sony A1' WHERE id IN (?, ?)",
+        (photos["bird1.jpg"], photos["bird3.jpg"]),
+    )
+    db.conn.execute(
+        "UPDATE photos SET camera_model='Canon R5' WHERE id=?",
+        (photos["bird2.jpg"],),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    # Unscoped: sees both models.
+    resp = client.get('/api/filters/values?field=camera_model')
+    assert {v["value"] for v in resp.get_json()["values"]} == {"Sony A1", "Canon R5"}
+    # folder_id narrows to only the January folder (bird2.jpg — Canon R5).
+    resp = client.get(
+        f'/api/filters/values?field=camera_model&folder_id={jan["id"]}'
+    )
+    assert resp.get_json()["values"] == [{"value": "Canon R5", "count": 1}]
+
+    # collection_id narrows to only the two picked photos (bird1 + bird3 — Sony A1).
+    collection_id = db.add_collection(
+        "Two Sonys",
+        json.dumps([{
+            "field": "photo_ids",
+            "value": [photos["bird1.jpg"], photos["bird3.jpg"]],
+        }]),
+    )
+    resp = client.get(
+        f'/api/filters/values?field=camera_model&collection_id={collection_id}'
+    )
+    assert resp.get_json()["values"] == [{"value": "Sony A1", "count": 2}]
+
+
 def test_api_photos_query_ids_only(app_and_db):
     """ids_only returns the complete matching id set in display order —
     select-all must resolve exactly what the filtered grid shows."""


### PR DESCRIPTION
## What this is

Phase 2 of the universal filter system ([plan](docs/plans/2026-07-19-universal-filters-plan.md), prototype #1319, backend #1324): the shared filter bar, live on Browse. This is the first user-visible phase.

## What changed

**New shared module** — `vireo/templates/_filterbar.html` + `vireo/static/vireo-filter.js` (IIFE on `window.VireoFilter`, following the `VireoTextSearch` pattern), implementing the prototype's validated interaction model with all evaluation server-side:

- **Quick search** = one replaceable clause (an any-group over filename/keyword/species/camera make+model/lens); typing `eagle` after `owl` replaces, never ANDs
- **Chips row** with the locked page-scope chip, `+N` overflow, and exact-semantics labels ("Rating is at least 3 stars", "Flag is one of Picked, Unflagged")
- **Quick filters**: rating with visible comparator (≥/=/≤); flags and colors multi-select into `is one of` rules
- **Rule builder** over the full `/api/filters/fields` registry: per-type operators, typeahead values with live facet counts (respecting the expression minus the edited rule), enum pills, `between` + relative-date inputs, Advanced logic groups (toggling it off never rewrites the tree)
- **Pause on `\`**: dimmed dashed chips, honest "N would match" note, persists across reload
- **Per-workspace persistence** in `workspaces.ui_state`; legacy deep-link params compile to an initial rule tree

**Browse rewiring** — every consumer of the old copy-pasted param soup now resolves the same rules through one path: `loadPhotos` (POST `/api/photos/query`), select-all (`ids_only`), the summary panel, the calendar heatmap, and the CLIP-search candidate scope. **No surface can disagree with the visible grid.** Calendar day-clicks are now a visible capture-date chip instead of hidden date inputs. Dashboard-scoped collections compose with filters and survive filter reloads (bug found by the existing dashboard e2e and fixed here).

**Backend additions**: `ids_only`/`collection_id`/`folder_id` on `/api/photos/query`; `rules=` on `/api/browse/summary`, `/api/photos/calendar`, `/api/photos/search`; `db.query_photo_ids`.

**Interaction hardening from real-browser driving** (the prototype review's recurring bug class, fixed structurally): typed edits commit via debounced input without re-rendering the rule tree, so blur/change races can't destroy a suggest option mid-click; detached-target clicks no longer close the popover; stale debounces are cancelled on every mutation.

**Removed**: the inline search box (+ match-case/whole-word buttons), rating stars, flag buttons, color/location-status/date widgets, and their five duplicated param-assembly blocks. CLIP search box stays as-is until Phase 3 folds it into the bar as the visual clause.

## Testing

- **7 new e2e tests** (`tests/e2e/test_browse_filterbar.py`): chip semantics, flag multi-select incl. NULL-flag rows, single replaceable quick-search, pause/resume via `\`, typeahead counts + pick, persistence across reload, and select-all == filtered grid
- **4 legacy e2e tests ported** to the new bar (search empty-state, anchor preservation, flag quick filters with new multi-select semantics, location deep-link)
- **3 new API tests** (ids_only, summary/calendar rules)
- Full standard suite: **1842 passed, 14 skipped**, 1 pre-existing env-dependent failure (`test_api_exiftool_status_reports_missing`, fails on clean main)
- Full e2e: **568 passed**, 1 pre-existing failure (lifelist, fails on clean main); the dashboard composability failure was real and is fixed in this PR
- Manually driven end-to-end in a real browser against a 12-photo seeded library (24-check drive script) at 1500px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out a universal filter bar on Browse with quick filters, advanced rule-building, live match totals, pause/resume, and clear controls.
  * Filter search, chips, and state now support deep linking, rule scoping, and persistence after reload.
  * “Select all” now selects every photo matching the active filters (not just the current page).
  * Browse summaries and calendar views now reflect active filter rules.
* **Bug Fixes**
  * Improved Browse search empty-state and clearing behavior; refined flag multi-select/toggle-to-clear semantics and location coordinate deep links.
* **Tests**
  * Added/updated end-to-end and API coverage for rule-based filtering, totals, scope, and ids-only queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->