### PR TITLE
Keep lightbox transform frozen during photo navigation

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1127,6 +1127,141 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     assert abs(carried["centerY"] - before["viewport"]["centerY"]) < 0.03
 
 
+def test_browse_lightbox_resize_deferred_during_transition_reapplies_after_load(
+    live_server, page
+):
+    """A resize queued while a navigation transition is pending must re-run
+    once the incoming photo decodes; otherwise a DPR/viewport change made
+    just before navigation would leave the incoming image on a stale source
+    tier until the user triggers another resize or zoom.
+    """
+    first_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/></svg>'
+    )
+    next_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="3000" height="3000" '
+        'viewBox="0 0 3000 3000"><rect width="3000" height="3000" fill="#426"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=first_svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").nth(1).wait_for(state="visible")
+    next_id = page.evaluate("window.photos[1].id")
+    held_original = {}
+
+    def hold_next_original(route):
+        if f"/photos/{next_id}/original" in route.request.url:
+            held_original["route"] = route
+            return
+        route.fulfill(body=first_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", hold_next_original)
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000;
+        }"""
+    )
+
+    # Prime the outgoing viewport so navigation triggers a real transition.
+    page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            window._lbCurrentSrcKey = 'original';
+            window._lbApplyViewportState({
+                zoom: window._lbNativeZoom,
+                centerX: 0.24,
+                centerY: 0.70,
+                oneToOne: true,
+            });
+            window._lbSaveViewportState(window._lightboxCurrentId);
+        }"""
+    )
+
+    # Instrument the deferred-refresh flush so we can verify it fires once the
+    # transition ends, and instrument _lbSetZoom so we can assert the frozen
+    # outgoing bitmap is never re-selected during the transition.
+    page.evaluate(
+        """() => {
+            window.__flushCalls = 0;
+            window.__originalFlush = window._lbFlushDeferredLightboxLayoutRefresh;
+            window._lbFlushDeferredLightboxLayoutRefresh = function() {
+                window.__flushCalls += 1;
+                return window.__originalFlush.apply(this, arguments);
+            };
+            window.__setZoomCallsWhilePending = 0;
+            window.__originalSetZoom = window._lbSetZoom;
+            window._lbSetZoom = function() {
+                if (window._lbVisualTransitionPending) {
+                    window.__setZoomCallsWhilePending += 1;
+                }
+                return window.__originalSetZoom.apply(this, arguments);
+            };
+        }"""
+    )
+
+    # Kick off navigation and, while the transition is pending, queue a
+    # resize-style refresh that requests a source-tier update. The 100ms
+    # debounce timer will fire before the incoming image decodes.
+    page.keyboard.press("ArrowRight")
+    page.wait_for_function("() => window._lbVisualTransitionPending === true")
+    page.evaluate(
+        """() => {
+            // Dispatch a window resize event; the lightbox resize handler
+            // calls scheduleLightboxLayoutRefresh(true).
+            window.dispatchEvent(new Event('resize'));
+        }"""
+    )
+
+    # Let the debounce timer fire while the transition is still pending. The
+    # early return preserves the deferred source-tier intent instead of
+    # calling _lbSetZoom on the frozen outgoing bitmap.
+    page.wait_for_timeout(200)
+    assert page.evaluate("window.__setZoomCallsWhilePending") == 0
+    assert page.evaluate("window.__flushCalls") == 0
+
+    # Complete the incoming image load.
+    held_original.pop("route").fulfill(
+        body=next_svg, content_type="image/svg+xml"
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbVisualTransitionPending === false
+                && img && img.complete && img.naturalWidth === 3000;
+        }"""
+    )
+
+    # handleInitialImageLoad drains the deferred refresh via the flush, which
+    # in turn reschedules the resize handler so the incoming photo picks up
+    # the queued source-tier update instead of dropping it on the floor.
+    page.wait_for_function(
+        "() => window.__flushCalls >= 1",
+        timeout=1000,
+    )
+    page.evaluate(
+        """() => {
+            window._lbSetZoom = window.__originalSetZoom;
+            delete window.__originalSetZoom;
+            window._lbFlushDeferredLightboxLayoutRefresh = window.__originalFlush;
+            delete window.__originalFlush;
+        }"""
+    )
+
+
 def test_browse_lightbox_mid_transition_save_keeps_navigation_handoff(
     live_server, page
 ):

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -994,6 +994,23 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
             const externalPanel = document.createElement('div');
             externalPanel.id = 'syncLightboxPanel';
             document.getElementById('lightboxOverlay').appendChild(externalPanel);
+            window.__lightboxTransformCallsWhilePending = 0;
+            window.__originalLightboxApplyTransform = window._lbApplyTransform;
+            window._lbApplyTransform = function() {
+                if (window._lbVisualTransitionPending) {
+                    window.__lightboxTransformCallsWhilePending += 1;
+                }
+                return window.__originalLightboxApplyTransform.apply(this, arguments);
+            };
+        }"""
+    )
+
+    # Queue the same delayed layout refresh that can be left behind when the
+    # bottom bar finishes laying out just before navigation starts.
+    page.evaluate(
+        """() => {
+            const wrap = document.getElementById('lightboxWrap');
+            wrap.style.height = `${wrap.clientHeight - 42}px`;
         }"""
     )
 
@@ -1052,6 +1069,11 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     page.evaluate("window.lightboxDelete()")
     expect(page.locator("#deleteModal")).not_to_have_class("modal-overlay open")
 
+    # The queued refresh must not re-clamp or move the outgoing bitmap while
+    # the next photo is still waiting to decode.
+    page.wait_for_timeout(150)
+    assert page.evaluate("window.__lightboxTransformCallsWhilePending") == 0
+
     while_loading = page.evaluate(
         """() => {
             const transform = document.getElementById('lightboxTransform');
@@ -1067,6 +1089,12 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
         "width": before["width"],
         "height": before["height"],
     }
+    page.evaluate(
+        """() => {
+            window._lbApplyTransform = window.__originalLightboxApplyTransform;
+            delete window.__originalLightboxApplyTransform;
+        }"""
+    )
 
     held_original.pop("route").fulfill(
         body=next_svg, content_type="image/svg+xml"

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7157,6 +7157,9 @@ function openLightbox(photoId, filename, photoList, options) {
     }
     _lbApplyTransform();
     _lbFlushDeferredOverlayApply();
+    if (typeof window._lbFlushDeferredLightboxLayoutRefresh === 'function') {
+      window._lbFlushDeferredLightboxLayoutRefresh();
+    }
     _lbPrimeAdjacentPhotos(_lbCurrentSrcKey);
     if (_lbCurrentSrcKey === 'full') _lbScheduleOriginalPreload(photoId);
   }
@@ -7178,6 +7181,9 @@ function openLightbox(photoId, filename, photoList, options) {
       if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
       _lbApplyTransform();
       _lbFlushDeferredOverlayApply();
+      if (typeof window._lbFlushDeferredLightboxLayoutRefresh === 'function') {
+        window._lbFlushDeferredLightboxLayoutRefresh();
+      }
       return;
     }
     _lbOriginalUnavailable = true;
@@ -7361,9 +7367,17 @@ function toggleLightboxZoom(e) {
 (function() {
   var resizeTimer = null;
   var refreshSourceTier = false;
+  var deferredRefreshPending = false;
   function scheduleLightboxLayoutRefresh(updateSourceTier) {
     var overlay = document.getElementById('lightboxOverlay');
-    if (!overlay || !overlay.classList.contains('active')) return;
+    if (!overlay || !overlay.classList.contains('active')) {
+      // Discard any refresh that was deferred while the lightbox was open
+      // so a stale intent cannot leak into the next session.
+      refreshSourceTier = false;
+      deferredRefreshPending = false;
+      if (resizeTimer) { clearTimeout(resizeTimer); resizeTimer = null; }
+      return;
+    }
     refreshSourceTier = refreshSourceTier || !!updateSourceTier;
     if (resizeTimer) clearTimeout(resizeTimer);
     resizeTimer = setTimeout(function() {
@@ -7375,8 +7389,15 @@ function toggleLightboxZoom(e) {
       // just before navigation may fire after the incoming metadata has
       // replaced the layout dimensions; applying it here would move the old
       // bitmap using the new photo's geometry. The image load/error handlers
-      // recompute and apply the current layout when the transition finishes.
-      if (_lbVisualTransitionPending) return;
+      // recompute and apply the current layout when the transition finishes,
+      // but they do not re-select the source tier — so preserve the pending
+      // update and let _lbFlushDeferredLightboxLayoutRefresh reschedule it
+      // once the transition clears.
+      if (_lbVisualTransitionPending) {
+        refreshSourceTier = shouldUpdateSourceTier || refreshSourceTier;
+        deferredRefreshPending = true;
+        return;
+      }
       _lbRecomputeNativeZoom();
       // A deferred 1:1 keeps _lbZoom at fit while the high-res source loads.
       // _lbSetZoom clears _lbPending1To1 (and its trailing reschedule retargets
@@ -7430,6 +7451,15 @@ function toggleLightboxZoom(e) {
       lightboxLayoutObserver.observe(wrap);
     }
   }
+  // Called by the image load/error handlers once _lbVisualTransitionPending
+  // clears. Reschedules any resize refresh that was skipped during the
+  // transition so the incoming photo can pick up a viewport/DPR change we
+  // deferred (e.g. selecting a sharper source tier after a window resize).
+  window._lbFlushDeferredLightboxLayoutRefresh = function() {
+    if (!deferredRefreshPending) return;
+    deferredRefreshPending = false;
+    scheduleLightboxLayoutRefresh(false);
+  };
 })();
 
 // Drag to pan when zoomed; single click (no drag) zooms out

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7370,6 +7370,13 @@ function toggleLightboxZoom(e) {
       resizeTimer = null;
       var shouldUpdateSourceTier = refreshSourceTier;
       refreshSourceTier = false;
+      // Arrow navigation deliberately keeps the outgoing bitmap and its
+      // transform frozen until the incoming image decodes. A resize queued
+      // just before navigation may fire after the incoming metadata has
+      // replaced the layout dimensions; applying it here would move the old
+      // bitmap using the new photo's geometry. The image load/error handlers
+      // recompute and apply the current layout when the transition finishes.
+      if (_lbVisualTransitionPending) return;
       _lbRecomputeNativeZoom();
       // A deferred 1:1 keeps _lbZoom at fit while the high-res source loads.
       // _lbSetZoom clears _lbPending1To1 (and its trailing reschedule retargets


### PR DESCRIPTION
## Summary

- Prevent delayed lightbox resize refreshes from moving the outgoing bitmap while the incoming photo is still loading.
- Preserve the existing load/error completion paths as the point where the new photo's layout is applied.
- Make the browser regression deterministic by queuing the problematic refresh and asserting no transform runs during the pending transition.

## Testing

- `python -m pytest -o addopts='' -q tests/e2e/test_browse_lightbox.py --tb=short` (36 passed)
- Regression test repeated 10 times successfully
- `python -m pytest -q vireo/tests/test_build_static.py --tb=short`
- `ruff check tests/e2e/test_browse_lightbox.py` and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lightbox transitions during arrow navigation by preventing resize-related layout updates from moving or re-clamping the outgoing image before the next image is ready.
  * Preserved the outgoing image’s position until the incoming image finishes loading, resulting in smoother visual transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->