### PR TITLE
Fix location assignment success notification

### DIFF
--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -115,6 +115,11 @@ def test_location_review_assigns_a_custom_name_to_coordinate_group(
     )
     page.locator("#locationReviewAssign").click()
 
+    success_toast = page.locator("#toastContainer > div").last
+    expect(success_toast).to_have_text(
+        'Assigned “Anza-Borrego Desert State Park” to 2 photos'
+    )
+    assert success_toast.evaluate("el => el.style.background") == "var(--accent)"
     expect(page.locator("#locationReviewEmptyTitle")).to_have_text(
         "All locations reviewed"
     )

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -1053,7 +1053,7 @@ body {
           method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)
         });
       }
-      showToast('Assigned “' + choice.name + '” to ' + formatNumber(group.count) + (group.count === 1 ? ' photo' : ' photos'));
+      showToast('Assigned “' + choice.name + '” to ' + formatNumber(group.count) + (group.count === 1 ? ' photo' : ' photos'), 'success');
       state.groups.splice(state.currentIndex, 1);
       state.assignedGroups += 1;
       if (state.currentIndex >= state.groups.length) state.currentIndex = Math.max(0, state.groups.length - 1);


### PR DESCRIPTION
## Summary

Location assignment confirmations now use the success notification style instead of appearing as errors. The shared toast helper defaults an unspecified notification type to `error`, so the assignment flow now explicitly passes `success`.

The location review end-to-end test now verifies both the confirmation message and its success styling. This prevents successful bulk assignments from displaying a misleading red banner.

## Validation

`pytest -q tests/e2e/test_location_review.py` — 5 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assignment notifications now indicate how many photos were assigned, using singular or plural wording as appropriate.

* **Bug Fixes**
  * Improved confirmation feedback after assigning a custom name to a group of photos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->