### PR TITLE
Improve sync change review clarity

### DIFF
--- a/tests/e2e/test_sync_panel.py
+++ b/tests/e2e/test_sync_panel.py
@@ -53,3 +53,61 @@ def test_escape_closes_lightbox_before_pending_changes_overlay(live_server, page
     page.keyboard.press("Escape")
 
     expect(sync_overlay).to_be_hidden()
+
+
+def test_location_changes_are_grouped_with_plain_language_delta(live_server, page):
+    """Identical location writes render once with thumbnails, not raw tokens."""
+    import config as cfg
+
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:2]
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = True
+    cfg.save(config)
+
+    florida_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES ('Florida', 'location')"
+    ).lastrowid
+    tallahassee_id = db.conn.execute(
+        "INSERT INTO keywords "
+        "(name, parent_id, type, latitude, longitude) "
+        "VALUES ('Tallahassee', ?, 'location', 30.4383, -84.2807)",
+        (florida_id,),
+    ).lastrowid
+    db.conn.commit()
+    for photo_id in photo_ids:
+        db.set_photo_location(photo_id, tallahassee_id)
+        db.queue_change(photo_id, "location", "effective")
+
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate("openSyncPreview()")
+
+    overlay = page.locator("#syncPreviewOverlay")
+    expect(overlay).to_be_visible()
+    expect(overlay.locator(".sync-review-group")).to_have_count(1)
+    expect(overlay.locator(".sync-review-group-title")).to_have_text(
+        "Location updated on 2 photos"
+    )
+    expect(overlay.locator(".sync-review-delta")).to_contain_text(
+        "No XMP sidecar"
+    )
+    expect(overlay.locator(".sync-review-delta")).to_contain_text(
+        "Tallahassee, Florida"
+    )
+    expect(overlay.locator(".sync-review-note")).to_contain_text(
+        "written to XMP as GPS metadata"
+    )
+    expect(overlay.locator(".sync-preview-thumb")).to_have_count(2)
+    expect(overlay).not_to_contain_text("effective")
+
+    # The Dashboard's compact pending-change detail consumes the same API;
+    # keep the internal token out of that secondary review surface too.
+    page.goto(f"{live_server['url']}/dashboard")
+    pending_card = page.locator("#pendingCard")
+    expect(pending_card).to_be_visible()
+    pending_card.click()
+    pending_detail = page.locator("#pendingDetail")
+    expect(pending_detail).to_contain_text(
+        "Location: No XMP sidecar → Tallahassee, Florida"
+    )
+    expect(pending_detail).not_to_contain_text("effective")

--- a/tests/e2e/test_sync_panel.py
+++ b/tests/e2e/test_sync_panel.py
@@ -148,3 +148,36 @@ def test_rating_preview_responds_to_selected_sidecar_creator(live_server, page):
         "No XMP sidecar"
     )
     expect(rating_group).to_contain_text("5 stars stays in Vireo")
+
+
+def test_rating_preview_accounts_for_auto_included_keyword_pair(
+    live_server, page,
+):
+    """A selected rename removal auto-includes its hidden sidecar-creating add."""
+    db = live_server["db"]
+    photo_id = live_server["data"]["photos"][0]
+    db.queue_change(photo_id, "rating", "5")
+    db.queue_change(photo_id, "keyword_add", "Raptor")
+    db.queue_change(photo_id, "keyword_remove", "Raptor")
+
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate("openSyncPreview()")
+
+    overlay = page.locator("#syncPreviewOverlay")
+    expect(overlay).to_be_visible()
+    overlay.get_by_text("Keyword additions").locator("input").uncheck()
+
+    rating_group = overlay.locator(".sync-review-group").filter(
+        has_text="Rating updated"
+    )
+    expect(rating_group.locator(".sync-review-after")).to_have_text("5 stars")
+    expect(rating_group).to_contain_text(
+        "Another selected change creates the XMP sidecar first"
+    )
+
+    overlay.get_by_text("Keyword removals").locator("input").uncheck()
+
+    rating_group = overlay.locator(".sync-review-group").filter(
+        has_text="XMP rating unchanged"
+    )
+    expect(rating_group).to_contain_text("5 stars stays in Vireo")

--- a/tests/e2e/test_sync_panel.py
+++ b/tests/e2e/test_sync_panel.py
@@ -111,3 +111,40 @@ def test_location_changes_are_grouped_with_plain_language_delta(live_server, pag
         "Location: No XMP sidecar → Tallahassee, Florida"
     )
     expect(pending_detail).not_to_contain_text("effective")
+
+
+def test_rating_preview_responds_to_selected_sidecar_creator(live_server, page):
+    """Filtering out the change that creates XMP updates the rating promise."""
+    db = live_server["db"]
+    photo_id = live_server["data"]["photos"][0]
+    db.queue_change(photo_id, "rating", "5")
+    db.queue_change(photo_id, "keyword_add", "Raptor")
+
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate("openSyncPreview()")
+
+    overlay = page.locator("#syncPreviewOverlay")
+    expect(overlay).to_be_visible()
+    rating_group = overlay.locator(".sync-review-group").filter(
+        has_text="Rating updated"
+    )
+    expect(rating_group.locator(".sync-review-before")).to_have_text(
+        "No XMP sidecar"
+    )
+    expect(rating_group.locator(".sync-review-after")).to_have_text("5 stars")
+    expect(rating_group).to_contain_text(
+        "Another selected change creates the XMP sidecar first"
+    )
+
+    overlay.get_by_text("Keyword additions").locator("input").uncheck()
+
+    rating_group = overlay.locator(".sync-review-group").filter(
+        has_text="XMP rating unchanged"
+    )
+    expect(rating_group.locator(".sync-review-before")).to_have_text(
+        "No XMP sidecar"
+    )
+    expect(rating_group.locator(".sync-review-after")).to_have_text(
+        "No XMP sidecar"
+    )
+    expect(rating_group).to_contain_text("5 stars stays in Vireo")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -253,6 +253,43 @@ def _sync_preview_absent_xmp_value(metadata, empty_value):
     return empty_value
 
 
+_SYNC_PREVIEW_FIELD_LABELS = {
+    "keyword_add": "Keyword",
+    "keyword_remove": "Keyword",
+    "keyword_remove_flat": "Keyword",
+    "rating": "Rating",
+    "flag": "Flag",
+    "location": "Location",
+    "edit_recipe": "Photo edits",
+}
+
+
+def _sync_preview_folder_offline_presentation(change_type):
+    """Presentation for a change whose photo folder isn't accessible.
+
+    ``sync_to_xmp`` calls ``os.path.isdir(os.path.dirname(xmp_path))`` before
+    every write; when it returns False the photo is recorded as
+    ``folder not accessible`` and none of the writers run. Mirror that no-op
+    in the review so a NAS-offline or unmounted-folder photo does not appear
+    to promise XMP changes that will never happen.
+    """
+    field = _SYNC_PREVIEW_FIELD_LABELS.get(
+        change_type,
+        change_type.replace("_", " ").strip().title() or "Metadata",
+    )
+    placeholder = "Folder not accessible"
+    return {
+        "field": field,
+        "action": "unchanged",
+        "before": placeholder,
+        "after": placeholder,
+        "after_detail": (
+            "Sync will skip this photo because its folder is offline; "
+            "no XMP will be written"
+        ),
+    }
+
+
 def _sync_preview_rating_label(value):
     if value in (None, "", "0", 0):
         return "Unrated"
@@ -276,10 +313,14 @@ def _sync_preview_flag_label(value):
 def _sync_preview_presentation(
     change, metadata, *, assigned_location=None, write_locations=False,
     sidecar_will_exist=False, sync_flags=False, paired_keyword_rename=False,
+    paired_add_value=None, folder_offline=False,
 ):
     """Translate one internal pending row into user-facing XMP before/after data."""
     change_type = change["change_type"]
     value = change["value"]
+
+    if folder_offline:
+        return _sync_preview_folder_offline_presentation(change_type)
 
     if change_type in {"keyword_add", "keyword_remove", "keyword_remove_flat"}:
         existing = next(
@@ -321,6 +362,29 @@ def _sync_preview_presentation(
                 "after_detail": (
                     "The matching keyword addition replaces only the "
                     "flat spelling; this hierarchy stays in XMP"
+                ),
+            }
+        # A paired flat-only rename (e.g. remove `‘apapane` + add `apapane`)
+        # is dispatched through the flat-only remove path in sync.py, and
+        # the paired write_sidecar then adds the clean spelling. Reporting
+        # the removal as `Not in XMP` hides that the keyword survives with
+        # a canonicalized flat spelling; show it as an unchanged keyword
+        # whose flat entry is being rewritten by the paired addition.
+        if (
+            change_type == "keyword_remove"
+            and paired_keyword_rename
+            and existing
+            and paired_add_value
+            and not hierarchy_display
+        ):
+            return {
+                "field": "Keyword",
+                "action": "unchanged",
+                "before": existing,
+                "after": paired_add_value,
+                "after_detail": (
+                    "The matching keyword addition rewrites this flat "
+                    "spelling; the keyword itself stays in XMP"
                 ),
             }
         xmp_value = existing or _sync_preview_absent_xmp_value(
@@ -10103,17 +10167,52 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 photo["folder"],
                 os.path.splitext(photo["filename"])[0] + ".xmp",
             )
-            metadata = read_sync_preview_metadata(xmp_path)
+            # Mirror the folder-accessibility guard in ``sync_to_xmp``: if
+            # the photo's folder is offline (a common NAS case), sync
+            # records the photo as ``folder not accessible`` and never
+            # runs any writer, so the review must not present writes
+            # against it either.
+            folder_offline = bool(photo["folder"]) and not os.path.isdir(
+                photo["folder"]
+            )
+            photo["folder_offline"] = folder_offline
+            if folder_offline:
+                # Skip filesystem access entirely — an unreachable XMP path
+                # would just re-derive the same "no sidecar" fallback.
+                metadata = {
+                    "status": "folder_offline",
+                    "keywords": set(),
+                    "hierarchical_keywords": set(),
+                    "rating": None,
+                    "rating_writable": False,
+                    "flag": None,
+                    "location": None,
+                    "previous_location": None,
+                    "location_source": None,
+                    "edit_recipe": None,
+                }
+            else:
+                metadata = read_sync_preview_metadata(xmp_path)
             assigned_location = None
-            if any(change["type"] == "location" for change in photo["changes"]):
+            if (
+                not folder_offline
+                and any(change["type"] == "location" for change in photo["changes"])
+            ):
                 assigned_location = _serialize_photo_location(
                     db, photo["photo_id"],
                 )
-            keyword_add_keys = {
-                keyword_match_key(change["value"])
-                for change in photo["changes"]
-                if change["type"] == "keyword_add" and change["value"]
-            }
+            # Map normalized-key -> original add value so a paired
+            # keyword_remove can display the clean spelling the paired
+            # ``write_sidecar`` will end up writing.
+            keyword_add_values_by_key = {}
+            for change in photo["changes"]:
+                if change["type"] == "keyword_add" and change["value"]:
+                    key = keyword_match_key(change["value"])
+                    if key:
+                        keyword_add_values_by_key.setdefault(
+                            key, change["value"],
+                        )
+            keyword_add_keys = set(keyword_add_values_by_key.keys())
             for change in photo["changes"]:
                 pending = changes_by_id[change["id"]]
                 auto_includes_keyword_add = bool(
@@ -10127,13 +10226,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     change["type"] == "keyword_remove"
                     and auto_includes_keyword_add
                 )
+                # An offline folder never runs any writer, so nothing
+                # creates a sidecar during that sync.
                 change["creates_xmp_sidecar"] = (
-                    auto_includes_keyword_add
-                    or _sync_preview_change_creates_sidecar(
-                        pending,
-                        sync_flags=sync_flags,
-                        write_locations=write_locations,
-                        assigned_location=assigned_location,
+                    not folder_offline
+                    and (
+                        auto_includes_keyword_add
+                        or _sync_preview_change_creates_sidecar(
+                            pending,
+                            sync_flags=sync_flags,
+                            write_locations=write_locations,
+                            assigned_location=assigned_location,
+                        )
                     )
                 )
 
@@ -10142,8 +10246,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             for change in photo["changes"]:
                 pending = changes_by_id[change["id"]]
+                paired_add_value = None
+                if change["type"] == "keyword_remove" and change[
+                    "paired_keyword_rename"
+                ]:
+                    paired_add_value = keyword_add_values_by_key.get(
+                        keyword_match_key(change["value"])
+                    )
                 if (
                     pending["change_type"] == "rating"
+                    and not folder_offline
                     and not metadata.get("rating_writable")
                 ):
                     change["rating_requires_sidecar"] = True
@@ -10158,6 +10270,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             paired_keyword_rename=change[
                                 "paired_keyword_rename"
                             ],
+                            paired_add_value=paired_add_value,
                         )
                     )
                     change["presentation_with_sidecar"] = (
@@ -10171,6 +10284,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             paired_keyword_rename=change[
                                 "paired_keyword_rename"
                             ],
+                            paired_add_value=paired_add_value,
                         )
                     )
                     change["presentation"] = change[
@@ -10186,6 +10300,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     write_locations=write_locations,
                     sync_flags=sync_flags,
                     paired_keyword_rename=change["paired_keyword_rename"],
+                    paired_add_value=paired_add_value,
+                    folder_offline=folder_offline,
                 )
 
         result = {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -275,6 +275,7 @@ def _sync_preview_flag_label(value):
 
 def _sync_preview_presentation(
     change, metadata, *, assigned_location=None, write_locations=False,
+    sidecar_will_exist=False,
 ):
     """Translate one internal pending row into user-facing XMP before/after data."""
     change_type = change["change_type"]
@@ -288,6 +289,22 @@ def _sync_preview_presentation(
             ),
             None,
         )
+        if existing is None and change_type == "keyword_remove":
+            hierarchy = next(
+                (
+                    keyword
+                    for keyword in sorted(
+                        metadata.get("hierarchical_keywords", set())
+                    )
+                    if any(
+                        keyword_match_key(segment) == keyword_match_key(value)
+                        for segment in keyword.split("|")
+                    )
+                ),
+                None,
+            )
+            if hierarchy:
+                existing = hierarchy.replace("|", " › ")
         xmp_value = existing or _sync_preview_absent_xmp_value(
             metadata, "Not in XMP",
         )
@@ -307,7 +324,7 @@ def _sync_preview_presentation(
 
     if change_type == "rating":
         before = _sync_preview_rating_label(metadata.get("rating"))
-        if not metadata.get("rating_writable"):
+        if not metadata.get("rating_writable") and not sidecar_will_exist:
             before = _sync_preview_absent_xmp_value(metadata, before)
             return {
                 "field": "XMP rating",
@@ -317,6 +334,17 @@ def _sync_preview_presentation(
                 "after_detail": (
                     f"{_sync_preview_rating_label(value)} stays in Vireo; "
                     "rating sync only updates an existing, readable XMP sidecar"
+                ),
+            }
+        if not metadata.get("rating_writable"):
+            before = _sync_preview_absent_xmp_value(metadata, before)
+            return {
+                "field": "Rating",
+                "action": "updated",
+                "before": before,
+                "after": _sync_preview_rating_label(value),
+                "after_detail": (
+                    "Another selected change creates the XMP sidecar first"
                 ),
             }
         return {
@@ -410,6 +438,16 @@ def _sync_preview_presentation(
         "before": "Current XMP value",
         "after": value or "Cleared",
     }
+
+
+def _sync_preview_change_creates_sidecar(change, *, sync_flags=False):
+    """Mirror sync operations that create a missing XMP sidecar before rating."""
+    change_type = change["change_type"]
+    if change_type == "keyword_add":
+        return True
+    if change_type == "flag":
+        return sync_flags
+    return False
 
 
 def _rank01(value, values):
@@ -9960,11 +9998,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         import config as cfg
 
+        effective_config = db.get_effective_config(cfg.load())
         write_locations = bool(
-            db.get_effective_config(cfg.load()).get(
-                "write_assigned_location_to_xmp", False,
-            )
+            effective_config.get("write_assigned_location_to_xmp", False)
         )
+        sync_flags = bool(effective_config.get("sync_flags_to_xmp", False))
         changes_by_id = {change["id"]: change for change in changes}
         for photo in by_photo.values():
             xmp_path = os.path.join(
@@ -9979,6 +10017,47 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
             for change in photo["changes"]:
                 pending = changes_by_id[change["id"]]
+                change["creates_xmp_sidecar"] = (
+                    _sync_preview_change_creates_sidecar(
+                        pending,
+                        sync_flags=sync_flags,
+                    )
+                )
+
+            sidecar_will_exist = any(
+                change["creates_xmp_sidecar"] for change in photo["changes"]
+            )
+            for change in photo["changes"]:
+                pending = changes_by_id[change["id"]]
+                if (
+                    pending["change_type"] == "rating"
+                    and not metadata.get("rating_writable")
+                ):
+                    change["rating_requires_sidecar"] = True
+                    change["presentation_without_sidecar"] = (
+                        _sync_preview_presentation(
+                            pending,
+                            metadata,
+                            assigned_location=assigned_location,
+                            write_locations=write_locations,
+                            sidecar_will_exist=False,
+                        )
+                    )
+                    change["presentation_with_sidecar"] = (
+                        _sync_preview_presentation(
+                            pending,
+                            metadata,
+                            assigned_location=assigned_location,
+                            write_locations=write_locations,
+                            sidecar_will_exist=True,
+                        )
+                    )
+                    change["presentation"] = change[
+                        "presentation_with_sidecar"
+                        if sidecar_will_exist
+                        else "presentation_without_sidecar"
+                    ]
+                    continue
                 change["presentation"] = _sync_preview_presentation(
                     pending,
                     metadata,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -307,8 +307,18 @@ def _sync_preview_presentation(
 
     if change_type == "rating":
         before = _sync_preview_rating_label(metadata.get("rating"))
-        if metadata.get("status") != "ok":
+        if not metadata.get("rating_writable"):
             before = _sync_preview_absent_xmp_value(metadata, before)
+            return {
+                "field": "XMP rating",
+                "action": "unchanged",
+                "before": before,
+                "after": before,
+                "after_detail": (
+                    f"{_sync_preview_rating_label(value)} stays in Vireo; "
+                    "rating sync only updates an existing, readable XMP sidecar"
+                ),
+            }
         return {
             "field": "Rating",
             "action": "updated",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -114,6 +114,7 @@ from web.photo_review import create_photo_review_blueprint
 from web.system import system_blueprint
 from web.workspaces import create_workspace_blueprint
 from werkzeug.exceptions import BadRequest
+from xmp import read_sync_preview_metadata
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
@@ -202,6 +203,203 @@ class _QuietRequestFilter(logging.Filter):
 
 
 logging.getLogger("werkzeug").addFilter(_QuietRequestFilter())
+
+
+def _sync_preview_coordinate_text(location):
+    """Return a compact, truthful coordinate label for sync review."""
+    if not location:
+        return None
+    latitude = location.get("latitude")
+    longitude = location.get("longitude")
+    if latitude is not None and longitude is not None:
+        return f"{latitude:.5f}, {longitude:.5f}"
+    raw_latitude = location.get("raw_latitude")
+    raw_longitude = location.get("raw_longitude")
+    if raw_latitude is None and raw_longitude is None:
+        return None
+    return ", ".join(
+        str(value) for value in (raw_latitude, raw_longitude)
+        if value is not None
+    )
+
+
+def _sync_preview_location_name(location):
+    """Format a location keyword leaf and its parents from specific to broad."""
+    if not location:
+        return None
+    names = [location.get("name")]
+    names.extend(
+        parent.get("name")
+        for parent in reversed(location.get("parent_chain") or [])
+    )
+    result = []
+    seen = set()
+    for name in names:
+        if not name:
+            continue
+        key = name.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(name)
+    return ", ".join(result) or None
+
+
+def _sync_preview_absent_xmp_value(metadata, empty_value):
+    if metadata.get("status") == "missing":
+        return "No XMP sidecar"
+    if metadata.get("status") == "unreadable":
+        return "Unreadable XMP sidecar"
+    return empty_value
+
+
+def _sync_preview_rating_label(value):
+    if value in (None, "", "0", 0):
+        return "Unrated"
+    try:
+        rating = int(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return f"{rating} star" if rating == 1 else f"{rating} stars"
+
+
+def _sync_preview_flag_label(value):
+    return {
+        None: "Unflagged",
+        "": "Unflagged",
+        "none": "Unflagged",
+        "flagged": "Picked",
+        "rejected": "Rejected",
+    }.get(value, str(value))
+
+
+def _sync_preview_presentation(
+    change, metadata, *, assigned_location=None, write_locations=False,
+):
+    """Translate one internal pending row into user-facing XMP before/after data."""
+    change_type = change["change_type"]
+    value = change["value"]
+
+    if change_type in {"keyword_add", "keyword_remove", "keyword_remove_flat"}:
+        existing = next(
+            (
+                keyword for keyword in metadata.get("keywords", set())
+                if keyword_match_key(keyword) == keyword_match_key(value)
+            ),
+            None,
+        )
+        xmp_value = existing or _sync_preview_absent_xmp_value(
+            metadata, "Not in XMP",
+        )
+        if change_type == "keyword_add":
+            return {
+                "field": "Keyword",
+                "action": "added",
+                "before": xmp_value,
+                "after": value,
+            }
+        return {
+            "field": "Keyword",
+            "action": "removed",
+            "before": xmp_value,
+            "after": "Not in XMP",
+        }
+
+    if change_type == "rating":
+        before = _sync_preview_rating_label(metadata.get("rating"))
+        if metadata.get("status") != "ok":
+            before = _sync_preview_absent_xmp_value(metadata, before)
+        return {
+            "field": "Rating",
+            "action": "updated",
+            "before": before,
+            "after": _sync_preview_rating_label(value),
+        }
+
+    if change_type == "flag":
+        before = _sync_preview_flag_label(metadata.get("flag"))
+        if metadata.get("status") != "ok":
+            before = _sync_preview_absent_xmp_value(metadata, before)
+        return {
+            "field": "Flag",
+            "action": "updated",
+            "before": before,
+            "after": _sync_preview_flag_label(value),
+        }
+
+    if change_type == "location":
+        current_coordinates = _sync_preview_coordinate_text(
+            metadata.get("location")
+        )
+        before = current_coordinates or _sync_preview_absent_xmp_value(
+            metadata, "No GPS in XMP",
+        )
+        location_coordinates = _sync_preview_coordinate_text(assigned_location)
+        location_name = _sync_preview_location_name(assigned_location)
+
+        if write_locations and location_coordinates:
+            return {
+                "field": "Location",
+                "action": "updated",
+                "before": before,
+                "after": location_name or location_coordinates,
+                "after_detail": (
+                    f"{location_coordinates} · from a location keyword"
+                ),
+            }
+
+        if metadata.get("location_source"):
+            restored_coordinates = _sync_preview_coordinate_text(
+                metadata.get("previous_location")
+            )
+            return {
+                "field": "Location",
+                "action": "cleared",
+                "before": before,
+                "after": restored_coordinates or "No GPS in XMP",
+                "after_detail": (
+                    "Restores the GPS that existed before Vireo"
+                    if restored_coordinates
+                    else "Removes Vireo-assigned GPS"
+                ),
+            }
+
+        return {
+            "field": "XMP location",
+            "action": "unchanged",
+            "before": before,
+            "after": before,
+            "after_detail": (
+                f"{location_name} stays in Vireo; writing its GPS to XMP is turned off"
+                if assigned_location and location_coordinates and not write_locations
+                else (
+                    f"{location_name or 'This location keyword'} has no GPS coordinates to write"
+                    if assigned_location and not location_coordinates
+                    else "No Vireo-assigned GPS needs to be removed"
+                )
+            ),
+        }
+
+    if change_type == "edit_recipe":
+        before = (
+            "Existing Vireo edits"
+            if metadata.get("edit_recipe")
+            else _sync_preview_absent_xmp_value(metadata, "No Vireo edits")
+        )
+        return {
+            "field": "Photo edits",
+            "action": "updated" if value else "cleared",
+            "before": before,
+            "after": "Updated Vireo edits" if value else "No Vireo edits",
+        }
+
+    field = change_type.replace("_", " ").strip().title() or "Metadata"
+    return {
+        "field": field,
+        "action": "updated",
+        "before": "Current XMP value",
+        "after": value or "Cleared",
+    }
 
 
 def _rank01(value, values):
@@ -9723,7 +9921,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/sync/preview")
     def api_sync_preview():
-        """Preview all pending changes grouped by photo."""
+        """Preview pending changes with the XMP values they will replace."""
         db = _get_db()
         changes = db.get_pending_changes()
         if not changes:
@@ -9750,9 +9948,38 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "value": c["value"],
             })
 
+        import config as cfg
+
+        write_locations = bool(
+            db.get_effective_config(cfg.load()).get(
+                "write_assigned_location_to_xmp", False,
+            )
+        )
+        changes_by_id = {change["id"]: change for change in changes}
+        for photo in by_photo.values():
+            xmp_path = os.path.join(
+                photo["folder"],
+                os.path.splitext(photo["filename"])[0] + ".xmp",
+            )
+            metadata = read_sync_preview_metadata(xmp_path)
+            assigned_location = None
+            if any(change["type"] == "location" for change in photo["changes"]):
+                assigned_location = _serialize_photo_location(
+                    db, photo["photo_id"],
+                )
+            for change in photo["changes"]:
+                pending = changes_by_id[change["id"]]
+                change["presentation"] = _sync_preview_presentation(
+                    pending,
+                    metadata,
+                    assigned_location=assigned_location,
+                    write_locations=write_locations,
+                )
+
         result = {
             "photos": list(by_photo.values()),
             "total_changes": len(changes),
+            "location_sync_enabled": write_locations,
         }
         _attach_nested_edit_recipes(db, result)
         return jsonify(result)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -275,7 +275,7 @@ def _sync_preview_flag_label(value):
 
 def _sync_preview_presentation(
     change, metadata, *, assigned_location=None, write_locations=False,
-    sidecar_will_exist=False, sync_flags=False,
+    sidecar_will_exist=False, sync_flags=False, paired_keyword_rename=False,
 ):
     """Translate one internal pending row into user-facing XMP before/after data."""
     change_type = change["change_type"]
@@ -304,7 +304,20 @@ def _sync_preview_presentation(
                 None,
             )
             if hierarchy:
-                existing = hierarchy.replace("|", " › ")
+                hierarchy = hierarchy.replace("|", " › ")
+            if hierarchy and paired_keyword_rename:
+                return {
+                    "field": "Keyword hierarchy",
+                    "action": "unchanged",
+                    "before": hierarchy,
+                    "after": hierarchy,
+                    "after_detail": (
+                        "The matching keyword addition replaces only the "
+                        "flat spelling; this hierarchy stays in XMP"
+                    ),
+                }
+            if hierarchy:
+                existing = hierarchy
         xmp_value = existing or _sync_preview_absent_xmp_value(
             metadata, "Not in XMP",
         )
@@ -10079,8 +10092,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 assigned_location = _serialize_photo_location(
                     db, photo["photo_id"],
                 )
+            keyword_add_keys = {
+                keyword_match_key(change["value"])
+                for change in photo["changes"]
+                if change["type"] == "keyword_add" and change["value"]
+            }
             for change in photo["changes"]:
                 pending = changes_by_id[change["id"]]
+                change["paired_keyword_rename"] = bool(
+                    change["type"] == "keyword_remove"
+                    and keyword_match_key(change["value"]) in keyword_add_keys
+                )
                 change["creates_xmp_sidecar"] = (
                     _sync_preview_change_creates_sidecar(
                         pending,
@@ -10108,6 +10130,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             write_locations=write_locations,
                             sidecar_will_exist=False,
                             sync_flags=sync_flags,
+                            paired_keyword_rename=change[
+                                "paired_keyword_rename"
+                            ],
                         )
                     )
                     change["presentation_with_sidecar"] = (
@@ -10118,6 +10143,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             write_locations=write_locations,
                             sidecar_will_exist=True,
                             sync_flags=sync_flags,
+                            paired_keyword_rename=change[
+                                "paired_keyword_rename"
+                            ],
                         )
                     )
                     change["presentation"] = change[
@@ -10132,6 +10160,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     assigned_location=assigned_location,
                     write_locations=write_locations,
                     sync_flags=sync_flags,
+                    paired_keyword_rename=change["paired_keyword_rename"],
                 )
 
         result = {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -275,7 +275,7 @@ def _sync_preview_flag_label(value):
 
 def _sync_preview_presentation(
     change, metadata, *, assigned_location=None, write_locations=False,
-    sidecar_will_exist=False,
+    sidecar_will_exist=False, sync_flags=False,
 ):
     """Translate one internal pending row into user-facing XMP before/after data."""
     change_type = change["change_type"]
@@ -314,6 +314,17 @@ def _sync_preview_presentation(
                 "action": "added",
                 "before": xmp_value,
                 "after": value,
+            }
+        if metadata.get("status") == "unreadable":
+            return {
+                "field": "XMP keyword",
+                "action": "unchanged",
+                "before": xmp_value,
+                "after": xmp_value,
+                "after_detail": (
+                    f"{value} cannot be removed because the XMP sidecar "
+                    "is unreadable"
+                ),
             }
         return {
             "field": "Keyword",
@@ -358,6 +369,17 @@ def _sync_preview_presentation(
         before = _sync_preview_flag_label(metadata.get("flag"))
         if metadata.get("status") != "ok":
             before = _sync_preview_absent_xmp_value(metadata, before)
+        if not sync_flags:
+            return {
+                "field": "XMP flag",
+                "action": "unchanged",
+                "before": before,
+                "after": before,
+                "after_detail": (
+                    f"{_sync_preview_flag_label(value)} stays in Vireo; "
+                    "flag sync to XMP is turned off"
+                ),
+            }
         return {
             "field": "Flag",
             "action": "updated",
@@ -10041,6 +10063,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             assigned_location=assigned_location,
                             write_locations=write_locations,
                             sidecar_will_exist=False,
+                            sync_flags=sync_flags,
                         )
                     )
                     change["presentation_with_sidecar"] = (
@@ -10050,6 +10073,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             assigned_location=assigned_location,
                             write_locations=write_locations,
                             sidecar_will_exist=True,
+                            sync_flags=sync_flags,
                         )
                     )
                     change["presentation"] = change[
@@ -10063,6 +10087,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     metadata,
                     assigned_location=assigned_location,
                     write_locations=write_locations,
+                    sync_flags=sync_flags,
                 )
 
         result = {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -446,6 +446,23 @@ def _sync_preview_presentation(
             if metadata.get("edit_recipe")
             else _sync_preview_absent_xmp_value(metadata, "No Vireo edits")
         )
+        if not value and not metadata.get("edit_recipe"):
+            if metadata.get("status") == "unreadable":
+                detail = (
+                    "The Vireo edit marker cannot be cleared because the "
+                    "XMP sidecar is unreadable"
+                )
+            elif metadata.get("status") == "missing":
+                detail = "No XMP sidecar contains Vireo edits to clear"
+            else:
+                detail = "No Vireo edit marker exists in XMP to clear"
+            return {
+                "field": "XMP photo edits",
+                "action": "unchanged",
+                "before": before,
+                "after": before,
+                "after_detail": detail,
+            }
         return {
             "field": "Photo edits",
             "action": "updated" if value else "cleared",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -485,13 +485,32 @@ def _sync_preview_presentation(
     }
 
 
-def _sync_preview_change_creates_sidecar(change, *, sync_flags=False):
-    """Mirror sync operations that create a missing XMP sidecar before rating."""
+def _sync_preview_change_creates_sidecar(
+    change, *, sync_flags=False, write_locations=False, assigned_location=None,
+):
+    """Mirror sync operations that create a missing XMP sidecar before rating.
+
+    Matches the write order in ``sync.py``: ``write_sidecar`` (keyword_add),
+    ``write_pick_flag`` when flag sync is enabled, ``write_gps_location``
+    when location sync is enabled and the linked location has valid
+    coordinates, and ``write_edit_recipe`` with a non-empty payload all
+    create a missing sidecar via ``_load_or_create_xmp``. ``write_rating``
+    and the ``remove_*`` paths do not, so they are excluded.
+    """
     change_type = change["change_type"]
     if change_type == "keyword_add":
         return True
     if change_type == "flag":
         return sync_flags
+    if change_type == "location":
+        if not write_locations or not assigned_location:
+            return False
+        return (
+            assigned_location.get("latitude") is not None
+            and assigned_location.get("longitude") is not None
+        )
+    if change_type == "edit_recipe":
+        return bool(change["value"])
     return False
 
 
@@ -10066,6 +10085,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     _sync_preview_change_creates_sidecar(
                         pending,
                         sync_flags=sync_flags,
+                        write_locations=write_locations,
+                        assigned_location=assigned_location,
                     )
                 )
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -289,35 +289,40 @@ def _sync_preview_presentation(
             ),
             None,
         )
-        if existing is None and change_type == "keyword_remove":
-            hierarchy = next(
-                (
-                    keyword
-                    for keyword in sorted(
-                        metadata.get("hierarchical_keywords", set())
-                    )
-                    if any(
-                        keyword_match_key(segment) == keyword_match_key(value)
-                        for segment in keyword.split("|")
-                    )
-                ),
-                None,
+        # Solo keyword_remove routes through remove_keywords() with
+        # hierarchical=True in sync.py, which drops every
+        # lr:hierarchicalSubject whose segments match this key in addition
+        # to the flat dc:subject entry. Collect every hierarchy sync would
+        # touch so the review reflects the full deletion.
+        matching_hierarchies = []
+        if change_type == "keyword_remove":
+            matching_hierarchies = sorted(
+                keyword
+                for keyword in metadata.get("hierarchical_keywords", set())
+                if any(
+                    keyword_match_key(segment) == keyword_match_key(value)
+                    for segment in keyword.split("|")
+                )
             )
-            if hierarchy:
-                hierarchy = hierarchy.replace("|", " › ")
-            if hierarchy and paired_keyword_rename:
-                return {
-                    "field": "Keyword hierarchy",
-                    "action": "unchanged",
-                    "before": hierarchy,
-                    "after": hierarchy,
-                    "after_detail": (
-                        "The matching keyword addition replaces only the "
-                        "flat spelling; this hierarchy stays in XMP"
-                    ),
-                }
-            if hierarchy:
-                existing = hierarchy
+        hierarchy_display = [
+            keyword.replace("|", " › ") for keyword in matching_hierarchies
+        ]
+        if (
+            change_type == "keyword_remove"
+            and paired_keyword_rename
+            and hierarchy_display
+        ):
+            hierarchy_text = "; ".join(hierarchy_display)
+            return {
+                "field": "Keyword hierarchy",
+                "action": "unchanged",
+                "before": hierarchy_text,
+                "after": hierarchy_text,
+                "after_detail": (
+                    "The matching keyword addition replaces only the "
+                    "flat spelling; this hierarchy stays in XMP"
+                ),
+            }
         xmp_value = existing or _sync_preview_absent_xmp_value(
             metadata, "Not in XMP",
         )
@@ -328,6 +333,18 @@ def _sync_preview_presentation(
                 "before": xmp_value,
                 "after": value,
             }
+        if change_type == "keyword_remove" and not paired_keyword_rename:
+            removed_entries = []
+            if existing:
+                removed_entries.append(existing)
+            removed_entries.extend(hierarchy_display)
+            if removed_entries:
+                return {
+                    "field": "Keyword",
+                    "action": "removed",
+                    "before": "; ".join(removed_entries),
+                    "after": "Not in XMP",
+                }
         if existing is None:
             if metadata.get("status") == "unreadable":
                 detail = (

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10099,12 +10099,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             }
             for change in photo["changes"]:
                 pending = changes_by_id[change["id"]]
-                change["paired_keyword_rename"] = bool(
-                    change["type"] == "keyword_remove"
+                auto_includes_keyword_add = bool(
+                    change["type"] in {"keyword_remove", "keyword_remove_flat"}
                     and keyword_match_key(change["value"]) in keyword_add_keys
                 )
+                change["auto_includes_keyword_add"] = (
+                    auto_includes_keyword_add
+                )
+                change["paired_keyword_rename"] = bool(
+                    change["type"] == "keyword_remove"
+                    and auto_includes_keyword_add
+                )
                 change["creates_xmp_sidecar"] = (
-                    _sync_preview_change_creates_sidecar(
+                    auto_includes_keyword_add
+                    or _sync_preview_change_creates_sidecar(
                         pending,
                         sync_flags=sync_flags,
                         write_locations=write_locations,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -315,16 +315,22 @@ def _sync_preview_presentation(
                 "before": xmp_value,
                 "after": value,
             }
-        if metadata.get("status") == "unreadable":
+        if existing is None:
+            if metadata.get("status") == "unreadable":
+                detail = (
+                    f"{value} cannot be removed because the XMP sidecar "
+                    "is unreadable"
+                )
+            elif metadata.get("status") == "missing":
+                detail = f"No XMP sidecar contains {value} to remove"
+            else:
+                detail = f"{value} is not present in XMP"
             return {
                 "field": "XMP keyword",
                 "action": "unchanged",
                 "before": xmp_value,
                 "after": xmp_value,
-                "after_detail": (
-                    f"{value} cannot be removed because the XMP sidecar "
-                    "is unreadable"
-                ),
+                "after_detail": detail,
             }
         return {
             "field": "Keyword",

--- a/vireo/sync.py
+++ b/vireo/sync.py
@@ -247,10 +247,6 @@ def sync_to_xmp(db, progress_callback=None, change_ids=None):
             if new_flag is not None:
                 write_pick_flag(xmp_path, new_flag)
 
-            # Write rating
-            if new_rating is not None:
-                write_rating(xmp_path, new_rating)
-
             if sync_location:
                 loc = db.get_assigned_photo_location(photo_id)
                 if loc and loc.get("latitude") is not None and loc.get("longitude") is not None:
@@ -267,6 +263,13 @@ def sync_to_xmp(db, progress_callback=None, change_ids=None):
 
             if edit_recipe_json is not None:
                 write_edit_recipe(xmp_path, edit_recipe_json)
+
+            # Write rating after every operation that can create a sidecar.
+            # Rating alone intentionally remains a no-op for missing XMP, but
+            # a selected keyword, flag, location, or edit write should make
+            # the same-photo rating persist rather than silently clear it.
+            if new_rating is not None:
+                write_rating(xmp_path, new_rating)
 
             if supported_ids:
                 synced += 1

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -208,7 +208,20 @@ function _syncChangeStyle(change) {
   return { icon: '~', color: 'var(--warning)' };
 }
 
-function _syncChangePresentation(change) {
+function _syncChangePresentation(change, photo, activeFilters) {
+  if (change.rating_requires_sidecar && photo) {
+    var sidecarWillExist = photo.changes.some(function(other) {
+      return other.id !== change.id &&
+        other.creates_xmp_sidecar &&
+        (!activeFilters || activeFilters.has(other.type));
+    });
+    if (sidecarWillExist && change.presentation_with_sidecar) {
+      return change.presentation_with_sidecar;
+    }
+    if (!sidecarWillExist && change.presentation_without_sidecar) {
+      return change.presentation_without_sidecar;
+    }
+  }
   if (change.presentation) return change.presentation;
   return {
     field: change.type.replace(/_/g, ' '),
@@ -224,7 +237,7 @@ function _syncGroupedChanges(data, activeFilters) {
   data.photos.forEach(function(photo) {
     photo.changes.forEach(function(change) {
       if (!activeFilters.has(change.type)) return;
-      var presentation = _syncChangePresentation(change);
+      var presentation = _syncChangePresentation(change, photo, activeFilters);
       var key = JSON.stringify([
         change.type,
         presentation.field,
@@ -475,7 +488,7 @@ function _syncRenderLightboxPanel(photoId) {
   var html = '<div style="font-weight:600;margin-bottom:6px;color:var(--accent);">Pending changes</div>';
   visible.forEach(function(c) {
     var style = _syncChangeStyle(c);
-    var presentation = _syncChangePresentation(c);
+    var presentation = _syncChangePresentation(c, photo, _syncActiveFilters);
     html += '<div style="display:flex;align-items:flex-start;gap:6px;padding:5px 0;">' +
       '<span style="color:' + style.color + ';font-weight:700;width:12px;text-align:center;">' + style.icon + '</span>' +
       '<div style="flex:1;min-width:0;">' +

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -27,6 +27,65 @@
   </div>
 </div>
 
+<style>
+  .sync-review-note {
+    margin: 0 0 14px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-secondary);
+    border-radius: 6px;
+    background: var(--bg-tertiary);
+    color: var(--text-dim);
+    font-size: 12px;
+    line-height: 1.45;
+  }
+  .sync-review-groups { display: flex; flex-direction: column; gap: 12px; }
+  .sync-review-group {
+    padding: 14px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 7px;
+    background: var(--bg-primary);
+  }
+  .sync-review-group-header { display: flex; align-items: flex-start; gap: 10px; }
+  .sync-review-group-title { color: var(--text-primary); font-size: 14px; font-weight: 650; }
+  .sync-review-delta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 7px;
+    margin-top: 7px;
+    color: var(--text-primary);
+    font-size: 13px;
+  }
+  .sync-review-before { color: var(--text-dim); }
+  .sync-review-arrow { color: var(--text-ghost); }
+  .sync-review-after { color: var(--text-primary); font-weight: 600; }
+  .sync-review-detail { margin-top: 4px; color: var(--text-dim); font-size: 11px; }
+  .sync-review-photos { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+  .sync-preview-photo { position: relative; min-width: 0; max-width: 100%; }
+  .sync-preview-photo img { max-width: 100%; }
+  .sync-preview-filename {
+    margin-top: 5px;
+    padding-right: 20px;
+    overflow: hidden;
+    color: var(--text-ghost);
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .sync-preview-discard {
+    position: absolute;
+    right: 0;
+    bottom: -2px;
+    border: 0;
+    background: none;
+    color: var(--text-ghost);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+  }
+  .sync-preview-discard:hover { color: var(--danger); }
+</style>
+
 <script>
 /* ---------- Sync Panel ---------- */
 
@@ -100,6 +159,9 @@ async function runSync(changeIds) {
 function updateSyncThumbSize(val) {
   _syncThumbSize = parseInt(val);
   document.getElementById('syncThumbSizeVal').textContent = val + 'px';
+  document.querySelectorAll('.sync-preview-photo').forEach(function(photo) {
+    photo.style.width = _syncThumbSize + 'px';
+  });
   document.querySelectorAll('.sync-preview-thumb').forEach(function(img) {
     img.style.width = _syncThumbSize + 'px';
     img.style.height = Math.round(_syncThumbSize * 2 / 3) + 'px';
@@ -126,6 +188,83 @@ async function openSyncPreview() {
   }
 }
 
+function _syncTypeLabel(type) {
+  return {
+    keyword_add: 'Keyword additions',
+    keyword_remove: 'Keyword removals',
+    keyword_remove_flat: 'Keyword removals',
+    rating: 'Ratings',
+    flag: 'Flags',
+    location: 'Locations',
+    edit_recipe: 'Photo edits'
+  }[type] || type.replace(/_/g, ' ');
+}
+
+function _syncChangeStyle(change) {
+  if (change.type === 'keyword_add') return { icon: '+', color: 'var(--accent)' };
+  if (change.type === 'keyword_remove' || change.type === 'keyword_remove_flat') {
+    return { icon: '\u2212', color: 'var(--danger)' };
+  }
+  return { icon: '~', color: 'var(--warning)' };
+}
+
+function _syncChangePresentation(change) {
+  if (change.presentation) return change.presentation;
+  return {
+    field: change.type.replace(/_/g, ' '),
+    action: 'updated',
+    before: 'Current XMP value',
+    after: change.value || 'Cleared'
+  };
+}
+
+function _syncGroupedChanges(data, activeFilters) {
+  var groups = [];
+  var groupsByKey = {};
+  data.photos.forEach(function(photo) {
+    photo.changes.forEach(function(change) {
+      if (!activeFilters.has(change.type)) return;
+      var presentation = _syncChangePresentation(change);
+      var key = JSON.stringify([
+        change.type,
+        presentation.field,
+        presentation.action,
+        presentation.before,
+        presentation.after,
+        presentation.before_detail || '',
+        presentation.after_detail || ''
+      ]);
+      var group = groupsByKey[key];
+      if (!group) {
+        group = {
+          type: change.type,
+          presentation: presentation,
+          entries: []
+        };
+        groupsByKey[key] = group;
+        groups.push(group);
+      }
+      group.entries.push({ photo: photo, change: change });
+    });
+  });
+  return groups;
+}
+
+function _syncGroupTitle(group) {
+  var count = group.entries.length;
+  var photoWord = count === 1 ? 'photo' : 'photos';
+  var presentation = group.presentation;
+  var connector = {
+    added: 'added to',
+    removed: 'removed from',
+    updated: 'updated on',
+    cleared: 'cleared from',
+    checked: 'checked on',
+    unchanged: 'unchanged on'
+  }[presentation.action] || presentation.action + ' on';
+  return presentation.field + ' ' + connector + ' ' + count + ' ' + photoWord;
+}
+
 function renderSyncPreview() {
   var data = _syncPreviewData;
   var content = document.getElementById('syncPreviewContent');
@@ -135,79 +274,86 @@ function renderSyncPreview() {
   }
 
   var allTypes = {};
-  data.photos.forEach(function(p) {
-    p.changes.forEach(function(c) { allTypes[c.type] = true; });
+  data.photos.forEach(function(photo) {
+    photo.changes.forEach(function(change) { allTypes[change.type] = true; });
   });
   var typeList = Object.keys(allTypes).sort();
-
-  if (_syncActiveFilters === null) {
-    _syncActiveFilters = new Set(typeList);
-  }
+  if (_syncActiveFilters === null) _syncActiveFilters = new Set(typeList);
 
   var html = '<div style="display:flex;gap:12px;align-items:center;margin-bottom:12px;flex-wrap:wrap;">';
   html += '<span style="font-size:12px;color:var(--text-dim);">Include:</span>';
-  typeList.forEach(function(t) {
-    var label = t.replace(/_/g, ' ');
-    var color = t === 'keyword_add' ? 'var(--accent)' : t === 'keyword_remove' ? 'var(--danger)' : 'var(--warning)';
-    var checked = _syncActiveFilters.has(t) ? ' checked' : '';
-    html += '<label style="display:flex;align-items:center;gap:4px;font-size:12px;color:' + color + ';cursor:pointer;">' +
-      '<input type="checkbox"' + checked + ' onchange="toggleSyncFilter(\'' + t + '\')" style="accent-color:' + color + ';"> ' +
-      label + '</label>';
+  typeList.forEach(function(type) {
+    var style = _syncChangeStyle({ type: type });
+    var checked = _syncActiveFilters.has(type) ? ' checked' : '';
+    html += '<label style="display:flex;align-items:center;gap:4px;font-size:12px;color:' + style.color + ';cursor:pointer;">' +
+      '<input type="checkbox"' + checked + ' onchange="toggleSyncFilter(\'' + type + '\')" style="accent-color:' + style.color + ';"> ' +
+      escapeHtml(_syncTypeLabel(type)) + '</label>';
   });
   html += '</div>';
 
-  var activeFilters = _syncActiveFilters;
-
   var visibleCount = 0;
   var visiblePhotos = 0;
-  data.photos.forEach(function(p) {
-    var visible = p.changes.filter(function(c) { return activeFilters.has(c.type); });
+  data.photos.forEach(function(photo) {
+    var visible = photo.changes.filter(function(change) {
+      return _syncActiveFilters.has(change.type);
+    });
     if (visible.length > 0) visiblePhotos++;
     visibleCount += visible.length;
   });
 
-  html += '<div style="display:flex;gap:8px;margin-bottom:12px;">' +
-    '<span style="font-size:12px;color:var(--text-dim);flex:1;">' + visibleCount + ' checked change(s) across ' + visiblePhotos + ' photo(s)</span>' +
+  var changeWord = visibleCount === 1 ? 'change' : 'changes';
+  var photoWord = visiblePhotos === 1 ? 'photo' : 'photos';
+  html += '<div style="display:flex;gap:8px;margin-bottom:12px;align-items:center;">' +
+    '<span style="font-size:12px;color:var(--text-dim);flex:1;">' + visibleCount + ' ' + changeWord + ' across ' + visiblePhotos + ' ' + photoWord + '</span>' +
     '<button onclick="discardAllChanges()" style="background:none;color:var(--danger);border:1px solid var(--danger);border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;">Discard All</button>' +
     '<button onclick="runVisibleSync()" style="background:var(--accent);color:var(--accent-text);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;font-weight:500;">Sync to XMP</button>' +
   '</div>';
 
-  data.photos.forEach(function(p) {
-    var visibleChanges = p.changes.filter(function(c) { return activeFilters.has(c.type); });
-    if (visibleChanges.length === 0) return;
+  if (_syncActiveFilters.has('location') && allTypes.location) {
+    if (data.location_sync_enabled) {
+      html += '<div class="sync-review-note"><strong style="color:var(--text-primary);">About location sync:</strong> Location keywords with coordinates are written to XMP as GPS metadata. Their names and hierarchy remain in Vireo.</div>';
+    } else {
+      html += '<div class="sync-review-note"><strong style="color:var(--text-primary);">About location sync:</strong> Writing assigned locations to XMP is turned off in Settings. Location keywords stay in Vireo; this check only removes GPS previously written by Vireo.</div>';
+    }
+  }
 
-    var changeIds = visibleChanges.map(function(c) { return c.id; });
-
-    html += '<div style="display:flex;gap:12px;padding:12px 0;border-bottom:1px solid var(--border-subtle);">';
-
-    var thumbUrl = window.vireoThumbnailUrl
-      ? window.vireoThumbnailUrl(p)
-      : '/thumbnails/' + p.photo_id + '.jpg';
-    html += '<div style="flex-shrink:0;">';
-    html += '<img class="sync-preview-thumb" src="' + escapeAttr(thumbUrl) + '" style="width:' + _syncThumbSize + 'px;height:' + Math.round(_syncThumbSize * 2 / 3) + 'px;object-fit:cover;border-radius:4px;cursor:pointer;display:block;" data-photo-id="' + p.photo_id + '" data-filename="' + escapeAttr(p.filename) + '">';
-    html += '</div>';
-
+  var groups = _syncGroupedChanges(data, _syncActiveFilters);
+  html += '<div class="sync-review-groups">';
+  groups.forEach(function(group) {
+    var presentation = group.presentation;
+    var style = _syncChangeStyle({ type: group.type });
+    var ids = group.entries.map(function(entry) { return entry.change.id; });
+    html += '<section class="sync-review-group">';
+    html += '<div class="sync-review-group-header">';
+    html += '<span style="color:' + style.color + ';font-weight:700;font-size:17px;width:16px;text-align:center;">' + style.icon + '</span>';
     html += '<div style="flex:1;min-width:0;">';
-
-    visibleChanges.forEach(function(c) {
-      var icon = c.type === 'keyword_add' ? '+' : c.type === 'keyword_remove' ? '\u2212' : '~';
-      var color = c.type === 'keyword_add' ? 'var(--accent)' : c.type === 'keyword_remove' ? 'var(--danger)' : 'var(--warning)';
-      var typeLabel = c.type.replace(/_/g, ' ');
-      html += '<div style="display:flex;align-items:center;gap:8px;padding:3px 0;">';
-      html += '<span style="color:' + color + ';font-weight:700;font-size:16px;width:16px;text-align:center;">' + icon + '</span>';
-      html += '<span style="font-size:15px;color:var(--text-primary);font-weight:600;">' + escapeHtml(c.value) + '</span>';
-      html += '<span style="font-size:11px;color:var(--text-dim);">' + typeLabel + '</span>';
-      html += '<button onclick="discardChange(' + c.id + ', this.closest(\'div\'))" style="margin-left:auto;background:none;border:none;color:var(--text-ghost);font-size:16px;cursor:pointer;padding:0 4px;" title="Discard">&times;</button>';
+    html += '<div class="sync-review-group-title">' + escapeHtml(_syncGroupTitle(group)) + '</div>';
+    html += '<div class="sync-review-delta"><span class="sync-review-before">' + escapeHtml(presentation.before) + '</span><span class="sync-review-arrow">\u2192</span><span class="sync-review-after">' + escapeHtml(presentation.after) + '</span></div>';
+    if (presentation.before_detail) {
+      html += '<div class="sync-review-detail">Before: ' + escapeHtml(presentation.before_detail) + '</div>';
+    }
+    if (presentation.after_detail) {
+      html += '<div class="sync-review-detail">' + escapeHtml(presentation.after_detail) + '</div>';
+    }
+    html += '</div>';
+    html += '<button onclick="discardSyncChanges([' + ids.join(',') + '])" style="background:none;border:none;color:var(--text-ghost);font-size:11px;cursor:pointer;white-space:nowrap;" title="Discard this group">Discard group</button>';
+    html += '</div>';
+    html += '<div class="sync-review-photos">';
+    group.entries.forEach(function(entry) {
+      var photo = entry.photo;
+      var change = entry.change;
+      var thumbUrl = window.vireoThumbnailUrl
+        ? window.vireoThumbnailUrl(photo)
+        : '/thumbnails/' + photo.photo_id + '.jpg';
+      html += '<div class="sync-preview-photo" style="width:' + _syncThumbSize + 'px;">';
+      html += '<img class="sync-preview-thumb" src="' + escapeAttr(thumbUrl) + '" style="width:' + _syncThumbSize + 'px;height:' + Math.round(_syncThumbSize * 2 / 3) + 'px;object-fit:cover;border-radius:4px;cursor:pointer;display:block;" data-photo-id="' + photo.photo_id + '" data-filename="' + escapeAttr(photo.filename) + '">';
+      html += '<div class="sync-preview-filename" title="' + escapeAttr(photo.filename) + '">' + escapeHtml(photo.filename) + '</div>';
+      html += '<button class="sync-preview-discard" onclick="event.stopPropagation();discardChange(' + change.id + ')" title="Discard this change" aria-label="Discard change for ' + escapeAttr(photo.filename) + '">&times;</button>';
       html += '</div>';
     });
-
-    html += '<div style="display:flex;align-items:center;gap:8px;margin-top:4px;">';
-    html += '<span style="font-size:11px;color:var(--text-ghost);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escapeHtml(p.filename) + '</span>';
-    html += '<button onclick="discardPhotoChanges([' + changeIds.join(',') + '], this)" style="margin-left:auto;background:none;color:var(--danger);border:none;font-size:11px;cursor:pointer;padding:0;" title="Discard all changes for this photo">discard</button>';
-    html += '</div>';
-
-    html += '</div></div>';
+    html += '</div></section>';
   });
+  html += '</div>';
 
   content.innerHTML = html;
 }
@@ -328,13 +474,15 @@ function _syncRenderLightboxPanel(photoId) {
   if (!panel) return;
   var html = '<div style="font-weight:600;margin-bottom:6px;color:var(--accent);">Pending changes</div>';
   visible.forEach(function(c) {
-    var icon = c.type === 'keyword_add' ? '+' : c.type === 'keyword_remove' ? '−' : '~';
-    var color = c.type === 'keyword_add' ? 'var(--accent)' : c.type === 'keyword_remove' ? 'var(--danger)' : 'var(--warning)';
-    var typeLabel = c.type.replace(/_/g, ' ');
-    html += '<div style="display:flex;align-items:center;gap:6px;padding:3px 0;">' +
-      '<span style="color:' + color + ';font-weight:700;width:12px;text-align:center;">' + icon + '</span>' +
-      '<span style="flex:1;color:var(--text-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escapeHtml(c.value) + '</span>' +
-      '<span style="font-size:10px;color:var(--text-dim);">' + typeLabel + '</span>' +
+    var style = _syncChangeStyle(c);
+    var presentation = _syncChangePresentation(c);
+    html += '<div style="display:flex;align-items:flex-start;gap:6px;padding:5px 0;">' +
+      '<span style="color:' + style.color + ';font-weight:700;width:12px;text-align:center;">' + style.icon + '</span>' +
+      '<div style="flex:1;min-width:0;">' +
+        '<div style="color:var(--text-primary);font-weight:600;">' + escapeHtml(presentation.field) + '</div>' +
+        '<div style="margin-top:2px;color:var(--text-dim);">' + escapeHtml(presentation.before) + ' \u2192 <span style="color:var(--text-primary);">' + escapeHtml(presentation.after) + '</span></div>' +
+        (presentation.after_detail ? '<div style="margin-top:2px;color:var(--text-ghost);font-size:10px;">' + escapeHtml(presentation.after_detail) + '</div>' : '') +
+      '</div>' +
       '<button data-sync-discard-change="' + c.id + '" style="background:none;border:none;color:var(--text-ghost);cursor:pointer;padding:0 4px;font-size:16px;line-height:1;" title="Discard this change">&times;</button>' +
       '</div>';
   });
@@ -407,22 +555,8 @@ function _syncForgetChanges(changeIds) {
   _syncPreviewData.photos = _syncPreviewData.photos.filter(function(p) { return p.changes.length > 0; });
 }
 
-async function discardChange(changeId, rowEl) {
-  try {
-    await safeFetch('/api/sync/discard', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({change_ids: [changeId]}),
-    });
-    _syncForgetChanges([changeId]);
-    if (rowEl) {
-      rowEl.style.opacity = '0.3';
-      rowEl.style.textDecoration = 'line-through';
-    }
-  } catch(e) {}
-}
-
-async function discardPhotoChanges(changeIds, btn) {
+async function discardSyncChanges(changeIds) {
+  if (!changeIds || changeIds.length === 0) return;
   try {
     await safeFetch('/api/sync/discard', {
       method: 'POST',
@@ -430,9 +564,16 @@ async function discardPhotoChanges(changeIds, btn) {
       body: JSON.stringify({change_ids: changeIds}),
     });
     _syncForgetChanges(changeIds);
-    var row = btn.closest('[style*="border-bottom"]');
-    if (row) row.style.display = 'none';
+    renderSyncPreview();
   } catch(e) {}
+}
+
+function discardChange(changeId) {
+  return discardSyncChanges([changeId]);
+}
+
+function discardPhotoChanges(changeIds) {
+  return discardSyncChanges(changeIds);
 }
 
 async function discardAllChanges() {

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -516,7 +516,7 @@ async function _syncDiscardFromLightbox(changeIds, photoId) {
     });
   } catch(e) { return; }
 
-  _syncForgetChanges(changeIds);
+  await _syncRefreshPreviewAfterDiscard(changeIds);
 
   var photoAfter = _syncFindPhotoData(photoId);
   var visibleAfter = _syncVisibleChangesFor(photoAfter);
@@ -568,6 +568,23 @@ function _syncForgetChanges(changeIds) {
   _syncPreviewData.photos = _syncPreviewData.photos.filter(function(p) { return p.changes.length > 0; });
 }
 
+// Refetch the preview after a discard so derived flags (creates_xmp_sidecar,
+// paired_keyword_rename) and per-change presentations reflect the new state.
+// Discarding one half of a same-key keyword_add/keyword_remove pair
+// invalidates the surviving remove's rename-pairing flags, and rating
+// previews rely on those flags to decide whether a sidecar will be
+// created; without the refetch, a rating queued alongside such a pair
+// can look like it will be written and then be silently dropped by
+// sync_to_xmp. If the refetch fails, fall back to a local removal so the
+// UI still reflects the discard.
+async function _syncRefreshPreviewAfterDiscard(changeIds) {
+  try {
+    _syncPreviewData = await safeFetch('/api/sync/preview', {}, { toast: false });
+  } catch(e) {
+    _syncForgetChanges(changeIds);
+  }
+}
+
 async function discardSyncChanges(changeIds) {
   if (!changeIds || changeIds.length === 0) return;
   try {
@@ -576,7 +593,7 @@ async function discardSyncChanges(changeIds) {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({change_ids: changeIds}),
     });
-    _syncForgetChanges(changeIds);
+    await _syncRefreshPreviewAfterDiscard(changeIds);
     renderSyncPreview();
   } catch(e) {}
 }

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -1385,7 +1385,17 @@ async function togglePendingDetail() {
       p.changes.forEach(function(c) {
         var color = c.type === 'keyword_add' ? 'var(--accent)' : c.type === 'keyword_remove' ? 'var(--danger)' : 'var(--text-secondary)';
         var label = c.type === 'keyword_add' ? '+ ' : c.type === 'keyword_remove' ? '- ' : '';
-        html += '<div style="font-size:12px;color:' + color + ';padding:2px 0;">' + label + escapeHtml(c.value) + ' <span style="color:var(--text-ghost);">(' + c.type.replace('_', ' ') + ')</span></div>';
+        var presentation = c.presentation || {
+          field: c.type.replace(/_/g, ' '),
+          before: 'Current XMP value',
+          after: c.value || 'Cleared'
+        };
+        html += '<div style="font-size:12px;color:' + color + ';padding:2px 0;">' +
+          label + '<span style="font-weight:600;">' + escapeHtml(presentation.field) + ':</span> ' +
+          '<span style="color:var(--text-dim);">' + escapeHtml(presentation.before) + '</span> \u2192 ' +
+          escapeHtml(presentation.after) +
+          (presentation.after_detail ? '<div style="color:var(--text-ghost);font-size:11px;margin-left:14px;">' + escapeHtml(presentation.after_detail) + '</div>' : '') +
+          '</div>';
       });
       html += '</div>';
     });

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -622,6 +622,55 @@ def test_sync_preview_does_not_promise_removal_from_unreadable_xmp(
     }
 
 
+def test_sync_preview_does_not_promise_edit_clear_from_unreadable_xmp(
+    client_with_photo,
+):
+    """Clearing a Vireo edit marker cannot modify a corrupt sidecar."""
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    with open(os.path.join(folder, "test.xmp"), "w") as sidecar:
+        sidecar.write("not xml")
+    db.queue_change(photo_id, "edit_recipe", "")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["presentation"] == {
+        "field": "XMP photo edits",
+        "action": "unchanged",
+        "before": "Unreadable XMP sidecar",
+        "after": "Unreadable XMP sidecar",
+        "after_detail": (
+            "The Vireo edit marker cannot be cleared because the XMP sidecar "
+            "is unreadable"
+        ),
+    }
+
+
+def test_sync_preview_treats_absent_edit_marker_clear_as_unchanged(
+    client_with_photo,
+):
+    """A clear against a missing sidecar accurately reports a no-op."""
+    app, db, photo_id = client_with_photo
+    db.queue_change(photo_id, "edit_recipe", "")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["presentation"] == {
+        "field": "XMP photo edits",
+        "action": "unchanged",
+        "before": "No XMP sidecar",
+        "after": "No XMP sidecar",
+        "after_detail": "No XMP sidecar contains Vireo edits to clear",
+    }
+
+
 def test_edit_history_recorded_on_rating(app_and_db):
     """Setting a rating records an entry in edit_history."""
     app, db = app_and_db

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -562,6 +562,66 @@ def test_sync_preview_shows_hierarchical_keyword_before_removal(
     }
 
 
+def test_sync_preview_treats_flag_as_unchanged_when_sync_is_disabled(
+    client_with_photo,
+):
+    """A stale queued flag does not promise an XMP write after opt-out."""
+    import config as cfg
+    from xmp import write_pick_flag
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    write_pick_flag(os.path.join(folder, "test.xmp"), "rejected")
+    db.queue_change(photo_id, "flag", "flagged")
+    config = cfg.load()
+    config["sync_flags_to_xmp"] = False
+    cfg.save(config)
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["creates_xmp_sidecar"] is False
+    assert change["presentation"] == {
+        "field": "XMP flag",
+        "action": "unchanged",
+        "before": "Rejected",
+        "after": "Rejected",
+        "after_detail": "Picked stays in Vireo; flag sync to XMP is turned off",
+    }
+
+
+def test_sync_preview_does_not_promise_removal_from_unreadable_xmp(
+    client_with_photo,
+):
+    """Keyword removal cannot modify a corrupt sidecar."""
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    with open(os.path.join(folder, "test.xmp"), "w") as sidecar:
+        sidecar.write("not xml")
+    db.queue_change(photo_id, "keyword_remove", "Raptor")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["presentation"] == {
+        "field": "XMP keyword",
+        "action": "unchanged",
+        "before": "Unreadable XMP sidecar",
+        "after": "Unreadable XMP sidecar",
+        "after_detail": (
+            "Raptor cannot be removed because the XMP sidecar is unreadable"
+        ),
+    }
+
+
 def test_edit_history_recorded_on_rating(app_and_db):
     """Setting a rating records an entry in edit_history."""
     app, db = app_and_db

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -1,3 +1,6 @@
+import os
+
+
 def test_set_color_label(app_and_db):
     """POST /api/photos/<id>/color_label sets the color label."""
     app, db = app_and_db
@@ -393,6 +396,86 @@ def test_sync_status(app_and_db):
     resp = client.get('/api/sync/status')
     data = resp.get_json()
     assert data['pending_count'] == 1
+
+
+def test_sync_preview_describes_location_keyword_as_xmp_delta(
+    client_with_photo,
+):
+    """The internal ``effective`` token never stands in for a location value."""
+    import config as cfg
+    from xmp import write_gps_location
+
+    app, db, photo_id = client_with_photo
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = True
+    cfg.save(config)
+
+    florida_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES ('Florida', 'location')"
+    ).lastrowid
+    tallahassee_id = db.conn.execute(
+        "INSERT INTO keywords "
+        "(name, parent_id, type, latitude, longitude) "
+        "VALUES ('Tallahassee', ?, 'location', 30.4383, -84.2807)",
+        (florida_id,),
+    ).lastrowid
+    db.conn.commit()
+    db.set_photo_location(photo_id, tallahassee_id)
+    db.queue_change(photo_id, "location", "effective")
+
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    write_gps_location(
+        os.path.join(folder, "test.xmp"),
+        48.8566,
+        2.3522,
+        source="keyword",
+    )
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["presentation"] == {
+        "field": "Location",
+        "action": "updated",
+        "before": "48.85660, 2.35220",
+        "after": "Tallahassee, Florida",
+        "after_detail": "30.43830, -84.28070 · from a location keyword",
+    }
+
+
+def test_sync_preview_explains_when_location_xmp_writes_are_disabled(
+    client_with_photo,
+):
+    """A queued cleanup check must not imply that a location will be written."""
+    app, db, photo_id = client_with_photo
+    location_id = db.conn.execute(
+        "INSERT INTO keywords "
+        "(name, type, latitude, longitude) "
+        "VALUES ('Tallahassee', 'location', 30.4383, -84.2807)"
+    ).lastrowid
+    db.conn.commit()
+    db.set_photo_location(photo_id, location_id)
+    db.queue_change(photo_id, "location", "effective")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["location_sync_enabled"] is False
+    change = payload["photos"][0]["changes"][0]
+    assert change["presentation"] == {
+        "field": "XMP location",
+        "action": "unchanged",
+        "before": "No XMP sidecar",
+        "after": "No XMP sidecar",
+        "after_detail": (
+            "Tallahassee stays in Vireo; writing its GPS to XMP is turned off"
+        ),
+    }
 
 
 def test_edit_history_recorded_on_rating(app_and_db):

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -727,6 +727,56 @@ def test_sync_preview_preserves_hierarchy_during_paired_keyword_rename(
     }
 
 
+def test_sync_preview_clears_rename_flags_after_discarding_paired_keyword_add(
+    client_with_photo,
+):
+    """Discarding one half of an add/remove pair must un-pair the survivor.
+
+    Before the fix, the frontend cached the preview locally and only
+    dropped the discarded change from the list, leaving the surviving
+    keyword_remove flagged as ``paired_keyword_rename=True`` and
+    ``creates_xmp_sidecar=True``. A rating queued alongside that pair
+    then displayed as if the sidecar would be created, but the actual
+    sync produced no sidecar and silently dropped the rating. Refetching
+    the preview after discard must yield up-to-date flags so the rating
+    presentation and sync payload agree.
+    """
+    from xmp import write_sidecar
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    write_sidecar(
+        os.path.join(folder, "test.xmp"),
+        flat_keywords=set(),
+        hierarchical_keywords={"Animals|Birds|Raptor"},
+    )
+    db.queue_change(photo_id, "keyword_remove", "Birds")
+    db.queue_change(photo_id, "keyword_add", "Birds")
+    db.queue_change(photo_id, "rating", "4")
+
+    client = app.test_client()
+    initial = client.get("/api/sync/preview").get_json()
+    changes = {c["type"]: c for c in initial["photos"][0]["changes"]}
+    assert changes["keyword_remove"]["paired_keyword_rename"] is True
+    assert changes["keyword_remove"]["creates_xmp_sidecar"] is True
+    add_id = changes["keyword_add"]["id"]
+
+    resp = client.post("/api/sync/discard", json={"change_ids": [add_id]})
+    assert resp.status_code == 200
+
+    refreshed = client.get("/api/sync/preview").get_json()
+    after = {c["type"]: c for c in refreshed["photos"][0]["changes"]}
+    assert "keyword_add" not in after
+    removal = after["keyword_remove"]
+    assert removal["paired_keyword_rename"] is False
+    assert removal["auto_includes_keyword_add"] is False
+    assert removal["creates_xmp_sidecar"] is False
+    assert removal["presentation"]["action"] == "removed"
+
+
 def test_sync_preview_treats_flag_as_unchanged_when_sync_is_disabled(
     client_with_photo,
 ):

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -682,6 +682,8 @@ def test_sync_preview_preserves_hierarchy_during_paired_keyword_rename(
     }
     removal = changes["keyword_remove"]
     assert removal["paired_keyword_rename"] is True
+    assert removal["auto_includes_keyword_add"] is True
+    assert removal["creates_xmp_sidecar"] is True
     assert removal["presentation"] == {
         "field": "Keyword hierarchy",
         "action": "unchanged",

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -857,6 +857,119 @@ def test_sync_preview_treats_absent_keyword_removal_as_unchanged(
     }
 
 
+def test_sync_preview_reports_paired_flat_rename_as_replacement(
+    client_with_photo,
+):
+    """A paired keyword_add/remove targeting an existing flat variant shows as replaced.
+
+    The sync path dispatches the removal through the flat-only path and
+    then ``write_sidecar`` writes the clean spelling, so the sidecar ends
+    with the paired add's value. Reporting the remove side as
+    ``Not in XMP`` hides that the keyword survives with a canonicalized
+    spelling; the review must present it as an unchanged keyword whose
+    flat entry is rewritten by the paired addition.
+    """
+    from xmp import write_sidecar
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    # Existing flat variant with a smart quote; both pending values
+    # normalize to the same key so ``sync_to_xmp`` pairs them.
+    write_sidecar(
+        os.path.join(folder, "test.xmp"),
+        flat_keywords={"‘apapane"},
+        hierarchical_keywords=set(),
+    )
+    db.queue_change(photo_id, "keyword_remove", "‘apapane")
+    db.queue_change(photo_id, "keyword_add", "apapane")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    changes = {
+        change["type"]: change
+        for change in response.get_json()["photos"][0]["changes"]
+    }
+    removal = changes["keyword_remove"]
+    assert removal["paired_keyword_rename"] is True
+    assert removal["auto_includes_keyword_add"] is True
+    assert removal["creates_xmp_sidecar"] is True
+    assert removal["presentation"] == {
+        "field": "Keyword",
+        "action": "unchanged",
+        "before": "‘apapane",
+        "after": "apapane",
+        "after_detail": (
+            "The matching keyword addition rewrites this flat spelling; "
+            "the keyword itself stays in XMP"
+        ),
+    }
+
+
+def test_sync_preview_skips_writes_when_folder_is_offline(client_with_photo):
+    """A photo whose folder is unmounted must not promise XMP writes.
+
+    ``sync_to_xmp`` guards every write with
+    ``os.path.isdir(os.path.dirname(xmp_path))`` and skips the photo with
+    ``folder not accessible`` when the check fails (a common NAS-offline
+    case). The preview endpoint would otherwise ask
+    ``read_sync_preview_metadata`` to inspect the unreachable path,
+    which treats it as an absent sidecar and surfaces writes such as
+    ``No XMP sidecar → Raptor`` for keyword additions that will never
+    actually run.
+    """
+    import shutil
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+
+    db.queue_change(photo_id, "keyword_add", "Raptor")
+    db.queue_change(photo_id, "rating", "4")
+
+    # Simulate the NAS going offline between when the photo was cataloged
+    # and when the preview is opened.
+    shutil.rmtree(folder)
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    photos = response.get_json()["photos"]
+    assert len(photos) == 1
+    assert photos[0]["folder_offline"] is True
+    changes = {change["type"]: change for change in photos[0]["changes"]}
+    offline_detail = (
+        "Sync will skip this photo because its folder is offline; "
+        "no XMP will be written"
+    )
+    assert changes["keyword_add"]["creates_xmp_sidecar"] is False
+    assert changes["keyword_add"]["presentation"] == {
+        "field": "Keyword",
+        "action": "unchanged",
+        "before": "Folder not accessible",
+        "after": "Folder not accessible",
+        "after_detail": offline_detail,
+    }
+    # Rating normally splits its presentation based on whether another
+    # selected change will create the sidecar. An offline folder makes
+    # sidecar creation impossible, so both variants collapse to the same
+    # "folder not accessible" message and the rating is not asked to
+    # split at all.
+    assert changes["rating"].get("rating_requires_sidecar") is not True
+    assert changes["rating"]["presentation"] == {
+        "field": "Rating",
+        "action": "unchanged",
+        "before": "Folder not accessible",
+        "after": "Folder not accessible",
+        "after_detail": offline_detail,
+    }
+
+
 def test_sync_preview_does_not_promise_edit_clear_from_unreadable_xmp(
     client_with_photo,
 ):

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -654,6 +654,46 @@ def test_sync_preview_shows_hierarchical_keyword_before_removal(
     }
 
 
+def test_sync_preview_preserves_hierarchy_during_paired_keyword_rename(
+    client_with_photo,
+):
+    """A normalized add/remove pair only replaces the flat XMP spelling."""
+    from xmp import write_sidecar
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    write_sidecar(
+        os.path.join(folder, "test.xmp"),
+        flat_keywords=set(),
+        hierarchical_keywords={"Animals|Birds|Raptor"},
+    )
+    db.queue_change(photo_id, "keyword_remove", "Birds")
+    db.queue_change(photo_id, "keyword_add", "Birds")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    changes = {
+        change["type"]: change
+        for change in response.get_json()["photos"][0]["changes"]
+    }
+    removal = changes["keyword_remove"]
+    assert removal["paired_keyword_rename"] is True
+    assert removal["presentation"] == {
+        "field": "Keyword hierarchy",
+        "action": "unchanged",
+        "before": "Animals › Birds › Raptor",
+        "after": "Animals › Birds › Raptor",
+        "after_detail": (
+            "The matching keyword addition replaces only the flat spelling; "
+            "this hierarchy stays in XMP"
+        ),
+    }
+
+
 def test_sync_preview_treats_flag_as_unchanged_when_sync_is_disabled(
     client_with_photo,
 ):

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -622,6 +622,26 @@ def test_sync_preview_does_not_promise_removal_from_unreadable_xmp(
     }
 
 
+def test_sync_preview_treats_absent_keyword_removal_as_unchanged(
+    client_with_photo,
+):
+    """A keyword removal against a missing sidecar accurately reports a no-op."""
+    app, db, photo_id = client_with_photo
+    db.queue_change(photo_id, "keyword_remove", "Raptor")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["presentation"] == {
+        "field": "XMP keyword",
+        "action": "unchanged",
+        "before": "No XMP sidecar",
+        "after": "No XMP sidecar",
+        "after_detail": "No XMP sidecar contains Raptor to remove",
+    }
+
+
 def test_sync_preview_does_not_promise_edit_clear_from_unreadable_xmp(
     client_with_photo,
 ):

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -499,6 +499,67 @@ def test_sync_preview_does_not_promise_rating_write_without_sidecar(
             "readable XMP sidecar"
         ),
     }
+    assert change["creates_xmp_sidecar"] is False
+    assert change["rating_requires_sidecar"] is True
+
+
+def test_sync_preview_accounts_for_selected_change_creating_rating_sidecar(
+    client_with_photo,
+):
+    """A selected keyword write creates the sidecar before rating sync runs."""
+    app, db, photo_id = client_with_photo
+    db.queue_change(photo_id, "rating", "5")
+    db.queue_change(photo_id, "keyword_add", "Raptor")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    changes = {
+        change["type"]: change
+        for change in response.get_json()["photos"][0]["changes"]
+    }
+    rating = changes["rating"]
+    assert changes["keyword_add"]["creates_xmp_sidecar"] is True
+    assert rating["rating_requires_sidecar"] is True
+    assert rating["presentation"] == rating["presentation_with_sidecar"]
+    assert rating["presentation_with_sidecar"] == {
+        "field": "Rating",
+        "action": "updated",
+        "before": "No XMP sidecar",
+        "after": "5 stars",
+        "after_detail": "Another selected change creates the XMP sidecar first",
+    }
+    assert rating["presentation_without_sidecar"]["action"] == "unchanged"
+
+
+def test_sync_preview_shows_hierarchical_keyword_before_removal(
+    client_with_photo,
+):
+    """A hierarchy-only keyword removal shows the XMP value it will delete."""
+    from xmp import write_sidecar
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    write_sidecar(
+        os.path.join(folder, "test.xmp"),
+        flat_keywords=set(),
+        hierarchical_keywords={"Animals|Birds|Raptor"},
+    )
+    db.queue_change(photo_id, "keyword_remove", "Birds")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["presentation"] == {
+        "field": "Keyword",
+        "action": "removed",
+        "before": "Animals › Birds › Raptor",
+        "after": "Not in XMP",
+    }
 
 
 def test_edit_history_recorded_on_rating(app_and_db):

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -654,6 +654,37 @@ def test_sync_preview_shows_hierarchical_keyword_before_removal(
     }
 
 
+def test_sync_preview_reports_flat_and_hierarchy_when_both_will_be_removed(
+    client_with_photo,
+):
+    """Solo keyword_remove drops flat + hierarchy; both must show in the review."""
+    from xmp import write_sidecar
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()["path"]
+    write_sidecar(
+        os.path.join(folder, "test.xmp"),
+        flat_keywords={"Raptor"},
+        hierarchical_keywords={"Animals|Birds|Raptor"},
+    )
+    db.queue_change(photo_id, "keyword_remove", "Raptor")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["paired_keyword_rename"] is False
+    assert change["presentation"] == {
+        "field": "Keyword",
+        "action": "removed",
+        "before": "Raptor; Animals › Birds › Raptor",
+        "after": "Not in XMP",
+    }
+
+
 def test_sync_preview_preserves_hierarchy_during_paired_keyword_rename(
     client_with_photo,
 ):

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -478,6 +478,29 @@ def test_sync_preview_explains_when_location_xmp_writes_are_disabled(
     }
 
 
+def test_sync_preview_does_not_promise_rating_write_without_sidecar(
+    client_with_photo,
+):
+    """Rating sync cannot create a sidecar, so the preview says it stays in Vireo."""
+    app, db, photo_id = client_with_photo
+    db.queue_change(photo_id, "rating", "5")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    change = response.get_json()["photos"][0]["changes"][0]
+    assert change["presentation"] == {
+        "field": "XMP rating",
+        "action": "unchanged",
+        "before": "No XMP sidecar",
+        "after": "No XMP sidecar",
+        "after_detail": (
+            "5 stars stays in Vireo; rating sync only updates an existing, "
+            "readable XMP sidecar"
+        ),
+    }
+
+
 def test_edit_history_recorded_on_rating(app_and_db):
     """Setting a rating records an entry in edit_history."""
     app, db = app_and_db

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -532,6 +532,98 @@ def test_sync_preview_accounts_for_selected_change_creating_rating_sidecar(
     assert rating["presentation_without_sidecar"]["action"] == "unchanged"
 
 
+def test_sync_preview_reports_rating_persisted_when_location_creates_sidecar(
+    client_with_photo,
+):
+    """Assigned GPS with the toggle on creates the sidecar before rating runs.
+
+    ``sync.py`` writes ``write_gps_location`` before ``write_rating``, so
+    the rating actually lands in the new sidecar. The preview must mirror
+    that instead of reporting the rating as staying in Vireo.
+    """
+    import config as cfg
+
+    app, db, photo_id = client_with_photo
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = True
+    cfg.save(config)
+
+    location_id = db.conn.execute(
+        "INSERT INTO keywords "
+        "(name, type, latitude, longitude) "
+        "VALUES ('Tallahassee', 'location', 30.4383, -84.2807)"
+    ).lastrowid
+    db.conn.commit()
+    db.set_photo_location(photo_id, location_id)
+    db.queue_change(photo_id, "rating", "4")
+    db.queue_change(photo_id, "location", "effective")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    changes = {
+        change["type"]: change
+        for change in response.get_json()["photos"][0]["changes"]
+    }
+    assert changes["location"]["creates_xmp_sidecar"] is True
+    rating = changes["rating"]
+    assert rating["presentation"] == rating["presentation_with_sidecar"]
+    assert rating["presentation_with_sidecar"]["action"] == "updated"
+    assert rating["presentation_with_sidecar"]["after"] == "4 stars"
+
+
+def test_sync_preview_does_not_persist_rating_when_location_lacks_gps(
+    client_with_photo,
+):
+    """A location keyword without coordinates cannot create the sidecar."""
+    import config as cfg
+
+    app, db, photo_id = client_with_photo
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = True
+    cfg.save(config)
+
+    # No latitude/longitude on the keyword -- ``sync.py`` will call
+    # ``remove_vireo_gps_location`` here, which never creates a sidecar.
+    location_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES ('Placeholder', 'location')"
+    ).lastrowid
+    db.conn.commit()
+    db.set_photo_location(photo_id, location_id)
+    db.queue_change(photo_id, "rating", "2")
+    db.queue_change(photo_id, "location", "effective")
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    changes = {
+        change["type"]: change
+        for change in response.get_json()["photos"][0]["changes"]
+    }
+    assert changes["location"]["creates_xmp_sidecar"] is False
+    assert changes["rating"]["presentation"]["action"] == "unchanged"
+
+
+def test_sync_preview_reports_rating_persisted_when_edit_recipe_creates_sidecar(
+    client_with_photo,
+):
+    """A non-empty edit recipe writes a sidecar via _load_or_create_xmp."""
+    app, db, photo_id = client_with_photo
+    db.queue_change(photo_id, "rating", "5")
+    db.queue_change(photo_id, "edit_recipe", '{"exposure": 0.5}')
+
+    response = app.test_client().get("/api/sync/preview")
+
+    assert response.status_code == 200
+    changes = {
+        change["type"]: change
+        for change in response.get_json()["photos"][0]["changes"]
+    }
+    assert changes["edit_recipe"]["creates_xmp_sidecar"] is True
+    assert changes["rating"]["presentation"]["action"] == "updated"
+    assert changes["rating"]["presentation"]["after"] == "5 stars"
+
+
 def test_sync_preview_shows_hierarchical_keyword_before_removal(
     client_with_photo,
 ):

--- a/vireo/tests/test_sync.py
+++ b/vireo/tests/test_sync.py
@@ -215,6 +215,35 @@ def test_sync_to_xmp_writes_edit_recipe(tmp_path):
     assert len(db.get_pending_changes()) == 0
 
 
+def test_sync_to_xmp_writes_rating_after_edit_recipe_creates_sidecar(tmp_path):
+    """A selected edit write creates XMP before the same-photo rating runs."""
+    from xml.etree import ElementTree as ET
+
+    from db import Database
+    from sync import sync_to_xmp
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+    os.remove(xmp_path)
+
+    db.queue_change(pid, "rating", "5")
+    db.queue_change(pid, "edit_recipe", '{"exposure":0.5}')
+
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    assert result["failed"] == 0
+    desc = ET.parse(xmp_path).getroot().find(
+        ".//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description"
+    )
+    assert desc.get("{http://ns.adobe.com/xap/1.0/}Rating") == "5"
+    assert desc.get("{https://vireo.app/ns/1.0/}editRecipe") == (
+        '{"exposure":0.5}'
+    )
+
+
 def test_sync_to_xmp_clears_edit_recipe_marker(tmp_path):
     """An empty edit_recipe change removes Vireo's XMP recipe marker."""
     from db import Database
@@ -546,6 +575,50 @@ def test_sync_to_xmp_writes_effective_location(tmp_path, monkeypatch):
     assert desc.get('{http://ns.adobe.com/exif/1.0/}GPSLatitude') == '48,51.396000N'
     assert desc.get('{http://ns.adobe.com/exif/1.0/}GPSLongitude') == '2,21.132000E'
     assert desc.get('{https://vireo.app/ns/1.0/}gpsSource') == 'keyword'
+
+
+def test_sync_to_xmp_writes_rating_after_location_creates_sidecar(
+    tmp_path, monkeypatch,
+):
+    """A selected GPS write creates XMP before the same-photo rating runs."""
+    from xml.etree import ElementTree as ET
+
+    import config as cfg
+    from db import Database
+    from sync import sync_to_xmp
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = True
+    cfg.save(config)
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+    os.remove(xmp_path)
+    location_id = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES ('Tallahassee', 'location', 30.4383, -84.2807)"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, location_id),
+    )
+    db.conn.commit()
+
+    db.queue_change(pid, "rating", "4")
+    db.queue_change(pid, "location", "effective")
+
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    assert result["failed"] == 0
+    desc = ET.parse(xmp_path).getroot().find(
+        ".//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description"
+    )
+    assert desc.get("{http://ns.adobe.com/xap/1.0/}Rating") == "4"
+    assert desc.get("{https://vireo.app/ns/1.0/}gpsSource") == "keyword"
 
 
 def test_sync_to_xmp_removes_stale_vireo_location_when_effective_location_missing(tmp_path, monkeypatch):

--- a/vireo/tests/test_xmp.py
+++ b/vireo/tests/test_xmp.py
@@ -240,6 +240,7 @@ def test_read_sync_preview_metadata_reports_current_and_previous_gps(sample_xmp)
     assert metadata["status"] == "ok"
     assert metadata["keywords"] == {"Bird", "Raptor"}
     assert metadata["rating"] == "4"
+    assert metadata["rating_writable"] is True
     assert metadata["flag"] == "flagged"
     assert metadata["location"]["latitude"] == pytest.approx(48.8566)
     assert metadata["location"]["longitude"] == pytest.approx(2.3522)
@@ -251,6 +252,7 @@ def test_read_sync_preview_metadata_reports_current_and_previous_gps(sample_xmp)
 def test_read_sync_preview_metadata_distinguishes_missing_and_unreadable(tmp_path):
     missing = read_sync_preview_metadata(tmp_path / "missing.xmp")
     assert missing["status"] == "missing"
+    assert missing["rating_writable"] is False
 
     corrupt = tmp_path / "corrupt.xmp"
     corrupt.write_text("not xml")

--- a/vireo/tests/test_xmp.py
+++ b/vireo/tests/test_xmp.py
@@ -239,6 +239,10 @@ def test_read_sync_preview_metadata_reports_current_and_previous_gps(sample_xmp)
 
     assert metadata["status"] == "ok"
     assert metadata["keywords"] == {"Bird", "Raptor"}
+    assert metadata["hierarchical_keywords"] == {
+        "Animals|Birds|Raptor",
+        "Location|Forest",
+    }
     assert metadata["rating"] == "4"
     assert metadata["rating_writable"] is True
     assert metadata["flag"] == "flagged"

--- a/vireo/tests/test_xmp.py
+++ b/vireo/tests/test_xmp.py
@@ -9,6 +9,7 @@ import pytest
 from xmp import (
     read_hierarchical_keywords,
     read_keywords,
+    read_sync_preview_metadata,
     remove_keywords,
     remove_vireo_gps_location,
     write_edit_recipe,
@@ -217,6 +218,43 @@ def test_remove_vireo_gps_location_restores_previous_gps(sample_xmp):
     assert "previousGPSLatitude" not in content
     assert "previousGPSLongitude" not in content
     assert "vireo:gpsSource" not in content
+
+
+def test_read_sync_preview_metadata_reports_current_and_previous_gps(sample_xmp):
+    """Sync review gets decimal before/after inputs from one sidecar parse."""
+    from xml.etree import ElementTree as ET
+
+    ns_rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    ns_exif = "http://ns.adobe.com/exif/1.0/"
+    tree = ET.parse(sample_xmp)
+    desc = tree.getroot().find(f".//{{{ns_rdf}}}Description")
+    desc.set(f"{{{ns_exif}}}GPSLatitude", "40,46.974000N")
+    desc.set(f"{{{ns_exif}}}GPSLongitude", "73,57.924000W")
+    tree.write(sample_xmp, xml_declaration=True, encoding="unicode")
+    write_gps_location(sample_xmp, 48.8566, 2.3522, source="keyword")
+    write_rating(sample_xmp, 4)
+    write_pick_flag(sample_xmp, "flagged")
+
+    metadata = read_sync_preview_metadata(sample_xmp)
+
+    assert metadata["status"] == "ok"
+    assert metadata["keywords"] == {"Bird", "Raptor"}
+    assert metadata["rating"] == "4"
+    assert metadata["flag"] == "flagged"
+    assert metadata["location"]["latitude"] == pytest.approx(48.8566)
+    assert metadata["location"]["longitude"] == pytest.approx(2.3522)
+    assert metadata["previous_location"]["latitude"] == pytest.approx(40.7829)
+    assert metadata["previous_location"]["longitude"] == pytest.approx(-73.9654)
+    assert metadata["location_source"] == "keyword"
+
+
+def test_read_sync_preview_metadata_distinguishes_missing_and_unreadable(tmp_path):
+    missing = read_sync_preview_metadata(tmp_path / "missing.xmp")
+    assert missing["status"] == "missing"
+
+    corrupt = tmp_path / "corrupt.xmp"
+    corrupt.write_text("not xml")
+    assert read_sync_preview_metadata(corrupt)["status"] == "unreadable"
 
 
 def test_write_gps_location_rejects_out_of_range_coords(sample_xmp):

--- a/vireo/xmp.py
+++ b/vireo/xmp.py
@@ -227,6 +227,7 @@ def read_sync_preview_metadata(xmp_path):
     empty = {
         "status": "missing",
         "keywords": set(),
+        "hierarchical_keywords": set(),
         "rating": None,
         "rating_writable": False,
         "flag": None,
@@ -253,15 +254,28 @@ def read_sync_preview_metadata(xmp_path):
         if li.text:
             keywords.add(li.text)
 
+    hierarchical_keywords = set()
+    for li in root.findall(
+        f".//{{{NS_LR}}}hierarchicalSubject/{{{NS_RDF}}}Bag/{{{NS_RDF}}}li"
+    ):
+        if li.text:
+            hierarchical_keywords.add(li.text)
+
     desc = root.find(f".//{{{NS_RDF}}}Description")
     if desc is None:
-        return {**empty, "status": "ok", "keywords": keywords}
+        return {
+            **empty,
+            "status": "ok",
+            "keywords": keywords,
+            "hierarchical_keywords": hierarchical_keywords,
+        }
 
     pick_to_flag = {"1": "flagged", "0": "none", "-1": "rejected"}
     raw_pick = desc.get(f"{{{NS_XMPDM}}}pick")
     return {
         "status": "ok",
         "keywords": keywords,
+        "hierarchical_keywords": hierarchical_keywords,
         "rating": desc.get(f"{{{NS_XMP}}}Rating"),
         "rating_writable": True,
         "flag": pick_to_flag.get(raw_pick, raw_pick),

--- a/vireo/xmp.py
+++ b/vireo/xmp.py
@@ -228,6 +228,7 @@ def read_sync_preview_metadata(xmp_path):
         "status": "missing",
         "keywords": set(),
         "rating": None,
+        "rating_writable": False,
         "flag": None,
         "location": None,
         "previous_location": None,
@@ -262,6 +263,7 @@ def read_sync_preview_metadata(xmp_path):
         "status": "ok",
         "keywords": keywords,
         "rating": desc.get(f"{{{NS_XMP}}}Rating"),
+        "rating_writable": True,
         "flag": pick_to_flag.get(raw_pick, raw_pick),
         "location": _sync_preview_gps_pair(desc),
         "previous_location": _sync_preview_gps_pair(

--- a/vireo/xmp.py
+++ b/vireo/xmp.py
@@ -155,6 +155,123 @@ def read_hierarchical_keywords(xmp_path):
     return results
 
 
+def _parse_gps_coordinate(value):
+    """Parse a common XMP GPS coordinate into decimal degrees.
+
+    XMP commonly stores coordinates as ``degrees,minutesN`` but files from
+    other tools may use decimal degrees or a three-part DMS value.  Preview
+    callers need a friendly value without rejecting an otherwise readable
+    sidecar just because its coordinate spelling is unfamiliar.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+
+    hemisphere = text[-1:].upper()
+    if hemisphere in {"N", "S", "E", "W"}:
+        text = text[:-1].strip()
+    else:
+        hemisphere = None
+
+    try:
+        parts = [float(part.strip()) for part in text.split(",")]
+        if len(parts) == 1:
+            decimal = parts[0]
+        elif len(parts) == 2:
+            decimal = abs(parts[0]) + parts[1] / 60.0
+            if parts[0] < 0:
+                decimal *= -1
+        elif len(parts) == 3:
+            decimal = abs(parts[0]) + parts[1] / 60.0 + parts[2] / 3600.0
+            if parts[0] < 0:
+                decimal *= -1
+        else:
+            return None
+    except (TypeError, ValueError):
+        return None
+
+    if hemisphere in {"S", "W"}:
+        decimal = -abs(decimal)
+    elif hemisphere in {"N", "E"}:
+        decimal = abs(decimal)
+    return decimal
+
+
+def _sync_preview_gps_pair(desc, namespace=NS_EXIF, prefix=""):
+    """Read one current or backed-up GPS pair for sync-review display."""
+    lat_attr = f"{{{namespace}}}{prefix}GPSLatitude"
+    lon_attr = f"{{{namespace}}}{prefix}GPSLongitude"
+    raw_latitude = desc.get(lat_attr)
+    raw_longitude = desc.get(lon_attr)
+    if raw_latitude is None and raw_longitude is None:
+        return None
+    return {
+        "latitude": _parse_gps_coordinate(raw_latitude),
+        "longitude": _parse_gps_coordinate(raw_longitude),
+        "raw_latitude": raw_latitude,
+        "raw_longitude": raw_longitude,
+    }
+
+
+def read_sync_preview_metadata(xmp_path):
+    """Read the sidecar fields shown by the pending-changes review.
+
+    This intentionally parses a sidecar once per photo so a review containing
+    several change types does not repeatedly touch the filesystem.  Missing
+    and malformed sidecars are distinguished: that difference matters in a
+    screen whose purpose is to explain exactly what will be written.
+    """
+    path = Path(xmp_path)
+    empty = {
+        "status": "missing",
+        "keywords": set(),
+        "rating": None,
+        "flag": None,
+        "location": None,
+        "previous_location": None,
+        "location_source": None,
+        "edit_recipe": None,
+    }
+    try:
+        if not path.exists():
+            return empty
+    except OSError:
+        return {**empty, "status": "unreadable"}
+
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError):
+        return {**empty, "status": "unreadable"}
+
+    keywords = set()
+    for li in root.findall(
+        f".//{{{NS_DC}}}subject/{{{NS_RDF}}}Bag/{{{NS_RDF}}}li"
+    ):
+        if li.text:
+            keywords.add(li.text)
+
+    desc = root.find(f".//{{{NS_RDF}}}Description")
+    if desc is None:
+        return {**empty, "status": "ok", "keywords": keywords}
+
+    pick_to_flag = {"1": "flagged", "0": "none", "-1": "rejected"}
+    raw_pick = desc.get(f"{{{NS_XMPDM}}}pick")
+    return {
+        "status": "ok",
+        "keywords": keywords,
+        "rating": desc.get(f"{{{NS_XMP}}}Rating"),
+        "flag": pick_to_flag.get(raw_pick, raw_pick),
+        "location": _sync_preview_gps_pair(desc),
+        "previous_location": _sync_preview_gps_pair(
+            desc, namespace=NS_VIREO, prefix="previous",
+        ),
+        "location_source": desc.get(f"{{{NS_VIREO}}}gpsSource"),
+        "edit_recipe": desc.get(f"{{{NS_VIREO}}}editRecipe"),
+    }
+
+
 def write_sidecar(xmp_path, flat_keywords, hierarchical_keywords):
     """Write or merge keywords into an XMP sidecar file.
 


### PR DESCRIPTION
## Summary

The sync review rendered raw queue tokens such as `effective`, obscuring the metadata that would actually be written.
This change reads current XMP state, presents explicit before-and-after values, groups identical changes across photos, and explains location keyword GPS behavior when writing assigned locations is enabled or disabled.
It also updates Dashboard pending-change details while preserving per-change, per-group, and lightbox review controls.

## Validation

Focused backend and Playwright coverage passes with `106 passed`; the broader suite reached `1849 passed, 14 skipped`, with only the unrelated environment-sensitive `test_api_exiftool_status_reports_missing` failing because Homebrew ExifTool is installed on this host.
