### PR TITLE
Open photo previews from location markers

### DIFF
--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -154,6 +154,10 @@ def test_location_review_photo_marker_opens_the_photo_preview(live_server, page)
                 (33.2550, -116.4050, photo_ids[1]),
             ],
         )
+        live_server["db"].conn.execute(
+            "UPDATE photos SET companion_path = ? WHERE id = ?",
+            ("bird1.jpg", photo_ids[0]),
+        )
 
     page.route("https://unpkg.com/**", _stub_leaflet)
     page.goto(f"{live_server['url']}/browse")
@@ -174,6 +178,12 @@ def test_location_review_photo_marker_opens_the_photo_preview(live_server, page)
         "src", f"/photos/{photo_ids[0]}/full"
     )
     expect(page.locator("#lightboxCounter")).to_contain_text("1 / 2")
+
+    page.evaluate("lightboxDelete()")
+    expect(page.locator("#deleteCompanionRow")).to_be_visible()
+    expect(page.locator("#deleteCompanionLabel")).to_have_text(
+        "Also delete 1 companion file"
+    )
 
 
 def test_location_review_thumbnail_opens_the_photo_preview(live_server, page):

--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from playwright.sync_api import expect
@@ -186,14 +187,20 @@ def test_location_review_photo_marker_opens_the_photo_preview(live_server, page)
         "Also delete 1 companion file"
     )
 
-    page.evaluate(
-        """() => {
-          var callback = _deleteCallback;
-          hideDeleteModal();
-          callback({deleted: 1});
-          closeLightbox();
-        }"""
-    )
+    with page.expect_request(
+        "**/api/location-review/saved-suggestions?*"
+    ) as suggestion_request:
+        page.evaluate(
+            """() => {
+              var callback = _deleteCallback;
+              hideDeleteModal();
+              callback({deleted: 1});
+              closeLightbox();
+            }"""
+        )
+    suggestion_params = parse_qs(urlparse(suggestion_request.value.url).query)
+    assert float(suggestion_params["lat"][0]) == pytest.approx(33.2554)
+    assert float(suggestion_params["lng"][0]) == pytest.approx(-116.4053)
     expect(page.locator("#locationReviewGroupTitle")).to_have_text("1 photo")
     expect(page.locator(".location-review-thumb")).to_have_count(1)
 

--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -217,6 +217,74 @@ def test_location_review_photo_marker_opens_the_photo_preview(live_server, page)
     )
 
 
+def test_location_review_lightbox_delete_keeps_selection_source_in_sync(
+    live_server, page,
+):
+    """Deleting a photo through the lightbox removes it from the saved selection.
+
+    Without this sync, reopening the review page reposts the deleted ID to
+    ``/api/location-review/preview``, which returns 404 and blocks the remaining
+    photos from being reviewed.
+    """
+    photo_ids = live_server["data"]["photos"][:2]
+    with live_server["db"].conn:
+        live_server["db"].conn.executemany(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            [
+                (33.2550, -116.4050, photo_ids[0]),
+                (33.2550, -116.4050, photo_ids[1]),
+            ],
+        )
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        "photoIds => sessionStorage.setItem('vireoLocationReviewSource', "
+        "JSON.stringify({photo_ids: photoIds}))",
+        photo_ids,
+    )
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("2 photos")
+
+    page.evaluate("window.__locationReviewLeafletMarkers[0].fire('click')")
+    expect(page.locator("#lightboxOverlay")).to_have_class(
+        "lightbox-overlay active"
+    )
+
+    page.evaluate("lightboxDelete()")
+    page.evaluate(
+        """() => {
+          var callback = _deleteCallback;
+          hideDeleteModal();
+          callback({deleted: 1});
+          closeLightbox();
+        }"""
+    )
+
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("1 photo")
+
+    stored = page.evaluate(
+        "() => JSON.parse(sessionStorage.getItem('vireoLocationReviewSource'))"
+    )
+    assert stored == {"photo_ids": [photo_ids[1]]}
+    selection_label = page.evaluate(
+        """() => {
+          var option = document.querySelector(
+            '#locationReviewCollection option[value=\"__selection__\"]'
+          );
+          return option && option.textContent;
+        }"""
+    )
+    assert selection_label == "Selected photos (1)"
+
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("1 photo")
+    expect(page.locator(".location-review-thumb")).to_have_count(1)
+    expect(
+        page.locator(f'.location-review-thumb[data-photo-id="{photo_ids[1]}"]')
+    ).to_be_visible()
+
+
 def test_location_review_thumbnail_opens_the_photo_preview(live_server, page):
     """The thumbnail strip offers the same preview affordance as map dots."""
     photo_id = live_server["data"]["photos"][0]

--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from playwright.sync_api import expect
 
 LEAFLET_STUB = """
@@ -151,7 +152,7 @@ def test_location_review_photo_marker_opens_the_photo_preview(live_server, page)
             "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
             [
                 (33.2550, -116.4050, photo_ids[0]),
-                (33.2550, -116.4050, photo_ids[1]),
+                (33.2554, -116.4053, photo_ids[1]),
             ],
         )
         live_server["db"].conn.execute(
@@ -200,7 +201,10 @@ def test_location_review_photo_marker_opens_the_photo_preview(live_server, page)
     page.locator("#locationReviewCustom").click()
     with page.expect_request("**/api/batch/location/text") as request_info:
         page.locator("#locationReviewAssign").click()
-    assert request_info.value.post_data_json["photo_ids"] == [photo_ids[1]]
+    assignment = request_info.value.post_data_json
+    assert assignment["photo_ids"] == [photo_ids[1]]
+    assert assignment["latitude"] == pytest.approx(33.2554)
+    assert assignment["longitude"] == pytest.approx(-116.4053)
     expect(page.locator("#locationReviewEmptyTitle")).to_have_text(
         "All locations reviewed"
     )

--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -3,6 +3,7 @@ import json
 from playwright.sync_api import expect
 
 LEAFLET_STUB = """
+window.__locationReviewLeafletMarkers = [];
 window.L = {
   tileLayer: function() { return {}; },
   map: function() {
@@ -18,12 +19,19 @@ window.L = {
   },
   divIcon: function(options) { return options; },
   marker: function(latlng) {
-    return {
+    var handlers = {};
+    var marker = {
       latlng: latlng,
       addTo: function() { return this; },
       bindTooltip: function() { return this; },
-      on: function() { return this; }
+      on: function(name, handler) { handlers[name] = handler; return this; },
+      fire: function(name) {
+        if (handlers[name]) handlers[name]({target: this});
+        return this;
+      }
     };
+    window.__locationReviewLeafletMarkers.push(marker);
+    return marker;
   }
 };
 """
@@ -133,6 +141,67 @@ def test_location_review_assigns_a_custom_name_to_coordinate_group(
         (photo_ids[0], "Anza-Borrego Desert State Park", 33.25515, -116.4051),
         (photo_ids[1], "Anza-Borrego Desert State Park", 33.25515, -116.4051),
     ]
+
+
+def test_location_review_photo_marker_opens_the_photo_preview(live_server, page):
+    """A photo dot opens its photo with the whole location group available."""
+    photo_ids = live_server["data"]["photos"][:2]
+    with live_server["db"].conn:
+        live_server["db"].conn.executemany(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            [
+                (33.2550, -116.4050, photo_ids[0]),
+                (33.2550, -116.4050, photo_ids[1]),
+            ],
+        )
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        "photoIds => sessionStorage.setItem('vireoLocationReviewSource', "
+        "JSON.stringify({photo_ids: photoIds}))",
+        photo_ids,
+    )
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("2 photos")
+
+    page.evaluate("window.__locationReviewLeafletMarkers[0].fire('click')")
+
+    expect(page.locator("#lightboxOverlay")).to_have_class(
+        "lightbox-overlay active"
+    )
+    expect(page.locator("#lightboxImg")).to_have_attribute(
+        "src", f"/photos/{photo_ids[0]}/full"
+    )
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 / 2")
+
+
+def test_location_review_thumbnail_opens_the_photo_preview(live_server, page):
+    """The thumbnail strip offers the same preview affordance as map dots."""
+    photo_id = live_server["data"]["photos"][0]
+    with live_server["db"].conn:
+        live_server["db"].conn.execute(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            (33.2550, -116.4050, photo_id),
+        )
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        "photoId => sessionStorage.setItem('vireoLocationReviewSource', "
+        "JSON.stringify({photo_ids: [photoId]}))",
+        photo_id,
+    )
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+
+    page.locator(f'.location-review-thumb[data-photo-id="{photo_id}"]').click()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class(
+        "lightbox-overlay active"
+    )
+    expect(page.locator("#lightboxImg")).to_have_attribute(
+        "src", f"/photos/{photo_id}/full"
+    )
 
 
 def test_browse_review_on_map_opens_the_selected_photos(live_server, page):

--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -185,6 +185,26 @@ def test_location_review_photo_marker_opens_the_photo_preview(live_server, page)
         "Also delete 1 companion file"
     )
 
+    page.evaluate(
+        """() => {
+          var callback = _deleteCallback;
+          hideDeleteModal();
+          callback({deleted: 1});
+          closeLightbox();
+        }"""
+    )
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("1 photo")
+    expect(page.locator(".location-review-thumb")).to_have_count(1)
+
+    page.locator("#locationReviewSearch").fill("Remaining photo location")
+    page.locator("#locationReviewCustom").click()
+    with page.expect_request("**/api/batch/location/text") as request_info:
+        page.locator("#locationReviewAssign").click()
+    assert request_info.value.post_data_json["photo_ids"] == [photo_ids[1]]
+    expect(page.locator("#locationReviewEmptyTitle")).to_have_text(
+        "All locations reviewed"
+    )
+
 
 def test_location_review_thumbnail_opens_the_photo_preview(live_server, page):
     """The thumbnail strip offers the same preview affordance as map dots."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6665,6 +6665,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             photo_data = [{
                 "id": item["photo"]["id"],
                 "filename": item["photo"]["filename"],
+                "companion_path": item["photo"]["companion_path"],
                 "timestamp": item["photo"]["timestamp"],
                 "latitude": item["lat"],
                 "longitude": item["lng"],

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7906,6 +7906,12 @@ function lightboxDelete() {
         refreshBrowseSidebarCounts();
       }
     }
+
+    try {
+      document.dispatchEvent(new CustomEvent('lightbox:photodeleted', {
+        detail: { photoId: currentId, result: data || null }
+      }));
+    } catch (_) {}
   });
 }
 /* ---------- iNat Submission ---------- */

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -135,14 +135,21 @@ body {
   border-top: 1px solid var(--border-primary);
 }
 .location-review-thumb {
+  appearance: none;
   width: 84px;
   min-width: 84px;
   height: 94px;
+  padding: 0;
   border: 1px solid var(--border-primary);
   border-radius: 5px;
   overflow: hidden;
   background: var(--bg-tertiary);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
 }
+.location-review-thumb:hover,
+.location-review-thumb:focus-visible { border-color: var(--accent); }
 .location-review-thumb img { width: 100%; height: 68px; object-fit: cover; display: block; }
 .location-review-thumb span {
   display: block;
@@ -295,6 +302,7 @@ body {
   background: var(--accent);
   border: 2px solid white;
   box-shadow: 0 1px 4px rgba(0,0,0,.5);
+  cursor: pointer;
 }
 .leaflet-control-layers {
   background: var(--bg-secondary) !important;
@@ -561,6 +569,12 @@ body {
     state.candidateMarkers = [];
   }
 
+  function openPhotoPreview(photo) {
+    var group = currentGroup();
+    if (!photo || !group || typeof openLightbox !== 'function') return;
+    openLightbox(photo.id, photo.filename || '', group.photos);
+  }
+
   function renderPhotoMarkers(group) {
     clearMapObjects();
     if (!state.map || !group) return;
@@ -582,6 +596,7 @@ body {
           },
           zIndex: 20,
         });
+        marker.addListener('click', function() { openPhotoPreview(photo); });
         state.photoMarkers.push(marker);
         bounds.extend(position);
       });
@@ -596,6 +611,7 @@ body {
           icon: L.divIcon({className: '', html: '<div class="location-review-photo-dot"></div>', iconSize: [15,15], iconAnchor: [7,7]}),
           title: photo.filename,
         }).addTo(state.map);
+        marker.on('click', function() { openPhotoPreview(photo); });
         state.photoMarkers.push(marker);
         latLngs.push([photo.latitude, photo.longitude]);
       });
@@ -714,11 +730,18 @@ body {
     var container = document.getElementById('locationReviewThumbnails');
     var visible = group.photos.slice(0, 24);
     container.innerHTML = visible.map(function(photo) {
-      return '<div class="location-review-thumb" title="' + escapeAttr(photo.filename) + '">' +
+      return '<button class="location-review-thumb" type="button" data-photo-id="' + photo.id + '" title="Open ' + escapeAttr(photo.filename) + '">' +
         '<img src="/thumbnails/' + photo.id + '.jpg" alt="" loading="lazy" onerror="this.style.visibility=\'hidden\'">' +
-        '<span>' + escapeHtml(photo.filename) + '</span></div>';
+        '<span>' + escapeHtml(photo.filename) + '</span></button>';
     }).join('') + (group.photos.length > visible.length
       ? '<div class="location-review-more">+' + formatNumber(group.photos.length - visible.length) + ' more</div>' : '');
+    container.querySelectorAll('[data-photo-id]').forEach(function(button) {
+      button.addEventListener('click', function() {
+        var photoId = parseInt(button.dataset.photoId, 10);
+        var photo = group.photos.find(function(item) { return item.id === photoId; });
+        openPhotoPreview(photo);
+      });
+    });
   }
 
   function renderGroupFacts(group) {

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -616,9 +616,7 @@ body {
       return;
     }
     refreshGroupMetadata(group);
-    renderGroupFacts(group);
-    renderPhotoMarkers(group);
-    updateProgress();
+    renderCurrentGroup();
   });
 
   function renderPhotoMarkers(group) {

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -602,10 +602,33 @@ body {
     group.captured_to = timestamps.length ? timestamps[timestamps.length - 1] : null;
   }
 
+  function dropPhotoFromSelectionSource(photoId) {
+    if (!state.source || !Array.isArray(state.source.photo_ids)) return;
+    if (state.source.photo_ids.indexOf(photoId) === -1) return;
+    state.source.photo_ids = state.source.photo_ids.filter(function(id) {
+      return id !== photoId;
+    });
+    try {
+      sessionStorage.setItem(
+        'vireoLocationReviewSource',
+        JSON.stringify({photo_ids: state.source.photo_ids.slice()})
+      );
+    } catch (e) {}
+    var selectionOption = document.querySelector(
+      '#locationReviewCollection option[value="__selection__"]'
+    );
+    if (selectionOption) {
+      selectionOption.textContent = 'Selected photos ('
+        + formatNumber(state.source.photo_ids.length) + ')';
+    }
+  }
+
   document.addEventListener('lightbox:photodeleted', function(event) {
     var photoId = Number(event.detail && event.detail.photoId);
+    if (!Number.isFinite(photoId)) return;
+    dropPhotoFromSelectionSource(photoId);
     var group = currentGroup();
-    if (!Number.isFinite(photoId) || !group || group.photo_ids.indexOf(photoId) === -1) return;
+    if (!group || group.photo_ids.indexOf(photoId) === -1) return;
     group.photos = group.photos.filter(function(photo) { return photo.id !== photoId; });
     group.photo_ids = group.photo_ids.filter(function(id) { return id !== photoId; });
     group.count = group.photos.length;

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -572,8 +572,26 @@ body {
   function openPhotoPreview(photo) {
     var group = currentGroup();
     if (!photo || !group || typeof openLightbox !== 'function') return;
-    openLightbox(photo.id, photo.filename || '', group.photos);
+    openLightbox(photo.id, photo.filename || '', group.photos.slice());
   }
+
+  document.addEventListener('lightbox:photodeleted', function(event) {
+    var photoId = Number(event.detail && event.detail.photoId);
+    var group = currentGroup();
+    if (!Number.isFinite(photoId) || !group || group.photo_ids.indexOf(photoId) === -1) return;
+    group.photos = group.photos.filter(function(photo) { return photo.id !== photoId; });
+    group.photo_ids = group.photo_ids.filter(function(id) { return id !== photoId; });
+    group.count = group.photos.length;
+    if (!group.count) {
+      state.groups.splice(state.currentIndex, 1);
+      if (state.currentIndex >= state.groups.length) state.currentIndex = Math.max(0, state.groups.length - 1);
+      renderCurrentGroup();
+      return;
+    }
+    renderGroupFacts(group);
+    renderPhotoMarkers(group);
+    updateProgress();
+  });
 
   function renderPhotoMarkers(group) {
     clearMapObjects();

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -575,6 +575,33 @@ body {
     openLightbox(photo.id, photo.filename || '', group.photos.slice());
   }
 
+  function refreshGroupMetadata(group) {
+    if (!group || !group.photos.length) return;
+    var referenceLng = Number(group.photos[0].longitude);
+    var centerLat = group.photos.reduce(function(total, photo) {
+      return total + Number(photo.latitude);
+    }, 0) / group.photos.length;
+    var lngDeltas = group.photos.map(function(photo) {
+      return ((Number(photo.longitude) - referenceLng + 180) % 360 + 360) % 360 - 180;
+    });
+    var centerLng = ((referenceLng + lngDeltas.reduce(function(total, value) {
+      return total + value;
+    }, 0) / group.photos.length + 180) % 360 + 360) % 360 - 180;
+    var timestamps = group.photos.map(function(photo) { return photo.timestamp; }).filter(Boolean).sort();
+    group.center = {lat: centerLat, lng: centerLng};
+    group.bounds = {
+      south: Math.min.apply(null, group.photos.map(function(photo) { return Number(photo.latitude); })),
+      west: Math.min.apply(null, group.photos.map(function(photo) { return Number(photo.longitude); })),
+      north: Math.max.apply(null, group.photos.map(function(photo) { return Number(photo.latitude); })),
+      east: Math.max.apply(null, group.photos.map(function(photo) { return Number(photo.longitude); })),
+    };
+    group.spread_m = Math.round(Math.max.apply(null, group.photos.map(function(photo) {
+      return distanceBetween(centerLat, centerLng, Number(photo.latitude), Number(photo.longitude));
+    })) * 10) / 10;
+    group.captured_from = timestamps.length ? timestamps[0] : null;
+    group.captured_to = timestamps.length ? timestamps[timestamps.length - 1] : null;
+  }
+
   document.addEventListener('lightbox:photodeleted', function(event) {
     var photoId = Number(event.detail && event.detail.photoId);
     var group = currentGroup();
@@ -588,6 +615,7 @@ body {
       renderCurrentGroup();
       return;
     }
+    refreshGroupMetadata(group);
     renderGroupFacts(group);
     renderPhotoMarkers(group);
     updateProgress();

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -7952,6 +7952,10 @@ def test_location_review_preview_groups_coordinates_without_geocoding(
             (37.7456, -119.5936, p3),  # a separate area
         ],
     )
+    db.conn.execute(
+        "UPDATE photos SET companion_path = ? WHERE id = ?",
+        ("bird1.jpg", p1),
+    )
     db.conn.commit()
     monkeypatch.setattr(
         places,
@@ -7974,6 +7978,9 @@ def test_location_review_preview_groups_coordinates_without_geocoding(
     assert body["skipped"] == []
     assert [group["count"] for group in body["groups"]] == [2, 1]
     assert body["groups"][0]["photo_ids"] == [p1, p2]
+    assert [
+        photo["companion_path"] for photo in body["groups"][0]["photos"]
+    ] == ["bird1.jpg", None]
     assert body["groups"][0]["spread_m"] > 0
     assert body["groups"][0]["center"]["lat"] == pytest.approx(33.2552)
 


### PR DESCRIPTION
## Summary

- Open the shared photo lightbox when a Review Photo Locations map marker is clicked in either Google Maps or Leaflet.
- Load the full coordinate group into the lightbox so users can navigate every photo at that location, and make the thumbnail strip clickable as well.
- Add browser coverage for marker previews, multi-photo navigation context, and thumbnail previews.

## Validation

- `pytest -q tests/e2e/test_location_review.py` (7 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Photo thumbnails and map markers in location review now open the photo preview.
  - Deleted photos are removed from the active review selection and group automatically.
  - Photo previews now retain companion-photo information.

- **Bug Fixes**
  - Prevented deleted photos from reappearing when reopening location review.
  - Updated group details and queue state after photo deletion.
  - Improved keyboard focus and click behavior for review thumbnails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->