### PR TITLE
Queue early Browse collection opens

### DIFF
--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -166,6 +166,62 @@ def test_queued_collection_open_yields_to_later_keyword_click(live_server, page)
     assert page.evaluate("activeCollectionId") is None
 
 
+def test_deep_link_replay_yields_to_sidebar_click(live_server, page):
+    """?collection_id=A must not overwrite a sidebar click on collection B.
+
+    Browsing to /browse?collection_id=A registers a post-init
+    filterByCollection(activeCollectionId) as the deep-link replay. A sidebar
+    click on collection B while /api/filters/fields is still pending queues
+    behind the same init promise. Because the .then handler was registered
+    first, it resumes first and, before the fix, its unconditional
+    filterByCollection(A) call bumped browseScopeGen — invalidating B's
+    queued open, so A opened over the user's real click (Codex review
+    r3624637674).
+    """
+    collections_by_name = {c["name"]: c["id"] for c in live_server["db"].get_collections()}
+    # Both collections must return non-empty grids: All Photos matches the
+    # 5 seeded photos, Untagged matches the 3 without a keyword. Empty
+    # collections would leave #grid .grid-card missing and hang the page
+    # load before we even queue the sidebar click.
+    deep_link_id = collections_by_name["All Photos"]
+    clicked_id = collections_by_name["Untagged"]
+    assert deep_link_id != clicked_id
+
+    held_routes = []
+    page.route(
+        "**/api/filters/fields",
+        lambda route: held_routes.append(route),
+    )
+
+    page.goto(live_server["url"] + f"/browse?collection_id={deep_link_id}")
+    page.wait_for_selector("#grid .grid-card", timeout=15000)
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "filter-field request was never issued"
+    assert not page.evaluate("VireoFilter.isReady()")
+
+    # User clicks a different collection in the sidebar while init is still
+    # pending — this queues behind browseFilterInitPromise.
+    page.evaluate(
+        "collectionId => { window._userCollectionClick = "
+        "filterByCollection(collectionId); }",
+        clicked_id,
+    )
+    held_routes[0].continue_()
+
+    page.wait_for_function(
+        "clickedId => VireoFilter.isReady() && openedCollectionId === clickedId",
+        arg=clicked_id,
+        timeout=15000,
+    )
+    # The deep-link replay must have skipped itself — otherwise it would
+    # have reopened deep_link_id after B's queued open bailed as stale.
+    page.wait_for_timeout(200)
+    assert page.evaluate("openedCollectionId") == clicked_id
+
+
 def test_quick_rating_filter_and_chip_semantics(live_server, page):
     _open_browse(page, live_server)
     assert _total(page) == 5

--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -72,6 +72,50 @@ def test_collection_open_waits_for_filter_bar_initialization(live_server, page):
     )
 
 
+def test_queued_collection_open_yields_to_later_folder_click(live_server, page):
+    """A queued early collection open must not clobber a later folder click."""
+    collection_id = next(
+        collection["id"]
+        for collection in live_server["db"].get_collections()
+        if collection["name"] == "GPS Without Location Keyword"
+    )
+    folder_id = live_server["data"]["folders"][1]
+    held_routes = []
+    page.route(
+        "**/api/filters/fields",
+        lambda route: held_routes.append(route),
+    )
+
+    page.goto(live_server["url"] + "/browse")
+    page.wait_for_selector("#grid .grid-card", timeout=15000)
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "filter-field request was never issued"
+    assert not page.evaluate("VireoFilter.isReady()")
+
+    # Early collection click queues behind the pending filter-bar init...
+    page.evaluate(
+        "collectionId => { window._earlyCollectionOpen = "
+        "filterByCollection(collectionId); }",
+        collection_id,
+    )
+    # ...but a later folder click changes scope before it can resume. The
+    # queued collection open must observe the newer scope and abort instead
+    # of overwriting the folder view.
+    page.evaluate("folderId => filterByFolder(folderId)", folder_id)
+    held_routes[0].continue_()
+
+    page.wait_for_function("VireoFilter.isReady()", timeout=15000)
+    # Give the queued collection continuation a chance to run so we can
+    # assert it aborted rather than clobbering activeFolderId/openedCollectionId.
+    page.wait_for_timeout(200)
+    assert page.evaluate("activeFolderId") == folder_id
+    assert page.evaluate("openedCollectionId") is None
+    assert page.evaluate("activeCollectionId") is None
+
+
 def test_quick_rating_filter_and_chip_semantics(live_server, page):
     _open_browse(page, live_server)
     assert _total(page) == 5

--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -119,12 +119,10 @@ def test_queued_collection_open_yields_to_later_folder_click(live_server, page):
 def test_queued_collection_open_yields_to_later_keyword_click(live_server, page):
     """A queued early collection open must not resume over a later keyword click.
 
-    filterByKeyword returns at the readiness guard while /api/filters/fields is
-    still pending. If it didn't bump browseScopeGen before returning, releasing
-    the fields request would let the queued filterByCollection resume and
-    overwrite the user's newer keyword intent. Bumping the gen up front
-    invalidates the queued open so nothing surprising lands (Codex review
-    r3624549744).
+    filterByKeyword is now queued behind browseFilterInitPromise (Codex review
+    r3624927534) — the gen bump at entry invalidates the queued
+    filterByCollection so it aborts, and the keyword rule is applied after
+    fields load rather than dropped, so the user's later click is honored.
     """
     collection_id = next(
         collection["id"]
@@ -152,18 +150,29 @@ def test_queued_collection_open_yields_to_later_keyword_click(live_server, page)
         "filterByCollection(collectionId); }",
         collection_id,
     )
-    # ...but a later keyword click races in before the fields resolve. The
-    # readiness guard drops it, but it must still advance browseScopeGen so
-    # the queued collection open observes a newer scope and aborts.
-    page.evaluate("filterByKeyword('anything')")
+    # ...but a later keyword click races in before the fields resolve. It
+    # advances browseScopeGen so the queued collection open observes a newer
+    # scope and aborts, then queues itself and applies once init resolves.
+    page.evaluate(
+        "() => { window._earlyKeywordClick = filterByKeyword('Red-tailed Hawk'); }"
+    )
     held_routes[0].continue_()
 
-    page.wait_for_function("VireoFilter.isReady()", timeout=15000)
+    # The keyword rule must actually land after init resolves — that's the
+    # difference from the old drop-the-click behavior, which left a
+    # deep-linked collection (or bootstrap grid) showing while the user's
+    # keyword selection was silently lost.
+    page.wait_for_function(
+        "() => VireoFilter.isReady() && activeKeyword === 'Red-tailed Hawk' && "
+        "VireoFilter.hasFilters()",
+        timeout=15000,
+    )
     # Give the queued collection continuation a chance to run so we can
-    # assert it aborted rather than replacing the user's later click.
+    # assert it aborted rather than clobbering the keyword selection.
     page.wait_for_timeout(200)
     assert page.evaluate("openedCollectionId") is None
     assert page.evaluate("activeCollectionId") is None
+    assert page.evaluate("activeKeyword") == "Red-tailed Hawk"
 
 
 def test_deep_link_replay_yields_to_sidebar_click(live_server, page):
@@ -220,6 +229,56 @@ def test_deep_link_replay_yields_to_sidebar_click(live_server, page):
     # have reopened deep_link_id after B's queued open bailed as stale.
     page.wait_for_timeout(200)
     assert page.evaluate("openedCollectionId") == clicked_id
+
+
+def test_pending_keyword_click_supersedes_deep_link_collection(live_server, page):
+    """A keyword clicked during pending init must displace the URL collection.
+
+    Opening ``/browse?collection_id=A`` starts the collection-scoped grid
+    while ``/api/filters/fields`` is still pending. A keyword click during
+    that window used to be dropped at the readiness guard — the bootstrap
+    ``.then`` then saw ``scopeChanged`` and skipped the deep-link replay,
+    but the collection A grid stayed on screen and the keyword rule was
+    never installed (Codex review r3624927534). filterByKeyword now queues
+    behind the init promise and applies once fields load, replacing the
+    collection scope with the user's later intent.
+    """
+    collections_by_name = {c["name"]: c["id"] for c in live_server["db"].get_collections()}
+    deep_link_id = collections_by_name["All Photos"]
+    held_routes = []
+    page.route(
+        "**/api/filters/fields",
+        lambda route: held_routes.append(route),
+    )
+
+    page.goto(live_server["url"] + f"/browse?collection_id={deep_link_id}")
+    page.wait_for_selector("#grid .grid-card", timeout=15000)
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "filter-field request was never issued"
+    assert not page.evaluate("VireoFilter.isReady()")
+
+    # Keyword click during pending init: previously dropped at the readiness
+    # guard, now queued behind browseFilterInitPromise.
+    page.evaluate(
+        "() => { window._earlyKeywordClick = filterByKeyword('Red-tailed Hawk'); }"
+    )
+    held_routes[0].continue_()
+
+    # After init, the keyword rule must land and the collection scope must
+    # be gone — the queued keyword continuation clears activeCollectionId
+    # and installs the rule. Only hawk1 carries the Red-tailed Hawk keyword
+    # tag (predictions don't tag), so the total drops from All Photos (5)
+    # to 1. The gap between "All Photos" and "keyword=Red-tailed Hawk"
+    # totals is what makes the fix observable.
+    page.wait_for_function(
+        "() => VireoFilter.isReady() && activeKeyword === 'Red-tailed Hawk' && "
+        "activeCollectionId === null && VireoFilter.hasFilters()",
+        timeout=15000,
+    )
+    _wait_total(page, 1)
 
 
 def test_restored_url_filters_apply_after_pending_folder_click(live_server, page):

--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -33,6 +33,45 @@ def _open_browse(page, live_server):
     )
 
 
+def test_collection_open_waits_for_filter_bar_initialization(live_server, page):
+    """An early collection click is queued while filter fields are loading."""
+    collection_id = next(
+        collection["id"]
+        for collection in live_server["db"].get_collections()
+        if collection["name"] == "GPS Without Location Keyword"
+    )
+    held_routes = []
+    page.route(
+        "**/api/filters/fields",
+        lambda route: held_routes.append(route),
+    )
+
+    page.goto(live_server["url"] + "/browse")
+    page.wait_for_selector("#grid .grid-card", timeout=15000)
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "filter-field request was never issued"
+    assert not page.evaluate("VireoFilter.isReady()")
+
+    # Do not return the promise from page.evaluate: the collection open must
+    # remain pending until the held registry request is released.
+    page.evaluate(
+        "collectionId => { window._earlyCollectionOpen = "
+        "filterByCollection(collectionId); }",
+        collection_id,
+    )
+    held_routes[0].continue_()
+
+    page.wait_for_function(
+        "collectionId => VireoFilter.isReady() && "
+        "openedCollectionId === collectionId && VireoFilter.hasFilters()",
+        arg=collection_id,
+        timeout=15000,
+    )
+
+
 def test_quick_rating_filter_and_chip_semantics(live_server, page):
     _open_browse(page, live_server)
     assert _total(page) == 5

--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -222,6 +222,59 @@ def test_deep_link_replay_yields_to_sidebar_click(live_server, page):
     assert page.evaluate("openedCollectionId") == clicked_id
 
 
+def test_restored_url_filters_apply_after_pending_folder_click(live_server, page):
+    """URL/persisted filter chips must run through the grid after a pending
+    sidebar click, not just render in the bar. Before the fix, the bootstrap
+    ``.then`` returned early on ``scopeChanged`` and skipped the post-init
+    ``VireoFilter.hasFilters()`` reload, so a folder click during pending
+    ``/api/filters/fields`` produced a folder-scoped grid with the URL rating
+    filter visible in the chip strip but never actually applied until the
+    user edited a chip (Codex review r3624766665).
+    """
+    yard_folder_id = live_server["data"]["folders"][1]
+    held_routes = []
+    page.route(
+        "**/api/filters/fields",
+        lambda route: held_routes.append(route),
+    )
+
+    # rating_min=4 restores as a "rating >= 4" chip; only hawk1 (park) has
+    # rating 4, so yard ∩ rating>=4 = 0 while yard alone = 2. That gap is
+    # what makes the fix observable.
+    page.goto(live_server["url"] + "/browse?rating_min=4")
+    # Wait for the sidebar to render so the folder click hits a real
+    # tree item; #gridContainer is present unconditionally and doesn't
+    # prove bootstrap has populated folders yet.
+    page.wait_for_function(
+        "folderId => document.querySelector("
+        "'#folderTree .tree-item[data-folder-id=\"' + folderId + '\"]')",
+        arg=yard_folder_id,
+        timeout=15000,
+    )
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "filter-field request was never issued"
+    assert not page.evaluate("VireoFilter.isReady()")
+
+    # Click yard folder while filter-bar init is pending. filterByFolder
+    # bumps browseScopeGen and runs reloadBrowseResults() with no rules yet,
+    # so the grid shows the 2 yard photos unfiltered by rating.
+    page.evaluate("folderId => filterByFolder(folderId)", yard_folder_id)
+    held_routes[0].continue_()
+
+    # After init, the bootstrap .then must have applied the restored rating
+    # rule against the yard folder scope; no yard photo has rating 4.
+    page.wait_for_function(
+        "folderId => VireoFilter.isReady() && VireoFilter.hasFilters() && "
+        "activeFolderId === folderId",
+        arg=yard_folder_id,
+        timeout=15000,
+    )
+    _wait_total(page, 0)
+
+
 def test_quick_rating_filter_and_chip_semantics(live_server, page):
     _open_browse(page, live_server)
     assert _total(page) == 5

--- a/tests/e2e/test_browse_filterbar.py
+++ b/tests/e2e/test_browse_filterbar.py
@@ -116,6 +116,56 @@ def test_queued_collection_open_yields_to_later_folder_click(live_server, page):
     assert page.evaluate("activeCollectionId") is None
 
 
+def test_queued_collection_open_yields_to_later_keyword_click(live_server, page):
+    """A queued early collection open must not resume over a later keyword click.
+
+    filterByKeyword returns at the readiness guard while /api/filters/fields is
+    still pending. If it didn't bump browseScopeGen before returning, releasing
+    the fields request would let the queued filterByCollection resume and
+    overwrite the user's newer keyword intent. Bumping the gen up front
+    invalidates the queued open so nothing surprising lands (Codex review
+    r3624549744).
+    """
+    collection_id = next(
+        collection["id"]
+        for collection in live_server["db"].get_collections()
+        if collection["name"] == "GPS Without Location Keyword"
+    )
+    held_routes = []
+    page.route(
+        "**/api/filters/fields",
+        lambda route: held_routes.append(route),
+    )
+
+    page.goto(live_server["url"] + "/browse")
+    page.wait_for_selector("#grid .grid-card", timeout=15000)
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "filter-field request was never issued"
+    assert not page.evaluate("VireoFilter.isReady()")
+
+    # Early collection click queues behind the pending filter-bar init...
+    page.evaluate(
+        "collectionId => { window._earlyCollectionOpen = "
+        "filterByCollection(collectionId); }",
+        collection_id,
+    )
+    # ...but a later keyword click races in before the fields resolve. The
+    # readiness guard drops it, but it must still advance browseScopeGen so
+    # the queued collection open observes a newer scope and aborts.
+    page.evaluate("filterByKeyword('anything')")
+    held_routes[0].continue_()
+
+    page.wait_for_function("VireoFilter.isReady()", timeout=15000)
+    # Give the queued collection continuation a chance to run so we can
+    # assert it aborted rather than replacing the user's later click.
+    page.wait_for_timeout(200)
+    assert page.evaluate("openedCollectionId") is None
+    assert page.evaluate("activeCollectionId") is None
+
+
 def test_quick_rating_filter_and_chip_semantics(live_server, page):
     _open_browse(page, live_server)
     assert _total(page) == 5

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2008,6 +2008,12 @@ var openedCollectionId = null;
 // finishes loading. Keep the init promise so an early collection click can
 // wait for the filter bar instead of being silently discarded.
 var browseFilterInitPromise = null;
+// Monotonic counter bumped by every sidebar scope switch
+// (filterByFolder/filterByKeyword/filterByCollection). A queued collection
+// open captures the gen at entry and aborts on resume if a later scope
+// change has advanced it — otherwise the queued click would clobber the
+// user's newer selection (Codex review r3624395785).
+var browseScopeGen = 0;
 
 var timelineMode = false;
 var calendarYear = new Date().getFullYear();
@@ -3151,6 +3157,7 @@ function toggleTree(e, el) {
 }
 
 function filterByFolder(folderId) {
+  browseScopeGen++;
   if (activeFolderId === folderId) {
     activeFolderId = null;
   } else {
@@ -3248,6 +3255,7 @@ function filterByKeyword(name) {
   // guard, addRule -> makeRule dereferences state.fields (still null)
   // and throws, leaving activeKeyword toggled but no rule/reload applied.
   if (!VireoFilter.isReady()) return;
+  browseScopeGen++;
   if (activeKeyword === name) {
     activeKeyword = null;
   } else {
@@ -3428,6 +3436,7 @@ async function filterByCollection(id, options) {
   // the click, though: wait for the in-flight init and apply the collection
   // as soon as the filter bar is ready. The bootstrap deep-link caller fires
   // from inside browseFilterInitPromise.then(...), so it proceeds immediately.
+  var myScopeGen = ++browseScopeGen;
   if (window.VireoFilter && !VireoFilter.isReady()) {
     if (!browseFilterInitPromise) return;
     try {
@@ -3436,6 +3445,11 @@ async function filterByCollection(id, options) {
       return;
     }
     if (!VireoFilter.isReady()) return;
+    // A later sidebar click (folder/keyword/collection) advanced the scope
+    // generation while we were waiting for filter-bar init. Applying this
+    // stale collection now would clobber the user's newer selection
+    // (Codex review r3624395785).
+    if (browseScopeGen !== myScopeGen) return;
   }
   // Guard: degraded (count_error) collections can't resolve their rules.
   var collectionMeta = collectionsById[id];

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2968,12 +2968,15 @@ async function bootstrapBrowse() {
     // selection (Codex review r3624637674).
     var bootstrapScopeGen = browseScopeGen;
     browseFilterInitPromise.then(function() {
-      if (browseScopeGen !== bootstrapScopeGen) {
-        // A user sidebar click (folder/keyword/collection) already changed
-        // scope while init was pending; their newer selection is
-        // authoritative, so skip the URL-driven deep-link/persisted replay.
-        return;
-      }
+      // A user sidebar click (folder/keyword/collection) may have changed
+      // scope while init was pending. Their newer selection is authoritative
+      // for the collection deep-link replay below — reopening the URL's
+      // collection over the user's later selection is the bug in Codex
+      // review r3624637674. But we must still apply any restored/URL filter
+      // chips: returning early here left them rendered in the bar without
+      // ever running through resetAndLoad, so the grid didn't match the
+      // visible chips until the user edited them (Codex review r3624766665).
+      var scopeChanged = browseScopeGen !== bootstrapScopeGen;
       VireoFilter.setResultTotal(totalPhotos);
       // Collection deep links must open showing exactly that collection \u2014
       // whether plain (?collection_id=..., historical endpoint behavior) or
@@ -3045,10 +3048,12 @@ async function bootstrapBrowse() {
           );
         }
       }
-      if (activeCollectionId && !dashboardCollectionScope) {
+      if (activeCollectionId && !dashboardCollectionScope && !scopeChanged) {
         // Plain collection deep link: open it into the filter bar as
         // editable chips (rules + visual round-trip), replacing the
-        // historical collection-endpoint mode.
+        // historical collection-endpoint mode. Skipped when a user sidebar
+        // click already claimed a different scope — their queued
+        // filterByCollection/filterByFolder/filterByKeyword owns the view.
         filterByCollection(activeCollectionId);
         return;
       }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3249,13 +3249,18 @@ function renderKeywordTree(keywords) {
 }
 
 function filterByKeyword(name) {
+  // Bump the scope generation BEFORE the readiness guard so an in-flight
+  // queued filterByCollection (awaiting browseFilterInitPromise) sees the
+  // newer intent and bails out on resume. Without this, the collection
+  // could resume after fields load and clobber the user's later click
+  // (Codex review r3624549744).
+  browseScopeGen++;
   // The sidebar tree is rendered from the /photos init payload, so a
   // slow /api/filters/fields (or workspace) round-trip leaves clickable
   // keywords in the DOM before VireoFilter.init resolves. Without this
   // guard, addRule -> makeRule dereferences state.fields (still null)
   // and throws, leaving activeKeyword toggled but no rule/reload applied.
   if (!VireoFilter.isReady()) return;
-  browseScopeGen++;
   if (activeKeyword === name) {
     activeKeyword = null;
   } else {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3267,19 +3267,35 @@ function renderKeywordTree(keywords) {
   };
 }
 
-function filterByKeyword(name) {
+async function filterByKeyword(name) {
   // Bump the scope generation BEFORE the readiness guard so an in-flight
   // queued filterByCollection (awaiting browseFilterInitPromise) sees the
   // newer intent and bails out on resume. Without this, the collection
   // could resume after fields load and clobber the user's later click
   // (Codex review r3624549744).
-  browseScopeGen++;
+  var myScopeGen = ++browseScopeGen;
   // The sidebar tree is rendered from the /photos init payload, so a
   // slow /api/filters/fields (or workspace) round-trip leaves clickable
   // keywords in the DOM before VireoFilter.init resolves. Without this
   // guard, addRule -> makeRule dereferences state.fields (still null)
-  // and throws, leaving activeKeyword toggled but no rule/reload applied.
-  if (!VireoFilter.isReady()) return;
+  // and throws. Dropping the click outright would leave the bootstrap
+  // grid (e.g. a ``?collection_id=A`` deep link's collection scope) in
+  // place while the user's later keyword selection is silently lost
+  // (Codex review r3624927534) — queue behind init and apply once ready,
+  // matching filterByCollection's pattern.
+  if (window.VireoFilter && !VireoFilter.isReady()) {
+    if (!browseFilterInitPromise) return;
+    try {
+      await browseFilterInitPromise;
+    } catch (e) {
+      return;
+    }
+    if (!VireoFilter.isReady()) return;
+    // A later sidebar click (folder/keyword/collection) advanced the scope
+    // while we were waiting for filter-bar init. Applying this stale
+    // keyword now would clobber the user's newer selection.
+    if (browseScopeGen !== myScopeGen) return;
+  }
   if (activeKeyword === name) {
     activeKeyword = null;
   } else {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2959,7 +2959,21 @@ async function bootstrapBrowse() {
       },
       onCollectionSaved: function() { loadCollections(); },
     });
+    // Snapshot the scope generation BEFORE we register the .then so we can
+    // tell whether a user sidebar click advanced it while init was pending.
+    // The bootstrap deep-link/persisted replay below unconditionally called
+    // filterByCollection/resetAndLoad, which bumps browseScopeGen and made
+    // any queued sidebar click (e.g. collection B awaiting init) resume as
+    // stale \u2014 reopening the URL's collection A over the user's later
+    // selection (Codex review r3624637674).
+    var bootstrapScopeGen = browseScopeGen;
     browseFilterInitPromise.then(function() {
+      if (browseScopeGen !== bootstrapScopeGen) {
+        // A user sidebar click (folder/keyword/collection) already changed
+        // scope while init was pending; their newer selection is
+        // authoritative, so skip the URL-driven deep-link/persisted replay.
+        return;
+      }
       VireoFilter.setResultTotal(totalPhotos);
       // Collection deep links must open showing exactly that collection \u2014
       // whether plain (?collection_id=..., historical endpoint behavior) or

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2004,6 +2004,10 @@ var dashboardCollectionScope = false;
 // the expression (so a user-edited chip set isn't silently reverted to
 // the saved collection on the next membership refresh).
 var openedCollectionId = null;
+// Sidebar collections render before the universal filter registry necessarily
+// finishes loading. Keep the init promise so an early collection click can
+// wait for the filter bar instead of being silently discarded.
+var browseFilterInitPromise = null;
 
 var timelineMode = false;
 var calendarYear = new Date().getFullYear();
@@ -2891,7 +2895,7 @@ async function bootstrapBrowse() {
     // Universal filter bar: registry + persisted/deep-linked state load
     // async; when it comes up with active filters the unfiltered first
     // paint above is stale, so reload through the rules path.
-    VireoFilter.init({
+    browseFilterInitPromise = VireoFilter.init({
       page: 'browse',
       root: document.getElementById('vireoFilterBar'),
       scopeLabel: 'Workspace \u00b7 All available photos',
@@ -2948,7 +2952,8 @@ async function bootstrapBrowse() {
         };
       },
       onCollectionSaved: function() { loadCollections(); },
-    }).then(function() {
+    });
+    browseFilterInitPromise.then(function() {
       VireoFilter.setResultTotal(totalPhotos);
       // Collection deep links must open showing exactly that collection \u2014
       // whether plain (?collection_id=..., historical endpoint behavior) or
@@ -3419,12 +3424,19 @@ async function filterByCollection(id, options) {
   // collections in the DOM before VireoFilter.init resolves. Without this
   // guard, the saved expression is pushed into the filter bar while
   // state.fields is still null and the in-flight init's restorePersisted/
-  // finish then overwrites the just-loaded rules/visual clause with the
-  // persisted Browse filters, silently dropping the collection click
-  // (Codex review r3622909557). filterByKeyword uses this same guard for
-  // the analogous race. The bootstrap deep-link caller fires from inside
-  // VireoFilter.init(...).then(...), so it is unaffected.
-  if (window.VireoFilter && !VireoFilter.isReady()) return;
+  // finish then overwrites the just-loaded rules/visual clause. Do not drop
+  // the click, though: wait for the in-flight init and apply the collection
+  // as soon as the filter bar is ready. The bootstrap deep-link caller fires
+  // from inside browseFilterInitPromise.then(...), so it proceeds immediately.
+  if (window.VireoFilter && !VireoFilter.isReady()) {
+    if (!browseFilterInitPromise) return;
+    try {
+      await browseFilterInitPromise;
+    } catch (e) {
+      return;
+    }
+    if (!VireoFilter.isReady()) return;
+  }
   // Guard: degraded (count_error) collections can't resolve their rules.
   var collectionMeta = collectionsById[id];
   if (!collectionMeta) {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -13400,7 +13400,7 @@ def test_browse_filter_by_collection_guards_degraded_rows():
     assert fn_start != -1, "filterByCollection function not found"
     # Grab enough of the function body to include the guard block. The guard
     # must reference count_error and return before the normal load path runs.
-    body = text[fn_start:fn_start + 2000]
+    body = text[fn_start:fn_start + 3000]
     assert "count_error" in body, (
         "browse.html filterByCollection does not check count_error"
     )


### PR DESCRIPTION
## Summary

Queue smart-collection opens behind Browse filter-bar initialization instead of silently discarding early clicks.
This fixes the order-dependent batch-location failures and keeps smart-collection refreshes on the intended collection.
Adds deterministic E2E coverage that holds filter-field loading and verifies the queued collection opens after initialization.

## Testing

- `pytest -q tests/e2e/test_location_section.py` (27 passed)
- `pytest -q tests/e2e/test_browse_filterbar.py vireo/tests/test_app.py::test_browse_filter_by_collection_guards_degraded_rows` (12 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Browse filter behavior while the filter bar is still loading.
  * Prevented delayed collection or deep-link actions from overriding newer folder or keyword selections.
  * Ensured restored URL and rating filters are applied correctly after navigation.
* **Tests**
  * Added end-to-end coverage for asynchronous initialization, queued interactions, deep links, and restored filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->