### PR TITLE
Improve nearby photo location suggestions

### DIFF
--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -56,6 +56,11 @@ GOOGLE_MAPS_STUB = """
   }
   function PlacesService() {
     this.nearbySearch = function(request, callback) {
+      window.__locationReviewNearbyRequests = window.__locationReviewNearbyRequests || [];
+      window.__locationReviewNearbyRequests.push({
+        type: request.type || null,
+        keyword: request.keyword || null
+      });
       if (request.type === 'park') {
         callback([{
           place_id: 'nearby-park',
@@ -63,6 +68,22 @@ GOOGLE_MAPS_STUB = """
           types: ['park'],
           vicinity: '100 Nearby Street',
           geometry: {location: new LatLng(32.751, -117.001)}
+        }], 'OK');
+      } else if (request.type === 'campground' && request.location.lat() > 33) {
+        callback([{
+          place_id: 'tamarisk-grove-campground',
+          name: 'Tamarisk Grove Campground',
+          types: ['campground', 'park'],
+          vicinity: 'Yaqui Pass Road',
+          geometry: {location: new LatLng(33.255, -116.405)}
+        }], 'OK');
+      } else if (!request.type && !request.keyword) {
+        callback([{
+          place_id: 'nearby-general-store',
+          name: 'Nearby General Store',
+          types: ['store'],
+          vicinity: '1 Main Street',
+          geometry: {location: request.location}
         }], 'OK');
       } else {
         callback([], 'ZERO_RESULTS');
@@ -251,6 +272,64 @@ def test_location_review_ranks_saved_and_google_places_by_distance(
     expect(saved_candidate.locator(".location-review-candidate-meta")).not_to_contain_text(
         "Saved location"
     )
+
+
+def test_location_review_suggests_campgrounds_and_can_show_all_nearby_places(
+    live_server, page,
+):
+    """Focused suggestions include campgrounds; the toggle broadens categories."""
+    photo_id = live_server["data"]["photos"][0]
+    with live_server["db"].conn:
+        live_server["db"].conn.execute(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            (33.2550, -116.4050, photo_id),
+        )
+
+    page.route(
+        "**/api/config",
+        lambda route: route.fulfill(json={"google_maps_api_key": "test-key"}),
+    )
+    page.route(
+        "https://maps.googleapis.com/maps/api/js**",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/javascript",
+            body=GOOGLE_MAPS_STUB,
+        ),
+    )
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        "photoId => sessionStorage.setItem('vireoLocationReviewSource', "
+        "JSON.stringify({photo_ids: [photoId]}))",
+        photo_id,
+    )
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+
+    nature_button = page.locator('[data-suggestion-mode="nature"]')
+    all_button = page.locator('[data-suggestion-mode="all"]')
+    expect(nature_button).to_have_attribute("aria-pressed", "true")
+    campground = page.locator(
+        ".location-review-candidate", has_text="Tamarisk Grove Campground"
+    )
+    expect(campground).to_be_visible()
+    expect(campground.locator(".location-review-candidate-meta")).to_contain_text(
+        "Campground"
+    )
+
+    all_button.click()
+
+    expect(all_button).to_have_attribute("aria-pressed", "true")
+    expect(nature_button).to_have_attribute("aria-pressed", "false")
+    expect(
+        page.locator(".location-review-candidate", has_text="Nearby General Store")
+    ).to_be_visible()
+    expect(campground).to_have_count(0)
+
+    requested_types = page.evaluate(
+        "() => window.__locationReviewNearbyRequests.map(request => request.type)"
+    )
+    assert "campground" in requested_types
+    assert None in requested_types
 
 
 def test_location_review_photo_marker_opens_the_photo_preview(live_server, page):

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -209,6 +209,29 @@ body {
   font-weight: 650;
 }
 .location-review-section-title small { color: var(--text-ghost); font-size: 10px; font-weight: 400; }
+.location-review-suggestion-mode {
+  display: flex;
+  width: max-content;
+  margin: -1px 0 9px;
+  padding: 2px;
+  border-radius: 7px;
+  background: var(--bg-primary);
+}
+.location-review-suggestion-mode button {
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 10px;
+  cursor: pointer;
+}
+.location-review-suggestion-mode button:hover { color: var(--text-primary); }
+.location-review-suggestion-mode button.active {
+  background: var(--bg-tertiary);
+  color: var(--accent);
+}
 .location-review-candidates { display: flex; flex-direction: column; gap: 7px; }
 .location-review-candidate {
   display: grid;
@@ -398,6 +421,10 @@ body {
             <span>Suggested locations</span>
             <small id="locationReviewSuggestionStatus">Looking nearby…</small>
           </div>
+          <div class="location-review-suggestion-mode location-review-hidden" id="locationReviewSuggestionMode" role="group" aria-label="Suggested location categories">
+            <button class="active" type="button" data-suggestion-mode="nature" aria-pressed="true">Parks &amp; nature</button>
+            <button type="button" data-suggestion-mode="all" aria-pressed="false">All nearby</button>
+          </div>
           <div class="location-review-candidates" id="locationReviewCandidates">
             <div class="location-review-loading">Finding saved and nearby locations…</div>
           </div>
@@ -448,8 +475,11 @@ body {
     selectedChoice: null,
     savedCandidates: [],
     googleCandidates: [],
+    googleCandidatesByMode: {nature: null, all: null},
     regionCandidates: [],
+    regionCandidatesLoaded: false,
     searchedCandidate: null,
+    suggestionMode: 'nature',
     config: null,
     mapMode: null,
     map: null,
@@ -463,7 +493,8 @@ body {
   var NATURAL_TYPES = {
     park: 'Park', state_park: 'State park', national_park: 'National park',
     wildlife_refuge: 'Wildlife refuge', nature_preserve: 'Nature preserve',
-    natural_feature: 'Natural feature', hiking_area: 'Hiking area',
+    natural_feature: 'Natural feature', hiking_area: 'Hiking area', campground: 'Campground',
+    rv_park: 'RV park',
     scenic_spot: 'Scenic spot', tourist_attraction: 'Place of interest',
   };
 
@@ -883,7 +914,9 @@ body {
     state.selectedChoice = null;
     state.savedCandidates = [];
     state.googleCandidates = [];
+    state.googleCandidatesByMode = {nature: null, all: null};
     state.regionCandidates = [];
+    state.regionCandidatesLoaded = false;
     state.searchedCandidate = null;
     document.getElementById('locationReviewSearch').value = '';
     var assign = document.getElementById('locationReviewAssign');
@@ -940,14 +973,26 @@ body {
     });
   }
 
-  async function loadGoogleSuggestions(group, token) {
+  async function loadGoogleSuggestions(group, token, mode) {
     if (state.mapMode !== 'google' || !state.placesService) return;
+    mode = mode || state.suggestionMode;
+    var cached = state.googleCandidatesByMode[mode];
+    if (cached) {
+      if (token === state.renderToken && mode === state.suggestionMode) {
+        state.googleCandidates = cached;
+      }
+      return;
+    }
     var location = new google.maps.LatLng(group.center.lat, group.center.lng);
     var radius = Math.min(50000, Math.max(10000, Number(group.spread_m || 0) + 12000));
-    var resultSets = await Promise.all([
-      nearbySearch({location: location, radius: radius, type: 'park'}),
-      nearbySearch({location: location, radius: radius, keyword: 'state park wildlife refuge nature preserve hiking area'}),
-    ]);
+    var requests = mode === 'all'
+      ? [{location: location, radius: radius}]
+      : [
+          {location: location, radius: radius, type: 'park'},
+          {location: location, radius: radius, type: 'campground'},
+          {location: location, radius: radius, keyword: 'state park wildlife refuge nature preserve hiking area'},
+        ];
+    var resultSets = await Promise.all(requests.map(nearbySearch));
     if (token !== state.renderToken) return;
     var center = group.center;
     var choices = [];
@@ -960,32 +1005,42 @@ body {
       });
     });
     choices.sort(function(a, b) { return a.distance_m - b.distance_m; });
-    state.googleCandidates = choices.slice(0, 8);
+    var seenPlaceIds = {};
+    choices = choices.filter(function(choice) {
+      if (seenPlaceIds[choice.place_id]) return false;
+      seenPlaceIds[choice.place_id] = true;
+      return true;
+    }).slice(0, 8);
+    state.googleCandidatesByMode[mode] = choices;
+    if (mode === state.suggestionMode) state.googleCandidates = choices;
 
-    var geocoder = new google.maps.Geocoder();
-    geocoder.geocode({location: location}, function(results, status) {
-      if (token !== state.renderToken || status !== 'OK') return;
-      var allowed = ['locality', 'administrative_area_level_2', 'administrative_area_level_1', 'country'];
-      var regionChoices = [];
-      (results || []).forEach(function(result) {
-        var matchedType = allowed.find(function(type) { return (result.types || []).indexOf(type) !== -1; });
-        if (!matchedType) return;
-        var component = (result.address_components || []).find(function(item) {
-          return (item.types || []).indexOf(matchedType) !== -1;
+    if (!state.regionCandidatesLoaded) {
+      state.regionCandidatesLoaded = true;
+      var geocoder = new google.maps.Geocoder();
+      geocoder.geocode({location: location}, function(results, status) {
+        if (token !== state.renderToken || status !== 'OK') return;
+        var allowed = ['locality', 'administrative_area_level_2', 'administrative_area_level_1', 'country'];
+        var regionChoices = [];
+        (results || []).forEach(function(result) {
+          var matchedType = allowed.find(function(type) { return (result.types || []).indexOf(type) !== -1; });
+          if (!matchedType) return;
+          var component = (result.address_components || []).find(function(item) {
+            return (item.types || []).indexOf(matchedType) !== -1;
+          });
+          if (!component) return;
+          var namedResult = Object.assign({}, result, {name: component.long_name});
+          var choice = googleResultToChoice(namedResult, {
+            locality: 'City or town', administrative_area_level_2: 'County or region',
+            administrative_area_level_1: 'State or province', country: 'Country'
+          }[matchedType]);
+          if (!choice) return;
+          choice.address_components = result.address_components;
+          regionChoices.push(choice);
         });
-        if (!component) return;
-        var namedResult = Object.assign({}, result, {name: component.long_name});
-        var choice = googleResultToChoice(namedResult, {
-          locality: 'City or town', administrative_area_level_2: 'County or region',
-          administrative_area_level_1: 'State or province', country: 'Country'
-        }[matchedType]);
-        if (!choice) return;
-        choice.address_components = result.address_components;
-        regionChoices.push(choice);
+        state.regionCandidates = regionChoices.slice(0, 4);
+        finishSuggestionRender(token);
       });
-      state.regionCandidates = regionChoices.slice(0, 4);
-      finishSuggestionRender(token);
-    });
+    }
   }
 
   function finishSuggestionRender(token) {
@@ -997,8 +1052,41 @@ body {
   }
 
   async function loadSuggestions(group, token) {
-    await Promise.all([loadSavedSuggestions(group, token), loadGoogleSuggestions(group, token)]);
+    await Promise.all([
+      loadSavedSuggestions(group, token),
+      loadGoogleSuggestions(group, token, state.suggestionMode),
+    ]);
     finishSuggestionRender(token);
+  }
+
+  function updateSuggestionModeControls() {
+    document.querySelectorAll('[data-suggestion-mode]').forEach(function(button) {
+      var active = button.dataset.suggestionMode === state.suggestionMode;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+  }
+
+  async function setSuggestionMode(mode) {
+    if ((mode !== 'nature' && mode !== 'all') || mode === state.suggestionMode) return;
+    var group = currentGroup();
+    if (!group) return;
+    state.suggestionMode = mode;
+    state.selectedChoice = null;
+    state.googleCandidates = state.googleCandidatesByMode[mode] || [];
+    updateSuggestionModeControls();
+    var assign = document.getElementById('locationReviewAssign');
+    assign.disabled = true;
+    assign.textContent = 'Select a location';
+    renderCandidates();
+    renderCandidateMarkers();
+    if (state.googleCandidatesByMode[mode]) {
+      finishSuggestionRender(state.renderToken);
+      return;
+    }
+    document.getElementById('locationReviewSuggestionStatus').textContent = 'Looking nearby…';
+    await loadGoogleSuggestions(group, state.renderToken, mode);
+    if (mode === state.suggestionMode) finishSuggestionRender(state.renderToken);
   }
 
   function distanceBetween(lat1, lng1, lat2, lng2) {
@@ -1056,6 +1144,7 @@ body {
           streetViewControl: false, fullscreenControl: true, clickableIcons: true,
         });
         state.placesService = new google.maps.places.PlacesService(state.map);
+        document.getElementById('locationReviewSuggestionMode').classList.remove('location-review-hidden');
         bindGoogleSearch();
         state.map.addListener('click', function(event) {
           if (!event.placeId) return;
@@ -1205,6 +1294,11 @@ body {
     renderCurrentGroup();
   });
   document.getElementById('locationReviewAssign').addEventListener('click', assignCurrentGroup);
+  document.querySelectorAll('[data-suggestion-mode]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      setSuggestionMode(button.dataset.suggestionMode);
+    });
+  });
   document.getElementById('locationReviewCustom').addEventListener('click', function() {
     var name = document.getElementById('locationReviewSearch').value.trim();
     if (!name) { showToast('Enter a friendly location name first.', 'error'); return; }


### PR DESCRIPTION
## Summary

The location-review map and suggestion panel used different Google data paths, and the focused Places search omitted campgrounds even when the basemap labeled one at the photo coordinates.
This change adds campground and RV park types, introduces accessible Parks & nature / All nearby controls, lazily caches each mode, and de-duplicates Google results before display.
Users can now select nearby campgrounds directly or broaden the results without losing the focused default.

## Validation

`pytest -o addopts='' -q tests/e2e/test_location_review.py` (10 passed); `pytest -q vireo/tests/test_photos_api.py -k 'location_review'` (3 passed); `ruff check tests/e2e/test_location_review.py`.
