### PR TITLE
Make lightbox release regression deterministic

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1005,15 +1005,6 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
         }"""
     )
 
-    # Queue the same delayed layout refresh that can be left behind when the
-    # bottom bar finishes laying out just before navigation starts.
-    page.evaluate(
-        """() => {
-            const wrap = document.getElementById('lightboxWrap');
-            wrap.style.height = `${wrap.clientHeight - 42}px`;
-        }"""
-    )
-
     page.keyboard.press("ArrowRight")
     page.wait_for_function("() => window._lbVisualTransitionPending === true")
     page.wait_for_function("() => window._lightboxCurrentId === window.photos[1].id")
@@ -1023,6 +1014,19 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     while "route" not in held_original and time.time() < deadline:
         page.wait_for_timeout(10)
     assert "route" in held_original
+
+    # Queue the delayed layout refresh only after navigation is definitely
+    # pending. Scheduling it before the key press races with slow CI control
+    # round-trips and can legitimately reflow the still-current photo before
+    # the transition begins, invalidating the baseline captured above.
+    page.evaluate(
+        """() => {
+            const wrap = document.getElementById('lightboxWrap');
+            wrap.style.height = `${wrap.clientHeight - 42}px`;
+        }"""
+    )
+    page.wait_for_timeout(150)
+    assert page.evaluate("window.__lightboxTransformCallsWhilePending") == 0
 
     # The outgoing bitmap remains visible while the incoming original is
     # loading, so its filename and position must remain visible too.
@@ -1068,11 +1072,6 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     expect(page.locator(".vireo-ctx-menu")).to_have_count(0)
     page.evaluate("window.lightboxDelete()")
     expect(page.locator("#deleteModal")).not_to_have_class("modal-overlay open")
-
-    # The queued refresh must not re-clamp or move the outgoing bitmap while
-    # the next photo is still waiting to decode.
-    page.wait_for_timeout(150)
-    assert page.evaluate("window.__lightboxTransformCallsWhilePending") == 0
 
     while_loading = page.evaluate(
         """() => {


### PR DESCRIPTION
## Summary

- Schedule the synthetic lightbox resize only after navigation is confirmed pending and the incoming image request is held.
- Remove the CI-speed race where the resize could legitimately settle before navigation and invalidate the captured transform baseline.
- Keep the regression's assertion that the production resize guard prevents transforms during a pending transition.

## Testing

- Target regression repeated 10 times successfully
- `python -m pytest -o addopts='' -q tests/e2e/test_browse_lightbox.py --tb=short` (37 passed)
- `ruff check tests/e2e/test_browse_lightbox.py` and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated lightbox end-to-end coverage to verify that off-center positioning is preserved while the next photo is loading.
  * Added checks confirming no layout adjustment occurs during the pending transition window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->