### PR TITLE
Fix dashboard collection drill-down bootstrap

### DIFF
--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -64,12 +64,19 @@ def test_dashboard_collection_drill_down_is_explicitly_composable(live_server, p
     page.locator("#scopeCollection").select_option(str(collection_id))
     page.locator("#scopePanel").get_by_role("button", name="Apply").click()
     expect(page.locator("#photoCount")).to_have_text("2")
-    page.locator("#monthChart .month-bar", has_text="2024-06").click()
+    with page.expect_response(re.compile(r"/api/browse/init\?")) as initial_response:
+        page.locator("#monthChart .month-bar", has_text="2024-06").click()
 
     query = parse_qs(urlparse(page.url).query)
     assert query["dashboard_scope"] == ["1"]
     assert query["collection_id"] == [str(collection_id)]
     assert query["date_from"] == ["2024-06-01"]
+    assert query["date_to"] == ["2024-06-30"]
+    initial_query = parse_qs(urlparse(initial_response.value.url).query)
+    assert initial_query["collection_id"] == [str(collection_id)]
+    assert initial_query["date_from"] == ["2024-06-01"]
+    assert initial_query["date_to"] == ["2024-06-30"]
+    expect(page.locator(".grid-card")).to_have_count(1)
     expect(page.locator(".grid-card-name")).to_have_text("robin1.jpg")
 
     page.goto(f"{live_server['url']}/browse?collection_id={collection_id}")

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2850,7 +2850,8 @@ async function bootstrapBrowse() {
     initParams.set('sort', document.getElementById('sortSelect').value);
     if (activeFolderId) initParams.set('folder_id', activeFolderId);
     ['date_from', 'date_to'].forEach(function(name) {
-      if (pageParams.has(name)) initParams.set(name, pageParams.get(name));
+      var value = pageParams.get(name);
+      if (value) initParams.set(name, value);
     });
     // Collection-only deep links keep their historical endpoint behavior,
     // while Dashboard links opt into composable filters via dashboard_scope.

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2842,10 +2842,16 @@ async function bootstrapBrowse() {
       dashboardCollectionScope = pageParams.get('dashboard_scope') === '1';
     }
     // Legacy filter deep-link params (rating_min/flag/keyword/dates/…) are
-    // compiled into an initial rule tree by VireoFilter.init below.
+    // compiled into an initial rule tree by VireoFilter.init below. Forward
+    // the capture-date bounds to the bootstrap endpoint as well so Dashboard
+    // drill-downs do not briefly paint the entire collection while the filter
+    // registry is still loading.
     var initParams = new URLSearchParams();
     initParams.set('sort', document.getElementById('sortSelect').value);
     if (activeFolderId) initParams.set('folder_id', activeFolderId);
+    ['date_from', 'date_to'].forEach(function(name) {
+      if (pageParams.has(name)) initParams.set(name, pageParams.get(name));
+    });
     // Collection-only deep links keep their historical endpoint behavior,
     // while Dashboard links opt into composable filters via dashboard_scope.
     // The combined init endpoint still needs the collection id for first paint


### PR DESCRIPTION
Forward Dashboard drill-down `date_from` and `date_to` values into Browse's initial bootstrap request so collection-scoped results are correct on first paint. This fixes the v0.27.0 release failure caused by Playwright seeing the unfiltered collection while the asynchronous filter registry loaded, and hardens the regression test to verify the initial request and wait for a single result. Validation: `573 passed, 1 skipped` in the exact release-gate browser suite; the six dashboard browser tests and backend collection/date intersection test also passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard drill-downs now consistently preserve selected collections and date ranges when opening browse views.
  * Browse pages now apply date filters immediately during initialization, preventing a temporary display of unfiltered results.
  * Improved consistency between dashboard URL filters and the resulting browse data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->