### PR TITLE
Allow local sync during new image checks

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12461,6 +12461,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 job_work_fn,
                 ephemeral=True,
                 counts_for_badge=False,
+                blocks_local_transitions=False,
                 workspace_id=ws_id,
                 config={"workspace_name": ws_name},
             )

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -375,7 +375,7 @@ class JobRunner:
 
     def start(self, job_type, work_fn, config=None, workspace_id=None,
               ephemeral=False, runtime_warning=None, counts_for_badge=True,
-              pausable=False):
+              pausable=False, blocks_local_transitions=True):
         """Start a background job.
 
         Args:
@@ -395,8 +395,12 @@ class JobRunner:
             counts_for_badge: if False, the job remains visible in job lists
                        but does not contribute to app/Dock attention badges.
             pausable: if True, pause_job() may suspend the worker the next
-                       time it calls is_cancelled(). Only set this for work
-                       that checks cancellation at safe boundaries.
+                      time it calls is_cancelled(). Only set this for work
+                      that checks cancellation at safe boundaries.
+            blocks_local_transitions: if False, Work Locally stage/sync/discard
+                      actions may proceed while this job runs. Reserve this
+                      for observational jobs whose results are safely dropped
+                      when a local transition invalidates their cache.
 
         Returns:
             job_id string
@@ -426,6 +430,7 @@ class JobRunner:
             "ephemeral": ephemeral,
             "counts_for_badge": counts_for_badge,
             "pausable": bool(pausable),
+            "blocks_local_transitions": bool(blocks_local_transitions),
             "runtime_warning": runtime_warning,
             # Pre-seeded so later writes from worker threads update an
             # existing key instead of inserting a new one: key insertion

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1236,3 +1236,74 @@ def test_folder_stage_endpoint_refuses_while_scan_is_paused(tmp_path, monkeypatc
         finally:
             runner.cancel_job(job_id)
         wait_for_job_via_client(client, job_id)
+
+
+def test_folder_sync_proceeds_while_observational_job_runs(tmp_path, monkeypatch):
+    """An automatic read-only probe must not hold local work hostage.
+
+    ``new_images_walk`` can take minutes on a large network library. Its
+    result is cache-generation guarded, so the sync's path invalidation makes
+    a result from the old local layout harmless; waiting for the walk only
+    turns an ambient navbar probe into a user-visible sync failure.
+    """
+    import threading
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+
+    source = tmp_path / "nas" / "photos"
+    source.mkdir(parents=True)
+    (source / "bird.jpg").write_bytes(b"original")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    workspace_id = db.create_workspace("Owner")
+    folder_id = db.add_folder(
+        str(source), name="photos", link_to_workspace=False,
+    )
+    db.add_workspace_folder(workspace_id, folder_id)
+    db.set_active_workspace(workspace_id)
+    stage_folder(db, folder_id, str(vireo_dir))
+    local_path = Path(db.get_folder(folder_id)["path"])
+    (local_path / "bird.jpg").write_bytes(b"edited")
+    db.close()
+
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    release = threading.Event()
+    started = threading.Event()
+
+    def observational_probe(_job):
+        started.set()
+        assert release.wait(timeout=10)
+        return {"ok": True}
+
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={},
+        ).status_code == 200
+        probe_id = app._job_runner.start(
+            "new_images_walk",
+            observational_probe,
+            workspace_id=workspace_id,
+            blocks_local_transitions=False,
+        )
+        try:
+            assert started.wait(timeout=2)
+            assert app._job_runner.get(probe_id)["status"] == "running"
+            response = client.post(
+                "/api/workspaces/active/local-folders/sync",
+                json={"folder_ids": [folder_id]},
+            )
+            assert response.status_code == 202, response.get_json()
+            sync_job = wait_for_job_via_client(
+                client, response.get_json()["job_id"],
+            )
+            assert sync_job["status"] == "completed"
+            assert (source / "bird.jpg").read_bytes() == b"edited"
+        finally:
+            release.set()
+        wait_for_job_via_client(client, probe_id)

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -2161,3 +2161,60 @@ def test_stage_endpoint_refuses_while_scan_is_paused(tmp_path, monkeypatch):
         finally:
             runner.cancel_job(job_id)
         wait_for_job_via_client(client, job_id)
+
+
+def test_workspace_sync_proceeds_while_observational_job_runs(
+        tmp_path, monkeypatch):
+    """Legacy workspace sync also ignores cache-safe background probes."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+
+    source = tmp_path / "nas" / "photos"
+    source.mkdir(parents=True)
+    (source / "bird.jpg").write_bytes(b"original")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    folder_id = db.add_folder(str(source), name="photos")
+    workspace_id = db._active_workspace_id
+    stage_workspace(db, workspace_id, str(vireo_dir))
+    local_path = Path(db.get_folder(folder_id)["path"])
+    (local_path / "bird.jpg").write_bytes(b"edited")
+    db.close()
+
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    release = threading.Event()
+    started = threading.Event()
+
+    def observational_probe(_job):
+        started.set()
+        assert release.wait(timeout=10)
+        return {"ok": True}
+
+    with app.test_client() as client:
+        probe_id = app._job_runner.start(
+            "new_images_walk",
+            observational_probe,
+            workspace_id=workspace_id,
+            blocks_local_transitions=False,
+        )
+        try:
+            assert started.wait(timeout=2)
+            assert app._job_runner.get(probe_id)["status"] == "running"
+            response = client.post(
+                "/api/workspaces/active/local-workspace/sync",
+                json={"confirm_deletions": False},
+            )
+            assert response.status_code == 202, response.get_json()
+            sync_job = wait_for_job_via_client(
+                client, response.get_json()["job_id"],
+            )
+            assert sync_job["status"] == "completed"
+            assert (source / "bird.jpg").read_bytes() == b"edited"
+        finally:
+            release.set()
+        wait_for_job_via_client(client, probe_id)

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -376,6 +376,7 @@ def test_api_new_images_registers_ephemeral_job_on_cache_cold(app_and_db, monkey
         assert job["status"] == "running"
         assert job["workspace_id"] == ws_id
         assert job["counts_for_badge"] is False
+        assert job["blocks_local_transitions"] is False
         # Job is tied to the workspace via config.workspace_name for the UI label.
         assert "workspace_name" in job["config"]
     finally:

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -98,6 +98,13 @@ def create_local_folder_blueprint(
             workspace_ids.update(affected_workspace_ids(db, root_id))
             workspace_ids.update(workspace_ids_for_folder_tree(db, root_id))
         for job in get_runner().list_jobs():
+            # Observational jobs such as the automatic new-images walk do not
+            # retain catalog writes or path mutations that a local transition
+            # can invalidate. Their cache generation is bumped when the
+            # transition rebases paths, so a result from the old layout is
+            # dropped instead of leaking back into the UI.
+            if job.get("blocks_local_transitions") is False:
+                continue
             # ``pausing``/``paused`` jobs still hold their original workspace
             # and root assumptions in the worker's memory. A stage/sync/discard
             # starting under them would race the paused work when it resumes,

--- a/vireo/web/local_workspace.py
+++ b/vireo/web/local_workspace.py
@@ -48,6 +48,11 @@ def create_local_workspace_blueprint(
         # scan/import is paused would silently orphan rows the manifest
         # doesn't cover once the paused job resumes.
         for job in get_runner().list_jobs():
+            # Observational jobs can opt out when their cache invalidation
+            # already makes an in-flight result from the old path layout
+            # harmless. The automatic new-images walk uses this path.
+            if job.get("blocks_local_transitions") is False:
+                continue
             if (
                 job.get("workspace_id") == workspace_id
                 and job.get("status") in {"queued", "running", "pausing", "paused"}


### PR DESCRIPTION
## Summary

The automatic new-image walk was registered as a workspace job, so Work Locally's broad exclusivity guard rejected sync even though the walk only reads data and its cache is generation-protected.

This adds a `blocks_local_transitions` job capability, opts the new-image walk out, and teaches both folder-scoped and legacy transition guards to honor it while leaving scans and imports blocking.

Regression tests cover both sync paths and assert production new-image jobs carry the non-blocking policy.

## Validation

`pytest -q vireo/tests/test_jobs.py vireo/tests/test_new_images_api.py vireo/tests/test_local_folder.py vireo/tests/test_local_workspace.py` — 160 passed, 3 skipped.