### PR TITLE
Universal filters Phase 3: CLIP visual clause in the filter bar

### DIFF
--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -146,3 +146,63 @@ def test_select_all_matches_filtered_grid(live_server, page):
     page.wait_for_function(
         "window.selectedPhotos && selectedPhotos.size === 3", timeout=8000,
     )
+
+
+def test_visual_search_error_state_is_honest(live_server, page):
+    """A visual clause that cannot run (no embeddings indexed) must show an
+    error chip + explanation and keep applying metadata filters — never
+    silently return zero results (Phase 3 hard requirement)."""
+    _open_browse(page, live_server)
+    search = page.locator(".vf-search input")
+    search.fill("an owl at dusk")
+    page.wait_for_selector(".vf-search-suggest button", timeout=8000)
+    page.locator('.vf-search-suggest [data-search-kind="visual"]').click()
+
+    # Visual chip appears in an error state, results stay metadata-only (5).
+    page.wait_for_selector(".vf-chip.visual", timeout=8000)
+    _wait_total(page, 5)
+    page.wait_for_function(
+        "document.querySelector('.vf-visual-note') && "
+        "!document.querySelector('.vf-visual-note').hidden",
+        timeout=8000,
+    )
+    note = page.inner_text(".vf-visual-note")
+    assert "metadata filters shown only" in note
+    assert page.locator(".vf-chip.visual.error").count() == 1
+
+    # Metadata rules still apply alongside the broken visual clause.
+    page.click(".vf-filters-btn")
+    page.click('.vf-quick-rating .vf-star[data-rating="4"]')
+    _wait_total(page, 1)
+    page.click(".vf-done")
+
+    # The clause persists across reload and stays honestly marked.
+    page.wait_for_timeout(1200)
+    page.reload()
+    page.wait_for_selector("#vireoFilterBar", timeout=15000)
+    _wait_total(page, 1, timeout=15000)
+    page.wait_for_selector(".vf-chip.visual", timeout=8000)
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent")
+    assert "Visually similar" in chips and "an owl at dusk" in chips
+
+    # Removing the visual chip keeps the metadata filter.
+    page.evaluate("document.querySelector('.vf-chip.visual .vf-chip-x').click()")
+    page.wait_for_function(
+        "!document.querySelector('.vf-chip.visual')", timeout=8000,
+    )
+    _wait_total(page, 1)
+
+
+def test_visual_strength_control_and_popover_row(live_server, page):
+    _open_browse(page, live_server)
+    page.evaluate("VireoFilter.visualSearch('a hawk in flight')")
+    page.wait_for_selector(".vf-chip.visual", timeout=8000)
+    page.click(".vf-filters-btn")
+    row = page.locator(".vf-visual-row")
+    assert row.is_visible()
+    assert "a hawk in flight" in row.inner_text()
+    page.click('.vf-visual-strength [data-strength="strict"]')
+    page.wait_for_timeout(400)
+    assert page.evaluate("VireoFilter.getVisual().strength") == "strict"
+    page.click('.vf-visual-row [data-action="visual-remove"]')
+    page.wait_for_function("!VireoFilter.getVisual()", timeout=8000)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5857,7 +5857,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             location_status = _request_location_status_filter()
             rules = _request_rules_arg()
             visual = _request_visual_arg()
-            rules = _apply_visual_to_rules(db, rules, visual, folder_id=folder_id)
+            rules = _apply_visual_to_rules(
+                db, rules, visual,
+                collection_id=collection_id, folder_id=folder_id,
+            )
         except ValueError as e:
             return json_error(str(e), 400)
         try:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3893,6 +3893,126 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             raise ValueError("rules must be valid JSON") from exc
         return _inject_active_visual_model(rules)
 
+    _VISUAL_STRENGTH_THRESHOLDS = {"broad": 0.10, "balanced": 0.15, "strict": 0.22}
+    # Query-text embeddings keyed by (model, prompt): the ONNX text encode is
+    # the expensive step and the same prompt is re-resolved by every surface
+    # (grid, summary, calendar, facet counts) plus each typeahead keystroke.
+    _text_query_cache = {}
+
+    def _validate_visual_arg(visual):
+        """Normalize a visual clause payload or raise ValueError."""
+        if visual is None:
+            return None
+        if not isinstance(visual, dict):
+            raise ValueError("visual must be an object")
+        prompt = visual.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("visual.prompt must be a non-empty string")
+        strength = visual.get("strength", "balanced")
+        if strength not in _VISUAL_STRENGTH_THRESHOLDS:
+            raise ValueError("visual.strength must be broad, balanced, or strict")
+        return {"prompt": prompt.strip(), "strength": strength}
+
+    def _request_visual_arg():
+        """Parse the optional ``visual`` query param (JSON clause)."""
+        raw = request.args.get("visual")
+        if not raw:
+            return None
+        try:
+            parsed = json.loads(raw)
+        except ValueError as exc:
+            raise ValueError("visual must be valid JSON") from exc
+        return _validate_visual_arg(parsed)
+
+    def _resolve_visual(db, rules, visual, collection_id=None, folder_id=None):
+        """Run a visual clause over the rule tree's candidate photos.
+
+        Returns ``(info, ordered_ids, sims_by_pid)``. ``info["status"]`` is
+        ``ok`` with ids ordered by similarity, or an unhealthy state
+        (``no_model`` / ``model_no_text_search`` / ``no_embeddings`` /
+        ``encoding_failed``) with ``ordered_ids is None`` — callers then
+        apply metadata rules only and surface the state. Never silently
+        zero results (design hard requirement).
+        """
+        import numpy as np
+        from models import get_active_model
+        base = {"prompt": visual["prompt"], "strength": visual["strength"]}
+        active = get_active_model()
+        if not active:
+            return {**base, "status": "no_model", "model": None}, None, None
+        model_name = active["name"]
+        base["model"] = model_name
+        if active.get("model_type", "bioclip") == "timm":
+            return {**base, "status": "model_no_text_search"}, None, None
+        candidates = db.query_photo_ids(
+            rules, collection_id=collection_id, folder_id=folder_id,
+        )
+        emb_pairs = db.get_photos_with_embedding(model_name, photo_ids=candidates)
+        if not emb_pairs:
+            return (
+                {**base, "status": "no_embeddings",
+                 "candidates": len(candidates), "indexed": 0},
+                None, None,
+            )
+        cache_key = (model_name, visual["prompt"])
+        query_vec = _text_query_cache.get(cache_key)
+        if query_vec is None:
+            from text_encoder import encode_text
+            try:
+                query_vec = encode_text(
+                    visual["prompt"],
+                    model_str=active["model_str"],
+                    pretrained_str=active.get("weights_path", ""),
+                )
+            except Exception as exc:
+                log.exception("Visual clause text encoding failed: %r", visual["prompt"])
+                return (
+                    {**base, "status": "encoding_failed", "error": str(exc)},
+                    None, None,
+                )
+            if len(_text_query_cache) > 64:
+                _text_query_cache.clear()
+            _text_query_cache[cache_key] = query_vec
+        pids = [pid for pid, _ in emb_pairs]
+        emb_matrix = np.stack(
+            [np.frombuffer(blob, dtype=np.float32) for _, blob in emb_pairs]
+        )
+        sims = emb_matrix @ query_vec
+        threshold = _VISUAL_STRENGTH_THRESHOLDS[visual["strength"]]
+        ordered_ids = []
+        sims_by_pid = {}
+        for i in np.argsort(sims)[::-1]:
+            if sims[i] < threshold:
+                break
+            pid = pids[int(i)]
+            ordered_ids.append(pid)
+            sims_by_pid[pid] = round(float(sims[i]), 4)
+        info = {**base, "status": "ok", "matched": len(ordered_ids),
+                "candidates": len(candidates), "indexed": len(emb_pairs)}
+        return info, ordered_ids, sims_by_pid
+
+    def _apply_visual_to_rules(db, rules, visual, collection_id=None, folder_id=None):
+        """For GET consumers (summary/calendar/values): when the visual
+        clause is healthy, restrict the rules to the matched ids (inlined
+        photo_ids — no bound-parameter cap) so counts describe the same
+        photos the visually-filtered grid shows. Unhealthy → rules
+        unchanged, matching the grid's metadata-only fallback.
+        """
+        if visual is None:
+            return rules
+        base_rules = rules if rules is not None else []
+        _info, ordered_ids, _sims = _resolve_visual(
+            db, base_rules, visual,
+            collection_id=collection_id, folder_id=folder_id,
+        )
+        if ordered_ids is None:
+            return rules
+        rules_list = (
+            [] if rules is None
+            else ([rules] if isinstance(rules, dict) else list(rules))
+        )
+        return rules_list + [{"field": "photo_ids", "value": ordered_ids}]
+
     def _request_location_status_filter():
         value = (request.args.get("location_status") or "").strip().lower()
         if not value:
@@ -5536,6 +5656,51 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ):
             return json_error("folder_id must be an integer", 400)
         rules = _inject_active_visual_model(rules)
+        try:
+            visual = _validate_visual_arg(payload.get("visual"))
+        except ValueError as exc:
+            return json_error(str(exc), 400)
+
+        visual_info = None
+        if visual is not None:
+            try:
+                visual_info, ordered_ids, sims_by_pid = _resolve_visual(
+                    db, rules, visual,
+                    collection_id=collection_id, folder_id=folder_id,
+                )
+            except ValueError as exc:
+                return json_error(str(exc), 400)
+            if ordered_ids is not None:
+                # Healthy visual clause: results are the similarity-ranked
+                # matches; sort is relevance by design while it is active.
+                if payload.get("ids_only"):
+                    return jsonify({"ids": ordered_ids, "total": len(ordered_ids),
+                                    "visual": visual_info})
+                start = (page - 1) * per_page
+                page_ids = ordered_ids[start:start + per_page]
+                photos_map = db.get_photos_by_ids(page_ids)
+                photo_dicts = [
+                    dict(photos_map[pid]) for pid in page_ids if pid in photos_map
+                ]
+                for entry in photo_dicts:
+                    entry["similarity"] = sims_by_pid.get(entry["id"])
+                _attach_location_statuses(db, photo_dicts)
+                _attach_species(db, photo_dicts)
+                _attach_species_representatives(db, photo_dicts)
+                _attach_detections(db, photo_dicts)
+                _attach_edit_recipes(db, photo_dicts)
+                return jsonify(
+                    {
+                        "photos": photo_dicts,
+                        "total": len(ordered_ids),
+                        "page": page,
+                        "per_page": per_page,
+                        "visual": visual_info,
+                    }
+                )
+            # Unhealthy: fall through to metadata-only results with the
+            # status attached so the UI can say why — never silently zero.
+
         if payload.get("ids_only"):
             # Select-all and other bulk flows need the complete matching id
             # set; it must resolve exactly the photos the filtered grid
@@ -5545,7 +5710,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                          folder_id=folder_id)
             except ValueError as exc:
                 return json_error(str(exc), 400)
-            return jsonify({"ids": ids, "total": len(ids)})
+            payload_out = {"ids": ids, "total": len(ids)}
+            if visual_info is not None:
+                payload_out["visual"] = visual_info
+            return jsonify(payload_out)
         try:
             photos = db.query_photos(rules, sort=sort, page=page, per_page=per_page,
                                      collection_id=collection_id, folder_id=folder_id)
@@ -5561,14 +5729,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         _attach_detections(db, photo_dicts)
         _attach_edit_recipes(db, photo_dicts)
 
-        return jsonify(
-            {
-                "photos": photo_dicts,
-                "total": total,
-                "page": page,
-                "per_page": per_page,
-            }
-        )
+        response = {
+            "photos": photo_dicts,
+            "total": total,
+            "page": page,
+            "per_page": per_page,
+        }
+        if visual_info is not None:
+            response["visual"] = visual_info
+        return jsonify(response)
 
     @app.route("/api/filters/fields")
     def api_filter_fields():
@@ -5614,6 +5783,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             limit_raw = 20
         limit = max(1, min(limit_raw, 500))
         rules = _inject_active_visual_model(rules)
+        try:
+            visual = _request_visual_arg()
+            rules = _apply_visual_to_rules(
+                db, rules, visual,
+                collection_id=collection_id, folder_id=folder_id,
+            )
+        except ValueError as exc:
+            return json_error(str(exc), 400)
         try:
             values = db.get_filter_field_values(
                 field, rules=rules, q=q, limit=limit,
@@ -5679,6 +5856,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             flag = _request_flag_filter()
             location_status = _request_location_status_filter()
             rules = _request_rules_arg()
+            visual = _request_visual_arg()
+            rules = _apply_visual_to_rules(db, rules, visual, folder_id=folder_id)
         except ValueError as e:
             return json_error(str(e), 400)
         try:
@@ -5711,6 +5890,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             flag = _request_flag_filter()
             location_status = _request_location_status_filter()
             rules = _request_rules_arg()
+            visual = _request_visual_arg()
+            rules = _apply_visual_to_rules(
+                db, rules, visual,
+                collection_id=collection_id, folder_id=folder_id,
+            )
         except ValueError as e:
             return json_error(str(e), 400)
         try:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -15442,9 +15442,22 @@ class Database:
         if photo_ids is not None:
             if not photo_ids:
                 return []
-            placeholders = ",".join("?" * len(photo_ids))
-            sql += f" AND pe.photo_id IN ({placeholders})"
-            params.extend(photo_ids)
+            # Chunk the id restriction: a broad universal-filter rule tree
+            # passes every photo id in the library here, which would blow
+            # past SQLITE_MAX_VARIABLE_NUMBER (999 on legacy builds) as a
+            # single IN (?,...) clause and fail before scoring runs.
+            results = []
+            for start in range(0, len(photo_ids), 900):
+                chunk = list(photo_ids)[start:start + 900]
+                placeholders = ",".join("?" * len(chunk))
+                rows = self.conn.execute(
+                    sql + f" AND pe.photo_id IN ({placeholders})",
+                    params + chunk,
+                ).fetchall()
+                results.extend(
+                    (row["photo_id"], row["embedding"]) for row in rows
+                )
+            return results
         rows = self.conn.execute(sql, params).fetchall()
         return [(row["photo_id"], row["embedding"]) for row in rows]
 

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -46,6 +46,8 @@
     page: 'browse',
     root: { mode: 'all', rules: [] },
     muted: false,
+    visual: null,       // {prompt, strength} — the CLIP clause, outside the tree
+    visualInfo: null,   // last server-reported visual status/coverage
     scopeLabel: '',
     scopeLocked: true,
     fields: null,          // registry from /api/filters/fields (key -> spec)
@@ -229,6 +231,14 @@
 
   function chipEntries() {
     const entries = [];
+    if (state.visual) {
+      const status = state.visualInfo && state.visualInfo.status;
+      entries.push({
+        visual: true,
+        error: Boolean(status && status !== 'ok'),
+        label: `✦ Visually similar · “${state.visual.prompt}”`,
+      });
+    }
     state.root.rules.forEach((node) => {
       if (isGroup(node) && node._qs) {
         entries.push({ node, label: `Search: “${node._qs_text}”`, qs: true });
@@ -253,13 +263,13 @@
   }
 
   function hasUserFilters() {
-    return state.root.rules.length > 0;
+    return state.root.rules.length > 0 || Boolean(state.visual);
   }
 
   // ---- mutation + change plumbing --------------------------------------
 
   function snapshot() {
-    snapshots.push(clone({ root: state.root, muted: state.muted }));
+    snapshots.push(clone({ root: state.root, muted: state.muted, visual: state.visual }));
     if (snapshots.length > 20) snapshots.shift();
   }
 
@@ -293,6 +303,7 @@
     if (!prev) return;
     state.root = prev.root;
     state.muted = prev.muted;
+    state.visual = prev.visual || null;
     render();
     schedulePersist();
     if (state.onChange) state.onChange({ reason: null });
@@ -315,7 +326,7 @@
     fetchJson('/api/photos/query', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rules, per_page: 1 }),
+      body: JSON.stringify({ rules, per_page: 1, visual: state.visual || undefined }),
     }).then((data) => {
       if (epoch !== wouldMatchEpoch || !state.muted) return;
       state.wouldMatch = data.total;
@@ -338,7 +349,9 @@
       if (ws.id !== state.workspaceId) return;
       const uiState = parseUiState(ws.ui_state);
       if (!uiState.universal_filters) uiState.universal_filters = {};
-      uiState.universal_filters[state.page] = { root: state.root, muted: state.muted };
+      uiState.universal_filters[state.page] = {
+        root: state.root, muted: state.muted, visual: state.visual,
+      };
       // The server JSON-encodes ui_state itself — send the object, or the
       // stored value ends up double-encoded and unreadable on restore.
       return fetch(`/api/workspaces/${state.workspaceId}`, {
@@ -368,6 +381,12 @@
       if (saved && saved.root && Array.isArray(saved.root.rules)) {
         state.root = saved.root;
         state.muted = Boolean(saved.muted);
+        state.visual = (
+          saved.visual && typeof saved.visual.prompt === 'string' && saved.visual.prompt
+        ) ? { prompt: saved.visual.prompt,
+              strength: ['broad', 'balanced', 'strict'].includes(saved.visual.strength)
+                ? saved.visual.strength : 'balanced' }
+          : null;
         return true;
       }
       return false;
@@ -455,11 +474,46 @@
     }, cleared ? { reason: 'quickSearchCleared' } : undefined);
   }
 
+  function applyVisualSearch(text) {
+    const value = String(text || '').trim();
+    mutate(() => {
+      // The visual clause and the quick-search clause are alternatives for
+      // the top bar: setting one replaces the other (prototype behavior).
+      state.root.rules = state.root.rules.filter((n) => !(isGroup(n) && n._qs));
+      state.visual = value
+        ? { prompt: value, strength: (state.visual && state.visual.strength) || 'balanced' }
+        : null;
+      if (!value) state.visualInfo = null;
+    });
+  }
+
+  function clearVisual() {
+    if (!state.visual) return;
+    mutate(() => { state.visual = null; state.visualInfo = null; });
+  }
+
+  function hideSearchSuggest() {
+    const drop = $('.vf-search-suggest');
+    if (drop) drop.hidden = true;
+  }
+
+  function showSearchSuggest() {
+    const drop = $('.vf-search-suggest');
+    const input = $('.vf-search input');
+    const q = input.value.trim();
+    if (!drop) return;
+    if (!q) { drop.hidden = true; return; }
+    drop.innerHTML = `
+      <button type="button" data-search-kind="text"><span>⌕</span><span>Search text for “${esc(q)}”</span><em>Enter</em></button>
+      <button type="button" data-search-kind="visual" class="vf-suggest-visual"><span>✦</span><span>Visually similar to “${esc(q)}”</span><em></em></button>`;
+    drop.hidden = false;
+  }
+
   function syncQuickSearchInput() {
     const input = $('.vf-search input');
     if (!input || document.activeElement === input) return;
     const group = quickSearchGroup();
-    input.value = group ? group._qs_text : '';
+    input.value = group ? group._qs_text : (state.visual ? state.visual.prompt : '');
   }
 
   // ---- rendering --------------------------------------------------------
@@ -482,7 +536,35 @@
     badge.hidden = count === 0;
     $('.vf-clear').hidden = !hasUserFilters();
     $('.vf-mute').hidden = !hasUserFilters() && !state.muted;
+    renderVisualNote();
     requestAnimationFrame(updateChipOverflow);
+  }
+
+  const VISUAL_STATUS_MESSAGES = {
+    no_model: 'No active model — visual search unavailable',
+    model_no_text_search: 'The active model does not support text search',
+    no_embeddings: 'No visual index for these photos',
+    encoding_failed: 'Visual search failed',
+  };
+
+  function renderVisualNote() {
+    const note = $('.vf-visual-note');
+    if (!note) return;
+    const info = state.visualInfo;
+    if (!state.visual || state.muted || !info) { note.hidden = true; return; }
+    if (info.status !== 'ok') {
+      note.textContent = `✦ ${VISUAL_STATUS_MESSAGES[info.status] || info.status} — metadata filters shown only`;
+      note.classList.add('error');
+      note.hidden = false;
+      return;
+    }
+    note.classList.remove('error');
+    if (info.indexed != null && info.candidates != null && info.indexed < info.candidates) {
+      note.textContent = `✦ Visual index covers ${info.indexed} of ${info.candidates} photos in scope`;
+      note.hidden = false;
+    } else {
+      note.hidden = true;
+    }
   }
 
   function renderMuteState() {
@@ -513,7 +595,7 @@
     const list = $('.vf-chips');
     $('.vf-scope-chip span').textContent = state.scopeLabel;
     list.innerHTML = chipEntries().map((entry, idx) =>
-      `<button class="vf-chip" data-chip="${idx}" type="button" title="Edit filters">
+      `<button class="vf-chip${entry.visual ? ' visual' : ''}${entry.error ? ' error' : ''}" data-chip="${idx}" type="button" title="Edit filters">
         <span>${esc(entry.label)}</span>
         <span class="vf-chip-x" data-chip-x="${idx}" role="button" aria-label="Remove ${esc(entry.label)}">×</span>
       </button>`).join('');
@@ -597,9 +679,17 @@
           suggest: Boolean(active.dataset.suggest),
         }
       : null;
-    tree.innerHTML = state.root.rules.length
+    const visualRow = state.visual ? `<div class="vf-rule-row vf-visual-row">
+      <span class="vf-visual-label">✦ Visually similar to “${esc(state.visual.prompt)}”</span>
+      <div class="vf-segmented vf-visual-strength">
+        ${['broad', 'balanced', 'strict'].map((s) =>
+          `<button type="button" data-action="visual-strength" data-strength="${s}" class="${state.visual.strength === s ? 'active' : ''}">${s}</button>`).join('')}
+      </div>
+      <button class="vf-remove" data-action="visual-remove" type="button" aria-label="Remove visual search">×</button>
+    </div>` : '';
+    tree.innerHTML = visualRow + (state.root.rules.length
       ? state.root.rules.map((node, i) => renderNode(node, String(i), 0)).join('')
-      : '<div class="vf-empty-rules">No rules yet. Use a quick filter or add any metadata field.</div>';
+      : (visualRow ? '' : '<div class="vf-empty-rules">No rules yet. Use a quick filter or add any metadata field.</div>'));
     if (restore) {
       const el = tree.querySelector(`[data-action="${restore.action}"][data-path="${restore.path}"]`);
       if (el) {
@@ -707,6 +797,9 @@
     const params = new URLSearchParams({ field: node.field, limit: '8' });
     if (q) params.set('q', q);
     params.set('rules', JSON.stringify(rules));
+    // A healthy visual clause narrows the count set server-side, so facet
+    // counts keep describing the visually-filtered grid.
+    if (state.visual && !state.muted) params.set('visual', JSON.stringify(state.visual));
     // Page scope (folder / dashboard-scoped collection) is passed as
     // separate params to /api/photos/query, so the visible grid is
     // restricted to that scope. Mirror it here or the counts advertised
@@ -814,14 +907,35 @@
   function installEvents() {
     const searchInput = $('.vf-search input');
     searchInput.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') { e.preventDefault(); applyQuickSearch(searchInput.value); }
-      else if (e.key === 'Escape') { searchInput.blur(); }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        hideSearchSuggest();
+        applyQuickSearch(searchInput.value);
+      } else if (e.key === 'Escape') { hideSearchSuggest(); searchInput.blur(); }
     });
+    searchInput.addEventListener('input', showSearchSuggest);
+    searchInput.addEventListener('focus', showSearchSuggest);
     searchInput.addEventListener('blur', () => {
-      // Blur with a cleared box removes the quick-search clause.
+      setTimeout(hideSearchSuggest, 150);
+      // Blur with a cleared box removes the quick-search clause (a visual
+      // clause set from this box clears the same way).
       if (!searchInput.value.trim() && quickSearchGroup()) applyQuickSearch('');
+      else if (!searchInput.value.trim() && state.visual) applyVisualSearch('');
       else syncQuickSearchInput();
     });
+    const searchSuggest = $('.vf-search-suggest');
+    if (searchSuggest) {
+      // mousedown beats the input's blur, so the pick is never lost.
+      searchSuggest.addEventListener('mousedown', (e) => {
+        const btn = e.target.closest('[data-search-kind]');
+        if (!btn) return;
+        e.preventDefault();
+        const value = searchInput.value;
+        hideSearchSuggest();
+        if (btn.dataset.searchKind === 'visual') applyVisualSearch(value);
+        else applyQuickSearch(value);
+      });
+    }
 
     $('.vf-filters-btn').addEventListener('click', () => openPopover());
     $('.vf-popover-close').addEventListener('click', () => openPopover(false));
@@ -829,11 +943,21 @@
     $('.vf-overflow').addEventListener('click', () => openPopover(true));
     $('.vf-mute').addEventListener('click', toggleMute);
     $('.vf-clear').addEventListener('click', () => {
-      mutate(() => { state.root = { mode: 'all', rules: [] }; state.muted = false; });
+      mutate(() => {
+        state.root = { mode: 'all', rules: [] };
+        state.muted = false;
+        state.visual = null;
+        state.visualInfo = null;
+      });
       toast('Filters cleared', true);
     });
     $('.vf-clear-rules').addEventListener('click', () => {
-      mutate(() => { state.root = { mode: 'all', rules: [] }; state.muted = false; });
+      mutate(() => {
+        state.root = { mode: 'all', rules: [] };
+        state.muted = false;
+        state.visual = null;
+        state.visualInfo = null;
+      });
       toast('Filters cleared', true);
     });
     $('.vf-toast button').addEventListener('click', () => { undo(); $('.vf-toast').hidden = true; });
@@ -845,7 +969,10 @@
         const entry = chipEntries()[Number(x.dataset.chipX)];
         if (entry) {
           mutate(() => {
-            if (isGroup(entry.node)) {
+            if (entry.visual) {
+              state.visual = null;
+              state.visualInfo = null;
+            } else if (isGroup(entry.node)) {
               state.root.rules = state.root.rules.filter((n) => n !== entry.node);
             } else removeByReference(state.root, entry.node);
           });
@@ -953,6 +1080,15 @@
       if (!target) return;
       const action = target.dataset.action;
       const path = target.dataset.path;
+      if (action === 'visual-strength') {
+        mutate(() => { if (state.visual) state.visual.strength = target.dataset.strength; });
+        return;
+      }
+      if (action === 'visual-remove') {
+        clearVisual();
+        toast('Visual search removed', true);
+        return;
+      }
       if (action === 'multi') {
         mutate(() => {
           const node = getNodeAtPath(path);
@@ -1048,6 +1184,15 @@
       });
     },
     getRules() { return effectiveRules(); },
+    getVisual() {
+      // Pause disables the visual clause with the rest of the user filters.
+      return (state.muted || !state.visual) ? null : clone(state.visual);
+    },
+    setVisualInfo(info) {
+      state.visualInfo = info || null;
+      if (state.ready) renderLight();
+    },
+    visualSearch(text) { applyVisualSearch(text); },
     getUserRules() { return userRules(); },
     addRule(field, op, value) {
       mutate(() => {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -471,6 +471,14 @@
     mutate(() => {
       state.root.rules = state.root.rules.filter((n) => !(isGroup(n) && n._qs));
       if (value) state.root.rules.unshift(buildQuickSearchGroup(value));
+      // The visual clause and the quick-search clause are alternatives for
+      // the top bar: setting one replaces the other. Without this, a
+      // text search would compose with a still-active visual clause
+      // (visual ∩ text) instead of replacing it.
+      if (value) {
+        state.visual = null;
+        state.visualInfo = null;
+      }
     }, cleared ? { reason: 'quickSearchCleared' } : undefined);
   }
 
@@ -1240,6 +1248,8 @@
       if (silent) {
         state.root = { mode: 'all', rules: [] };
         state.muted = false;
+        state.visual = null;
+        state.visualInfo = null;
         schedulePersist();
         if (state.ready) render();
         return;
@@ -1247,6 +1257,8 @@
       mutate(() => {
         state.root = { mode: 'all', rules: [] };
         state.muted = false;
+        state.visual = null;
+        state.visualInfo = null;
       });
     },
     isReady() { return !!state.ready && !!state.fields; },

--- a/vireo/templates/_filterbar.html
+++ b/vireo/templates/_filterbar.html
@@ -9,6 +9,7 @@
       <input type="search" autocomplete="off" spellcheck="false"
              placeholder="Search photos…" aria-label="Search photos">
       <kbd>⌘F</kbd>
+      <div class="vf-search-suggest" role="listbox" hidden></div>
     </div>
     <button class="vf-filters-btn" type="button" aria-expanded="false">
       <span aria-hidden="true">≡</span> Filters <span class="vf-count" hidden>0</span>
@@ -27,6 +28,7 @@
   </div>
 
   <div class="vf-paused-note" hidden></div>
+  <div class="vf-visual-note" hidden></div>
 
   <div class="vf-popover" role="dialog" aria-label="Edit photo filters" hidden>
     <div class="vf-popover-header">
@@ -133,6 +135,19 @@
 .vf-chip-x:hover { background: var(--bg-tertiary); color: var(--text-primary); }
 .vf-overflow { cursor: pointer; flex: none; }
 .vf-paused-note { margin-top: 6px; padding: 5px 9px; border-radius: 6px; background: color-mix(in srgb, var(--warning) 12%, var(--bg-tertiary)); color: var(--warning); font-size: 12px; }
+.vf-visual-note { margin-top: 6px; padding: 5px 9px; border-radius: 6px; background: color-mix(in srgb, #a782ff 12%, var(--bg-tertiary)); color: color-mix(in srgb, #a782ff 70%, var(--text-primary)); font-size: 12px; }
+.vf-visual-note.error { background: color-mix(in srgb, var(--danger) 12%, var(--bg-tertiary)); color: var(--danger); }
+.vf-chip.visual { border-color: color-mix(in srgb, #a782ff 65%, var(--border-secondary)); background: color-mix(in srgb, #a782ff 10%, var(--bg-primary)); }
+.vf-chip.error { border-color: var(--danger); color: var(--danger); }
+.vf-search-suggest { position: absolute; top: 38px; left: 0; right: 0; z-index: 5010; overflow: hidden; padding: 4px; border: 1px solid var(--border-secondary); border-radius: 8px; background: var(--bg-panel); box-shadow: 0 12px 32px rgba(0,0,0,.3); }
+.vf-search-suggest button { width: 100%; display: flex; align-items: center; gap: 9px; padding: 7px 9px; border: 0; border-radius: 6px; background: transparent; color: var(--text-secondary); text-align: left; cursor: pointer; font-size: 12px; }
+.vf-search-suggest button:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.vf-search-suggest button > span:first-child { width: 20px; text-align: center; color: var(--accent); }
+.vf-search-suggest .vf-suggest-visual > span:first-child { color: #a782ff; }
+.vf-search-suggest em { margin-left: auto; color: var(--text-faint); font-size: 10px; font-style: normal; }
+.vf-visual-row { grid-template-columns: 1fr auto 25px; }
+.vf-visual-label { color: color-mix(in srgb, #a782ff 70%, var(--text-primary)); font-size: 12px; padding-left: 2px; }
+.vf-visual-strength button { text-transform: capitalize; }
 .vf-popover { position: absolute; top: calc(100% + 8px); left: 0; z-index: 5000; width: min(680px, 100%); max-height: min(72vh, 640px); overflow-y: auto; border: 1px solid var(--border-secondary); border-radius: 11px; background: var(--bg-panel); box-shadow: 0 18px 50px rgba(0,0,0,.34); }
 .vf-popover-header { position: sticky; top: 0; z-index: 2; display: flex; justify-content: space-between; align-items: flex-start; padding: 13px 16px 10px; background: var(--bg-panel); border-bottom: 1px solid var(--border-primary); }
 .vf-popover-header h2 { margin: 0; font-size: 15px; color: var(--text-primary); }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1531,15 +1531,6 @@ body.sidebar-resizing {
     <div class="filter-bar browse-filter-shell">
       {% include '_filterbar.html' %}
       <div class="browse-view-controls">
-        <input type="text" id="clipSearchInput" placeholder="CLIP search: describe what you see..."
-               onkeydown="if(event.key==='Enter')runClipSearch()">
-        <button id="clipSearchBtn" onclick="runClipSearch()"
-                style="background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:4px;padding:5px 12px;font-size:12px;cursor:pointer;white-space:nowrap;">
-          Search
-        </button>
-        <button id="clipClearBtn" onclick="clearClipSearch()" style="display:none;background:none;color:var(--text-faint);border:none;padding:4px 8px;font-size:12px;cursor:pointer;">
-          Clear
-        </button>
         <select id="sortSelect" onchange="applyFilters()" title="Sort order">
           <option value="date">Capture date (oldest)</option>
           <option value="date_desc">Capture date (newest)</option>
@@ -2006,8 +1997,7 @@ var timelineMode = false;
 var calendarYear = new Date().getFullYear();
 var selectedDay = null;
 var calendarData = null;
-var clipSearchActive = false;
-var clipSearchSeq = 0;
+// CLIP search is now the filter bar's visual clause (VireoFilter.getVisual).
 
 var bestBatchData = null;
 var keywordAutocompleteCache = null;
@@ -2428,7 +2418,6 @@ function hasActiveBrowseFilter() {
     activeFolderId ||
     activeKeyword ||
     activeCollectionId ||
-    clipSearchActive ||
     (window.VireoFilter && VireoFilter.hasFilters())
   );
 }
@@ -2670,7 +2659,7 @@ var SKEL_POOL = 300;
 function updateGridTail() {
   var grid = document.getElementById('grid');
   var tail = document.getElementById('gridTail');
-  var remaining = (allLoaded || clipSearchActive) ? 0 : totalPhotos - photos.length;
+  var remaining = allLoaded ? 0 : totalPhotos - photos.length;
   var cards = grid.getElementsByClassName('grid-card');
   var lastCard = cards.length ? cards[cards.length - 1] : null;
   if (remaining <= 0 || !lastCard) {
@@ -3303,17 +3292,6 @@ async function filterByCollection(id, options) {
   activeKeyword = null;
   activeCollectionId = id;
   dashboardCollectionScope = false;
-  if (clipSearchActive && getClipSearchQuery()) {
-    selectedPhotos.clear();
-    selectedPhotoId = null;
-    selectedIndex = -1;
-    closeDetail();
-    refreshCardSelectionVisuals();
-    updateBatchBar();
-    document.getElementById('gridContainer').scrollTop = 0;
-    await runClipSearch();
-    return;
-  }
   photos = [];
   currentPage = 1;
   allLoaded = false;
@@ -3919,11 +3897,6 @@ async function resetAndLoad(options) {
   var preserveAnchor = !!(options && options.preserveAnchor);
   var anchor = preserveAnchor ? captureSelectedPhotoAnchor() : null;
   var restoreEpoch = anchor ? ++anchorRestoreEpoch : null;
-  if (clipSearchActive) {
-    clipSearchActive = false;
-    document.getElementById('clipSearchInput').value = '';
-    document.getElementById('clipClearBtn').style.display = 'none';
-  }
   photos = [];
   currentPage = 1;
   allLoaded = false;
@@ -4054,6 +4027,8 @@ async function loadPhotos(options) {
       page: reqPage,
       per_page: reqPerPage,
     };
+    var loadVisual = window.VireoFilter && VireoFilter.getVisual ? VireoFilter.getVisual() : null;
+    if (loadVisual) body.visual = loadVisual;
     if (activeFolderId) body.folder_id = activeFolderId;
     if (activeCollectionId && dashboardCollectionScope) body.collection_id = activeCollectionId;
     fetchOptions = {
@@ -4068,6 +4043,12 @@ async function loadPhotos(options) {
     if (epoch !== loadEpoch) return;  // grid was reset mid-flight; drop stale response
     totalPhotos = data.total;
     if (window.VireoFilter && VireoFilter.setResultTotal) VireoFilter.setResultTotal(totalPhotos);
+    if (window.VireoFilter && VireoFilter.setVisualInfo) {
+      VireoFilter.setVisualInfo(data.visual || null);
+    }
+    (data.photos || []).forEach(function(p) {
+      if (p.similarity != null) p._similarity = p.similarity;
+    });
     var firstNewIdx = photos.length;
 
     if (data.photos.length === 0) {
@@ -4155,6 +4136,7 @@ async function loadCalendarData() {
   // filters (the visible grid still applies the date rule).
   var rules = getBrowseRulesWithoutTimestamp();
   if (rules) params.set('rules', JSON.stringify(rules));
+  appendVisualScopeParams(params);
 
   calendarData = await safeFetch('/api/photos/calendar?' + params.toString());
   renderCalendar();
@@ -4359,120 +4341,19 @@ function toggleDetectionBoxes() {
   renderGrid();
 }
 
-function getClipSearchQuery() {
-  var input = document.getElementById('clipSearchInput');
-  return input ? input.value.trim() : '';
-}
-
-function appendClipSearchScopeParams(params) {
-  if (activeCollectionId) {
-    params.set('collection_id', activeCollectionId);
-    // Dashboard-scoped collection Browse composes the collection with the
-    // active rules/folder in the grid — CLIP/select-all search must match
-    // that scope. Backend intersects collection_id with rules/folder_id.
-    // Legacy collection view (activeCollectionId && !dashboardCollectionScope)
-    // clears activeCollectionId as soon as a filter is applied (see
-    // VireoFilter.init.onChange), so composing here is a no-op in that path.
-    if (!dashboardCollectionScope) return;
-  }
-  if (activeFolderId) params.set('folder_id', activeFolderId);
-  var rules = getBrowseRules();
-  if (rules) params.set('rules', JSON.stringify(rules));
+function appendVisualScopeParams(params) {
+  // Summary/calendar/typeahead counts must describe the same photos the
+  // visually-filtered grid shows; the backend narrows to the matched set
+  // when the clause is healthy and leaves rules untouched otherwise.
+  var visual = window.VireoFilter && VireoFilter.getVisual ? VireoFilter.getVisual() : null;
+  if (visual) params.set('visual', JSON.stringify(visual));
 }
 
 function reloadBrowseResults(options) {
-  if (clipSearchActive && getClipSearchQuery()) {
-    runClipSearch();
-  } else {
-    resetAndLoad(options);
-  }
-}
-
-async function runClipSearch() {
-  var query = getClipSearchQuery();
-  if (!query) {
-    if (clipSearchActive) clearClipSearch();
-    return;
-  }
-
-  var searchSeq = ++clipSearchSeq;
-  loadEpoch++;
-  selectAllRequestSeq++;
-  var epoch = loadEpoch;
-  loading = false;
-  photos = [];
-  allLoaded = true;
-  selectedPhotos.clear();
-  selectedPhotoId = null;
-  selectedIndex = -1;
-  closeDetail();
-  document.getElementById('grid').innerHTML = '';
-  document.getElementById('loadingState').style.display = 'block';
-  document.getElementById('loadingState').textContent = 'Searching...';
-  clipSearchActive = true;
-  document.getElementById('clipClearBtn').style.display = '';
-  var keepLoadingMessage = false;
-
-  try {
-    var params = new URLSearchParams();
-    params.set('q', query);
-    params.set('limit', 100);
-    params.set('threshold', 0.15);
-    appendClipSearchScopeParams(params);
-    var data = await safeFetch('/api/photos/search?' + params.toString());
-    if (searchSeq !== clipSearchSeq || epoch !== loadEpoch) return;
-
-    if (data.reason) {
-      var msg = {
-        'model_no_text_search': 'Text search is not supported by ' + (data.model_used || 'this model') + '. Switch to a BioCLIP model in Settings.',
-        'no_embeddings': 'No search index found for ' + (data.model_used || 'this model') + '. Run classification first to enable text search.',
-        'no_model': 'No model available. Download one in Settings.'
-      }[data.reason] || 'Search returned no results.';
-      document.getElementById('loadingState').textContent = msg;
-      keepLoadingMessage = true;
-      return;
-    }
-
-    photos = data.results.map(function(r) {
-      var p = r.photo;
-      p._similarity = r.similarity;
-      return p;
-    });
-    totalPhotos = data.total_matches;
-    allLoaded = true;
-
-    renderGrid();
-    var refreshIds = photos.map(function(p) { return p.id; });
-    loadInatStatus(refreshIds).then(function() {
-      if (searchSeq === clipSearchSeq && epoch === loadEpoch) refreshGridCards(refreshIds);
-    });
-    fetchColorLabels(refreshIds).then(function() {
-      if (searchSeq === clipSearchSeq && epoch === loadEpoch) refreshGridCards(refreshIds);
-    });
-    var summary = document.getElementById('filterSummary');
-    summary.textContent = data.total_matches + ' matches' + (data.model_used ? ' (' + data.model_used + ')' : '');
-  } catch(e) {
-    if (searchSeq !== clipSearchSeq || epoch !== loadEpoch) return;
-    document.getElementById('loadingState').textContent = 'Search failed: ' + (e.message || e);
-    keepLoadingMessage = true;
-    return;
-  } finally {
-    if (searchSeq === clipSearchSeq && epoch === loadEpoch && !keepLoadingMessage) {
-      document.getElementById('loadingState').style.display = 'none';
-    }
-  }
-}
-
-function clearClipSearch() {
-  clipSearchSeq++;
-  clipSearchActive = false;
-  document.getElementById('clipSearchInput').value = '';
-  document.getElementById('clipClearBtn').style.display = 'none';
-  resetAndLoad();
+  resetAndLoad(options);
 }
 
 function updateScrollPosition() {
-  if (clipSearchActive) return;
   var el = document.getElementById('filterSummary');
   if (photos.length === 0) {
     el.textContent = totalPhotos + ' photos';
@@ -4656,7 +4537,7 @@ function rearmInfiniteScrollObserver() {
    successful page load until the viewport is covered by real cards. */
 function ensureViewportHydrated() {
   if (infiniteScrollObserverDisconnected || !infiniteScrollObserverIsNative) return;
-  if (loading || allLoaded || clipSearchActive || anchorScanDepth > 0) return;
+  if (loading || allLoaded || anchorScanDepth > 0) return;
   if (photos.length === 0) return;
   var tail = document.getElementById('gridTail');
   if (!tail || !tail.firstElementChild) return;
@@ -4774,28 +4655,6 @@ async function selectAllMatchingPhotos() {
   var requestSeq = ++selectAllRequestSeq;
   var requestEpoch = loadEpoch;
 
-  if (clipSearchActive) {
-    var query = document.getElementById('clipSearchInput').value.trim();
-    if (!query) return;
-    var searchParams = new URLSearchParams();
-    searchParams.set('q', query);
-    searchParams.set('threshold', 0.15);
-    searchParams.set('ids_only', '1');
-    appendClipSearchScopeParams(searchParams);
-    showToast('Selecting all matching search results...');
-    try {
-      var searchData = await safeFetch('/api/photos/search?' + searchParams.toString(), {}, { toast: false });
-      if (requestSeq !== selectAllRequestSeq || requestEpoch !== loadEpoch) return;
-      selectedPhotos.clear();
-      (searchData.photo_ids || []).forEach(function(id) { selectedPhotos.add(id); });
-      renderGrid();
-      updateBatchBar();
-      showToast('Selected ' + selectedPhotos.size.toLocaleString() + ' search result' + (selectedPhotos.size === 1 ? '' : 's'));
-    } catch(e) {
-      showToast('Could not select all search results: ' + (e.message || e), 'error');
-    }
-    return;
-  }
 
   var url;
   var fetchOpts = {};
@@ -4808,6 +4667,8 @@ async function selectAllMatchingPhotos() {
       sort: document.getElementById('sortSelect').value,
       ids_only: true,
     };
+    var idsVisual = window.VireoFilter && VireoFilter.getVisual ? VireoFilter.getVisual() : null;
+    if (idsVisual) idsBody.visual = idsVisual;
     if (activeFolderId) idsBody.folder_id = activeFolderId;
     if (activeCollectionId && dashboardCollectionScope) idsBody.collection_id = activeCollectionId;
     fetchOpts = {
@@ -6599,6 +6460,7 @@ async function loadSummary() {
   if (activeFolderId) params.set('folder_id', activeFolderId);
   var rules = getBrowseRules();
   if (rules) params.set('rules', JSON.stringify(rules));
+  appendVisualScopeParams(params);
   if (activeCollectionId) params.set('collection_id', activeCollectionId);
 
   try {

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -9984,3 +9984,161 @@ def test_api_photos_calendar_accepts_rules(app_and_db):
     # bird3.jpg (rating 5, 2024-06-10) is the only match in 2024
     assert resp.get_json()["days"] == {"2024-06-10": 1}
     assert client.get('/api/photos/calendar?rules=notjson').status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Universal filter visual clause (Phase 3).
+# ---------------------------------------------------------------------------
+
+
+def _stub_clip(monkeypatch, model_name="test-clip", model_type="bioclip"):
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "name": model_name,
+        "model_type": model_type,
+        "model_str": "fake",
+        "weights_path": "",
+    } if model_name else None)
+    monkeypatch.setitem(
+        sys.modules,
+        "text_encoder",
+        types.SimpleNamespace(
+            encode_text=lambda *_args, **_kwargs: np.array([1.0, 0.0], dtype=np.float32)
+        ),
+    )
+
+
+def _seed_embeddings(db, model_name="test-clip"):
+    photos = {p["filename"]: p["id"] for p in db.get_photos(sort="name")}
+    for name, vec in [
+        ("bird1.jpg", [0.95, 0.0]),
+        ("bird2.jpg", [0.8, 0.0]),
+        ("bird3.jpg", [0.05, 0.0]),
+    ]:
+        db.upsert_photo_embedding(
+            photos[name], model_name, np.array(vec, dtype=np.float32).tobytes()
+        )
+    return photos
+
+
+def test_api_photos_query_visual_ranks_by_similarity(app_and_db, monkeypatch):
+    app, db = app_and_db
+    photos = _seed_embeddings(db)
+    _stub_clip(monkeypatch)
+    client = app.test_client()
+    resp = client.post('/api/photos/query', json={
+        "rules": [],
+        "visual": {"prompt": "a bird", "strength": "balanced"},
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["visual"]["status"] == "ok"
+    assert data["visual"]["matched"] == 2
+    assert data["visual"]["indexed"] == 3
+    assert [p["filename"] for p in data["photos"]] == ["bird1.jpg", "bird2.jpg"]
+    assert data["photos"][0]["similarity"] == 0.95
+    assert data["total"] == 2
+
+    # Metadata rules constrain the candidate set before scoring.
+    resp = client.post('/api/photos/query', json={
+        "rules": [{"field": "filename", "op": "is", "value": "bird2.jpg"}],
+        "visual": {"prompt": "a bird", "strength": "balanced"},
+    })
+    data = resp.get_json()
+    assert [p["filename"] for p in data["photos"]] == ["bird2.jpg"]
+
+    # Strength changes the threshold: strict drops bird2 (0.8 >= 0.22 stays;
+    # broad keeps everything above 0.10).
+    resp = client.post('/api/photos/query', json={
+        "rules": [],
+        "visual": {"prompt": "a bird", "strength": "broad"},
+    })
+    assert resp.get_json()["visual"]["matched"] == 2
+
+    # ids_only returns the ranked id set.
+    resp = client.post('/api/photos/query', json={
+        "rules": [], "ids_only": True,
+        "visual": {"prompt": "a bird", "strength": "balanced"},
+    })
+    data = resp.get_json()
+    assert data["ids"] == [photos["bird1.jpg"], photos["bird2.jpg"]]
+
+
+def test_api_photos_query_visual_error_states(app_and_db, monkeypatch):
+    app, db = app_and_db
+    client = app.test_client()
+
+    # No active model: metadata rules still apply, status is surfaced.
+    _stub_clip(monkeypatch, model_name=None)
+    resp = client.post('/api/photos/query', json={
+        "rules": [{"field": "rating", "op": ">=", "value": 4}],
+        "visual": {"prompt": "a bird"},
+    })
+    data = resp.get_json()
+    assert data["visual"]["status"] == "no_model"
+    assert data["total"] == 1  # metadata-only fallback, not zero
+
+    # timm models have no text tower.
+    _stub_clip(monkeypatch, model_type="timm")
+    resp = client.post('/api/photos/query', json={
+        "rules": [], "visual": {"prompt": "a bird"},
+    })
+    assert resp.get_json()["visual"]["status"] == "model_no_text_search"
+
+    # No embeddings stored for the active model.
+    _stub_clip(monkeypatch)
+    resp = client.post('/api/photos/query', json={
+        "rules": [], "visual": {"prompt": "a bird"},
+    })
+    data = resp.get_json()
+    assert data["visual"]["status"] == "no_embeddings"
+    assert data["total"] == 3
+
+    # Malformed clauses 400.
+    assert client.post('/api/photos/query', json={
+        "rules": [], "visual": {"prompt": "   "},
+    }).status_code == 400
+    assert client.post('/api/photos/query', json={
+        "rules": [], "visual": {"prompt": "x", "strength": "extreme"},
+    }).status_code == 400
+
+
+def test_api_summary_and_values_respect_visual(app_and_db, monkeypatch):
+    """Facet counts and the summary must describe the visually-filtered set."""
+    import json as _json
+    app, db = app_and_db
+    _seed_embeddings(db)
+    _stub_clip(monkeypatch)
+    photos = {p["filename"]: p["id"] for p in db.get_photos(sort="name")}
+    db.conn.execute("UPDATE photos SET camera_model='Sony A1' WHERE id IN (?, ?)",
+                    (photos["bird1.jpg"], photos["bird3.jpg"]))
+    db.conn.commit()
+
+    client = app.test_client()
+    visual = _json.dumps({"prompt": "a bird", "strength": "balanced"})
+    resp = client.get(f'/api/browse/summary?visual={visual}')
+    assert resp.status_code == 200
+    assert resp.get_json()["filtered_total"] == 2  # bird1 + bird2 only
+
+    # bird3 (Sony, below threshold) must not appear in facet counts.
+    resp = client.get(f'/api/filters/values?field=camera_model&visual={visual}')
+    assert resp.get_json()["values"] == [{"value": "Sony A1", "count": 1}]
+
+
+def test_embedding_fetch_chunks_over_999_ids(app_and_db):
+    """A broad rule tree passes every photo id as the candidate set; the
+    embedding fetch must chunk below SQLITE_MAX_VARIABLE_NUMBER."""
+    _, db = app_and_db
+    fid = db.get_photos()[0]["folder_id"]
+    ids = []
+    rows = []
+    for i in range(1200):
+        pid = db.add_photo(folder_id=fid, filename=f"bulk{i}.jpg", extension=".jpg",
+                           file_size=10, file_mtime=1.0)
+        ids.append(pid)
+        rows.append(pid)
+    vec = np.array([0.5, 0.5], dtype=np.float32).tobytes()
+    for pid in rows:
+        db.upsert_photo_embedding(pid, "test-clip", vec)
+    pairs = db.get_photos_with_embedding("test-clip", photo_ids=ids)
+    assert len(pairs) == 1200

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -10125,6 +10125,35 @@ def test_api_summary_and_values_respect_visual(app_and_db, monkeypatch):
     assert resp.get_json()["values"] == [{"value": "Sony A1", "count": 1}]
 
 
+def test_api_calendar_scopes_visual_to_collection(app_and_db, monkeypatch):
+    """Calendar's visual clause must resolve within the collection scope.
+
+    If the collection has no active-model embeddings but the wider
+    workspace does, the clause must fail 'no_embeddings' and fall back
+    to metadata-only within the collection — matching the grid — rather
+    than injecting outside-collection matches that get intersected away.
+    """
+    app, db = app_and_db
+    photos = {p["filename"]: p["id"] for p in db.get_photos(sort="name")}
+    for name, vec in [("bird1.jpg", [0.95, 0.0]), ("bird2.jpg", [0.8, 0.0])]:
+        db.upsert_photo_embedding(
+            photos[name], "test-clip", np.array(vec, dtype=np.float32).tobytes()
+        )
+    # bird3 (the only photo in the collection) has no embedding.
+    collection_id = db.add_collection(
+        "Only bird3",
+        json.dumps([{"field": "photo_ids", "value": [photos["bird3.jpg"]]}]),
+    )
+    _stub_clip(monkeypatch)
+    client = app.test_client()
+    visual = json.dumps({"prompt": "a bird", "strength": "balanced"})
+    resp = client.get(
+        f"/api/photos/calendar?year=2024&collection_id={collection_id}&visual={visual}"
+    )
+    assert resp.status_code == 200
+    assert list(resp.get_json()["days"].keys()) == ["2024-06-10"]
+
+
 def test_embedding_fetch_chunks_over_999_ids(app_and_db):
     """A broad rule tree passes every photo id as the candidate set; the
     embedding fetch must chunk below SQLITE_MAX_VARIABLE_NUMBER."""


### PR DESCRIPTION
## What this is

Phase 3 of the universal filter system ([plan](docs/plans/2026-07-19-universal-filters-plan.md); prototype #1319, backend #1324, filter bar #1329): CLIP visual search becomes the filter bar's **visual clause**, replacing Browse's standalone CLIP box.

## How it works

Type in the search box and pick **"✦ Visually similar to …"** from the suggestion menu (Enter still does text search — the two are alternatives for the top bar, exactly as prototyped). The clause appears as a distinct purple chip, composes with all metadata rules (rules select candidates → similarity ranks them), and offers a broad/balanced/strict strength control in the popover.

**Honest error states** (the CORE_PHILOSOPHY hard requirement): when the clause can't run — no active model, a timm model without a text tower, no embeddings indexed, or encoding failure — results fall back to metadata-only **with the status surfaced** as an error chip + "metadata filters shown only" note. Never a silent zero. When coverage is partial, a note reports "Visual index covers N of M photos in scope".

**Every surface stays consistent**: select-all, the summary panel, the calendar, and typeahead facet counts all include the visual clause when healthy (server-side narrowing via inlined matched ids), so nothing can disagree with the visible grid. Pause (`\`) disables the visual clause with the rest; persistence, undo, and the paused "N would match" count all carry it.

## Plan-flagged fix

`get_photos_with_embedding` chunked: the old single `IN (?,…)` clause would exceed `SQLITE_MAX_VARIABLE_NUMBER` for any broad rule tree over a large catalog (the plan-review finding). Now ≤900-id batches, tested with 1200 candidates.

## Testing

- Backend: similarity ranking + rule composition, strength thresholds, all four error statuses (metadata fallback asserted non-zero), `ids_only` ranking, summary/facet-count consistency under the clause, >999-id chunking
- E2E: honest error state end-to-end (error chip, note, metadata rules still filtering, persistence across reload, chip removal) and the strength control
- Full standard suite: **1847 passed, 14 skipped**, 1 pre-existing env-dependent failure (exiftool status; fails on clean main). Browse+dashboard e2e: **141 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual search to the universal Browse filter bar, including prompt suggestions and adjustable matching strength.
  * Visual search now works alongside metadata filters and preserves result ordering with similarity indicators.
  * Added clear status messaging for unavailable, failed, or incomplete visual searches.
  * Unified visual filtering across Browse results, summaries, calendars, counts, and bulk selection.
* **Bug Fixes**
  * Large visual-search candidate sets are now handled reliably without query-size failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->