### PR TITLE
Universal filters Phase 5: collections round-trip + legacy filter cleanup

### DIFF
--- a/docs/plans/2026-07-19-universal-filters-plan.md
+++ b/docs/plans/2026-07-19-universal-filters-plan.md
@@ -147,6 +147,22 @@ Nothing user-visible changes in this phase.
    keep thin param→rules shims only where external deep links need them.
 3. Docs: update README/help for the filter bar and `\` shortcut.
 
+### Phase 5 outcome — residual legacy surface (documented, deliberate)
+
+The callerless legacy filter branches were deleted (summary, calendar,
+geo, text-search scope, browse/init). Three holdouts keep the legacy
+params on `/api/photos`, `/api/photos/ids`, and the
+`get_photos`/`get_photo_ids`/`count_filtered_photos` trio:
+
+- the Misses page's page-local filter UI (`misses.html` →
+  `_miss_filter_photo_ids`) — a future candidate for filter-bar adoption;
+- the photo editor's keyword search (`photo_editor.html`);
+- bulk "fetch everything" pipeline callers (`per_page=999999`, no filter
+  kwargs).
+
+These are shims in the plan's sense: thin, tested, and no longer
+duplicated anywhere else.
+
 ## Review-cycle regressions to guard (from prototype PR #1319)
 
 - Facet-count helper must drop the edited clause from its group

--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -206,3 +206,47 @@ def test_visual_strength_control_and_popover_row(live_server, page):
     assert page.evaluate("VireoFilter.getVisual().strength") == "strict"
     page.click('.vf-visual-row [data-action="visual-remove"]')
     page.wait_for_function("!VireoFilter.getVisual()", timeout=8000)
+
+
+def test_save_as_collection_and_reopen(live_server, page):
+    """Phase 5: the bar's expression saves as a Collection and reopens into
+    the bar as editable chips (rules + visual round-trip)."""
+    _open_browse(page, live_server)
+    search = page.locator(".vf-search input")
+    search.fill("hawk")
+    search.press("Enter")
+    _wait_total(page, 3)
+    page.evaluate("VireoFilter.visualSearch('a soaring hawk')")
+    page.wait_for_selector(".vf-chip.visual", timeout=8000)
+
+    page.click(".vf-filters-btn")
+    page.click(".vf-save-collection")
+    page.wait_for_selector(".vf-save-modal:not([hidden])", timeout=8000)
+    preview = page.inner_text(".vf-save-preview")
+    assert "Visually similar" in preview
+    page.fill(".vf-save-name", "Soaring hawks")
+    page.click(".vf-save-confirm")
+    page.wait_for_function(
+        "window.collectionsById && Object.values(collectionsById)"
+        ".some(c => c.name === 'Soaring hawks')",
+        timeout=8000,
+    )
+    # Sidebar row carries the visual marker.
+    page.wait_for_selector(".collection-visual-mark", timeout=8000)
+
+    # Clear everything, then reopen the collection into the bar.
+    page.click(".vf-done")
+    page.click(".vf-clear")
+    page.wait_for_function(
+        "!VireoFilter.hasFilters()", timeout=8000,
+    )
+    cid = page.evaluate(
+        "Object.values(collectionsById).find(c => c.name === 'Soaring hawks').id"
+    )
+    page.evaluate(f"filterByCollection({cid})")
+    page.wait_for_selector(".vf-chip.visual", timeout=8000)
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent")
+    assert "a soaring hawk" in chips
+    # Quick-search group round-trips too (the hawk text clause).
+    assert "hawk" in chips
+    assert page.evaluate("VireoFilter.getVisual().prompt") == "a soaring hawk"

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -456,8 +456,9 @@ def test_needs_identification_refreshes_after_identification_added(live_server, 
         and r.request.method == "POST"
         and r.status == 200
     ), page.expect_response(
-        lambda r: f"/api/collections/{collection_id}/photos" in r.url
-        and r.status == 200
+        # Collections open into the filter bar now; membership-change
+        # refreshes re-evaluate the expression through the query path.
+        lambda r: "/api/photos/query" in r.url and r.status == 200
     ):
         keyword_input.press("Enter")
 
@@ -1111,12 +1112,21 @@ def test_filterByCollection_clears_multiselect_set(live_server, page):
     assert page.evaluate("selectedPhotos.size") == 1
 
     # Switch to a collection; stale selection must drop before loadPhotos.
+    # Collections now open INTO the filter bar as an editable expression
+    # (Phase 5) — the reload goes through resetAndLoad, which clears the
+    # selection; the chips prove the collection's rules were applied.
+    page.evaluate("loadCollections()")
+    page.wait_for_function(
+        f"window.collectionsById && collectionsById[{collection_id}]", timeout=4000
+    )
     page.evaluate(f"filterByCollection({collection_id})")
     page.wait_for_function(
-        f"activeCollectionId === {collection_id}", timeout=2000
+        "document.querySelector('.vf-chips') && "
+        "document.querySelector('.vf-chips').textContent.includes('File extension')",
+        timeout=4000,
     )
 
-    assert page.evaluate("selectedPhotos.size") == 0
+    page.wait_for_function("selectedPhotos.size === 0", timeout=4000)
     assert page.evaluate("selectedPhotoId") is None
     expect(bar).to_be_hidden()
 
@@ -1162,12 +1172,19 @@ def test_filterByCollection_cancels_pending_search_debounce(live_server, page):
     page.locator(".grid-card").first.wait_for(state="visible")
 
     # Text sitting in the quick-search box (no Enter yet) must not apply
-    # later and kick the user out of collection mode.
+    # later and overwrite the opened collection's expression.
+    page.evaluate("loadCollections()")
+    page.wait_for_function(
+        f"window.collectionsById && collectionsById[{collection_id}]", timeout=4000
+    )
     page.locator(".vf-search input").fill("hum")
     page.evaluate(f"filterByCollection({collection_id})")
     page.wait_for_function(
-        f"activeCollectionId === {collection_id}", timeout=2000
+        "document.querySelector('.vf-chips') && "
+        "document.querySelector('.vf-chips').textContent.includes('File extension')",
+        timeout=4000,
     )
 
     page.wait_for_timeout(350)
-    assert page.evaluate("activeCollectionId") == collection_id
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent")
+    assert "File extension" in chips and "hum" not in chips

--- a/tests/e2e/test_collection_context_menu.py
+++ b/tests/e2e/test_collection_context_menu.py
@@ -49,8 +49,12 @@ def test_collection_right_click_shows_menu(live_server, page):
 
 
 def test_collection_filter_fires_filter(live_server, page):
-    """Clicking 'Filter by this Collection' sets activeCollectionId."""
-    cid = _seed_collection(live_server, "Picks A")
+    """Clicking 'Filter by this Collection' opens its rules into the bar."""
+    import json as _json
+    db = live_server["db"]
+    db.add_collection(
+        "Picks A", _json.dumps([{"field": "extension", "op": "is", "value": ".jpg"}]),
+    )
     url = live_server["url"]
     page.goto(f"{url}/browse")
 
@@ -67,8 +71,11 @@ def test_collection_filter_fires_filter(live_server, page):
     ).click()
     expect(menu).to_be_hidden()
 
+    # Collections open into the filter bar as editable chips (Phase 5).
     page.wait_for_function(
-        f"window.activeCollectionId === {cid}", timeout=3000
+        "document.querySelector('.vf-chips') && "
+        "document.querySelector('.vf-chips').textContent.includes('File extension')",
+        timeout=4000,
     )
 
 
@@ -108,8 +115,10 @@ def test_collection_click_preserves_selected_member_position(live_server, page):
         ".tree-item[data-collection-id]", has_text="All Test Photos"
     ).click()
 
+    # The "all" sentinel collection opens as an empty expression (show
+    # everything); the selected member must survive the switch.
     page.wait_for_function(
-        f"window.activeCollectionId === {cid} && window.selectedPhotoId === {target_id}",
+        f"window.selectedPhotoId === {target_id}",
         timeout=3000,
     )
     page.locator(f'.grid-card[data-id="{target_id}"]').wait_for(state="visible")
@@ -142,245 +151,13 @@ def test_collection_click_preserves_selected_member_position(live_server, page):
     assert abs(after_top - before_top) <= 1
 
 
-def test_stale_collection_switch_does_not_restore_anchor(live_server, page):
-    """An older collection switch must not restore after a newer switch wins."""
-    import json as _json
-
-    db = live_server["db"]
-    first_id = db.add_collection(
-        "First Collection",
-        _json.dumps([{"field": "all"}]),
-    )
-    second_id = db.add_collection(
-        "Second Collection",
-        _json.dumps([{"field": "all"}]),
-    )
-    target_id = live_server["data"]["photos"][3]
-
-    url = live_server["url"]
-    page.goto(f"{url}/browse")
-
-    page.locator(f'.grid-card[data-id="{target_id}"]').wait_for(state="visible")
-    page.locator(f'.grid-card[data-id="{target_id}"]').click()
-
-    page.evaluate(
-        """() => {
-          perPage = 1;
-          observer.disconnect();
-          window.__restoreAnchorCalls = 0;
-          const realRestore = window.restorePhotoAnchor;
-          window.restorePhotoAnchor = function(anchor) {
-            window.__restoreAnchorCalls += 1;
-            return realRestore(anchor);
-          };
-
-          const realLoadPhotos = window.loadPhotos;
-          let calls = 0;
-          window.__releaseFirstCollectionLoad = null;
-          window.loadPhotos = async function() {
-            calls += 1;
-            if (calls === 1) {
-              await new Promise(resolve => {
-                window.__releaseFirstCollectionLoad = resolve;
-              });
-            }
-            return realLoadPhotos();
-          };
-        }"""
-    )
-
-    page.evaluate("(collectionId) => { window.__firstSwitch = filterByCollection(collectionId); }", first_id)
-    page.wait_for_function("typeof window.__releaseFirstCollectionLoad === 'function'")
-
-    page.evaluate("window.selectedPhotoId = null")
-    page.evaluate("(collectionId) => filterByCollection(collectionId)", second_id)
-    page.wait_for_function(f"window.activeCollectionId === {second_id}")
-
-    page.evaluate("window.__releaseFirstCollectionLoad()")
-    page.wait_for_function("window.__firstSwitch && true")
-    page.evaluate("() => window.__firstSwitch")
-    page.wait_for_timeout(50)
-
-    assert page.evaluate("window.activeCollectionId") == second_id
-    assert page.evaluate("window.__restoreAnchorCalls") == 0
-
-
-def test_collection_anchor_does_not_override_new_selection(live_server, page):
-    """Delayed anchor restore must not clobber a user's newer selection."""
-    import json as _json
-
-    db = live_server["db"]
-    collection_id = db.add_collection(
-        "Delayed Collection",
-        _json.dumps([{"field": "all"}]),
-    )
-    original_id = live_server["data"]["photos"][3]
-    new_id = live_server["data"]["photos"][0]
-
-    url = live_server["url"]
-    page.goto(f"{url}/browse")
-
-    page.locator(f'.grid-card[data-id="{original_id}"]').wait_for(state="visible")
-    page.locator(f'.grid-card[data-id="{original_id}"]').click()
-
-    page.evaluate(
-        """() => {
-          perPage = 1;
-          observer.disconnect();
-          window.__restoreAnchorCalls = 0;
-          const realRestore = window.restorePhotoAnchor;
-          window.restorePhotoAnchor = function(anchor) {
-            window.__restoreAnchorCalls += 1;
-            return realRestore(anchor);
-          };
-
-          const realLoadPhotos = window.loadPhotos;
-          window.__loadPhotoCalls = 0;
-          window.__releaseSecondLoad = null;
-          window.loadPhotos = async function() {
-            window.__loadPhotoCalls += 1;
-            if (window.__loadPhotoCalls === 2) {
-              await new Promise(resolve => {
-                window.__releaseSecondLoad = resolve;
-              });
-            }
-            return realLoadPhotos();
-          };
-        }"""
-    )
-
-    page.evaluate(
-        "(collectionId) => { window.__switchPromise = filterByCollection(collectionId); }",
-        collection_id,
-    )
-    page.wait_for_function("typeof window.__releaseSecondLoad === 'function'")
-
-    page.evaluate(
-        """(photoId) => {
-          const idx = photos.findIndex(p => p.id === photoId);
-          selectPhoto({shiftKey: false, metaKey: false, ctrlKey: false}, photoId, idx);
-        }""",
-        new_id,
-    )
-
-    page.evaluate("window.__releaseSecondLoad()")
-    page.evaluate("() => window.__switchPromise")
-    page.wait_for_timeout(50)
-
-    assert page.evaluate("window.selectedPhotoId") == new_id
-    assert page.evaluate("window.__restoreAnchorCalls") == 0
-    assert page.evaluate("window.__loadPhotoCalls") == 2
-
-
-def test_collection_switch_clears_selection_during_anchor_scan(live_server, page):
-    """Old-view selections must not stay armed while the anchor scan is pending."""
-    import json as _json
-
-    db = live_server["db"]
-    collection_id = db.add_collection(
-        "Slow Anchor Collection",
-        _json.dumps([{"field": "all"}]),
-    )
-    target_id = live_server["data"]["photos"][3]
-
-    url = live_server["url"]
-    page.goto(f"{url}/browse")
-
-    page.locator(f'.grid-card[data-id="{target_id}"]').wait_for(state="visible")
-    page.locator(f'.grid-card[data-id="{target_id}"]').click()
-    page.wait_for_function(f"window.selectedPhotoId === {target_id}")
-
-    page.evaluate(
-        """() => {
-          perPage = 1;
-          observer.disconnect();
-          const realLoadPhotos = window.loadPhotos;
-          let calls = 0;
-          window.__releaseSecondLoad = null;
-          window.loadPhotos = async function() {
-            calls += 1;
-            if (calls === 2) {
-              await new Promise(resolve => {
-                window.__releaseSecondLoad = resolve;
-              });
-            }
-            return realLoadPhotos();
-          };
-        }"""
-    )
-
-    page.evaluate(
-        "(collectionId) => { window.__switchPromise = filterByCollection(collectionId); }",
-        collection_id,
-    )
-    page.wait_for_function("typeof window.__releaseSecondLoad === 'function'")
-
-    assert page.evaluate("window.selectedPhotoId") is None
-    assert page.evaluate("window.getActiveSelection().length") == 0
-    assert page.evaluate("document.getElementById('batchBar').style.display") == "none"
-
-    page.evaluate("window.__releaseSecondLoad()")
-    page.evaluate("() => window.__switchPromise")
-
-    page.wait_for_function(
-        f"window.activeCollectionId === {collection_id} && window.selectedPhotoId === {target_id}",
-        timeout=3000,
-    )
-
-
-def test_stale_anchor_scan_stops_after_collection_changes(live_server, page):
-    """A stale anchor scan must not keep paginating a newer collection."""
-    import json as _json
-
-    db = live_server["db"]
-    first_id = db.add_collection(
-        "First Scan Collection",
-        _json.dumps([{"field": "all"}]),
-    )
-    second_id = db.add_collection(
-        "Second Scan Collection",
-        _json.dumps([{"field": "all"}]),
-    )
-    original_id = live_server["data"]["photos"][3]
-
-    url = live_server["url"]
-    page.goto(f"{url}/browse")
-
-    page.locator(f'.grid-card[data-id="{original_id}"]').wait_for(state="visible")
-    page.locator(f'.grid-card[data-id="{original_id}"]').click()
-
-    page.evaluate(
-        """() => {
-          perPage = 1;
-          observer.disconnect();
-          window.__loadPhotoCalls = 0;
-          const realLoadPhotos = window.loadPhotos;
-          window.__releaseSecondLoad = null;
-          window.loadPhotos = async function() {
-            window.__loadPhotoCalls += 1;
-            if (window.__loadPhotoCalls === 2) {
-              await new Promise(resolve => {
-                window.__releaseSecondLoad = resolve;
-              });
-            }
-            return realLoadPhotos();
-          };
-        }"""
-    )
-
-    page.evaluate("(collectionId) => { window.__firstSwitch = filterByCollection(collectionId); }", first_id)
-    page.wait_for_function("typeof window.__releaseSecondLoad === 'function'")
-
-    page.evaluate("window.selectedPhotoId = null")
-    page.evaluate("(collectionId) => filterByCollection(collectionId)", second_id)
-    page.wait_for_function(f"window.activeCollectionId === {second_id}")
-
-    page.evaluate("window.__releaseSecondLoad()")
-    page.evaluate("() => window.__firstSwitch")
-    page.wait_for_timeout(50)
-
-    assert page.evaluate("window.activeCollectionId") == second_id
-    assert page.evaluate("window.__loadPhotoCalls") == 3
+# NOTE (Phase 5): the four stale-anchor-scan orchestration tests that lived
+# here exercised filterByCollection's bespoke await/anchor pipeline, which
+# was deleted when collections started opening into the filter bar. The
+# shared resetAndLoad path they now route through has its own epoch/anchor
+# guards, covered by test_browse_search_empty_state.py (anchor preservation
+# on filter change) and test_browse_single_select.py
+# (test_filterByCollection_clears_multiselect_set).
 
 
 def test_collection_duplicate_fires_endpoint_and_rerenders(live_server, page):

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -74,8 +74,9 @@ def test_dashboard_collection_drill_down_is_explicitly_composable(live_server, p
     assert query["date_to"] == ["2024-06-30"]
     initial_query = parse_qs(urlparse(initial_response.value.url).query)
     assert initial_query["collection_id"] == [str(collection_id)]
-    assert initial_query["date_from"] == ["2024-06-01"]
-    assert initial_query["date_to"] == ["2024-06-30"]
+    # /api/browse/init is scope-only since Phase 5 — the date bounds compile
+    # into the filter bar client-side and apply via /api/photos/query.
+    assert "date_from" not in initial_query
     expect(page.locator(".grid-card")).to_have_count(1)
     expect(page.locator(".grid-card-name")).to_have_text("robin1.jpg")
 

--- a/tests/e2e/test_dashboard.py
+++ b/tests/e2e/test_dashboard.py
@@ -84,6 +84,40 @@ def test_dashboard_collection_drill_down_is_explicitly_composable(live_server, p
     expect(page.locator(".grid-card")).to_have_count(2)
 
 
+def test_dashboard_scoped_visual_collection_link_loads_visual_clause(live_server, page):
+    """A bookmarked drilldown into a visual collection
+    (``?dashboard_scope=1&collection_id=<visual>``) must load the saved
+    rules + visual expression into the filter bar. ``/api/browse/init`` and
+    ``/api/photos/query`` only evaluate ``rules`` in the dashboard-scope
+    path, so keeping the scope would silently widen to every metadata match
+    and drop the visual clause (Codex review r3621519730)."""
+    import json as _json
+
+    db = live_server["db"]
+    visual_id = db.add_collection(
+        "Soaring hawks",
+        _json.dumps([{"field": "rating", "op": ">=", "value": 3}]),
+        visual_json=_json.dumps(
+            {"prompt": "a soaring hawk", "strength": "balanced"},
+        ),
+    )
+
+    page.goto(
+        f"{live_server['url']}/browse"
+        f"?dashboard_scope=1&collection_id={visual_id}"
+    )
+    page.wait_for_selector("#vireoFilterBar", timeout=15000)
+    # filterByCollection() ran → visual chip is loaded into the bar.
+    page.wait_for_selector(".vf-chip.visual", timeout=15000)
+    assert (
+        page.evaluate("VireoFilter.getVisual() && VireoFilter.getVisual().prompt")
+        == "a soaring hawk"
+    )
+    # dashboardCollectionScope was cleared so subsequent filter edits behave
+    # like a plain reopen, not a scoped drilldown.
+    assert page.evaluate("dashboardCollectionScope") is False
+
+
 def test_dashboard_rejects_reversed_url_dates_and_labels_open_ranges(live_server, page):
     """Bookmarked dates are validated and summaries match open-ended semantics."""
     page.goto(

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -536,8 +536,8 @@ def test_exif_accept_batches_selection_and_refreshes_smart_collection(
     page.locator(".grid-card").first.wait_for(state="visible")
     page.evaluate("(collectionId) => filterByCollection(collectionId)", collection_id)
     page.wait_for_function(
-        "(collectionId) => activeCollectionId === collectionId && photos.length === 3",
-        arg=collection_id,
+        # Collections open into the filter bar as an expression (Phase 5).
+        "() => window.VireoFilter && VireoFilter.hasFilters() && photos.length === 3",
     )
 
     page.locator(f".grid-card[data-id='{photo_ids[0]}']").click()
@@ -548,7 +548,9 @@ def test_exif_accept_batches_selection_and_refreshes_smart_collection(
     page.wait_for_function("() => selectedPhotos.size === 3")
 
     page.locator("#locationExifSuggestion button.accept-btn").click()
-    page.wait_for_function("() => activeCollectionId !== null && photos.length === 0")
+    page.wait_for_function(
+        "() => window.VireoFilter && VireoFilter.hasFilters() && photos.length === 0"
+    )
 
     for photo_id in photo_ids:
         row = db.conn.execute(
@@ -1702,8 +1704,8 @@ def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     page.locator(".grid-card").first.wait_for(state="visible")
     page.evaluate("(collectionId) => filterByCollection(collectionId)", collection_id)
     page.wait_for_function(
-        "(collectionId) => activeCollectionId === collectionId && photos.length === 3",
-        arg=collection_id,
+        # Collections open into the filter bar as an expression (Phase 5).
+        "() => window.VireoFilter && VireoFilter.hasFilters() && photos.length === 3",
     )
 
     page.locator(f".grid-card[data-id='{photo_ids[0]}']").click()
@@ -1715,7 +1717,9 @@ def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     inp = page.locator("#locationInput")
     inp.fill("the meadow")
     inp.press("Enter")
-    page.wait_for_function("() => activeCollectionId !== null && photos.length === 0")
+    page.wait_for_function(
+        "() => window.VireoFilter && VireoFilter.hasFilters() && photos.length === 0"
+    )
 
     for photo_id in photo_ids:
         row = db.conn.execute(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10508,8 +10508,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # instead: the sidebar (browse.html) renders an empty count
             # span for null photo_count, and the ✦ visual marker already
             # tells users this collection is visually resolved.
+            #
+            # Still validate the metadata rules though — skipping the count
+            # was also the only validation path that caught malformed JSON
+            # or unresolvable rule fields. Without this check, a visual
+            # collection with degraded rules would look healthy in the
+            # sidebar and only 400 later when Browse routes those bad rules
+            # through ``/api/photos/query`` (Codex review r3621304875).
             if c["visual_json"] is not None:
                 d["photo_count"] = None
+                _, degraded = _collection_rules_state(db, c["rules"])
+                if degraded:
+                    d["count_error"] = True
+                    app.logger.warning(
+                        "Visual collection %s (%s) has unresolvable rules; marking degraded",
+                        c["id"],
+                        c["name"],
+                    )
             else:
                 try:
                     d["photo_count"] = db.count_collection_photos(c["id"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6355,6 +6355,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         q = request.args.get("q") or None
         folder_id = request.args.get("folder_id", None, type=int)
         collection_id = request.args.get("collection_id", None, type=int)
+        # ``get_filter_field_values`` narrows counts through
+        # ``_build_collection_query``, which reads only ``collections.rules``.
+        # Without ``visual``, a saved visual collection would silently widen
+        # the typeahead counts to every metadata match (Codex review
+        # r3622521597).
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         # Clamp ``limit`` to a positive bounded range. Werkzeug's ``type=int``
         # cheerfully parses ``?limit=0``/``?limit=-5`` (SQLite treats a
         # negative ``LIMIT`` as "no limit" and returns everything), and
@@ -6436,6 +6444,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         year = request.args.get("year", date.today().year, type=int)
         folder_id = request.args.get("folder_id", None, type=int)
         collection_id = request.args.get("collection_id", None, type=int)
+        # ``get_calendar_data`` narrows through ``_build_collection_query``,
+        # which reads only ``collections.rules``. Without ``visual``, a saved
+        # visual collection would silently widen calendar counts to every
+        # metadata match (Codex review r3622521597).
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         try:
             rules = _request_rules_arg()
             visual = _request_visual_arg()
@@ -6460,6 +6475,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         folder_id = request.args.get("folder_id", None, type=int)
         collection_id = request.args.get("collection_id", None, type=int)
+        # ``get_browse_summary`` narrows through ``_build_collection_query``,
+        # which reads only ``collections.rules``. Without ``visual``, a saved
+        # visual collection would silently widen the summary to every
+        # metadata match (Codex review r3622521597). Browse itself clears
+        # ``activeCollectionId`` when opening a collection into the filter
+        # bar, so its ``/api/browse/summary`` calls never carry a visual
+        # collection id; this guards direct API callers.
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         try:
             rules = _request_rules_arg()
             visual = _request_visual_arg()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6008,6 +6008,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         sort = request.args.get("sort", "date")
         folder_id = request.args.get("folder_id", None, type=int)
         collection_id = request.args.get("collection_id", None, type=int)
+        # Rules-only path: ``db.get_photos``'s collection restriction is
+        # built by ``_build_collection_query`` and evaluates ``rules`` alone.
+        # ``/api/v1/photos`` aliases this view, so a headless caller that
+        # scopes to a visual collection here would silently widen to every
+        # metadata match instead of the saved visual result set (Codex
+        # review r3621634298).
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         rating_min = request.args.get("rating_min", None, type=int)
         date_from = request.args.get("date_from", None)
         date_to = request.args.get("date_to", None)
@@ -6324,6 +6333,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         sort = request.args.get("sort", "date")
         folder_id = request.args.get("folder_id", None, type=int)
         collection_id = request.args.get("collection_id", None, type=int)
+        # Rules-only path — see ``api_photos``. ``db.get_photo_ids`` also
+        # goes through ``_build_collection_query``, so a visual collection
+        # id would silently widen to every metadata match (Codex review
+        # r3621634298).
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         rating_min = request.args.get("rating_min", None, type=int)
         date_from = request.args.get("date_from", None)
         date_to = request.args.get("date_to", None)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4576,30 +4576,57 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         folder_id = request.args.get("folder_id", None, type=int)
         collection_id = request.args.get("collection_id", None, type=int)
 
+        # ``db.get_photos(collection_id=...)`` / ``count_filtered_photos`` both
+        # expand only ``collections.rules`` — the same rules-only path guarded
+        # elsewhere by ``_reject_visual_collection``. A visual-only collection
+        # stores ``rules: []``, so running it through that path here would
+        # silently widen first paint to every workspace photo. The client's
+        # ``bootstrapBrowse()`` calls ``filterByCollection()`` right after,
+        # which reloads through ``/api/photos/query`` with the visual clause,
+        # but the wrong grid still flashes between the two — and any failure
+        # before ``filterByCollection()`` runs leaves the user staring at the
+        # widened scope. Drop the ``collection_id`` from the photo query and
+        # return an empty grid so the wrong data can never appear (Codex
+        # review on PR #1343). Folders/keywords/collections are still returned
+        # so the sidebar bootstraps.
+        visual_first_paint = False
+        if collection_id is not None:
+            coll_row = db.conn.execute(
+                "SELECT visual_json FROM collections "
+                "WHERE id = ? AND workspace_id = ?",
+                (collection_id, db._ws_id()),
+            ).fetchone()
+            if coll_row is not None and coll_row["visual_json"] is not None:
+                visual_first_paint = True
+
         # First paint is scope-only (folder / collection / sort); metadata
         # filter deep links compile into the filter bar client-side, which
         # reloads through /api/photos/query once initialized (Phase 5 —
         # legacy per-field params removed from this endpoint).
-        try:
-            photos = db.get_photos(
-                folder_id=folder_id,
-                collection_id=collection_id,
-                page=page,
-                per_page=per_page,
-                sort=sort,
-            )
-        except ValueError as exc:
-            return json_error(str(exc), 400)
-        if not any([folder_id, collection_id]):
-            total = db.count_photos()
+        if visual_first_paint:
+            photos = []
+            total = 0
         else:
             try:
-                total = db.count_filtered_photos(
+                photos = db.get_photos(
                     folder_id=folder_id,
                     collection_id=collection_id,
+                    page=page,
+                    per_page=per_page,
+                    sort=sort,
                 )
             except ValueError as exc:
                 return json_error(str(exc), 400)
+            if not any([folder_id, collection_id]):
+                total = db.count_photos()
+            else:
+                try:
+                    total = db.count_filtered_photos(
+                        folder_id=folder_id,
+                        collection_id=collection_id,
+                    )
+                except ValueError as exc:
+                    return json_error(str(exc), 400)
         folders = db.get_folder_tree()
         keywords = db.get_keyword_tree()
         collections = db.get_collections()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7023,11 +7023,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return None, json_error("photo_ids or collection_id required", 400)
 
         row = db.conn.execute(
-            "SELECT id FROM collections WHERE id = ? AND workspace_id = ?",
+            "SELECT id, visual_json FROM collections "
+            "WHERE id = ? AND workspace_id = ?",
             (collection_id, db._ws_id()),
         ).fetchone()
         if row is None:
             return None, json_error("collection not found", 404)
+        # get_collection_photo_ids evaluates ``rules`` only; a visual-only
+        # collection would silently expand to every metadata match. The
+        # picker filters these out, but reject here as the boundary.
+        if row["visual_json"] is not None:
+            return None, json_error(_VISUAL_COLLECTION_MSG, 400)
         return db.get_collection_photo_ids(collection_id), None
 
     def _location_review_groups(photos, cluster_radius_m=750.0):
@@ -10485,6 +10491,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     )
                 except (TypeError, ValueError):
                     d["can_add_photos"] = False
+            # ``has_visual`` lets clients that funnel a collection through
+            # the legacy rules-only path (``/api/collections/<id>/photos``,
+            # ``/photo-ids``, pipeline/misses ``collection_id``) hide or
+            # disable visual collections in their pickers. Those paths
+            # evaluate ``rules`` only — a visual-only collection would
+            # otherwise silently widen the scope to every metadata match.
+            # Browse opens the same collection into the filter bar, where
+            # the visual clause IS resolved (see collectionsById /
+            # loadExpression), so surfacing the flag here lets the two
+            # flows behave differently without every caller re-parsing
+            # ``visual_json``.
+            d["has_visual"] = c["visual_json"] is not None
             result.append(d)
         return jsonify(result)
 
@@ -10677,10 +10695,54 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("collection not found", 404)
         return jsonify({"ok": True, "id": new_id})
 
+    def _collection_row(db, collection_id):
+        """Return the (workspace-scoped) collection row or None."""
+        return db.conn.execute(
+            "SELECT id, name, rules, visual_json FROM collections "
+            "WHERE id = ? AND workspace_id = ?",
+            (collection_id, db._ws_id()),
+        ).fetchone()
+
+    _VISUAL_COLLECTION_MSG = (
+        "This collection has a visual-search clause. The rules-only "
+        "endpoint would silently widen the scope to every metadata "
+        "match, so it is refused here. Open the collection from Browse "
+        "to see the visual results."
+    )
+
+    def _reject_visual_collection(db, collection_id):
+        """Return a 400 response if the collection is visual, else None.
+
+        The consumers that call ``db.get_collection_photos`` /
+        ``collection_photo_ids`` (pipeline stages, sharpness/cull/classify/
+        regroup/masks jobs, predictions-compare, misses filter, import
+        preview) evaluate ``rules`` only. A visual-only collection would
+        otherwise silently scope those runs to every metadata-matching
+        photo instead of the visually-matched subset — the fix Codex
+        flagged in review r3620423210. Pickers hide these collections too,
+        but this is the source-of-truth boundary check.
+        """
+        if collection_id is None:
+            return None
+        if not isinstance(collection_id, int) or isinstance(collection_id, bool):
+            return None
+        row = _collection_row(db, collection_id)
+        if row is not None and row["visual_json"] is not None:
+            return json_error(_VISUAL_COLLECTION_MSG, 400)
+        return None
+
     @app.route("/api/collections/<int:collection_id>/photos")
     def api_collection_photos(collection_id):
         import config as cfg
         db = _get_db()
+        # This endpoint evaluates ``rules`` only (see
+        # ``get_collection_photos`` → ``_build_collection_query``); reject
+        # visual collections up front so the pipeline/review/etc. consumers
+        # that hit it don't silently scope to every metadata-matching
+        # photo instead of the visually-matched subset.
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         page = request.args.get("page", 1, type=int)
         default_per_page = cfg.load().get("photos_per_page", 50)
         per_page = max(1, min(request.args.get("per_page", default_per_page, type=int), _MAX_PER_PAGE))
@@ -10715,6 +10777,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_collection_photo_ids(collection_id):
         """Return every photo ID matching a collection."""
         db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         try:
             photo_ids = db.get_collection_photo_ids(collection_id)
         except ValueError as e:
@@ -13356,6 +13421,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         collection_id = request.args.get("collection_id", None, type=int)
         status = request.args.get("status", None)
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         try:
             rules = _request_rules_arg()
             visual = _request_visual_arg()
@@ -13476,6 +13544,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         collection_id = request.args.get("collection_id", None, type=int)
         if not collection_id:
             return json_error("collection_id required")
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
 
         photos = db.get_collection_photos(collection_id, per_page=999999)
         photo_ids = [p["id"] for p in photos]
@@ -14308,9 +14379,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 flag=flag,
             ))
         if collection_id is not None:
-            valid_ids = {c["id"] for c in db.get_collections()}
-            if collection_id not in valid_ids:
+            # ``collection_photo_ids`` (like ``get_collection_photos``)
+            # evaluates ``rules`` only. Refuse a visual-only collection
+            # here so the Misses page does not silently widen its scope
+            # to every metadata match — the picker filter is the primary
+            # gate; this is defense-in-depth for API callers.
+            valid = {c["id"]: c for c in db.get_collections()}
+            if collection_id not in valid:
                 raise ValueError("collection not found")
+            if valid[collection_id]["visual_json"] is not None:
+                raise ValueError(
+                    "visual collections have no rules-only expansion; "
+                    "open the collection from Browse instead"
+                )
             collection_ids = db.collection_photo_ids(collection_id)
             photo_ids = (
                 collection_ids
@@ -17107,6 +17188,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("collection_id required", 400)
 
         db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         try:
             photos = db.get_collection_photos(collection_id, page=1, per_page=100000)
         except ValueError as e:
@@ -19986,8 +20070,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_job_previews():
         body = request.get_json(silent=True) or {}
         collection_id = body.get("collection_id")
+        db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         runner = app._job_runner
-        active_ws = _get_db()._active_workspace_id
+        active_ws = db._active_workspace_id
 
         def work(job):
             import contextlib
@@ -23670,9 +23758,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_job_sharpness():
         body = request.get_json(silent=True) or {}
         collection_id = body.get("collection_id")
+        db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
 
         runner = app._job_runner
-        active_ws = _get_db()._active_workspace_id
+        active_ws = db._active_workspace_id
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
 
@@ -23769,6 +23861,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         if not collection_id:
             return json_error("collection_id required")
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
 
         params = ClassifyParams(
             collection_id=collection_id,
@@ -24815,13 +24910,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """Run culling analysis as a background job."""
         body = request.get_json(silent=True) or {}
         collection_id = body.get("collection_id")
+        db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         separate_file_types = body.get("separate_file_types", True)
         time_window = body.get("time_window", 60)
         phash_threshold = body.get("phash_threshold", 19)
         cross_bucket_merge = body.get("cross_bucket_merge", False)
 
         runner = app._job_runner
-        active_ws = _get_db()._active_workspace_id
+        active_ws = db._active_workspace_id
 
         def work(job):
             from culling import analyze_for_culling
@@ -25032,6 +25131,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
 
         db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = effective_cfg.get("pipeline", {})
         sam2_variant = pipeline_cfg.get("sam2_variant")
@@ -25360,14 +25462,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         body = request.get_json(silent=True) or {}
         collection_id = body.get("collection_id")
+        db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
 
         import config as cfg
 
-        effective_cfg = _get_db().get_effective_config(cfg.load())
+        effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = effective_cfg.get("pipeline", {})
 
         runner = app._job_runner
-        active_ws = _get_db()._active_workspace_id
+        active_ws = db._active_workspace_id
 
         def work(job):
             from pipeline import (
@@ -25901,6 +26007,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "Process only accepts photos already in the workspace; "
                 "use Import for " + ", ".join(filesystem_scopes)
             )
+
+        # Pipeline stages iterate ``thread_db.get_collection_photos(...)``
+        # (see pipeline_job / classify_job / sharpness / culling), which
+        # evaluates ``rules`` only. Reject visual collections here so a
+        # run isn't silently scoped to every metadata-matching photo
+        # instead of the visually-matched subset.
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
 
         # Folder scope: resolve folder_ids to their active-workspace subtrees
         # and materialize an ad-hoc collection, then proceed as a collection
@@ -27390,6 +27505,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
 
         db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = {**effective_cfg.get("pipeline", {}), **overrides}
 
@@ -27468,6 +27586,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
 
         db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = {**effective_cfg.get("pipeline", {}), **overrides}
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6179,6 +6179,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             not isinstance(collection_id, int) or isinstance(collection_id, bool)
         ):
             return json_error("collection_id must be an integer", 400)
+        # Rules-only scoping path: ``query_photo_ids`` / ``query_photos`` /
+        # ``count_photos_for_rules`` all funnel through
+        # ``_append_collection_restriction`` → ``_build_collection_query``,
+        # which reads only ``collections.rules``. An API/headless caller
+        # posting ``{"collection_id": <visual id>}`` would therefore silently
+        # widen to every metadata match instead of the saved visual result
+        # set; the Browse reopen path already sends the stored ``rules`` +
+        # ``visual`` without relying on ``collection_id`` (Codex review
+        # r3621903988).
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         folder_id = payload.get("folder_id")
         if folder_id is not None and (
             not isinstance(folder_id, int) or isinstance(folder_id, bool)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4403,6 +4403,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not isinstance(prompt, str) or not prompt.strip():
             raise ValueError("visual.prompt must be a non-empty string")
         strength = visual.get("strength", "balanced")
+        # An unhashable strength (e.g. ``["broad"]``) makes ``strength in
+        # _VISUAL_STRENGTH_THRESHOLDS`` raise ``TypeError``, which would
+        # escape the 400 handler in the collection create/update paths as
+        # a 500 (CodeRabbit review r3620473547 outside-diff note).
+        if not isinstance(strength, str):
+            raise ValueError("visual.strength must be a string")
         if strength not in _VISUAL_STRENGTH_THRESHOLDS:
             raise ValueError("visual.strength must be broad, balanced, or strict")
         return {"prompt": prompt.strip(), "strength": strength}
@@ -9946,7 +9952,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         folders = [dict(row) for row in db.get_folder_tree()]
         collection_rows = db.conn.execute(
-            "SELECT id, name, rules FROM collections "
+            "SELECT id, name, rules, visual_json FROM collections "
             "WHERE workspace_id = ? ORDER BY name COLLATE NOCASE, id",
             (db._ws_id(),),
         ).fetchall()
@@ -9957,14 +9963,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "id": row["id"],
                 "name": row["name"],
                 "degraded": degraded,
+                # Dashboard scope path (/api/stats, /api/coverage, and the
+                # Dashboard Browse drilldown link) resolves collection_id
+                # through ``_build_collection_query``, which evaluates
+                # ``rules`` only. A visual collection selected here would
+                # silently widen to every metadata match (Codex review
+                # r3620636595), so stats.html disables these picker options.
+                "has_visual": row["visual_json"] is not None,
             })
         return jsonify({"folders": folders, "collections": collections})
 
     @app.route("/api/stats")
     def api_stats():
         db = _get_db()
+        scope = _dashboard_scope_args()
+        err = _reject_visual_collection(db, scope.get("collection_id"))
+        if err is not None:
+            return err
         try:
-            stats = db.get_dashboard_stats(**_dashboard_scope_args())
+            stats = db.get_dashboard_stats(**scope)
         except ValueError as exc:
             return json_error(str(exc), 400)
         return jsonify(stats)
@@ -9979,6 +9996,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         db = _get_db()
         scope = _dashboard_scope_args()
+        err = _reject_visual_collection(db, scope.get("collection_id"))
+        if err is not None:
+            return err
         try:
             return jsonify({
                 "overall": db.get_coverage_stats(**scope),
@@ -10721,12 +10741,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo instead of the visually-matched subset — the fix Codex
         flagged in review r3620423210. Pickers hide these collections too,
         but this is the source-of-truth boundary check.
+
+        Coerce the raw JSON value before the ``visual_json`` lookup:
+        SQLite's ``WHERE id = ?`` still matches integer id 1 when handed
+        ``"1"`` or ``True``, so an early ``isinstance`` bail-out would let
+        a string- or bool-typed id skip the guard and hit the rules-only
+        path anyway (Codex review r3620636582). Return a 400 on an
+        unparseable id so callers can't silently widen the scope.
         """
-        if collection_id is None:
+        coerced = _coerce_collection_id(collection_id)
+        if coerced is None:
             return None
-        if not isinstance(collection_id, int) or isinstance(collection_id, bool):
-            return None
-        row = _collection_row(db, collection_id)
+        if coerced is False:
+            return json_error("collection_id must be an integer", 400)
+        row = _collection_row(db, coerced)
         if row is not None and row["visual_json"] is not None:
             return json_error(_VISUAL_COLLECTION_MSG, 400)
         return None

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6099,9 +6099,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         search (which only loads embeddings for the active model — see
         ``api_photo_text_search``) can't use it. Inject the current active
         model here so the filter and visual search agree on what "has an
-        index" means; smart-collection storage paths keep the rule
-        verbatim so a saved collection stays portable across model
-        switches.
+        index" means; smart-collection storage paths (POST/PUT
+        ``/api/collections``) also normalize before persisting so a
+        collection's saved rules match what the preview counter showed at
+        save time (Codex review r3621749904) — otherwise the sidebar
+        count and the reopened result set silently diverge from the
+        preview when embeddings from multiple models exist.
 
         When no active model is configured (fresh library, or every
         installed model was removed while cached embeddings remain), the
@@ -10602,6 +10605,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not name:
             return json_error("name required")
         try:
+            # Pin ``has_visual_index`` leaves to the active model before
+            # counting/persisting so the sidebar count on reopen matches
+            # what the save-time preview counter showed — otherwise a
+            # library with embeddings from multiple models silently
+            # widens the collection to "any embedding exists" (Codex
+            # review r3621749904).
+            rules = _inject_active_visual_model(rules)
             db.count_photos_for_rules(rules)
             # The visual clause is saved alongside rules — a collection
             # saved from an expression with a visual component must
@@ -10683,6 +10693,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if "rules" in body:
             rules = body.get("rules")
             try:
+                # Same active-model pinning as POST so the persisted
+                # rules match what the save-time preview counted
+                # (Codex review r3621749904).
+                rules = _inject_active_visual_model(rules)
                 db.count_photos_for_rules(rules)
             except ValueError as e:
                 return json_error(str(e), 400)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10496,16 +10496,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # rules (raised by _build_query_from_rules) and malformed JSON in
             # the rules column (json.JSONDecodeError is a ValueError subclass).
             # Anything else bubbles up as a 500 so real infra failures surface.
-            try:
-                d["photo_count"] = db.count_collection_photos(c["id"])
-            except ValueError:
-                app.logger.exception(
-                    "Failed to count photos for collection %s (%s)",
-                    c["id"],
-                    c["name"],
-                )
+            #
+            # Visual collections narrow the result set at open time via the
+            # filter bar's visual clause; ``count_collection_photos`` only
+            # evaluates ``rules``, so a saved visual collection with e.g.
+            # ``rules: []`` would return the workspace-wide metadata count
+            # here while Browse shows a much smaller set on reopen
+            # (Codex review r3620935217). Resolving the visual clause on
+            # every listing would run the embedding for every visual
+            # collection on every page load — too expensive. Omit the count
+            # instead: the sidebar (browse.html) renders an empty count
+            # span for null photo_count, and the ✦ visual marker already
+            # tells users this collection is visually resolved.
+            if c["visual_json"] is not None:
                 d["photo_count"] = None
-                d["count_error"] = True
+            else:
+                try:
+                    d["photo_count"] = db.count_collection_photos(c["id"])
+                except ValueError:
+                    app.logger.exception(
+                        "Failed to count photos for collection %s (%s)",
+                        c["id"],
+                        c["name"],
+                    )
+                    d["photo_count"] = None
+                    d["count_error"] = True
             # Degraded rows must never advertise manual-add support: the
             # add-to-collection modal filters only on can_add_photos, and
             # /api/collections/<id>/add-photos calls set(ids_rule["value"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -20849,6 +20849,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("photo_ids must be a list of integers")
 
         db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         if not raw_ids and collection_id is not None:
             raw_ids = [
                 p["id"]
@@ -28324,6 +28327,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ids_only = request.args.get("ids_only", "").lower() in ("1", "true", "yes")
 
         db = _get_db()
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
 
         # Determine current model
         from models import get_active_model

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5020,8 +5020,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 f"eye_detect_override must be boolean, got "
                 f"{type(eye_detect_override_body).__name__}", 400,
             )
+        # Reject visual collections before the plan resolves the scope:
+        # ``compute_plan`` → ``pipeline._resolve_collection_photo_ids()`` →
+        # ``get_collection_photos()`` evaluates ``rules`` only and ignores
+        # ``visual_json``. Without this guard, an API caller or stale/bookmarked
+        # Process page body posting a visual collection id would receive a plan
+        # computed over every metadata match — advertising a widened runnable
+        # job even though ``/api/jobs/pipeline`` already rejects the same id at
+        # start time (Codex review r3622041639).
+        db = _get_db()
+        collection_id = _coerce_collection_id(body.get("collection_id"))
+        if collection_id is False:
+            return json_error("collection_id must be an integer", 400)
+        err = _reject_visual_collection(db, collection_id)
+        if err is not None:
+            return err
         params = PipelinePlanParams(
-            collection_id=body.get("collection_id"),
+            collection_id=collection_id,
             photo_ids=scope_photo_ids,
             exclude_photo_ids=body.get("exclude_photo_ids") or [],
             skip_classify=bool(body.get("skip_classify")),
@@ -5039,7 +5054,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             preview_max_size=body.get("preview_max_size"),
             review_mode=review_mode,
         )
-        db = _get_db()
         return jsonify(compute_plan(db, params, db_path))
 
     @app.route("/api/folders")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4635,7 +4635,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
                 continue
             else:
-                d["can_add_photos"] = _collection_accepts_manual_photos(parsed_rules)
+                # A visual-only collection stores ``rules: []`` which
+                # ``_collection_accepts_manual_photos`` treats as addable,
+                # but ``/add-photos`` would just append to ``photo_ids``
+                # without touching ``visual_json`` — the manually added
+                # photos would only show up in the reopened collection
+                # if they also matched the hidden visual clause, making
+                # the add silently ineffective (Codex r3620791304).
+                d["can_add_photos"] = (
+                    c["visual_json"] is None
+                    and _collection_accepts_manual_photos(parsed_rules)
+                )
             collection_dicts.append(d)
 
         return jsonify(
@@ -10504,6 +10514,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # rule is bad enough to fail count, it isn't safe to merge into.
             if d.get("count_error"):
                 d["can_add_photos"] = False
+            elif c["visual_json"] is not None:
+                # Visual collections store ``rules: []`` which
+                # ``_collection_accepts_manual_photos`` treats as addable,
+                # but ``/add-photos`` would only append to ``photo_ids``
+                # and leave ``visual_json`` alone — the manually added
+                # photos would only surface in the reopened collection
+                # if they also matched the hidden visual prompt, so
+                # the add is silently ineffective (Codex r3620791304).
+                d["can_add_photos"] = False
             else:
                 try:
                     d["can_add_photos"] = _collection_accepts_manual_photos(
@@ -10658,11 +10677,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error("photo_ids must be integers")
 
         row = db.conn.execute(
-            "SELECT rules FROM collections WHERE id = ? AND workspace_id = ?",
+            "SELECT rules, visual_json FROM collections WHERE id = ? AND workspace_id = ?",
             (collection_id, db._ws_id()),
         ).fetchone()
         if not row:
             return json_error("Collection not found", 404)
+
+        # Belt-and-suspenders backstop for the picker gate: a visual
+        # collection stores ``rules: []`` which passes
+        # ``_collection_accepts_manual_photos``, but appending to
+        # ``photo_ids`` here would not touch ``visual_json``, so the
+        # manually added photos would only surface on reopen if they
+        # also matched the hidden visual prompt — a silent no-op
+        # (Codex r3620791304). Reject the request explicitly so the UI
+        # picker (which already hides these) can't be bypassed by a
+        # bookmarked or hand-crafted POST.
+        if row["visual_json"] is not None:
+            return json_error(
+                "Cannot add photos to a visual collection; open it in "
+                "Browse and refine the visual clause instead.",
+                400,
+            )
 
         rules = json.loads(row["rules"])
         if not _collection_accepts_manual_photos(rules):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4569,19 +4569,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         sort = request.args.get("sort", "date")
         folder_id = request.args.get("folder_id", None, type=int)
         collection_id = request.args.get("collection_id", None, type=int)
-        rating_min = request.args.get("rating_min", None, type=int)
-        date_from = request.args.get("date_from", None)
-        date_to = request.args.get("date_to", None)
-        keyword = request.args.get("keyword", None)
-        keyword_match_case = _request_bool_arg("keyword_match_case")
-        keyword_whole_word = _request_bool_arg("keyword_whole_word")
-        color_label = request.args.get("color_label", None)
-        try:
-            flag = _request_flag_filter()
-            location_status = _request_location_status_filter()
-        except ValueError as e:
-            return json_error(str(e), 400)
 
+        # First paint is scope-only (folder / collection / sort); metadata
+        # filter deep links compile into the filter bar client-side, which
+        # reloads through /api/photos/query once initialized (Phase 5 —
+        # legacy per-field params removed from this endpoint).
         try:
             photos = db.get_photos(
                 folder_id=folder_id,
@@ -4589,34 +4581,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 page=page,
                 per_page=per_page,
                 sort=sort,
-                rating_min=rating_min,
-                date_from=date_from,
-                date_to=date_to,
-                keyword=keyword,
-                keyword_match_case=keyword_match_case,
-                keyword_whole_word=keyword_whole_word,
-                color_label=color_label,
-                flag=flag,
-                location_status=location_status,
             )
         except ValueError as exc:
             return json_error(str(exc), 400)
-        if not any([folder_id, collection_id, rating_min, date_from, date_to, keyword, color_label, flag, location_status]):
+        if not any([folder_id, collection_id]):
             total = db.count_photos()
         else:
             try:
                 total = db.count_filtered_photos(
                     folder_id=folder_id,
                     collection_id=collection_id,
-                    rating_min=rating_min,
-                    date_from=date_from,
-                    date_to=date_to,
-                    keyword=keyword,
-                    keyword_match_case=keyword_match_case,
-                    keyword_whole_word=keyword_whole_word,
-                    color_label=color_label,
-                    flag=flag,
-                    location_status=location_status,
                 )
             except ValueError as exc:
                 return json_error(str(exc), 400)
@@ -6373,15 +6347,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         year = request.args.get("year", date.today().year, type=int)
         folder_id = request.args.get("folder_id", None, type=int)
-        rating_min = request.args.get("rating_min", None, type=int)
-        keyword = request.args.get("keyword", None)
-        keyword_match_case = _request_bool_arg("keyword_match_case")
-        keyword_whole_word = _request_bool_arg("keyword_whole_word")
         collection_id = request.args.get("collection_id", None, type=int)
-        color_label = request.args.get("color_label", None)
         try:
-            flag = _request_flag_filter()
-            location_status = _request_location_status_filter()
             rules = _request_rules_arg()
             visual = _request_visual_arg()
             rules, _visual_info = _apply_visual_to_rules(
@@ -6392,12 +6359,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), 400)
         try:
             data = db.get_calendar_data(
-                year=year, folder_id=folder_id, rating_min=rating_min, keyword=keyword,
-                keyword_match_case=keyword_match_case,
-                keyword_whole_word=keyword_whole_word,
+                year=year, folder_id=folder_id,
                 collection_id=collection_id,
-                color_label=color_label, flag=flag,
-                location_status=location_status,
                 rules=rules,
             )
         except ValueError as e:
@@ -6408,17 +6371,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_browse_summary():
         db = _get_db()
         folder_id = request.args.get("folder_id", None, type=int)
-        rating_min = request.args.get("rating_min", None, type=int)
-        date_from = request.args.get("date_from", None)
-        date_to = request.args.get("date_to", None)
-        keyword = request.args.get("keyword", None)
-        keyword_match_case = _request_bool_arg("keyword_match_case")
-        keyword_whole_word = _request_bool_arg("keyword_whole_word")
         collection_id = request.args.get("collection_id", None, type=int)
-        color_label = request.args.get("color_label", None)
         try:
-            flag = _request_flag_filter()
-            location_status = _request_location_status_filter()
             rules = _request_rules_arg()
             visual = _request_visual_arg()
             rules, _visual_info = _apply_visual_to_rules(
@@ -6430,16 +6384,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             summary = db.get_browse_summary(
                 folder_id=folder_id,
-                rating_min=rating_min,
-                date_from=date_from,
-                date_to=date_to,
-                keyword=keyword,
-                keyword_match_case=keyword_match_case,
-                keyword_whole_word=keyword_whole_word,
                 collection_id=collection_id,
-                color_label=color_label,
-                flag=flag,
-                location_status=location_status,
                 rules=rules,
             )
         except ValueError as e:
@@ -6742,13 +6687,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_photos_geo():
         db = _get_db()
         folder_id = request.args.get("folder_id", None, type=int)
-        rating_min = request.args.get("rating_min", None, type=int)
-        date_from = request.args.get("date_from", None)
-        date_to = request.args.get("date_to", None)
-        keyword = request.args.get("keyword", None)
-        keyword_match_case = _request_bool_arg("keyword_match_case")
-        keyword_whole_word = _request_bool_arg("keyword_whole_word")
-        species = request.args.get("species", None)
         try:
             rules = _request_rules_arg()
             visual = _request_visual_arg()
@@ -6781,13 +6719,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             photos = db.get_geolocated_photos(
                 folder_id=folder_id,
-                rating_min=rating_min,
-                date_from=date_from,
-                date_to=date_to,
-                keyword=keyword,
-                keyword_match_case=keyword_match_case,
-                keyword_whole_word=keyword_whole_word,
-                species=species,
                 rules=rules,
             )
         except ValueError as e:
@@ -10569,9 +10500,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("name required")
         try:
             db.count_photos_for_rules(rules)
+            # The visual clause is saved alongside rules — a collection
+            # saved from an expression with a visual component must
+            # reproduce the same result set on reopen, not silently drop
+            # to metadata-only.
+            visual = _validate_visual_arg(body.get("visual"))
         except ValueError as e:
             return json_error(str(e), 400)
-        cid = db.add_collection(name, json.dumps(rules))
+        cid = db.add_collection(
+            name, json.dumps(rules),
+            visual_json=json.dumps(visual) if visual else None,
+        )
         return jsonify({"ok": True, "id": cid})
 
     @app.route("/api/collections/preview", methods=["POST"])
@@ -10646,6 +10585,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error(str(e), 400)
             updates.append("rules = ?")
             params.append(json.dumps(rules))
+        if "visual" in body:
+            try:
+                visual = _validate_visual_arg(body.get("visual"))
+            except ValueError as e:
+                return json_error(str(e), 400)
+            updates.append("visual_json = ?")
+            params.append(json.dumps(visual) if visual else None)
         if updates:
             params.extend([collection_id, db._ws_id()])
             db.conn.execute(
@@ -28175,19 +28121,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         limit = min(max(1, request.args.get("limit", 50, type=int)), 1000)
         threshold = request.args.get("threshold", 0.15, type=float)
         folder_id = request.args.get("folder_id", None, type=int)
-        rating_min = request.args.get("rating_min", None, type=int)
-        date_from = request.args.get("date_from", None)
-        date_to = request.args.get("date_to", None)
-        keyword = request.args.get("keyword", None)
-        keyword_match_case = _request_bool_arg("keyword_match_case")
-        keyword_whole_word = _request_bool_arg("keyword_whole_word")
-        color_label = request.args.get("color_label", None)
         collection_id = request.args.get("collection_id", None, type=int)
-        try:
-            flag = _request_flag_filter()
-            location_status = _request_location_status_filter()
-        except ValueError as e:
-            return json_error(str(e), 400)
         ids_only = request.args.get("ids_only", "").lower() in ("1", "true", "yes")
 
         db = _get_db()
@@ -28224,19 +28158,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error(str(e), 400)
         elif collection_id is not None:
             candidate_photo_ids = db.get_collection_photo_ids(collection_id)
-        elif any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag, location_status]):
-            candidate_photo_ids = db.get_photo_ids(
-                folder_id=folder_id,
-                rating_min=rating_min,
-                date_from=date_from,
-                date_to=date_to,
-                keyword=keyword,
-                keyword_match_case=keyword_match_case,
-                keyword_whole_word=keyword_whole_word,
-                color_label=color_label,
-                flag=flag,
-                location_status=location_status,
-            )
+        elif folder_id is not None:
+            # Candidate scope arrives as rules / a collection / a folder —
+            # the legacy per-field scope params were removed in Phase 5
+            # (no caller sends them; visual search runs through
+            # /api/photos/query).
+            candidate_photo_ids = db.get_photo_ids(folder_id=folder_id)
 
         if candidate_photo_ids == []:
             if ids_only:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -18739,19 +18739,20 @@ class Database:
         self.conn.commit()
 
     def duplicate_collection(self, collection_id):
-        """Copy a collection (name + rules) within the active workspace.
+        """Copy a collection (name + rules + visual clause) within the active workspace.
 
         The new collection's name is ``"{original} (copy)"``; if that name is
         already taken, append an incrementing counter like ``"(copy 2)"``.
-        Rules are copied verbatim, which means static collections (photo_ids
-        rules) keep their memberships.
+        Rules and ``visual_json`` are copied verbatim, which means static
+        collections (photo_ids rules) keep their memberships and visual
+        collections keep their visual clause.
 
         Returns the new collection id. Raises ``ValueError`` if the source
         collection isn't in the active workspace.
         """
         ws = self._ws_id()
         row = self.conn.execute(
-            "SELECT name, rules FROM collections WHERE id = ? AND workspace_id = ?",
+            "SELECT name, rules, visual_json FROM collections WHERE id = ? AND workspace_id = ?",
             (collection_id, ws),
         ).fetchone()
         if not row:
@@ -18771,8 +18772,8 @@ class Database:
             n += 1
 
         cur = self.conn.execute(
-            "INSERT INTO collections (name, rules, workspace_id) VALUES (?, ?, ?)",
-            (new_name, row["rules"], ws),
+            "INSERT INTO collections (name, rules, workspace_id, visual_json) VALUES (?, ?, ?, ?)",
+            (new_name, row["rules"], ws, row["visual_json"]),
         )
         self.conn.commit()
         return cur.lastrowid

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -790,10 +790,11 @@ class Database:
             );
 
             CREATE TABLE IF NOT EXISTS collections (
-                id          INTEGER PRIMARY KEY,
-                name        TEXT,
-                rules       TEXT,
-                workspace_id INTEGER REFERENCES workspaces(id) ON DELETE CASCADE
+                id           INTEGER PRIMARY KEY,
+                name         TEXT,
+                rules        TEXT,
+                workspace_id INTEGER REFERENCES workspaces(id) ON DELETE CASCADE,
+                visual_json  TEXT
             );
 
             CREATE TABLE IF NOT EXISTS pending_changes (

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1502,6 +1502,17 @@ class Database:
                 "ALTER TABLE photos ADD COLUMN hash_status TEXT"
             )
 
+        # Migration: collections carry the universal filter's visual clause
+        # alongside rules — the clause deliberately lives outside the rule
+        # tree, so without this column a saved expression with a visual
+        # component would silently reopen as metadata-only.
+        try:
+            self.conn.execute("SELECT visual_json FROM collections LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE collections ADD COLUMN visual_json TEXT"
+            )
+
         # Migration: promote EXIF camera fields out of the exif_data JSON
         # blob into real columns so the universal filter engine can query
         # them with indexes and plain SQL (design:
@@ -7378,17 +7389,15 @@ class Database:
         self,
         year,
         folder_id=None,
-        rating_min=None,
-        keyword=None,
-        keyword_match_case=False,
-        keyword_whole_word=False,
         collection_id=None,
-        color_label=None,
-        flag=None,
-        location_status=None,
         rules=None,
     ):
-        """Return daily photo counts for a given year, scoped to active workspace."""
+        """Return daily photo counts for a given year, scoped to active workspace.
+
+        Metadata filtering arrives exclusively as a universal-filter ``rules``
+        tree (the legacy per-field params were removed in Phase 5 once the
+        filter bar became the only caller).
+        """
         ws = self._ws_id()
         conditions = ["wf.workspace_id = ?", "p.timestamp IS NOT NULL",
                       "substr(p.timestamp, 1, 4) = ?"]
@@ -7431,27 +7440,6 @@ class Database:
             placeholders = ",".join("?" for _ in subtree)
             conditions.append(f"p.folder_id IN ({placeholders})")
             where_params.extend(subtree)
-        if rating_min is not None:
-            conditions.append("p.rating >= ?")
-            where_params.append(rating_min)
-        if flag is not None:
-            conditions.append("COALESCE(p.flag, 'none') = ?")
-            where_params.append(flag)
-        self._append_location_status_filter(conditions, location_status)
-        if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(
-                keyword,
-                match_case=keyword_match_case,
-                whole_word=keyword_whole_word,
-            )
-            if kw_clause:
-                conditions.append(kw_clause)
-                where_params.extend(kw_params)
-        if color_label is not None:
-            join_clause += "\nJOIN photo_color_labels pcl ON pcl.photo_id = p.id AND pcl.workspace_id = ?"
-            join_params.append(ws)
-            conditions.append("pcl.color = ?")
-            where_params.append(color_label)
 
         params = join_params + where_params
 
@@ -7761,16 +7749,7 @@ class Database:
     def get_browse_summary(
         self,
         folder_id=None,
-        rating_min=None,
-        date_from=None,
-        date_to=None,
-        keyword=None,
-        keyword_match_case=False,
-        keyword_whole_word=False,
         collection_id=None,
-        color_label=None,
-        flag=None,
-        location_status=None,
         rules=None,
     ):
         """Return summary stats for the browse panel, scoped to active workspace and filters.
@@ -7782,7 +7761,9 @@ class Database:
         """
         ws = self._ws_id()
 
-        # Build shared filter conditions
+        # Build shared filter conditions. Metadata filtering arrives
+        # exclusively as a universal-filter ``rules`` tree (legacy per-field
+        # params removed in Phase 5).
         conditions = ["wf.workspace_id = ?"]
         join_params = []
         where_params = [ws]
@@ -7791,19 +7772,6 @@ class Database:
             placeholders = ",".join("?" for _ in subtree)
             conditions.append(f"p.folder_id IN ({placeholders})")
             where_params.extend(subtree)
-        if rating_min is not None:
-            conditions.append("p.rating >= ?")
-            where_params.append(rating_min)
-        if date_from is not None:
-            conditions.append("p.timestamp >= ?")
-            where_params.append(date_from)
-        if date_to is not None:
-            conditions.append("p.timestamp <= ?")
-            where_params.append(_inclusive_date_to(date_to))
-        if flag is not None:
-            conditions.append("COALESCE(p.flag, 'none') = ?")
-            where_params.append(flag)
-        self._append_location_status_filter(conditions, location_status)
 
         # When browsing a collection, restrict photos to those matching the
         # collection's rules by using a subquery from _build_collection_query.
@@ -7840,22 +7808,6 @@ class Database:
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
-        if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(
-                keyword,
-                match_case=keyword_match_case,
-                whole_word=keyword_whole_word,
-            )
-            if kw_clause:
-                conditions.append(kw_clause)
-                where_params.extend(kw_params)
-
-        if color_label is not None:
-            join_clause += "\nJOIN photo_color_labels pcl ON pcl.photo_id = p.id AND pcl.workspace_id = ?"
-            join_params.append(self._ws_id())
-            conditions.append("pcl.color = ?")
-            where_params.append(color_label)
-
         # join_params must precede where_params because JOIN placeholders appear
         # in the SQL before the WHERE placeholders.
         params = join_params + where_params
@@ -7957,20 +7909,14 @@ class Database:
     def get_geolocated_photos(
         self,
         folder_id=None,
-        rating_min=None,
-        date_from=None,
-        date_to=None,
-        keyword=None,
-        keyword_match_case=False,
-        keyword_whole_word=False,
-        species=None,
         rules=None,
     ):
-        """Return all geolocated photos with optional species, scoped to active workspace.
+        """Return all geolocated photos, scoped to active workspace.
 
         ``rules`` (a universal-filter rule tree) restricts the plottable set
         exactly like Browse's grid — the Map page passes the shared filter
-        bar's expression here so the full field vocabulary works on Map.
+        bar's expression here, which is the only metadata filtering this
+        method supports (legacy per-field params removed in Phase 5).
 
         Returns photos that have either non-null EXIF latitude/longitude OR a
         ``type='location'`` keyword link whose keyword has non-null coords. No
@@ -7997,15 +7943,6 @@ class Database:
             placeholders = ",".join("?" for _ in subtree)
             conditions.append(f"p.folder_id IN ({placeholders})")
             params.extend(subtree)
-        if rating_min is not None:
-            conditions.append("p.rating >= ?")
-            params.append(rating_min)
-        if date_from is not None:
-            conditions.append("p.timestamp >= ?")
-            params.append(date_from)
-        if date_to is not None:
-            conditions.append("p.timestamp <= ?")
-            params.append(_inclusive_date_to(date_to))
         if rules is not None:
             r_folder_join, r_join_clause, r_where, r_params = (
                 self._build_query_from_rules(rules)
@@ -8040,45 +7977,18 @@ class Database:
             "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')"
             f"\n{location_subquery}"
         )
-        if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(
-                keyword,
-                match_case=keyword_match_case,
-                whole_word=keyword_whole_word,
-            )
-            if kw_clause:
-                conditions.append(kw_clause)
-                params.extend(kw_params)
-
-        # Match any species tag on the photo, not just MIN(name) — a photo can be
-        # tagged with multiple species keywords.
-        if species is not None:
-            conditions.append(
-                """EXISTS (SELECT 1 FROM photo_keywords pk_f
-                           JOIN keywords k_f ON k_f.id = pk_f.keyword_id
-                           WHERE pk_f.photo_id = p.id
-                             AND k_f.is_species = 1
-                             AND k_f.name = ?)"""
-            )
-            params.append(species)
-
         where = "WHERE " + " AND ".join(conditions)
 
-        # When filtering by species, surface that species in the row so the map
-        # popup/legend match the active filter. Otherwise fall back to the
-        # most-recently-tagged species keyword (highest rowid), which reflects
-        # the user's latest confirmed identification when multiple tags exist.
-        if species is not None:
-            species_col_sql = "? AS species"
-            species_col_params = [species]
-        else:
-            species_col_sql = (
-                "(SELECT k2.name FROM photo_keywords pk2 "
-                "JOIN keywords k2 ON k2.id = pk2.keyword_id "
-                "WHERE pk2.photo_id = p.id AND k2.is_species = 1 "
-                "ORDER BY pk2.rowid DESC LIMIT 1) AS species"
-            )
-            species_col_params = []
+        # Surface the most-recently-tagged species keyword (highest rowid),
+        # which reflects the user's latest confirmed identification when
+        # multiple tags exist.
+        species_col_sql = (
+            "(SELECT k2.name FROM photo_keywords pk2 "
+            "JOIN keywords k2 ON k2.id = pk2.keyword_id "
+            "WHERE pk2.photo_id = p.id AND k2.is_species = 1 "
+            "ORDER BY pk2.rowid DESC LIMIT 1) AS species"
+        )
+        species_col_params = []
 
         query = f"""
             SELECT p.id,
@@ -18782,11 +18692,18 @@ class Database:
 
     # -- Collections --
 
-    def add_collection(self, name, rules_json):
-        """Insert a smart collection. Returns the collection id."""
+    def add_collection(self, name, rules_json, visual_json=None):
+        """Insert a smart collection. Returns the collection id.
+
+        ``visual_json`` stores the universal filter's visual clause
+        (``{prompt, strength}`` JSON) when the saved expression has one, so
+        save → reopen reproduces the same result set instead of silently
+        dropping to metadata-only.
+        """
         cur = self.conn.execute(
-            "INSERT INTO collections (name, rules, workspace_id) VALUES (?, ?, ?)",
-            (name, rules_json, self._ws_id()),
+            "INSERT INTO collections (name, rules, workspace_id, visual_json) "
+            "VALUES (?, ?, ?, ?)",
+            (name, rules_json, self._ws_id(), visual_json),
         )
         self.conn.commit()
         return cur.lastrowid
@@ -18794,7 +18711,8 @@ class Database:
     def get_collections(self):
         """Return all collections for the active workspace."""
         return self.conn.execute(
-            "SELECT id, name, rules FROM collections WHERE workspace_id = ? ORDER BY name",
+            "SELECT id, name, rules, visual_json FROM collections "
+            "WHERE workspace_id = ? ORDER BY name",
             (self._ws_id(),),
         ).fetchall()
 

--- a/vireo/static/help.json
+++ b/vireo/static/help.json
@@ -2,121 +2,313 @@
   {
     "question": "How do I add photos to Vireo?",
     "category": "Getting Started",
-    "keywords": ["scan", "import", "add", "folder", "photos", "directory"],
+    "keywords": [
+      "scan",
+      "import",
+      "add",
+      "folder",
+      "photos",
+      "directory"
+    ],
     "answer": "Open Import, leave Add in place selected, and click Browse to choose one or more folders. Select an After import processing option, then click Start import. Vireo adds supported photos and their subfolders to the active workspace without moving or copying them. Choose Copy to archive instead when you want Vireo to copy photos into your archive."
   },
   {
     "question": "How do I classify my photos?",
     "category": "Getting Started",
-    "keywords": ["classify", "identify", "species", "scan", "pipeline", "AI"],
+    "keywords": [
+      "classify",
+      "identify",
+      "species",
+      "scan",
+      "pipeline",
+      "AI"
+    ],
     "answer": "When adding photos, choose a processing option under After import before clicking Start import. For photos already in the workspace, open Process, select the workspace folders, choose a strategy, and click Start Pipeline. Jobs shows progress; it is not where processing starts."
   },
   {
     "question": "How do I review processing results?",
     "category": "Getting Started",
-    "keywords": ["review", "results", "cull", "keep", "reject", "triage"],
+    "keywords": [
+      "review",
+      "results",
+      "cull",
+      "keep",
+      "reject",
+      "triage"
+    ],
     "answer": "Open Process Review to inspect classifications and any available quality recommendations. When culling analysis is available, open Cull to rapidly mark photos keep, review, or reject using keyboard shortcuts."
   },
   {
     "question": "How do I save my decisions to my photo files?",
     "category": "Getting Started",
-    "keywords": ["sync", "xmp", "sidecar", "save", "export", "metadata", "lightroom"],
+    "keywords": [
+      "sync",
+      "xmp",
+      "sidecar",
+      "save",
+      "export",
+      "metadata",
+      "lightroom"
+    ],
     "answer": "Use the Sync feature to write changes to XMP sidecar files. This writes standard metadata that Lightroom, Darktable, and other tools can read. Your original image files are never modified."
   },
   {
     "question": "Where are my photos stored?",
     "category": "Photos",
-    "keywords": ["storage", "location", "files", "disk", "move", "copy"],
-    "answer": "On your filesystem, exactly where you put them. Vireo reads photos in place and never moves, copies, or uploads them. The database is just a cache \u2014 you can rebuild it anytime from your files."
+    "keywords": [
+      "storage",
+      "location",
+      "files",
+      "disk",
+      "move",
+      "copy"
+    ],
+    "answer": "On your filesystem, exactly where you put them. Vireo reads photos in place and never moves, copies, or uploads them. The database is just a cache — you can rebuild it anytime from your files."
   },
   {
     "question": "Does Vireo modify my original photo files?",
     "category": "Photos",
-    "keywords": ["modify", "original", "raw", "change", "alter", "safe"],
+    "keywords": [
+      "modify",
+      "original",
+      "raw",
+      "change",
+      "alter",
+      "safe"
+    ],
     "answer": "No. Metadata is written to XMP sidecar files (.xmp) alongside your photos. Your original image files are never touched."
   },
   {
     "question": "How do I delete or remove a photo?",
     "category": "Photos",
-    "keywords": ["delete", "remove", "trash", "discard"],
+    "keywords": [
+      "delete",
+      "remove",
+      "trash",
+      "discard"
+    ],
     "answer": "In Browse view, select a photo and use the reject action. This marks the photo for rejection but does not delete the file from disk. Vireo never deletes your files."
   },
   {
     "question": "How do I move photos to a different folder?",
     "category": "Photos",
-    "keywords": ["move", "relocate", "organize", "folder", "destination"],
+    "keywords": [
+      "move",
+      "relocate",
+      "organize",
+      "folder",
+      "destination"
+    ],
     "answer": "Use the Move page to relocate photos to a different folder. Select photos and choose a destination. Vireo moves the actual files on disk and updates its database."
   },
   {
     "question": "What is the Process page?",
     "category": "Classification",
-    "keywords": ["pipeline", "steps", "detection", "classification", "quality", "scoring"],
+    "keywords": [
+      "pipeline",
+      "steps",
+      "detection",
+      "classification",
+      "quality",
+      "scoring"
+    ],
     "answer": "The Process page runs indexing, species classification, feature extraction, and quality scoring for photos already in the active workspace. Use Import to add new photos; use Process when you want to run or rerun selected processing stages."
   },
   {
     "question": "What species can Vireo identify?",
     "category": "Classification",
-    "keywords": ["species", "identify", "model", "iNaturalist", "birds", "animals"],
+    "keywords": [
+      "species",
+      "identify",
+      "model",
+      "iNaturalist",
+      "birds",
+      "animals"
+    ],
     "answer": "Over 10,000 species, depending on the model. The iNaturalist-trained classifier covers the broadest range. You can run multiple models and compare predictions."
   },
   {
     "question": "How does culling work?",
     "category": "Culling",
-    "keywords": ["cull", "triage", "sort", "keep", "reject", "review", "quality"],
+    "keywords": [
+      "cull",
+      "triage",
+      "sort",
+      "keep",
+      "reject",
+      "review",
+      "quality"
+    ],
     "answer": "The Cull page groups similar photos and lets you quickly decide which to keep. Vireo scores photos on focus, exposure, composition, and noise to suggest the best shots. Use keyboard shortcuts to move through photos rapidly."
   },
   {
     "question": "How do I add keywords to photos?",
     "category": "Keywords",
-    "keywords": ["keyword", "tag", "label", "taxonomy", "hierarchy"],
-    "answer": "Open the Keywords page to manage your keyword hierarchy. You can add keywords to individual photos or in bulk. Keywords are global \u2014 they're shared across all workspaces."
+    "keywords": [
+      "keyword",
+      "tag",
+      "label",
+      "taxonomy",
+      "hierarchy"
+    ],
+    "answer": "Open the Keywords page to manage your keyword hierarchy. You can add keywords to individual photos or in bulk. Keywords are global — they're shared across all workspaces."
   },
   {
     "question": "Can I import keywords from Lightroom?",
     "category": "Keywords",
-    "keywords": ["lightroom", "import", "lrcat", "catalog", "keyword", "hierarchy"],
+    "keywords": [
+      "lightroom",
+      "import",
+      "lrcat",
+      "catalog",
+      "keyword",
+      "hierarchy"
+    ],
     "answer": "Yes. Vireo can import keyword hierarchies from Lightroom catalog files (.lrcat). Your XMP sidecars are also compatible with Lightroom, so you can use both tools on the same library."
   },
   {
     "question": "What are collections?",
     "category": "Collections",
-    "keywords": ["collection", "group", "album", "organize", "set"],
+    "keywords": [
+      "collection",
+      "group",
+      "album",
+      "organize",
+      "set"
+    ],
     "answer": "Collections let you group photos together regardless of which folder they're in. Collections are workspace-scoped, so each workspace has its own set."
   },
   {
     "question": "What are workspaces?",
     "category": "Workspaces",
-    "keywords": ["workspace", "scope", "separate", "project", "session"],
+    "keywords": [
+      "workspace",
+      "scope",
+      "separate",
+      "project",
+      "session"
+    ],
     "answer": "Workspaces let you organize your work into separate contexts. Each workspace has its own predictions, collections, and pending changes. Photos and keywords are shared across all workspaces. A Default workspace is created automatically."
   },
   {
     "question": "How do I create a new workspace?",
     "category": "Workspaces",
-    "keywords": ["create", "new", "workspace", "add"],
+    "keywords": [
+      "create",
+      "new",
+      "workspace",
+      "add"
+    ],
     "answer": "Go to the Workspace page and click the button to create a new workspace. Give it a name and it's ready to use. You can switch between workspaces from the workspace switcher."
   },
   {
     "question": "Do I need an internet connection?",
     "category": "Settings",
-    "keywords": ["internet", "offline", "connection", "cloud", "upload", "network"],
+    "keywords": [
+      "internet",
+      "offline",
+      "connection",
+      "cloud",
+      "upload",
+      "network"
+    ],
     "answer": "Only for downloading AI models on first use. After that, everything runs locally on your machine. No cloud processing, no uploads, no accounts."
   },
   {
     "question": "Do I need a GPU?",
     "category": "Settings",
-    "keywords": ["gpu", "cuda", "nvidia", "cpu", "speed", "performance", "hardware"],
-    "answer": "No, but it helps. Classification runs on CPU if no GPU is available \u2014 it's just slower. A CUDA-compatible NVIDIA GPU will significantly speed up large scans."
+    "keywords": [
+      "gpu",
+      "cuda",
+      "nvidia",
+      "cpu",
+      "speed",
+      "performance",
+      "hardware"
+    ],
+    "answer": "No, but it helps. Classification runs on CPU if no GPU is available — it's just slower. A CUDA-compatible NVIDIA GPU will significantly speed up large scans."
   },
   {
     "question": "How do I use Vireo with Darktable?",
     "category": "Settings",
-    "keywords": ["darktable", "editor", "external", "develop", "raw", "processing", "dng", "nikon"],
+    "keywords": [
+      "darktable",
+      "editor",
+      "external",
+      "develop",
+      "raw",
+      "processing",
+      "dng",
+      "nikon"
+    ],
     "answer": "Configure the Darktable binary path in Settings. You can then send photos to Darktable for editing, apply styles, and export processed versions. If you shoot Nikon High Efficiency NEFs, enable auto-convert to DNG and configure Adobe DNG Converter if Vireo cannot auto-detect it."
   },
   {
     "question": "Is Vireo free?",
     "category": "Settings",
-    "keywords": ["free", "cost", "price", "license", "open source", "MIT"],
+    "keywords": [
+      "free",
+      "cost",
+      "price",
+      "license",
+      "open source",
+      "MIT"
+    ],
     "answer": "Yes. Vireo is free and open source under the MIT license. You can use it, modify it, and contribute to it."
+  },
+  {
+    "question": "How do I filter photos?",
+    "category": "Browsing",
+    "keywords": [
+      "filter",
+      "filters",
+      "search",
+      "rules",
+      "chips",
+      "rating",
+      "flag",
+      "color",
+      "camera",
+      "date"
+    ],
+    "answer": "Every photo page (Browse, Map, Review, Duplicates) shares one filter bar. Type in the search box and press Enter for a text search, or open Filters for quick rating/flag/color filters and a rule builder over every metadata field — camera, lens, ISO, capture date (including “in the last N months”), species, and more. Active filters appear as chips you can remove individually; the dashed chip shows the page's fixed scope. Flags and colors multi-select into a single “is one of” rule, and typed values suggest real values from your library with live match counts."
+  },
+  {
+    "question": "How do I search photos visually?",
+    "category": "Browsing",
+    "keywords": [
+      "visual",
+      "clip",
+      "similar",
+      "semantic",
+      "search",
+      "describe"
+    ],
+    "answer": "Type a description in the filter bar's search box and choose “✦ Visually similar to …” from the suggestion menu. The visual clause appears as a purple chip, combines with your other filters, and offers broad/balanced/strict strength in the Filters popover. If visual search can't run (no active model, or no visual index yet), the chip shows an error state and your metadata filters keep working — results are never silently empty."
+  },
+  {
+    "question": "How do I temporarily disable my filters?",
+    "category": "Browsing",
+    "keywords": [
+      "pause",
+      "resume",
+      "disable",
+      "backslash",
+      "mute",
+      "filters"
+    ],
+    "answer": "Press \\ (backslash) or click Pause in the filter bar. All filters are disabled without being lost — chips dim, and a note reports how many photos would match. Press \\ again or click Resume to re-apply them. The paused state persists per workspace."
+  },
+  {
+    "question": "How do I save my filters as a Collection?",
+    "category": "Browsing",
+    "keywords": [
+      "save",
+      "collection",
+      "smart",
+      "filters",
+      "reuse"
+    ],
+    "answer": "Open Filters and click “Save as Collection…”. The saved Collection stores your full expression — including a visual search clause if one is active (marked with ✦ in the sidebar). Clicking a Collection opens its rules back into the filter bar as editable chips, so you can refine it and re-save."
   }
 ]

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1393,18 +1393,25 @@
       if (state.ready) renderLight();
     },
     visualSearch(text) { applyVisualSearch(text); },
-    loadExpression(rules, visual) {
+    loadExpression(rules, visual, opts) {
       // Open a saved Collection into the bar as editable chips. Accepts the
       // stored rules JSON (legacy flat list or grouped tree) and the
-      // visual_json clause; both become live, editable state. The
-      // 'expressionLoaded' reason lets pages preserve the photo anchor —
-      // a selected member of the opened collection should stay in place.
+      // visual_json clause; both become live, editable state.
+      //
+      // The default 'expressionLoaded' reason lets pages preserve the photo
+      // anchor — a selected member of the opened collection should stay in
+      // place. Membership-refresh callers (a keyword/tag change while the
+      // collection is open) pass ``{ reason: 'expressionRefreshed' }`` so
+      // the anchor is NOT preserved: the selected photo may have just left
+      // the collection, and loadUntilPhotoRendered would then page through
+      // the whole refreshed set looking for it (Codex review r3622521603).
       let root = { mode: 'all', rules: [] };
       if (Array.isArray(rules)) root = { mode: 'all', rules: clone(rules) };
       else if (rules && Array.isArray(rules.rules)) root = clone(rules);
       // Legacy default collections use the {"field": "all"} sentinel (no
       // condition) — opening one is simply "show everything", not a chip.
       root.rules = root.rules.filter((r) => !(r && r.field === 'all'));
+      const reason = (opts && opts.reason) || 'expressionLoaded';
       mutate(() => {
         state.root = root;
         state.muted = false;
@@ -1415,7 +1422,7 @@
                 ? visual.strength : 'balanced' }
           : null;
         state.visualInfo = null;
-      }, { reason: 'expressionLoaded' });
+      }, { reason });
     },
     getUserRules() { return userRules(); },
     addRule(field, op, value) {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1260,8 +1260,9 @@
     // reopen (CodeRabbit review r3620473554).
     // Preserve the root's group mode (any/none) so the count reflects
     // what the saved collection actually matches, not an all-mode
-    // flattening of it (Codex review r3620791294).
-    const rules = state.root.rules.length ? clone(state.root) : { mode: 'all', rules: [] };
+    // flattening of it (Codex review r3620791294). ``userRules()`` is
+    // the shared helper for that shape.
+    const rules = userRules();
     const preview = $('.vf-save-preview');
     preview.textContent = expressionSummary();
     fetchJson('/api/photos/query', {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -220,6 +220,10 @@
   }
 
   function ruleLabel(rule) {
+    if (rule.field === 'photo_ids') {
+      const n = Array.isArray(rule.value) ? rule.value.length : 0;
+      return `${n} hand-picked photo${n === 1 ? '' : 's'}`;
+    }
     const spec = state.fields[rule.field] || { label: rule.field, type: 'text' };
     const opLabel = OP_LABELS[rule.op] || rule.op;
     return `${spec.label} ${opLabel} ${valueLabel(spec, rule)}`;
@@ -555,6 +559,8 @@
     badge.hidden = count === 0;
     $('.vf-clear').hidden = !hasUserFilters();
     $('.vf-mute').hidden = !hasUserFilters() && !state.muted;
+    const saveBtn = $('.vf-save-collection');
+    if (saveBtn) saveBtn.hidden = !hasUserFilters();
     renderVisualNote();
     renderHandoff();
     requestAnimationFrame(updateChipOverflow);
@@ -1002,6 +1008,17 @@
       toast('Filters cleared', true);
     });
     $('.vf-toast button').addEventListener('click', () => { undo(); $('.vf-toast').hidden = true; });
+    const saveCollectionBtn = $('.vf-save-collection');
+    if (saveCollectionBtn) {
+      saveCollectionBtn.addEventListener('click', openSaveModal);
+      $('.vf-save-cancel').addEventListener('click', closeSaveModal);
+      $('.vf-save-backdrop').addEventListener('click', closeSaveModal);
+      $('.vf-save-confirm').addEventListener('click', confirmSaveCollection);
+      $('.vf-save-name').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') confirmSaveCollection();
+        else if (e.key === 'Escape') closeSaveModal();
+      });
+    }
 
     $('.vf-chip-row').addEventListener('click', (e) => {
       const x = e.target.closest('[data-chip-x]');
@@ -1197,6 +1214,60 @@
     window.addEventListener('resize', updateChipOverflow);
   }
 
+  function expressionSummary() {
+    const parts = [];
+    if (state.visual) parts.push(`✦ Visually similar to “${state.visual.prompt}” (${state.visual.strength})`);
+    chipEntries().forEach((entry) => { if (!entry.visual) parts.push(entry.label); });
+    return parts.join(' AND ') || 'No filters';
+  }
+
+  function openSaveModal() {
+    const modal = $('.vf-save-modal');
+    const backdrop = $('.vf-save-backdrop');
+    // Post-save semantics: the saved Collection reopens unmuted with the
+    // visual clause applied — preview THAT count, never the paused view's.
+    const context = state.getContextRules ? state.getContextRules() : [];
+    const rules = { mode: 'all', rules: clone(context).concat(clone(state.root.rules)) };
+    const preview = $('.vf-save-preview');
+    preview.textContent = expressionSummary();
+    fetchJson('/api/photos/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rules, per_page: 1, visual: state.visual || undefined }),
+    }).then((data) => {
+      preview.textContent = `${Number(data.total).toLocaleString()} matching photo${data.total === 1 ? '' : 's'} — ${expressionSummary()}`;
+    }).catch(() => {});
+    $('.vf-save-name').value = '';
+    modal.hidden = false;
+    backdrop.hidden = false;
+    setTimeout(() => $('.vf-save-name').focus(), 0);
+  }
+
+  function closeSaveModal() {
+    $('.vf-save-modal').hidden = true;
+    $('.vf-save-backdrop').hidden = true;
+  }
+
+  function confirmSaveCollection() {
+    const name = $('.vf-save-name').value.trim();
+    if (!name) { $('.vf-save-name').focus(); return; }
+    fetchJson('/api/collections', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        rules: state.root.rules.length ? state.root : [],
+        visual: state.visual || null,
+      }),
+    }).then(() => {
+      closeSaveModal();
+      toast(`Saved “${name}” as a Collection`);
+      if (state.onCollectionSaved) state.onCollectionSaved();
+    }).catch((e) => {
+      toast(`Could not save: ${e.message}`);
+    });
+  }
+
   const HANDOFF_PAGES = [
     ['browse', '/browse', 'Browse', 'Workspace · All available photos'],
     ['map', '/map', 'Map', 'Adds: plottable locations scope'],
@@ -1233,6 +1304,7 @@
       state.onChange = options.onChange || null;
       state.getContextRules = options.getContextRules || null;
       state.getScope = options.getScope || null;
+      state.onCollectionSaved = options.onCollectionSaved || null;
       rootEl = typeof options.root === 'string' ? document.querySelector(options.root) : options.root;
       if (!rootEl) return Promise.reject(new Error('VireoFilter: missing root element'));
       return loadRegistry().then(() => {
@@ -1287,6 +1359,30 @@
       if (state.ready) renderLight();
     },
     visualSearch(text) { applyVisualSearch(text); },
+    loadExpression(rules, visual) {
+      // Open a saved Collection into the bar as editable chips. Accepts the
+      // stored rules JSON (legacy flat list or grouped tree) and the
+      // visual_json clause; both become live, editable state. The
+      // 'expressionLoaded' reason lets pages preserve the photo anchor —
+      // a selected member of the opened collection should stay in place.
+      let root = { mode: 'all', rules: [] };
+      if (Array.isArray(rules)) root = { mode: 'all', rules: clone(rules) };
+      else if (rules && Array.isArray(rules.rules)) root = clone(rules);
+      // Legacy default collections use the {"field": "all"} sentinel (no
+      // condition) — opening one is simply "show everything", not a chip.
+      root.rules = root.rules.filter((r) => !(r && r.field === 'all'));
+      mutate(() => {
+        state.root = root;
+        state.muted = false;
+        state.visual = (
+          visual && typeof visual.prompt === 'string' && visual.prompt
+        ) ? { prompt: visual.prompt,
+              strength: ['broad', 'balanced', 'strict'].includes(visual.strength)
+                ? visual.strength : 'balanced' }
+          : null;
+        state.visualInfo = null;
+      }, { reason: 'expressionLoaded' });
+    },
     getUserRules() { return userRules(); },
     addRule(field, op, value) {
       mutate(() => {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -259,11 +259,34 @@
     return state.root.rules.length ? clone(state.root) : { mode: 'all', rules: [] };
   }
 
+  // AND the page-context rules with the user's root expression while
+  // preserving that expression's group mode. Concatenating
+  // ``state.root.rules`` directly into an outer ``{mode: 'all', rules: …}``
+  // wrapper would flatten a saved ``{mode: 'any'}`` or ``{mode: 'none'}``
+  // root — the Edit Rules modal in Browse can save either — from OR/NOT
+  // into AND, silently changing what the reopened collection matches
+  // (Codex review r3620791294). Non-'all' roots are wrapped as a nested
+  // child so the outer AND with the context is honored without collapsing
+  // the inner OR/NOT.
+  function composeWithContext(context, root) {
+    const ctx = clone(context);
+    const rootMode = (root && root.mode) || 'all';
+    const rootRules = (root && Array.isArray(root.rules)) ? root.rules : [];
+    if (rootMode === 'all') {
+      if (!ctx.length && !rootRules.length) return [];
+      return { mode: 'all', rules: ctx.concat(clone(rootRules)) };
+    }
+    if (!ctx.length) return clone(root);
+    return { mode: 'all', rules: ctx.concat([clone(root)]) };
+  }
+
   function effectiveRules() {
     const context = state.getContextRules ? state.getContextRules() : [];
-    const user = state.muted ? [] : state.root.rules;
-    if (!context.length && !user.length) return [];
-    return { mode: 'all', rules: clone(context).concat(clone(user)) };
+    if (state.muted) {
+      if (!context.length) return [];
+      return { mode: 'all', rules: clone(context) };
+    }
+    return composeWithContext(context, state.root);
   }
 
   function hasUserFilters() {
@@ -326,7 +349,10 @@
   function refreshWouldMatch() {
     const epoch = ++wouldMatchEpoch;
     const context = state.getContextRules ? state.getContextRules() : [];
-    const rules = { mode: 'all', rules: clone(context).concat(clone(state.root.rules)) };
+    // Mirror effectiveRules' mode-preserving compose: a paused-view
+    // "would match" counter must reflect what unpausing would apply, not
+    // an AND-flattened version of an any/none root (Codex r3620791294).
+    const rules = composeWithContext(context, state.root);
     fetchJson('/api/photos/query', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1232,7 +1258,10 @@
     // getContextRules() in the preview would show a folder-scoped count
     // that disagrees with what the collection actually contains on
     // reopen (CodeRabbit review r3620473554).
-    const rules = { mode: 'all', rules: clone(state.root.rules) };
+    // Preserve the root's group mode (any/none) so the count reflects
+    // what the saved collection actually matches, not an all-mode
+    // flattening of it (Codex review r3620791294).
+    const rules = state.root.rules.length ? clone(state.root) : { mode: 'all', rules: [] };
     const preview = $('.vf-save-preview');
     preview.textContent = expressionSummary();
     fetchJson('/api/photos/query', {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1226,8 +1226,13 @@
     const backdrop = $('.vf-save-backdrop');
     // Post-save semantics: the saved Collection reopens unmuted with the
     // visual clause applied — preview THAT count, never the paused view's.
-    const context = state.getContextRules ? state.getContextRules() : [];
-    const rules = { mode: 'all', rules: clone(context).concat(clone(state.root.rules)) };
+    // Preview the same expression confirmSaveCollection persists
+    // (state.root + visual), NOT the current view's page-context scope:
+    // the reopened collection matches globally, so including
+    // getContextRules() in the preview would show a folder-scoped count
+    // that disagrees with what the collection actually contains on
+    // reopen (CodeRabbit review r3620473554).
+    const rules = { mode: 'all', rules: clone(state.root.rules) };
     const preview = $('.vf-save-preview');
     preview.textContent = expressionSummary();
     fetchJson('/api/photos/query', {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -315,7 +315,15 @@
     // the root of a whole class of prototype-review bugs.
     if (options.lightRender) renderLight();
     else render();
-    schedulePersist();
+    // Persistence writes the expanded rule tree into ui_state. Opening a
+    // saved collection would then snapshot its whole photo_ids list into
+    // every workspace-state fetch, and a later reload would restore that
+    // stale expansion instead of re-resolving the live collection —
+    // membership edits/deletes wouldn't show through (Codex r3623087117).
+    // Callers opening a saved expression pass ``noPersist: true`` so the
+    // load itself isn't persisted; subsequent user edits go through
+    // mutate() again without the flag and persist normally.
+    if (!options.noPersist) schedulePersist();
     // `reason` (optional string) is forwarded to onChange so pages can
     // pick per-cause reload behavior — e.g. Browse preserving the
     // selected-photo anchor when a quick search is cleared but not for
@@ -1423,7 +1431,11 @@
                 ? visual.strength : 'balanced' }
           : null;
         state.visualInfo = null;
-      }, { reason });
+        // See mutate()'s noPersist note (Codex r3623087117): opening a
+        // saved collection should not snapshot its expanded rule list
+        // (e.g. a huge photo_ids array from a manual collection) into
+        // workspaces.ui_state.
+      }, { reason, noPersist: true });
     },
     getUserRules() { return userRules(); },
     addRule(field, op, value) {

--- a/vireo/templates/_filterbar.html
+++ b/vireo/templates/_filterbar.html
@@ -104,11 +104,27 @@
 
     <footer class="vf-popover-footer">
       <span class="vf-match-count"></span>
-      <button class="vf-done" type="button">Done</button>
+      <div class="vf-footer-actions">
+        <button class="vf-save-collection vf-text-btn" type="button" hidden>Save as Collection…</button>
+        <button class="vf-done" type="button">Done</button>
+      </div>
     </footer>
   </div>
 
   <div class="vf-toast" role="status" aria-live="polite" hidden><span></span><button type="button">Undo</button></div>
+
+  <div class="vf-save-backdrop" hidden></div>
+  <div class="vf-save-modal" role="dialog" aria-modal="true" aria-label="Save as Collection" hidden>
+    <h2>Save as Collection</h2>
+    <p class="vf-save-preview"></p>
+    <label>Collection name
+      <input class="vf-save-name" type="text" autocomplete="off">
+    </label>
+    <div class="vf-save-actions">
+      <button class="vf-save-cancel" type="button">Cancel</button>
+      <button class="vf-save-confirm" type="button">Save Collection</button>
+    </div>
+  </div>
 </div>
 
 <style>
@@ -159,6 +175,16 @@
 .vf-handoff-menu button { width: 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 2px; padding: 7px 9px; border: 0; border-radius: 6px; background: transparent; color: var(--text-secondary); text-align: left; cursor: pointer; font-size: 12px; }
 .vf-handoff-menu button:hover { background: var(--bg-tertiary); color: var(--text-primary); }
 .vf-handoff-menu button small { color: var(--text-faint); font-size: 10px; }
+.vf-footer-actions { display: flex; align-items: center; gap: 14px; }
+.vf-save-backdrop { position: fixed; inset: 0; z-index: 6000; background: rgba(0,0,0,.45); }
+.vf-save-modal { position: fixed; z-index: 6001; top: 50%; left: 50%; width: min(400px, calc(100vw - 40px)); transform: translate(-50%, -50%); padding: 16px; border: 1px solid var(--border-secondary); border-radius: 11px; background: var(--bg-panel); box-shadow: 0 18px 50px rgba(0,0,0,.4); }
+.vf-save-modal h2 { margin: 0 0 6px; font-size: 15px; color: var(--text-primary); }
+.vf-save-preview { margin: 0 0 12px; padding: 8px 10px; border-radius: 7px; background: var(--bg-secondary); color: var(--text-muted); font-size: 12px; line-height: 1.5; }
+.vf-save-modal label { display: grid; gap: 6px; color: var(--text-muted); font-size: 12px; }
+.vf-save-modal input { height: 32px; padding: 0 9px; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-input); color: var(--text-primary); }
+.vf-save-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; }
+.vf-save-cancel { padding: 6px 12px; border: 1px solid var(--border-secondary); border-radius: 7px; background: transparent; color: var(--text-secondary); cursor: pointer; }
+.vf-save-confirm { padding: 6px 14px; border: 0; border-radius: 7px; background: var(--accent); color: var(--accent-text); cursor: pointer; font-weight: 700; }
 .vf-popover { position: absolute; top: calc(100% + 8px); left: 0; z-index: 5000; width: min(680px, 100%); max-height: min(72vh, 640px); overflow-y: auto; border: 1px solid var(--border-secondary); border-radius: 11px; background: var(--bg-panel); box-shadow: 0 18px 50px rgba(0,0,0,.34); }
 .vf-popover-header { position: sticky; top: 0; z-index: 2; display: flex; justify-content: space-between; align-items: flex-start; padding: 13px 16px 10px; background: var(--bg-panel); border-bottom: 1px solid var(--border-primary); }
 .vf-popover-header h2 { margin: 0; font-size: 15px; color: var(--text-primary); }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2970,8 +2970,28 @@ async function bootstrapBrowse() {
       // (Codex review r3620935211). Treat the collection as a composable
       // dashboard-style scope for this case: keep the URL filter chips
       // and scope /api/photos/query by the collection alongside them.
+      //
+      // Exception — visual collections: /api/photos/query's collection
+      // restriction evaluates ``rules`` only, not ``visual_json``. Composing
+      // URL filters this way would silently drop the visual clause and
+      // widen to every metadata match with the URL filter (Codex review
+      // r3621403147). Fall through to filterByCollection() instead so the
+      // saved rules + visual expression loads correctly; the URL filter
+      // chips are cleared because loadExpression() replaces state.root, so
+      // surface a toast so the drop isn't silent.
+      var deepLinkedCollection = collectionLink ? collectionsById[activeCollectionId] : null;
+      var deepLinkedIsVisual = !!(deepLinkedCollection && deepLinkedCollection.visual_json);
       if (collectionLink && hasExplicitFilterParams && !dashboardCollectionScope) {
-        dashboardCollectionScope = true;
+        if (deepLinkedIsVisual) {
+          if (typeof showToast === 'function') {
+            showToast(
+              'Opened the visual collection — URL filters (rating/date/etc.) were dropped so the visual clause applies. Edit the filter bar to add them back.',
+              'info'
+            );
+          }
+        } else {
+          dashboardCollectionScope = true;
+        }
       }
       if (activeCollectionId && !dashboardCollectionScope) {
         // Plain collection deep link: open it into the filter bar as

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2842,17 +2842,12 @@ async function bootstrapBrowse() {
       dashboardCollectionScope = pageParams.get('dashboard_scope') === '1';
     }
     // Legacy filter deep-link params (rating_min/flag/keyword/dates/…) are
-    // compiled into an initial rule tree by VireoFilter.init below. Forward
-    // the capture-date bounds to the bootstrap endpoint as well so Dashboard
-    // drill-downs do not briefly paint the entire collection while the filter
-    // registry is still loading.
+    // compiled into an initial rule tree by VireoFilter.init below, which
+    // reloads through /api/photos/query — the bootstrap endpoint is
+    // scope-only (Phase 5 removed its legacy filter params).
     var initParams = new URLSearchParams();
     initParams.set('sort', document.getElementById('sortSelect').value);
     if (activeFolderId) initParams.set('folder_id', activeFolderId);
-    ['date_from', 'date_to'].forEach(function(name) {
-      var value = pageParams.get(name);
-      if (value) initParams.set(name, value);
-    });
     // Collection-only deep links keep their historical endpoint behavior,
     // while Dashboard links opt into composable filters via dashboard_scope.
     // The combined init endpoint still needs the collection id for first paint
@@ -2898,7 +2893,12 @@ async function bootstrapBrowse() {
         // selected photo, and loadUntilPhotoRendered would then keep paging
         // through the whole matching set (potentially many /api/photos/query
         // requests) just to prove the anchor is gone.
-        var preserveAnchor = info && info.reason === 'quickSearchCleared';
+        var preserveAnchor = info && (
+          info.reason === 'quickSearchCleared' ||
+          // A selected member of a just-opened collection should stay
+          // anchored (it existed in the old collection view too).
+          info.reason === 'expressionLoaded'
+        );
         resetAndLoad(preserveAnchor ? { preserveAnchor: true } : undefined);
         // Summary panel (photo count, classified, top species) is a separate
         // endpoint from the grid; without this the filter changes the grid
@@ -2918,6 +2918,7 @@ async function bootstrapBrowse() {
             ? activeCollectionId : null,
         };
       },
+      onCollectionSaved: function() { loadCollections(); },
     }).then(function() {
       VireoFilter.setResultTotal(totalPhotos);
       // Collection deep links must open showing exactly that collection \u2014
@@ -2939,10 +2940,12 @@ async function bootstrapBrowse() {
       var collectionLink = !!urlParams.get('collection_id');
       if (collectionLink && !hasExplicitFilterParams && VireoFilter.hasFilters()) {
         VireoFilter.clearAll(true);
-        // Plain collection: /api/browse/init already painted the collection
-        // and there are no filters left to apply, so skip the reload
-        // entirely. Dashboard-scoped: same story \u2014 the init call included
-        // collection_id, so the just-painted grid already matches.
+      }
+      if (activeCollectionId && !dashboardCollectionScope) {
+        // Plain collection deep link: open it into the filter bar as
+        // editable chips (rules + visual round-trip), replacing the
+        // historical collection-endpoint mode.
+        filterByCollection(activeCollectionId);
         return;
       }
       if (VireoFilter.hasFilters()) {
@@ -2987,8 +2990,11 @@ function renderCollectionList(collections) {
     var trailing = unavailable
       ? '<span class="collection-unavailable-badge">unavailable</span>'
       : '<span class="count">' + (c.photo_count != null ? c.photo_count : '') + '</span>';
+    var visualMark = c.visual_json
+      ? '<span class="collection-visual-mark" title="Includes a visual search clause">\u2726</span>'
+      : '';
     html += '<div class="' + itemClass + '" data-collection-id="' + c.id + '" data-collection-kind="' + kind + '"' + titleAttr + ' onclick="filterByCollection(' + c.id + ')">' +
-      '<span class="collection-name">' + escapeHtml(c.name) + '</span>' +
+      '<span class="collection-name">' + escapeHtml(c.name) + '</span>' + visualMark +
       '<span class="collection-kind-badge ' + kind + '">' + kindLabel + '</span>' +
       resolveBtn +
       trailing + '</div>';
@@ -3231,8 +3237,16 @@ function scheduleCollectionCountsRefresh() {
 }
 
 function refreshActiveCollectionAfterMembershipChange() {
-  if (!activeCollectionId) return;
-  filterByCollection(activeCollectionId, { preserveAnchor: false });
+  if (activeCollectionId) {
+    filterByCollection(activeCollectionId, { preserveAnchor: false });
+    return;
+  }
+  // Collections open into the filter bar now (Phase 5): when a membership
+  // change (tag/untag, add/remove) happens while an expression is active,
+  // re-evaluate it so photos that no longer match leave the grid.
+  if (window.VireoFilter && VireoFilter.hasFilters()) {
+    resetAndLoad({ preserveAnchor: false });
+  }
 }
 
 // When bulk-removing the keyword that currently drives the filter, the
@@ -3275,91 +3289,40 @@ function refreshBrowseSidebarCounts() {
 }
 
 async function filterByCollection(id, options) {
-  // Guard: degraded (count_error) collections would 400 /api/collections/<id>/photos.
-  // Surface the reason instead of silently reloading into an error state. The
-  // sidebar renders these rows as `.tree-item.unavailable` and the context menu
-  // suppresses "Filter by this Collection", so this branch also catches any
-  // programmatic caller (deep-link, membership-change refresh) that pre-dates
-  // the guard.
+  // Guard: degraded (count_error) collections can't resolve their rules.
   var collectionMeta = collectionsById[id];
+  if (!collectionMeta) {
+    // Programmatic callers (deep links, tests, refresh paths) can race the
+    // sidebar render — fetch the list before giving up.
+    await loadCollections();
+    collectionMeta = collectionsById[id];
+  }
   if (collectionMeta && collectionMeta.count_error) {
     if (typeof showToast === 'function') {
       showToast(
         (collectionMeta.name || 'This collection') +
-          " is unavailable — its rules could not be resolved. Right-click → Edit Rules to fix it.",
+          " is unavailable \u2014 its rules could not be resolved. Right-click \u2192 Edit Rules to fix it.",
         'error'
       );
     }
     return;
   }
-  var preserveAnchor = !(options && options.preserveAnchor === false);
-  var anchor = preserveAnchor ? captureSelectedPhotoAnchor() : null;
-  var restoreEpoch = anchor ? ++anchorRestoreEpoch : null;
+  if (!collectionMeta) return;
+  // Opening a collection loads its saved expression into the filter bar as
+  // editable chips (rules + visual clause round-trip). The expression IS
+  // the filter; loadExpression's onChange reload refreshes the grid with
+  // anchor preservation handled by the shared path.
   activeFolderId = null;
   activeKeyword = null;
-  activeCollectionId = id;
+  activeCollectionId = null;
   dashboardCollectionScope = false;
-  photos = [];
-  currentPage = 1;
-  allLoaded = false;
-  var collectionLoadEpoch = ++loadEpoch;  // invalidate any in-flight loadPhotos response
-  loading = false;     // safe to clear: the stale response will be dropped
-  // Selection cannot be safely carried across a dataset switch: a surviving
-  // Set or single-focus id can arm actions against hidden photos. A single
-  // focused photo is restored below only after proving it exists in the
-  // destination collection and no user interaction has superseded it.
-  selectedPhotos.clear();
-  selectedPhotoId = null;
-  selectedIndex = -1;
-  refreshCardSelectionVisuals();
-  updateBatchBar();
-  document.getElementById('grid').innerHTML = '';
-  document.getElementById('gridContainer').scrollTop = 0;
-  if (anchor) hideDetailPanel();
-  else closeDetail();
-  function collectionRequestIsCurrent() {
-    return collectionLoadEpoch === loadEpoch && activeCollectionId === id;
-  }
-  function anchorScanShouldContinue() {
-    return collectionRequestIsCurrent() && anchorRestoreEpoch === restoreEpoch;
-  }
-  if (anchor) anchorScanDepth++;
+  var rules = [];
+  var visual = null;
+  try { rules = JSON.parse(collectionMeta.rules || '[]'); } catch (e) { rules = []; }
   try {
-    await loadPhotos();
-    if (!collectionRequestIsCurrent()) return;
-    if (!anchor) return;
-
-    var card = await loadUntilPhotoRendered(anchor.photoId, anchorScanShouldContinue);
-    if (!collectionRequestIsCurrent()) return;
-    if (!anchorRestoreIsPending(anchor, restoreEpoch)) return;
-    if (!card) {
-      clearActiveSelectionAndDetail();
-      return;
-    }
-    selectedPhotoId = anchor.photoId;
-    selectedIndex = photos.findIndex(function(p) { return p.id === anchor.photoId; });
-    refreshCardSelectionVisuals();
-    updateBatchBar();
-    if (anchor.detailVisible) loadDetail(anchor.photoId);
-    requestAnimationFrame(function() {
-      if (!collectionRequestIsCurrent()) return;
-      if (!anchorSelectionIsCurrent(anchor, restoreEpoch)) return;
-      restorePhotoAnchor(anchor);
-      updateScrollPosition();
-    });
-  } finally {
-    if (anchor) {
-      anchorScanDepth = Math.max(0, anchorScanDepth - 1);
-      // Auto-hydration was suppressed for every loadPhotos() call while a scan
-      // was open (including ones from unrelated folder/keyword switches). When
-      // the last scan ends, resume the normal path so the current grid fills
-      // its viewport instead of stalling on skeletons until a manual scroll.
-      if (anchorScanDepth === 0) {
-        rearmInfiniteScrollObserver();
-        requestAnimationFrame(ensureViewportHydrated);
-      }
-    }
-  }
+    visual = collectionMeta.visual_json ? JSON.parse(collectionMeta.visual_json) : null;
+  } catch (e) { visual = null; }
+  VireoFilter.loadExpression(rules, visual);
 }
 
 /* ---------- Collection Modal ---------- */

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -8163,8 +8163,19 @@ async function deleteCollectionById(cid, name) {
     return;
   }
   // If we were filtering by the deleted collection, clear the filter.
+  // ``activeCollectionId`` covers dashboard-scope collection links; opened
+  // collections now live under ``openedCollectionId`` (their saved
+  // expression is loaded into the filter bar instead of being applied as a
+  // scope), so we need to clear that path too — otherwise the sidebar row
+  // disappears but the filter bar and grid keep applying the deleted
+  // collection's expression until the user manually clears it (Codex
+  // review r3621903982).
   if (activeCollectionId === cid) {
     activeCollectionId = null;
+    resetAndLoad();
+  } else if (openedCollectionId === cid) {
+    openedCollectionId = null;
+    if (VireoFilter.hasFilters()) VireoFilter.clearAll(true);
     resetAndLoad();
   }
   await loadCollections();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2993,6 +2993,26 @@ async function bootstrapBrowse() {
           dashboardCollectionScope = true;
         }
       }
+      // Dashboard-scoped visual collection links (?dashboard_scope=1&collection_id=<visual>
+      // [&rating_min=...]): /api/browse/init and /api/photos/query both restrict
+      // by the collection's ``rules`` and ignore ``visual_json`` in the dashboard
+      // scope path, so keeping dashboardCollectionScope=true would silently widen
+      // to every metadata match (Codex review r3621519730). Drop the scope so we
+      // fall through to filterByCollection() and the saved rules + visual
+      // expression loads correctly; any URL filter chips are cleared by
+      // loadExpression() replacing state.root, so surface a toast if we dropped
+      // filters the user asked for.
+      if (collectionLink && dashboardCollectionScope && deepLinkedIsVisual) {
+        dashboardCollectionScope = false;
+        if (typeof showToast === 'function') {
+          showToast(
+            hasExplicitFilterParams
+              ? 'Opened the visual collection — dashboard scope and URL filters were dropped so the visual clause applies. Edit the filter bar to add them back.'
+              : 'Opened the visual collection — dashboard scope was dropped so the visual clause applies.',
+            'info'
+          );
+        }
+      }
       if (activeCollectionId && !dashboardCollectionScope) {
         // Plain collection deep link: open it into the filter bar as
         // editable chips (rules + visual round-trip), replacing the

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3414,6 +3414,17 @@ function refreshBrowseSidebarCounts() {
 }
 
 async function filterByCollection(id, options) {
+  // The sidebar collection list is rendered from the initial /photos payload,
+  // so a slow /api/filters/fields (or workspace) round-trip leaves clickable
+  // collections in the DOM before VireoFilter.init resolves. Without this
+  // guard, the saved expression is pushed into the filter bar while
+  // state.fields is still null and the in-flight init's restorePersisted/
+  // finish then overwrites the just-loaded rules/visual clause with the
+  // persisted Browse filters, silently dropping the collection click
+  // (Codex review r3622909557). filterByKeyword uses this same guard for
+  // the analogous race. The bootstrap deep-link caller fires from inside
+  // VireoFilter.init(...).then(...), so it is unaffected.
+  if (window.VireoFilter && !VireoFilter.isReady()) return;
   // Guard: degraded (count_error) collections can't resolve their rules.
   var collectionMeta = collectionsById[id];
   if (!collectionMeta) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1992,6 +1992,18 @@ var activeCollectionId = null;
 // A Dashboard deep link can combine a collection with date/keyword filters.
 // Normal collection clicks keep the historical collection-only behavior.
 var dashboardCollectionScope = false;
+// Which saved collection (if any) is currently loaded into the filter bar
+// as editable chips. Phase 5's ``filterByCollection`` clears
+// ``activeCollectionId`` when it hands off to the filter bar (because the
+// expression IS the filter and the historical "collection endpoint" mode
+// is gone), so we need a separate handle to reload the expression after
+// membership edits — refreshActiveCollectionAfterMembershipChange used to
+// only reload the sidebar counts, leaving a stale photo_ids list in the
+// bar until the user reopened the collection (CodeRabbit review
+// r3620473562). Cleared by the filter bar's onChange when the user edits
+// the expression (so a user-edited chip set isn't silently reverted to
+// the saved collection on the next membership refresh).
+var openedCollectionId = null;
 
 var timelineMode = false;
 var calendarYear = new Date().getFullYear();
@@ -2886,6 +2898,16 @@ async function bootstrapBrowse() {
       onChange: function(info) {
         if (timelineMode) loadCalendarData();
         if (activeCollectionId && !dashboardCollectionScope) activeCollectionId = null;
+        // Any user-driven change to the filter chips means the bar no
+        // longer represents the saved collection verbatim — drop the
+        // handle so a later membership refresh doesn't silently revert
+        // the user's edits back to the collection's saved expression.
+        // Our own filterByCollection() → loadExpression() fires onChange
+        // with reason 'expressionLoaded'; that path already sets
+        // openedCollectionId above, so leave it alone.
+        if (openedCollectionId && info && info.reason !== 'expressionLoaded') {
+          openedCollectionId = null;
+        }
         // A cleared quick search is the one filter edit where the previously
         // selected photo is expected to reappear in the wider result set \u2014
         // preserve the anchor so the detail panel and scroll position don't
@@ -2940,6 +2962,16 @@ async function bootstrapBrowse() {
       var collectionLink = !!urlParams.get('collection_id');
       if (collectionLink && !hasExplicitFilterParams && VireoFilter.hasFilters()) {
         VireoFilter.clearAll(true);
+      }
+      // A ?collection_id=...&rating_min=4 (or &date_from=..., etc.) link
+      // compiles the URL filter params into rules above; if we then called
+      // filterByCollection() its loadExpression() would REPLACE state.root
+      // with the saved collection rules and silently drop the URL filters
+      // (Codex review r3620935211). Treat the collection as a composable
+      // dashboard-style scope for this case: keep the URL filter chips
+      // and scope /api/photos/query by the collection alongside them.
+      if (collectionLink && hasExplicitFilterParams && !dashboardCollectionScope) {
+        dashboardCollectionScope = true;
       }
       if (activeCollectionId && !dashboardCollectionScope) {
         // Plain collection deep link: open it into the filter bar as
@@ -3241,6 +3273,31 @@ function refreshActiveCollectionAfterMembershipChange() {
     filterByCollection(activeCollectionId, { preserveAnchor: false });
     return;
   }
+  // A collection opened into the filter bar carries a static rules snapshot
+  // (the saved photo_ids list plus any user-picked chips). loadCollections()
+  // refreshes the sidebar counts but the bar keeps the STALE photo_ids
+  // rule until the user manually reopens the collection, so an add/remove
+  // just made from Browse doesn't show up in the current grid (CodeRabbit
+  // review r3620473562). Refetch the collection metadata and reopen so
+  // the bar's photo_ids expression matches the fresh membership.
+  if (openedCollectionId) {
+    var reopenId = openedCollectionId;
+    // Ensure filterByCollection sees the freshest rules/visual_json, not
+    // whatever the last renderCollectionList cached; loadCollections
+    // (called by callers of this function) refreshes collectionsById via
+    // loadCollectionCounts, but that's async — sequence with a fetch.
+    safeFetch('/api/collections', {}, { toast: false }).then(function(list) {
+      if (Array.isArray(list)) {
+        list.forEach(function(c) { collectionsById[c.id] = c; });
+      }
+      filterByCollection(reopenId, { preserveAnchor: false });
+    }).catch(function() {
+      // Even without the refresh, opening the cached copy is closer to
+      // right than leaving the stale expression in place.
+      filterByCollection(reopenId, { preserveAnchor: false });
+    });
+    return;
+  }
   // Collections open into the filter bar now (Phase 5): when a membership
   // change (tag/untag, add/remove) happens while an expression is active,
   // re-evaluate it so photos that no longer match leave the grid.
@@ -3316,6 +3373,9 @@ async function filterByCollection(id, options) {
   activeKeyword = null;
   activeCollectionId = null;
   dashboardCollectionScope = false;
+  // Track which collection is currently loaded so post-membership refresh
+  // can pull fresh rules/photo_ids without waiting for a user reopen.
+  openedCollectionId = id;
   var rules = [];
   var visual = null;
   try { rules = JSON.parse(collectionMeta.rules || '[]'); } catch (e) { rules = []; }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3348,11 +3348,21 @@ function refreshActiveCollectionAfterMembershipChange() {
       if (Array.isArray(list)) {
         list.forEach(function(c) { collectionsById[c.id] = c; });
       }
-      filterByCollection(reopenId, { preserveAnchor: false });
+      // The user can switch scope (folder click, keyword click, filter
+      // change) while this fetch is in flight; those paths clear
+      // ``openedCollectionId``. Reopening unconditionally would reinstate
+      // the old collection and wipe the user's new scope (Codex review
+      // r3622743705). Only reopen if the same collection is still open.
+      if (openedCollectionId === reopenId) {
+        filterByCollection(reopenId, { preserveAnchor: false });
+      }
     }).catch(function() {
       // Even without the refresh, opening the cached copy is closer to
-      // right than leaving the stale expression in place.
-      filterByCollection(reopenId, { preserveAnchor: false });
+      // right than leaving the stale expression in place — but still
+      // only if the user hasn't already moved on.
+      if (openedCollectionId === reopenId) {
+        filterByCollection(reopenId, { preserveAnchor: false });
+      }
     });
     return;
   }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3998,10 +3998,17 @@ async function saveCollection() {
 
   try {
     var url = collectionEditingId ? '/api/collections/' + collectionEditingId : '/api/collections';
+    // This modal only edits rules — the preview and controls never surface
+    // the stored visual clause. When editing an existing visual collection,
+    // leaving visual_json in place would silently apply a hidden visual
+    // prompt on reopen that the user just previewed without (Codex review
+    // r3623087112). Clear it so the saved collection matches the preview.
+    var body = {name: name, rules: rules};
+    if (collectionEditingId) body.visual = null;
     await safeFetch(url, {
       method: collectionEditingId ? 'PUT' : 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({name: name, rules: rules}),
+      body: JSON.stringify(body),
     });
     hideCollectionModal();
     loadCollections();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3159,6 +3159,17 @@ function filterByFolder(folderId) {
   var hadSidebarKeyword = activeKeyword !== null;
   activeKeyword = null;
   activeCollectionId = null;
+  // Sidebar scope changes leave the "reopened collection" association
+  // stale: without this, tagging a keyword next fires
+  // refreshActiveCollectionAfterMembershipChange, which sees
+  // openedCollectionId still set and calls filterByCollection() —
+  // filterByCollection clears activeFolderId, unexpectedly replacing
+  // the user's folder-scoped view with the original collection
+  // (Codex review r3622204141). filterByKeyword goes through
+  // VireoFilter.addRule → onChange → the openedCollectionId clear at
+  // browse init, but filterByFolder's reloadBrowseResults() path
+  // bypasses VireoFilter, so clear it explicitly here.
+  openedCollectionId = null;
   document.querySelectorAll('#folderTree .tree-item').forEach(function(el) {
     el.classList.toggle('active', parseInt(el.dataset.folderId) === activeFolderId);
   });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2903,9 +2903,12 @@ async function bootstrapBrowse() {
         // handle so a later membership refresh doesn't silently revert
         // the user's edits back to the collection's saved expression.
         // Our own filterByCollection() → loadExpression() fires onChange
-        // with reason 'expressionLoaded'; that path already sets
-        // openedCollectionId above, so leave it alone.
-        if (openedCollectionId && info && info.reason !== 'expressionLoaded') {
+        // with reason 'expressionLoaded' (opening) or 'expressionRefreshed'
+        // (membership-change refresh); both paths set openedCollectionId
+        // above, so leave it alone.
+        if (openedCollectionId && info &&
+            info.reason !== 'expressionLoaded' &&
+            info.reason !== 'expressionRefreshed') {
           openedCollectionId = null;
         }
         // A cleared quick search is the one filter edit where the previously
@@ -2918,7 +2921,11 @@ async function bootstrapBrowse() {
         var preserveAnchor = info && (
           info.reason === 'quickSearchCleared' ||
           // A selected member of a just-opened collection should stay
-          // anchored (it existed in the old collection view too).
+          // anchored (it existed in the old collection view too). But a
+          // membership-refresh reopen (reason 'expressionRefreshed') skips
+          // this — the selected photo may have just left the collection,
+          // and loadUntilPhotoRendered would otherwise page through the
+          // whole refreshed set looking for it (Codex review r3622521603).
           info.reason === 'expressionLoaded'
         );
         resetAndLoad(preserveAnchor ? { preserveAnchor: true } : undefined);
@@ -3433,7 +3440,15 @@ async function filterByCollection(id, options) {
   try {
     visual = collectionMeta.visual_json ? JSON.parse(collectionMeta.visual_json) : null;
   } catch (e) { visual = null; }
-  VireoFilter.loadExpression(rules, visual);
+  // Membership-refresh callers pass {preserveAnchor: false} to avoid paging
+  // through the whole refreshed collection looking for a photo that may
+  // have just left it; propagate via a distinct reason so the shared
+  // onChange handler skips anchor preservation for that path (Codex review
+  // r3622521603).
+  var preserveAnchor = !(options && options.preserveAnchor === false);
+  VireoFilter.loadExpression(rules, visual, {
+    reason: preserveAnchor ? 'expressionLoaded' : 'expressionRefreshed',
+  });
 }
 
 /* ---------- Collection Modal ---------- */

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -433,6 +433,15 @@ async function loadCollections() {
         opt.disabled = true;
         opt.textContent = c.name + ' (unavailable — edit rules to fix)';
         opt.title = "This collection's rules could not be resolved. Edit it in Browse to make it usable.";
+      } else if (c.has_visual) {
+        // Cull consumes the collection via get_collection_photos, which
+        // is rules-only — picking a visual collection here would silently
+        // scope the analysis to every metadata match. The regroup-live
+        // endpoint 400s visual collections; disable the option so the
+        // user sees why up front.
+        opt.disabled = true;
+        opt.textContent = c.name + ' (visual — open in Browse)';
+        opt.title = 'Visual collections can only be used from Browse, where the filter bar resolves the visual-search clause.';
       }
       sel.appendChild(opt);
     });

--- a/vireo/templates/id_conflicts.html
+++ b/vireo/templates/id_conflicts.html
@@ -578,10 +578,18 @@ async function loadCollections() {
         opt.disabled = true;
         opt.textContent = c.name + ' (unavailable — edit rules to fix)';
         opt.title = "This collection's rules could not be resolved. Edit it in Browse to make it usable.";
+      } else if (c.has_visual) {
+        // /api/predictions/compare consumes the collection via
+        // get_collection_photos, which is rules-only — a visual
+        // collection would silently widen the comparison to every
+        // metadata match. Match the server-side 400 in the picker.
+        opt.disabled = true;
+        opt.textContent = c.name + ' (visual — open in Browse)';
+        opt.title = 'Visual collections can only be used from Browse, where the filter bar resolves the visual-search clause.';
       }
       sel.appendChild(opt);
     });
-    var all = data.find(function(c) { return c.name === 'All Photos' && !c.count_error; });
+    var all = data.find(function(c) { return c.name === 'All Photos' && !c.count_error && !c.has_visual; });
     if (all) {
       sel.value = all.id;
       loadComparison();

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -507,6 +507,13 @@ body {
       if (collection.count_error) {
         option.disabled = true;
         option.textContent = collection.name + ' (unavailable — edit rules to fix)';
+      } else if (collection.has_visual) {
+        // Location review consumes the collection via
+        // get_collection_photo_ids, which is rules-only. Match the
+        // server-side 400 by disabling with an explanatory label.
+        option.disabled = true;
+        option.textContent = collection.name + ' (visual — open in Browse)';
+        option.title = 'Visual collections can only be used from Browse, where the filter bar resolves the visual-search clause.';
       }
       select.appendChild(option);
     });

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -701,8 +701,18 @@ async function initMissFilters() {
   (results[0] || []).forEach(function(c) {
     var option = document.createElement('option');
     option.value = c.id;
-    option.textContent = c.name + (c.photo_count == null ? '' : ' (' + c.photo_count + ')');
-    option.disabled = !!c.count_error;
+    if (c.has_visual) {
+      // Misses filter consumes the collection via
+      // collection_photo_ids, which is rules-only — a visual
+      // collection would silently expand the filter to every
+      // metadata match. Server 400s the request too.
+      option.disabled = true;
+      option.textContent = c.name + ' (visual — open in Browse)';
+      option.title = 'Visual collections can only be used from Browse, where the filter bar resolves the visual-search clause.';
+    } else {
+      option.textContent = c.name + (c.photo_count == null ? '' : ' (' + c.photo_count + ')');
+      option.disabled = !!c.count_error;
+    }
     collectionSelect.appendChild(option);
   });
   var folderSelect = document.getElementById('missFolderFilter');

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1199,17 +1199,25 @@ async function loadCollections() {
     var collections = await safeFetch('/api/collections', {}, { toast: false });
     if (!Array.isArray(collections)) return;
     collections.forEach(function(c) {
-      // count_error means /api/collections couldn't resolve this collection's
-      // rules — selecting it would 500 the downstream /photos endpoint and
-      // leave the pipeline advertising a source it can't actually run. Show
-      // it disabled with a hint so the user knows to edit the rules instead.
-      var disabled = c.count_error ? ' disabled' : '';
-      var label = c.count_error
-        ? escapeHtml(c.name) + ' (unavailable — edit rules to fix)'
-        : escapeHtml(c.name);
-      var title = c.count_error
-        ? ' title="This collection\'s rules could not be resolved. Edit it in Browse to make it usable."'
-        : '';
+      // Two reasons to disable an option:
+      //   count_error — /api/collections could not resolve this collection's
+      //   rules, so the downstream /photos endpoint would 500 and the
+      //   pipeline would advertise a source it can't actually run.
+      //   has_visual — visual collections resolve through the filter bar's
+      //   visual clause, but the pipeline consumes them via
+      //   get_collection_photos (rules-only). Selecting one here would
+      //   silently scope the run to every metadata-matching photo instead
+      //   of the visually-matched subset. Open it from Browse instead.
+      var disabled = (c.count_error || c.has_visual) ? ' disabled' : '';
+      var label = escapeHtml(c.name);
+      var title = '';
+      if (c.count_error) {
+        label += ' (unavailable — edit rules to fix)';
+        title = ' title="This collection\'s rules could not be resolved. Edit it in Browse to make it usable."';
+      } else if (c.has_visual) {
+        label += ' (visual — open in Browse)';
+        title = ' title="Visual collections can only be used from Browse, where the filter bar resolves the visual-search clause."';
+      }
       sel.innerHTML += '<option value="' + c.id + '"' + disabled + title + '>' + label + '</option>';
     });
   } catch(e) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -4298,6 +4298,13 @@ function populateReviewScopeCollections(collections) {
       opt.disabled = true;
       opt.textContent = c.name + ' (unavailable — edit rules to fix)';
       opt.title = "This collection's rules could not be resolved. Edit it in Browse to make it usable.";
+    } else if (c.has_visual) {
+      // Reflow scopes to the collection via the rules-only reflow endpoint;
+      // a visual collection would silently widen the scope to every
+      // metadata match. Disable to match the server-side 400.
+      opt.disabled = true;
+      opt.textContent = c.name + ' (visual — open in Browse)';
+      opt.title = 'Visual collections can only be used from Browse, where the filter bar resolves the visual-search clause.';
     } else {
       var count = c.photo_count != null ? ' (' + c.photo_count + ')' : '';
       opt.textContent = c.name + count;

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -916,6 +916,17 @@ async function loadCollectionFilter() {
         opt.disabled = true;
         opt.textContent = c.name + ' (unavailable — edit rules to fix)';
         opt.title = "This collection's rules could not be resolved. Edit it in Browse to make it usable.";
+      } else if (c.has_visual) {
+        // Visual collections resolve their result set through the filter
+        // bar's visual clause (see Browse). The Review picker funnels the
+        // selected collection through /api/collections/<id>/photos, which
+        // only evaluates ``rules`` — picking one here would silently
+        // widen the review scope to every metadata match. Disable with a
+        // tooltip so the option is visible but not usable, and the server
+        // already 400s the endpoint as a defense-in-depth backstop.
+        opt.disabled = true;
+        opt.textContent = c.name + ' (visual — open in Browse)';
+        opt.title = 'Visual collections can only be used from Browse, where the filter bar resolves the visual-search clause.';
       }
       sel.appendChild(opt);
     });

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -564,9 +564,17 @@ async function loadDashboardOptions() {
   (dashboardOptions.collections || []).forEach(function(collection) {
     var option = document.createElement('option');
     option.value = collection.id;
-    option.textContent = collection.name
-      + (collection.degraded ? ' (unavailable — rule error)' : '');
-    if (collection.degraded) option.disabled = true;
+    // Dashboard scope (/api/stats, /api/coverage, and the Browse
+    // drilldown link) evaluates rules only via _build_collection_query,
+    // so a visual collection selected here would silently widen to every
+    // metadata match. The has_visual flag surfaces from
+    // /api/dashboard/options; disable those options and 400 server-side
+    // as belt-and-suspenders.
+    var suffix = '';
+    if (collection.degraded) suffix = ' (unavailable — rule error)';
+    else if (collection.has_visual) suffix = ' (visual — open from Browse)';
+    option.textContent = collection.name + suffix;
+    if (collection.degraded || collection.has_visual) option.disabled = true;
     collectionSelect.appendChild(option);
   });
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3981,7 +3981,8 @@ def test_text_search_applies_browse_scope_filters(app_and_db, monkeypatch):
             pid, "BioCLIP-2", np.array(emb, dtype=np.float32).tobytes()
         )
 
-    rating_resp = client.get("/api/photos/search?q=bird&threshold=-1&rating_min=5")
+    rules = json.dumps([{"field": "rating", "op": ">=", "value": 5}])
+    rating_resp = client.get(f"/api/photos/search?q=bird&threshold=-1&rules={rules}")
     assert rating_resp.status_code == 200
     assert [r["photo"]["id"] for r in rating_resp.get_json()["results"]] == [p3]
 
@@ -13404,7 +13405,9 @@ def test_browse_filter_by_collection_guards_degraded_rows():
         "browse.html filterByCollection does not check count_error"
     )
     guard_end = body.find("return;")
-    fetch_start = body.find("loadPhotos")
+    # Collections open into the filter bar now (Phase 5): the load path is
+    # VireoFilter.loadExpression rather than a collection-endpoint fetch.
+    fetch_start = body.find("loadExpression")
     assert guard_end != -1 and fetch_start != -1 and guard_end < fetch_start, (
         "browse.html filterByCollection does not early-return before loading"
     )

--- a/vireo/tests/test_collection_duplicate_api.py
+++ b/vireo/tests/test_collection_duplicate_api.py
@@ -63,6 +63,35 @@ def test_duplicate_collection_copies_static_photo_memberships(app_and_db):
     assert orig_photos == set(pids)
 
 
+def test_duplicate_collection_copies_visual_clause(app_and_db):
+    """A visual collection duplicates with its visual_json intact — otherwise
+    the copy silently drops back to a metadata-only match (Codex review
+    r3620636596 / CodeRabbit review r3620473547)."""
+    app, db = app_and_db
+    _clear_default_collections(db)
+
+    rules = [{"field": "rating", "op": ">=", "value": 3}]
+    visual = {"prompt": "bird in flight", "strength": "balanced"}
+    with app.test_client() as c:
+        resp = c.post(
+            "/api/collections",
+            json={"name": "Visual Picks", "rules": rules, "visual": visual},
+        )
+        assert resp.status_code == 200
+        cid = resp.get_json()["id"]
+
+        resp = c.post(f"/api/collections/{cid}/duplicate", json={})
+        assert resp.status_code == 200
+        new_id = resp.get_json()["id"]
+
+    row = db.conn.execute(
+        "SELECT rules, visual_json FROM collections WHERE id = ?", (new_id,)
+    ).fetchone()
+    assert json.loads(row["rules"]) == rules
+    assert row["visual_json"] is not None
+    assert json.loads(row["visual_json"]) == visual
+
+
 def test_duplicate_unknown_collection_returns_404(app_and_db):
     app, _ = app_and_db
     with app.test_client() as c:

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -628,3 +628,47 @@ def test_visual_collection_not_advertised_as_manual_add_target(app_and_db):
                        json={"photo_ids": [pid]})
     assert resp.status_code == 400
     assert "visual collection" in resp.get_json()["error"]
+
+
+def test_list_collections_flags_degraded_visual_collection(app_and_db):
+    """Visual collections skip ``count_collection_photos`` (too expensive to
+    resolve embeddings on every list), but that call was also the only path
+    that surfaced malformed JSON or unresolvable rule fields. Without a
+    separate validation the sidebar reports a broken visual collection as
+    healthy and Browse only 400s later when ``filterByCollection()`` routes
+    the bad rules through ``/api/photos/query`` (Codex review r3621304875)."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    # Healthy visual collection: valid rules JSON + resolvable field.
+    healthy = db.add_collection(
+        "Healthy visual",
+        json.dumps([{"field": "rating", "op": ">=", "value": 3}]),
+        visual_json=json.dumps({"prompt": "bird", "strength": "balanced"}),
+    )
+    # Degraded visual collection: rules JSON references an unresolvable
+    # field so ``rules_resolvable`` returns False.
+    degraded = db.add_collection(
+        "Degraded visual",
+        json.dumps([{"field": "not_a_real_field", "op": "=", "value": "x"}]),
+        visual_json=json.dumps({"prompt": "bird", "strength": "balanced"}),
+    )
+
+    by_name = {c["name"]: c for c in client.get("/api/collections").get_json()}
+
+    # Both are visual, so photo_count is omitted regardless.
+    assert by_name["Healthy visual"]["photo_count"] is None
+    assert by_name["Degraded visual"]["photo_count"] is None
+    # Only the degraded one carries the flag the sidebar picks up.
+    assert by_name["Healthy visual"].get("count_error") is not True
+    assert by_name["Degraded visual"].get("count_error") is True
+    # Degraded rules must also lock out manual add — same rationale as the
+    # plain-collection degraded path in browse_init.
+    assert by_name["Degraded visual"]["can_add_photos"] is False
+
+    # Sanity: the IDs round-trip cleanly.
+    assert {c["id"] for c in [by_name["Healthy visual"], by_name["Degraded visual"]]} == {
+        healthy,
+        degraded,
+    }

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -672,3 +672,113 @@ def test_list_collections_flags_degraded_visual_collection(app_and_db):
         healthy,
         degraded,
     }
+
+
+def test_create_collection_pins_active_model_on_has_visual_index(
+    app_and_db, monkeypatch,
+):
+    """Saving a filter with ``has_visual_index`` must persist the active
+    visual model — otherwise the rules-only sidebar count (which treats a
+    model-less rule as "any embedding exists") silently disagrees with
+    the save-time preview counter, which /api/photos/query pins to the
+    active model. Codex review r3621749904 on PR #1343."""
+    import models as models_mod
+    monkeypatch.setattr(
+        models_mod, "get_active_model",
+        lambda: {"name": "current-model", "id": "current-model",
+                 "downloaded": True},
+    )
+
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/collections",
+        json={
+            "name": "Indexed",
+            "rules": [{"field": "has_visual_index", "op": "is", "value": 1}],
+        },
+    )
+    assert resp.status_code == 200, resp.get_json()
+    cid = resp.get_json()["id"]
+
+    row = db.conn.execute(
+        "SELECT rules FROM collections WHERE id = ?", (cid,),
+    ).fetchone()
+    stored = json.loads(row["rules"])
+    # The rule leaf now carries ``model`` matching what /api/photos/query
+    # would have counted at preview time.
+    assert stored[0]["model"] == "current-model"
+
+
+def test_update_collection_pins_active_model_on_has_visual_index(
+    app_and_db, monkeypatch,
+):
+    """PUT /api/collections/<id> mirrors POST's normalization so editing
+    a saved collection's rules can't reintroduce a model-less
+    ``has_visual_index`` leaf. Codex review r3621749904."""
+    import models as models_mod
+    monkeypatch.setattr(
+        models_mod, "get_active_model",
+        lambda: {"name": "current-model", "id": "current-model",
+                 "downloaded": True},
+    )
+
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/collections",
+        json={"name": "Indexed",
+              "rules": [{"field": "rating", "op": ">=", "value": 3}]},
+    )
+    cid = resp.get_json()["id"]
+
+    resp = client.put(
+        f"/api/collections/{cid}",
+        json={"rules": [{"field": "has_visual_index",
+                          "op": "is", "value": 1}]},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+    row = db.conn.execute(
+        "SELECT rules FROM collections WHERE id = ?", (cid,),
+    ).fetchone()
+    stored = json.loads(row["rules"])
+    assert stored[0]["model"] == "current-model"
+
+
+def test_create_collection_preserves_explicit_has_visual_index_model(
+    app_and_db, monkeypatch,
+):
+    """When a saved rule already names a model (an existing collection
+    imported/edited manually), POST must leave it alone — otherwise
+    normalization would overwrite the user's explicit choice with
+    whatever model happens to be active."""
+    import models as models_mod
+    monkeypatch.setattr(
+        models_mod, "get_active_model",
+        lambda: {"name": "current-model", "id": "current-model",
+                 "downloaded": True},
+    )
+
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/collections",
+        json={"name": "Indexed",
+              "rules": [{"field": "has_visual_index", "op": "is",
+                          "value": 1, "model": "legacy-model"}]},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    cid = resp.get_json()["id"]
+
+    row = db.conn.execute(
+        "SELECT rules FROM collections WHERE id = ?", (cid,),
+    ).fetchone()
+    stored = json.loads(row["rules"])
+    assert stored[0]["model"] == "legacy-model"

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -583,3 +583,48 @@ def test_collection_photos_still_serves_plain_collection(app_and_db):
     assert resp.status_code == 200
     data = resp.get_json()
     assert "photos" in data and "total" in data
+
+
+def test_visual_collection_not_advertised_as_manual_add_target(app_and_db):
+    """A visual collection stores ``rules: []`` which
+    ``_collection_accepts_manual_photos`` treats as addable, but the
+    ``/add-photos`` endpoint only appends to ``photo_ids`` and leaves
+    ``visual_json`` alone — the added photos only surface on reopen if
+    they also match the hidden visual prompt, so the add is silently
+    ineffective. Both listing endpoints must therefore drop
+    ``can_add_photos`` for visual collections so the Browse
+    add-to-collection modal never offers one (Codex r3620791304)."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    visual = db.add_collection(
+        "Visual",
+        json.dumps([]),
+        visual_json=json.dumps({"prompt": "bird", "strength": "balanced"}),
+    )
+    client.post(
+        "/api/collections",
+        json={"name": "Manual", "rules": [{"field": "photo_ids", "value": []}]},
+    )
+
+    listed = {c["name"]: c for c in client.get("/api/collections").get_json()}
+    assert listed["Visual"]["can_add_photos"] is False
+    assert listed["Visual"]["has_visual"] is True
+    # Sanity check: a plain manual collection is still addable so this
+    # test doesn't regress the picker gate for the normal case.
+    assert listed["Manual"]["can_add_photos"] is True
+
+    init = client.get("/api/browse/init").get_json()
+    by_name = {c["name"]: c for c in init["collections"]}
+    assert by_name["Visual"]["can_add_photos"] is False
+    assert by_name["Manual"]["can_add_photos"] is True
+
+    # Defense-in-depth: even if a caller reaches /add-photos directly
+    # (bookmark, hand-crafted POST), the endpoint refuses so a stale UI
+    # can't smuggle a silent no-op past the picker.
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    resp = client.post(f"/api/collections/{visual}/add-photos",
+                       json={"photo_ids": [pid]})
+    assert resp.status_code == 400
+    assert "visual collection" in resp.get_json()["error"]

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -513,6 +513,27 @@ def test_list_collections_flags_visual(app_and_db):
     assert by_name["Plain"]["has_visual"] is False
 
 
+def test_create_collection_rejects_non_string_visual_strength(app_and_db):
+    """A JSON array for ``visual.strength`` is unhashable, so
+    ``strength in _VISUAL_STRENGTH_THRESHOLDS`` raises TypeError; without
+    an explicit type check that TypeError escapes the 400 handler as a 500
+    (CodeRabbit review r3620473547 outside-diff note)."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/collections",
+        json={
+            "name": "Bad strength",
+            "rules": [],
+            "visual": {"prompt": "bird", "strength": ["broad"]},
+        },
+    )
+    assert resp.status_code == 400, resp.get_json()
+    assert "strength" in resp.get_json()["error"]
+
+
 def test_collection_photos_rejects_visual_collection(app_and_db):
     """``/api/collections/<id>/photos`` refuses visual collections. The
     endpoint only evaluates ``rules``; without this reject the Review and

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -806,6 +806,36 @@ def test_create_collection_pins_active_model_on_has_visual_index(
     assert stored[0]["model"] == "current-model"
 
 
+def test_update_collection_clears_visual_json_when_visual_null(app_and_db):
+    """PUT /api/collections/<id> with ``visual: null`` clears the stored
+    visual_json. Browse's rules-only Edit Rules modal sends this so an
+    existing visual collection can't silently reopen with a hidden
+    visual prompt the user just previewed without (Codex review
+    r3623087112)."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    cid = _make_visual_collection(db, name="Visual", prompt="a bird")
+    row = db.conn.execute(
+        "SELECT visual_json FROM collections WHERE id = ?", (cid,),
+    ).fetchone()
+    assert row["visual_json"] is not None
+
+    resp = client.put(
+        f"/api/collections/{cid}",
+        json={"name": "Visual",
+              "rules": [{"field": "rating", "op": ">=", "value": 3}],
+              "visual": None},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+    row = db.conn.execute(
+        "SELECT visual_json FROM collections WHERE id = ?", (cid,),
+    ).fetchone()
+    assert row["visual_json"] is None
+
+
 def test_update_collection_pins_active_model_on_has_visual_index(
     app_and_db, monkeypatch,
 ):

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -469,3 +469,96 @@ def test_collection_add_photos_deduplicates(app_and_db):
     )
     assert resp.status_code == 200
     assert resp.get_json()["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Visual collections must not be silently expanded by rules-only consumers.
+# See Codex review r3620423210 on PR #1343 — a visual-only saved expression
+# saved into ``collections.visual_json`` was still selectable by legacy
+# consumers (``/api/collections/<id>/photos``, pipeline stages), whose
+# ``get_collection_photos`` evaluates ``rules`` only. The consumer would
+# silently scope its run to every metadata match instead of the
+# visually-matched subset. These tests pin the boundary contract: pickers
+# see ``has_visual``, and every rules-only endpoint 400s a visual collection.
+# ---------------------------------------------------------------------------
+
+
+def _make_visual_collection(db, name="Visual", rules=None, prompt="a bird"):
+    """Insert a collection whose visual_json is set, mirroring what the
+    Save-as-Collection flow persists for expressions with a visual clause."""
+    if rules is None:
+        rules = [{"field": "rating", "op": ">=", "value": 3}]
+    return db.add_collection(
+        name,
+        json.dumps(rules),
+        visual_json=json.dumps({"prompt": prompt, "strength": "balanced"}),
+    )
+
+
+def test_list_collections_flags_visual(app_and_db):
+    """``/api/collections`` exposes ``has_visual`` so pickers can hide or
+    disable visual collections wherever the downstream path is rules-only."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    _make_visual_collection(db, name="Visual birds")
+    client.post(
+        "/api/collections",
+        json={"name": "Plain", "rules": [{"field": "rating", "op": ">=", "value": 3}]},
+    )
+
+    by_name = {c["name"]: c for c in client.get("/api/collections").get_json()}
+    assert by_name["Visual birds"]["has_visual"] is True
+    assert by_name["Plain"]["has_visual"] is False
+
+
+def test_collection_photos_rejects_visual_collection(app_and_db):
+    """``/api/collections/<id>/photos`` refuses visual collections. The
+    endpoint only evaluates ``rules``; without this reject the Review and
+    Pipeline pickers (which funnel through it) would silently scope their
+    workload to every metadata match instead of the visually-matched subset.
+    """
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    cid = _make_visual_collection(db)
+
+    resp = client.get(f"/api/collections/{cid}/photos")
+    assert resp.status_code == 400
+    assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_collection_photo_ids_rejects_visual_collection(app_and_db):
+    """``/api/collections/<id>/photo-ids`` refuses visual collections for
+    the same reason as ``/photos`` — rules-only expansion would widen the
+    caller's scope past the visual clause."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    cid = _make_visual_collection(db)
+
+    resp = client.get(f"/api/collections/{cid}/photo-ids")
+    assert resp.status_code == 400
+    assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_collection_photos_still_serves_plain_collection(app_and_db):
+    """The visual-rejection guard must not touch plain (rules-only)
+    collections — the /photos endpoint remains the normal path for them."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/collections",
+        json={"name": "Plain", "rules": [{"field": "rating", "op": ">=", "value": 3}]},
+    )
+    cid = resp.get_json()["id"]
+
+    resp = client.get(f"/api/collections/{cid}/photos")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "photos" in data and "total" in data

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -674,6 +674,100 @@ def test_list_collections_flags_degraded_visual_collection(app_and_db):
     }
 
 
+def test_browse_init_visual_collection_scope_returns_empty_first_paint(app_and_db):
+    """``/api/browse/init?collection_id=<visual>`` cannot resolve the
+    visual clause — ``db.get_photos(collection_id=...)`` /
+    ``count_filtered_photos`` expand only ``collections.rules``, the same
+    rules-only path guarded elsewhere by ``_reject_visual_collection``.
+    For a visual-only collection (rules ``[]``) that would silently widen
+    the first paint to the entire workspace instead of the saved visual
+    result set; the client's ``filterByCollection()`` reloads through
+    ``/api/photos/query`` right after, but the wrong grid still flashes
+    between the two — and any failure before ``filterByCollection()``
+    runs leaves the user staring at the widened scope. Return
+    ``photos: []`` and ``total: 0`` for the collection scope's first
+    paint so the wrong data can never appear (Codex review on PR #1343)."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    # Baseline: unfiltered init returns every workspace photo. This is
+    # exactly the scope that would leak through if the guard regressed.
+    baseline = client.get("/api/browse/init").get_json()
+    assert baseline["total"] >= 1
+    assert len(baseline["photos"]) >= 1
+
+    visual = db.add_collection(
+        "Visual only",
+        json.dumps([]),
+        visual_json=json.dumps({"prompt": "bird", "strength": "balanced"}),
+    )
+
+    resp = client.get(f"/api/browse/init?collection_id={visual}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["photos"] == []
+    assert data["total"] == 0
+    # Sidebar bootstrap payload is still there so Browse can render
+    # folders/keywords/collections while filterByCollection() takes over.
+    by_name = {c["name"]: c for c in data["collections"]}
+    assert "Visual only" in by_name
+    assert "folders" in data and "keywords" in data
+
+
+def test_browse_init_visual_collection_ignores_rules_scope(app_and_db):
+    """A visual collection whose ``rules`` would match every photo (e.g.
+    ``[]`` or an ``all`` sentinel) must not have those rules applied at
+    first paint either — the browse init endpoint has no way to combine
+    the visual clause here, so it deliberately drops the scope. Guards
+    against a future edit that "helpfully" falls back to the rules when
+    the visual clause is present (Codex review on PR #1343)."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    # Rules that would count every workspace photo — proving the fix
+    # never widens/reveals them for a visual collection.
+    visual = db.add_collection(
+        "Visual widest",
+        json.dumps([{"field": "all"}]),
+        visual_json=json.dumps({"prompt": "bird", "strength": "balanced"}),
+    )
+
+    resp = client.get(f"/api/browse/init?collection_id={visual}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["photos"] == []
+    assert data["total"] == 0
+
+
+def test_browse_init_plain_collection_still_scopes_normally(app_and_db):
+    """The visual-scope guard must not touch plain (rules-only)
+    collections — the first paint remains the normal rules-only path so
+    Browse deep links to smart collections still open showing the
+    matching photos before ``filterByCollection()`` runs."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    photo_ids = [
+        row["id"] for row in db.conn.execute("SELECT id FROM photos").fetchall()
+    ]
+    assert len(photo_ids) >= 1
+
+    plain = db.add_collection(
+        "Plain",
+        json.dumps([{"field": "photo_ids", "value": photo_ids[:1]}]),
+    )
+
+    resp = client.get(f"/api/browse/init?collection_id={plain}")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 1
+    assert [p["id"] for p in data["photos"]] == photo_ids[:1]
+
+
 def test_create_collection_pins_active_model_on_has_visual_index(
     app_and_db, monkeypatch,
 ):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -458,8 +458,13 @@ def test_get_photos_filter_by_flag(tmp_path):
     assert [p['filename'] for p in rejects] == ['reject.jpg']
     assert db.count_filtered_photos(flag='flagged') == 1
     assert db.count_filtered_photos(flag='rejected') == 1
-    assert db.get_browse_summary(flag='flagged')['filtered_total'] == 1
-    assert db.get_calendar_data(2024, flag='rejected')['days'] == {'2024-01-02': 1}
+    # get_browse_summary filters via rules only (Phase 5).
+    assert db.get_browse_summary(
+        rules=[{"field": "flag", "op": "is", "value": "flagged"}]
+    )['filtered_total'] == 1
+    assert db.get_calendar_data(
+        2024, rules=[{"field": "flag", "op": "is", "value": "rejected"}]
+    )['days'] == {'2024-01-02': 1}
 
 
 def test_get_photos_filter_by_date_range(tmp_path):
@@ -4890,7 +4895,8 @@ def test_get_calendar_data_filters(tmp_path):
     data = db.get_calendar_data(year=2024, folder_id=jan["id"])
     assert list(data["days"].keys()) == ["2024-01-20"]
 
-    data = db.get_calendar_data(year=2024, rating_min=4)
+    data = db.get_calendar_data(
+        year=2024, rules=[{"field": "rating", "op": ">=", "value": 4}])
     assert list(data["days"].keys()) == ["2024-06-10"]
 
 
@@ -4953,13 +4959,15 @@ def test_get_geolocated_photos_filters(tmp_path):
     db.update_photo_rating(p1, 2)
     db.update_photo_rating(p2, 5)
 
-    # Filter by rating
-    results = db.get_geolocated_photos(rating_min=4)
+    # Metadata filtering flows exclusively through the universal-filter
+    # rules tree (legacy per-field params removed in Phase 5).
+    results = db.get_geolocated_photos(
+        rules=[{"field": "rating", "op": ">=", "value": 4}])
     assert len(results) == 1
     assert results[0]['filename'] == 'b.jpg'
 
-    # Filter by date range
-    results = db.get_geolocated_photos(date_from='2024-03-01')
+    results = db.get_geolocated_photos(
+        rules=[{"field": "timestamp", "op": ">=", "value": "2024-03-01"}])
     assert len(results) == 1
     assert results[0]['filename'] == 'b.jpg'
 
@@ -4978,16 +4986,16 @@ def test_get_geolocated_photos_keyword_search_options(tmp_path):
     db.tag_photo(p1, db.add_keyword('Western Tanager'))
     db.tag_photo(p2, db.add_keyword('Common Tern'))
 
+    # Keyword filtering on Map now uses the shared rule vocabulary (the
+    # legacy tokenized keyword param with case/whole-word options was
+    # removed in Phase 5 along with its endpoint surface).
     assert {
-        r['filename'] for r in db.get_geolocated_photos(keyword='tern')
+        r['filename'] for r in db.get_geolocated_photos(
+            rules=[{"field": "keyword", "op": "contains", "value": "tern"}])
     } == {'western.jpg', 'tern.jpg'}
     assert {
-        r['filename']
-        for r in db.get_geolocated_photos(keyword='tern', keyword_whole_word=True)
-    } == {'tern.jpg'}
-    assert {
-        r['filename']
-        for r in db.get_geolocated_photos(keyword='Tern', keyword_match_case=True)
+        r['filename'] for r in db.get_geolocated_photos(
+            rules=[{"field": "keyword", "op": "is", "value": "Common Tern"}])
     } == {'tern.jpg'}
 
 
@@ -5052,11 +5060,13 @@ def test_get_geolocated_photos_species_filter(tmp_path):
     for pr in preds:
         db.accept_prediction(pr['id'])
 
-    results = db.get_geolocated_photos(species='Red-tailed Hawk')
+    results = db.get_geolocated_photos(
+        rules=[{"field": "species", "op": "is", "value": "Red-tailed Hawk"}])
     assert len(results) == 1
     assert results[0]['filename'] == 'hawk.jpg'
 
-    results = db.get_geolocated_photos(species='Great Blue Heron')
+    results = db.get_geolocated_photos(
+        rules=[{"field": "species", "op": "is", "value": "Great Blue Heron"}])
     assert len(results) == 1
     assert results[0]['filename'] == 'heron.jpg'
 
@@ -5080,15 +5090,17 @@ def test_get_geolocated_photos_species_filter_multi_species(tmp_path):
     for pr in db.get_predictions(photo_ids=[p1]):
         db.accept_prediction(pr['id'])
 
-    # Photo is tagged with both; either filter value must return it,
-    # and the species label in the returned row must match the filter.
-    rows = db.get_geolocated_photos(species='Red-tailed Hawk')
+    # Photo is tagged with both; either rules value must return it. The
+    # species display column shows the latest-confirmed identification
+    # (single-column display; the multi-species truth lives in keywords).
+    rows = db.get_geolocated_photos(
+        rules=[{"field": "species", "op": "is", "value": "Red-tailed Hawk"}])
     assert len(rows) == 1
-    assert rows[0]['species'] == 'Red-tailed Hawk'
-    rows = db.get_geolocated_photos(species='Sparrow')
+    rows = db.get_geolocated_photos(
+        rules=[{"field": "species", "op": "is", "value": "Sparrow"}])
     assert len(rows) == 1
-    assert rows[0]['species'] == 'Sparrow'
-    assert db.get_geolocated_photos(species='Cardinal') == []
+    assert db.get_geolocated_photos(
+        rules=[{"field": "species", "op": "is", "value": "Cardinal"}]) == []
 
 
 def test_get_geolocated_photos_falls_back_to_keyword_coords(tmp_path):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3395,6 +3395,34 @@ def test_jobs_previews_rejects_visual_collection(app_and_db):
         assert "visual-search clause" in resp.get_json()["error"]
 
 
+def test_jobs_previews_rejects_visual_collection_when_id_is_a_json_string(app_and_db):
+    """The visual guard must coerce non-int JSON types before the
+    ``visual_json`` lookup — SQLite's ``WHERE id = ?`` matches integer id 1
+    when handed the string ``"1"`` or ``True``, so an early ``isinstance``
+    bail-out would let a string- or bool-typed id skip the guard and hit
+    the rules-only path anyway (Codex review r3620636582)."""
+    app, _ = app_and_db
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/previews", json={"collection_id": str(col_id)},
+        )
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_jobs_previews_rejects_non_integer_collection_id(app_and_db):
+    """An unparseable ``collection_id`` (e.g. ``[1]``) is rejected outright
+    so a caller can't slip past the guard with an exotic type."""
+    app, _ = app_and_db
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/previews", json={"collection_id": [1]},
+        )
+        assert resp.status_code == 400, resp.get_json()
+        assert "must be an integer" in resp.get_json()["error"]
+
+
 @pytest.mark.parametrize(
     "extra",
     [

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3423,6 +3423,21 @@ def test_jobs_previews_rejects_non_integer_collection_id(app_and_db):
         assert "must be an integer" in resp.get_json()["error"]
 
 
+def test_jobs_offline_cache_rejects_visual_collection(app_and_db):
+    """``/api/jobs/offline-cache`` expands ``collection_id`` via
+    ``db.get_collection_photos(...)`` which evaluates ``rules`` only. A
+    visual collection would silently cache every metadata match instead
+    of the visually-matched subset (Codex review r3621094501)."""
+    app, _ = app_and_db
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/offline-cache", json={"collection_id": col_id},
+        )
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
 @pytest.mark.parametrize(
     "extra",
     [

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3296,13 +3296,12 @@ def _make_visual_collection(app):
 
     from db import Database
 
-    db = Database(app.config["DB_PATH"])
-    db.set_active_workspace(db._active_workspace_id)
-    return db.add_collection(
-        "Visual test",
-        json_mod.dumps([{"field": "rating", "op": ">=", "value": 3}]),
-        visual_json=json_mod.dumps({"prompt": "a bird", "strength": "balanced"}),
-    )
+    with Database(app.config["DB_PATH"]) as db:
+        return db.add_collection(
+            "Visual test",
+            json_mod.dumps([{"field": "rating", "op": ">=", "value": 3}]),
+            visual_json=json_mod.dumps({"prompt": "a bird", "strength": "balanced"}),
+        )
 
 
 def test_pipeline_rejects_visual_collection(app_and_db, monkeypatch):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3284,6 +3284,117 @@ def test_pipeline_miss_enabled_accepts_bools(app_and_db, monkeypatch):
             assert cfg["miss_enabled"] is value
 
 
+def _make_visual_collection(app):
+    """Insert a collection with a saved visual clause.
+
+    Pipeline stages iterate photos through ``get_collection_photos`` which
+    evaluates ``rules`` only — feeding a visual collection here would
+    silently scope the run to every metadata match instead of the
+    visually-matched subset (Codex review r3620423210 on PR #1343).
+    """
+    import json as json_mod
+
+    from db import Database
+
+    db = Database(app.config["DB_PATH"])
+    db.set_active_workspace(db._active_workspace_id)
+    return db.add_collection(
+        "Visual test",
+        json_mod.dumps([{"field": "rating", "op": ">=", "value": 3}]),
+        visual_json=json_mod.dumps({"prompt": "a bird", "strength": "balanced"}),
+    )
+
+
+def test_pipeline_rejects_visual_collection(app_and_db, monkeypatch):
+    """``/api/jobs/pipeline`` refuses a visual collection_id.
+
+    pipeline_job stages iterate ``thread_db.get_collection_photos(...)``,
+    which does not resolve ``visual_json``. Without a boundary check the
+    stages would silently process every metadata match instead of the
+    visually-matched subset.
+    """
+    app, _ = app_and_db
+    _fake_active_model(monkeypatch)
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={"collection_id": col_id})
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_jobs_sharpness_rejects_visual_collection(app_and_db):
+    """``/api/jobs/sharpness`` scores every photo returned by
+    ``get_collection_photos`` (see sharpness.score_collection_photos).
+    A visual collection would silently score every metadata match."""
+    app, _ = app_and_db
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/sharpness", json={"collection_id": col_id})
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_jobs_classify_rejects_visual_collection(app_and_db):
+    """``/api/jobs/classify`` runs detection/classification per collection
+    photo (classify_job); a visual collection here would silently classify
+    every metadata match instead of the visual subset."""
+    app, _ = app_and_db
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/classify", json={"collection_id": col_id})
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_jobs_cull_rejects_visual_collection(app_and_db):
+    """``/api/jobs/cull`` (culling.analyze_for_culling) reads
+    ``get_collection_photos``; a visual collection would silently analyze
+    every metadata match."""
+    app, _ = app_and_db
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/cull", json={"collection_id": col_id})
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_jobs_regroup_rejects_visual_collection(app_and_db):
+    """``/api/jobs/regroup`` (pipeline.run_full_pipeline via
+    load_photo_features) reads ``get_collection_photos``; reject visual
+    collections at the boundary."""
+    app, _ = app_and_db
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/regroup", json={"collection_id": col_id})
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_jobs_extract_masks_rejects_visual_collection(app_and_db):
+    """``/api/jobs/extract-masks`` (SAM2 mask extraction) reads
+    ``get_collection_photos``; reject visual collections at the boundary."""
+    app, _ = app_and_db
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/extract-masks", json={"collection_id": col_id},
+        )
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
+def test_jobs_previews_rejects_visual_collection(app_and_db):
+    """``/api/jobs/previews`` iterates the collection to precompute preview
+    JPEGs; reject visual collections so previews aren't warmed for the
+    wider metadata set."""
+    app, _ = app_and_db
+    col_id = _make_visual_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/previews", json={"collection_id": col_id})
+        assert resp.status_code == 400, resp.get_json()
+        assert "visual-search clause" in resp.get_json()["error"]
+
+
 @pytest.mark.parametrize(
     "extra",
     [

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -502,3 +502,31 @@ def test_api_misses_since_restricts_to_recent_run(client, db_with_misses):
     r2 = client.get("/api/misses?category=clipped&since=2026-04-21T00:00:00%2B00:00")
     assert r2.status_code == 200
     assert r2.get_json()["photos"] == []
+
+
+def test_api_misses_rejects_visual_collection(client, db_with_misses):
+    """The Misses page filter funnels ``collection_id`` through
+    ``collection_photo_ids``, which evaluates ``rules`` only. A visual
+    collection would silently widen the miss scope to every metadata
+    match instead of the visually-matched subset — Codex review
+    r3620423210 on PR #1343 flagged the equivalent risk for
+    ``/api/collections/<id>/photos``; the misses filter has the same
+    boundary. Reject with 400 so the front-end picker (which disables
+    the same options) has a defense-in-depth backstop.
+    """
+    _, db, _ = db_with_misses
+    visual_cid = db.add_collection(
+        "Visual", json.dumps([{"field": "rating", "op": ">=", "value": 3}]),
+        visual_json=json.dumps({"prompt": "bird", "strength": "balanced"}),
+    )
+
+    r = client.get(f"/api/misses?collection_id={visual_cid}")
+    assert r.status_code == 400
+    assert "visual collections" in r.get_json()["error"]
+
+    r_prev = client.post(
+        "/api/misses/preview",
+        data=json.dumps({"collection_id": visual_cid}),
+        content_type="application/json",
+    )
+    assert r_prev.status_code == 400

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -334,6 +334,24 @@ def test_api_photo_search_ids_only_returns_all_matches(app_and_db, monkeypatch):
     assert "results" not in data
 
 
+def test_api_photo_search_rejects_visual_collection(app_and_db):
+    """``/api/photos/search?collection_id=<visual>`` expands the scope via
+    ``db.get_collection_photo_ids(...)`` which evaluates ``rules`` only.
+    A visual collection would silently widen the CLIP-scored candidate set
+    to every metadata match instead of the visually-matched subset
+    (Codex review r3621094501)."""
+    app, db = app_and_db
+    visual = db.add_collection(
+        "Visual",
+        json.dumps([{"field": "rating", "op": ">=", "value": 3}]),
+        visual_json=json.dumps({"prompt": "bird", "strength": "balanced"}),
+    )
+    client = app.test_client()
+    resp = client.get(f"/api/photos/search?q=bird&collection_id={visual}")
+    assert resp.status_code == 400, resp.get_json()
+    assert "visual-search clause" in resp.get_json()["error"]
+
+
 def test_api_photos_filter_rating(app_and_db):
     """GET /api/photos?rating_min= filters by minimum rating."""
     app, _ = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -171,12 +171,30 @@ def test_dashboard_and_browse_share_collection_date_scope(app_and_db):
     assert coverage.status_code == 200
     assert coverage.get_json()["overall"]["total"] == 1
 
-    for path in ("/api/browse/init", "/api/photos", "/api/photos/ids"):
+    for path in ("/api/photos", "/api/photos/ids"):
         response = client.get(f"{path}?{query}")
         assert response.status_code == 200
         body = response.get_json()
         result_ids = body.get("photo_ids") or [photo["id"] for photo in body["photos"]]
         assert result_ids == [photos[2]["id"]]
+
+    # /api/browse/init is scope-only since Phase 5: it paints the collection,
+    # and the filter bar applies the date rules through /api/photos/query.
+    init = client.get(f"/api/browse/init?collection_id={collection_id}&sort=name")
+    assert init.status_code == 200
+    assert [p["id"] for p in init.get_json()["photos"]] == [
+        photos[0]["id"], photos[2]["id"],
+    ]
+    query_resp = client.post("/api/photos/query", json={
+        "rules": [
+            {"field": "timestamp", "op": ">=", "value": "2024-06-01"},
+            {"field": "timestamp", "op": "<=", "value": "2024-06-30"},
+        ],
+        "collection_id": collection_id,
+        "ids_only": True,
+    })
+    assert query_resp.status_code == 200
+    assert query_resp.get_json()["ids"] == [photos[2]["id"]]
 
 
 def test_dashboard_options_flags_degraded_collections(app_and_db):
@@ -968,10 +986,12 @@ def test_api_photos_calendar(app_and_db):
 
 
 def test_api_photos_calendar_with_filters(app_and_db):
-    """GET /api/photos/calendar respects folder_id and rating_min filters."""
+    """GET /api/photos/calendar filters via a universal-filter rules tree."""
+    import json as _json
     app, db = app_and_db
     client = app.test_client()
-    resp = client.get("/api/photos/calendar?year=2024&rating_min=4")
+    rules = _json.dumps([{"field": "rating", "op": ">=", "value": 4}])
+    resp = client.get(f"/api/photos/calendar?year=2024&rules={rules}")
     data = resp.get_json()
     assert list(data["days"].keys()) == ["2024-06-10"]
 
@@ -1033,8 +1053,10 @@ def test_api_photos_geo_with_filters(app_and_db):
     db.conn.execute("UPDATE photos SET latitude=1.0, longitude=2.0 WHERE filename IN ('bird1.jpg','bird3.jpg')")
     db.conn.commit()
 
+    import json as _json
     client = app.test_client()
-    resp = client.get('/api/photos/geo?rating_min=4')
+    rules = _json.dumps([{"field": "rating", "op": ">=", "value": 4}])
+    resp = client.get(f'/api/photos/geo?rules={rules}')
     assert resp.status_code == 200
     data = resp.get_json()
     assert len(data['photos']) == 1
@@ -1065,7 +1087,9 @@ def test_api_photos_geo_includes_gps_stats(app_and_db):
     assert data['total_without_gps'] == 2
     assert data['total_photos'] == 3
     # Verify global stats stay consistent even with filters active
-    resp2 = client.get('/api/photos/geo?rating_min=5')
+    import json as _json
+    rules = _json.dumps([{"field": "rating", "op": ">=", "value": 5}])
+    resp2 = client.get(f'/api/photos/geo?rules={rules}')
     data2 = resp2.get_json()
     assert data2['total_filtered'] == 0  # no rated-5 geo photos
     assert data2['total_with_gps'] == 1  # global count unchanged
@@ -1086,8 +1110,10 @@ def test_api_photos_geo_species_filter(app_and_db):
     for pr in preds:
         db.accept_prediction(pr['id'])
 
+    import json as _json
     client = app.test_client()
-    resp = client.get('/api/photos/geo?species=Cardinal')
+    rules = _json.dumps([{"field": "species", "op": "is", "value": "Cardinal"}])
+    resp = client.get(f'/api/photos/geo?rules={rules}')
     data = resp.get_json()
     assert len(data['photos']) == 1
     assert data['photos'][0]['species'] == 'Cardinal'
@@ -10582,3 +10608,57 @@ def test_api_predictions_surfaces_visual_status(app_and_db, monkeypatch):
     resp = client.get('/api/predictions')
     assert resp.status_code == 200
     assert "visual" not in resp.get_json()
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: collections round-trip {rules, visual}.
+# ---------------------------------------------------------------------------
+
+
+def test_collection_save_and_reopen_round_trips_visual(app_and_db, monkeypatch):
+    """Saving an expression with a visual clause and reopening it must
+    reproduce the same result set — never silently drop to metadata-only."""
+    import json as _json
+    app, db = app_and_db
+    _seed_embeddings(db)
+    _stub_clip(monkeypatch)
+    client = app.test_client()
+
+    rules = [{"field": "rating", "op": ">=", "value": 3}]
+    visual = {"prompt": "a bird", "strength": "balanced"}
+    resp = client.post('/api/collections', json={
+        "name": "Visual birds", "rules": rules, "visual": visual,
+    })
+    assert resp.status_code == 200
+    cid = resp.get_json()["id"]
+
+    listed = {c["name"]: c for c in client.get('/api/collections').get_json()}
+    saved = listed["Visual birds"]
+    assert _json.loads(saved["rules"]) == rules
+    assert _json.loads(saved["visual_json"]) == visual
+
+    # Reopening = querying with the stored pair; must equal the original.
+    direct = client.post('/api/photos/query', json={
+        "rules": rules, "visual": visual, "ids_only": True,
+    }).get_json()
+    reopened = client.post('/api/photos/query', json={
+        "rules": _json.loads(saved["rules"]),
+        "visual": _json.loads(saved["visual_json"]),
+        "ids_only": True,
+    }).get_json()
+    assert reopened["ids"] == direct["ids"]
+    assert reopened["visual"]["status"] == "ok"
+
+    # Metadata-only collections keep NULL visual_json and old behavior.
+    resp = client.post('/api/collections', json={"name": "Plain", "rules": rules})
+    assert resp.status_code == 200
+    listed = {c["name"]: c for c in client.get('/api/collections').get_json()}
+    assert listed["Plain"]["visual_json"] is None
+
+    # PUT can set and clear the clause; malformed clauses 400.
+    assert client.put(f'/api/collections/{cid}', json={"visual": None}).status_code == 200
+    listed = {c["name"]: c for c in client.get('/api/collections').get_json()}
+    assert listed["Visual birds"]["visual_json"] is None
+    assert client.post('/api/collections', json={
+        "name": "Bad", "rules": [], "visual": {"prompt": "  "},
+    }).status_code == 400

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -221,6 +221,37 @@ def test_dashboard_options_flags_degraded_collections(app_and_db):
         assert client.get(f"/api/coverage?collection_id={cid}").status_code == 400
 
 
+def test_dashboard_options_flags_visual_collections(app_and_db):
+    """Visual collections carry a ``has_visual`` flag so stats.html's scope
+    picker disables them — a visual collection selected in Dashboard scope
+    would silently widen to every metadata match because /api/stats and
+    /api/coverage resolve collection_id through ``_build_collection_query``
+    (rules-only). Codex review r3620636595."""
+    app, db = app_and_db
+    plain = db.add_collection("Plain", "[]")
+    visual = db.add_collection(
+        "Visual",
+        json.dumps([{"field": "rating", "op": ">=", "value": 3}]),
+        visual_json=json.dumps({"prompt": "bird", "strength": "balanced"}),
+    )
+
+    client = app.test_client()
+    resp = client.get("/api/dashboard/options")
+    assert resp.status_code == 200
+    by_id = {c["id"]: c for c in resp.get_json()["collections"]}
+    assert by_id[plain]["has_visual"] is False
+    assert by_id[visual]["has_visual"] is True
+
+    # Server-side belt-and-suspenders: a bookmarked /dashboard link with the
+    # visual collection id 400s so the panels don't render metadata-only
+    # numbers passed off as visual-scoped.
+    assert client.get(f"/api/stats?collection_id={visual}").status_code == 400
+    assert client.get(f"/api/coverage?collection_id={visual}").status_code == 400
+    # Plain collections still work.
+    assert client.get(f"/api/stats?collection_id={plain}").status_code == 200
+    assert client.get(f"/api/coverage?collection_id={plain}").status_code == 200
+
+
 def test_dashboard_scope_rejects_foreign_collection(app_and_db):
     """Scope ids cannot cross workspace boundaries."""
     app, db = app_and_db

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2700,6 +2700,59 @@ def test_api_pipeline_plan_collection_scope(app_and_db):
     assert data["stages"]["Extract"]["detail"]["eligible"] == 0
 
 
+def test_api_pipeline_plan_rejects_visual_collection(app_and_db):
+    """A visual collection posted to /api/pipeline/plan must 400 rather
+    than be planned via the rules-only scope. ``compute_plan`` →
+    ``pipeline._resolve_collection_photo_ids()`` → ``get_collection_photos()``
+    evaluates ``rules`` only; without this guard a stale/bookmarked Process
+    page body would advertise a widened runnable job over every metadata
+    match even though ``/api/jobs/pipeline`` already rejects the same id
+    (Codex review r3622041639).
+    """
+    import json as json_mod
+
+    app, db = app_and_db
+    cid = db.add_collection(
+        "Visual pipeline scope",
+        json_mod.dumps([]),
+        visual_json=json_mod.dumps({"prompt": "a bird", "strength": "balanced"}),
+    )
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "collection_id": cid,
+            "skip_classify": True,
+            "skip_eye_keypoints": True,
+            "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 400
+    assert "visual" in resp.get_json()["error"].lower()
+
+
+def test_api_pipeline_plan_rejects_stringly_typed_collection_id(app_and_db):
+    """The stringly-typed coercion guard must fire before the visual lookup
+    too: ``{"collection_id": "not-an-int"}`` would otherwise be forwarded to
+    ``PipelinePlanParams(collection_id=...)`` and blow up later, or worse,
+    a string that happens to parse as int could still slip past the
+    visual-json check (Codex review r3620636582 pattern).
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "collection_id": "not-an-int",
+            "skip_classify": True,
+            "skip_eye_keypoints": True,
+            "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 400
+    assert "collection_id" in resp.get_json()["error"]
+
+
 # -------- compute_plan: import-mode honesty --------
 #
 # These tests pin the core bug fix: when the user is about to import a


### PR DESCRIPTION
## What this is

The **final phase** of the universal filter epic ([plan](docs/plans/2026-07-19-universal-filters-plan.md); prototype #1319 → backend #1324 → Browse #1329 → visual #1330 → all pages #1332): saved filters and collections become one thing, and the legacy filter paths the epic was born to replace are deleted.

## Save ⇄ open round-trip

- **Save as Collection…** in the filter bar's popover: the preview shows the post-save count (rules + visual clause, unmuted — the paused view's count never leaks in, per the prototype-review rule). Collections with a visual clause get a ✦ marker in the sidebar.
- **collections.visual_json** (new nullable column): the visual clause persists alongside `rules`, and `POST`/`PUT /api/collections` validate + round-trip it. An API test asserts save → reopen produces the identical id set with `status: ok` — an expression with a visual component can never silently reopen as metadata-only.
- **Opening a collection loads it into the bar as editable chips** — click, context menu, or deep link. This replaces the historical collection-endpoint mode: the expression IS the filter, refinable and re-savable. Manual collections read as "N hand-picked photos"; the legacy `{"field": "all"}` sentinel opens as show-everything; selected members stay anchored; tagging/untagging re-evaluates the open expression (e2e-verified via the Needs Identification flow).

## Legacy cleanup (survey-driven)

A caller survey established which legacy branches were dead. **Deleted** (zero callers): the per-field metadata params on `get_browse_summary`/`get_calendar_data`/`get_geolocated_photos` and their endpoints, `/api/photos/search`'s legacy scope params, and `/api/browse/init`'s filter params (first paint is scope-only; deep-linked filters compile client-side). **Kept and documented in the plan doc**: `/api/photos`(+`/ids`) legacy params for the three remaining consumers — the Misses page's local filter UI (a future filter-bar adoption candidate), the photo editor's keyword search, and bulk pipeline fetches.

~15 tests of the removed behavior were rewritten to rules equivalents; 4 e2e tests orchestrating the deleted bespoke collection anchor-scan pipeline were removed with a pointer to the surviving coverage in the shared-path tests.

## Docs

`help.json` gains entries for the filter bar, visual search, pause (`\`), and save-as-collection.

## Testing

- Full e2e: **581 passed**, 3 pre-existing failures (sync_panel ×2 + lifelist — fail identically on clean main)
- Standard suite: **1925 passed, 14 skipped**, 1 pre-existing env failure (exiftool status)
- New: collections round-trip API test (incl. PUT set/clear + 400s), save/reopen e2e with visual clause and sidebar marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save active filters (including visual searches) as reusable Collections and reopen them to restore editable filter chips and visual settings.
  * Visual Collections are now flagged in Browse with visual indicators and integrated into the filter expression flow.
* **Documentation**
  * Updated help content and keywords for filtering, visual search, disabling/pause behavior, and saving Collections.
* **Bug Fixes**
  * Improved Browse filter switching/restoration (anchor behavior, chips, debounce) and clarified scope handling.
  * Enforced consistent restrictions so visual Collections are handled only where intended.
* **Tests**
  * Added/updated E2E and API coverage for save/reopen round-trips and visual-collection rejection boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->