### PR TITLE
Clarify location assignments without GPS

### DIFF
--- a/tests/e2e/test_sync_panel.py
+++ b/tests/e2e/test_sync_panel.py
@@ -132,6 +132,38 @@ def test_location_changes_are_grouped_with_plain_language_delta(
     expect(pending_detail).not_to_contain_text("effective")
 
 
+def test_location_without_gps_is_shown_as_added(live_server, page, tmp_path):
+    """A coordinate-less assignment must not look like an unchanged location."""
+    db = live_server["db"]
+    photo_id = live_server["data"]["photos"][0]
+    _make_photo_folders_accessible(live_server, tmp_path, [photo_id])
+
+    reserve_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'location')",
+        ("Pu'u Wa'awa'a Forest Reserve",),
+    ).lastrowid
+    db.conn.commit()
+    db.set_photo_location(photo_id, reserve_id)
+    db.queue_change(photo_id, "location", "effective")
+
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate("openSyncPreview()")
+
+    overlay = page.locator("#syncPreviewOverlay")
+    expect(overlay.locator(".sync-review-group-title")).to_have_text(
+        "Location added to 1 photo"
+    )
+    expect(overlay.locator(".sync-review-delta")).to_contain_text(
+        "Pu'u Wa'awa'a Forest Reserve"
+    )
+    expect(overlay.locator(".sync-review-detail")).to_contain_text(
+        "is assigned in Vireo"
+    )
+    expect(overlay.locator(".sync-review-detail")).to_contain_text(
+        "has no GPS coordinates to write to XMP"
+    )
+
+
 def test_rating_preview_responds_to_selected_sidecar_creator(
     live_server, page, tmp_path,
 ):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -509,6 +509,35 @@ def _sync_preview_presentation(
                 ),
             }
 
+        if assigned_location:
+            if location_coordinates:
+                detail = (
+                    f"{location_name} is assigned in Vireo; writing its GPS "
+                    "to XMP is turned off"
+                )
+            else:
+                detail = (
+                    f"{location_name or 'This location'} is assigned in Vireo; "
+                    "it has no GPS coordinates to write to XMP"
+                )
+
+            if metadata.get("location_source"):
+                restored_coordinates = _sync_preview_coordinate_text(
+                    metadata.get("previous_location")
+                )
+                if restored_coordinates:
+                    detail += f"; XMP GPS returns to {restored_coordinates}"
+                else:
+                    detail += "; previously Vireo-assigned GPS is removed from XMP"
+
+            return {
+                "field": "Location",
+                "action": "added",
+                "before": before,
+                "after": location_name or "Assigned location",
+                "after_detail": detail,
+            }
+
         if metadata.get("location_source"):
             restored_coordinates = _sync_preview_coordinate_text(
                 metadata.get("previous_location")
@@ -530,15 +559,7 @@ def _sync_preview_presentation(
             "action": "unchanged",
             "before": before,
             "after": before,
-            "after_detail": (
-                f"{location_name} stays in Vireo; writing its GPS to XMP is turned off"
-                if assigned_location and location_coordinates and not write_locations
-                else (
-                    f"{location_name or 'This location keyword'} has no GPS coordinates to write"
-                    if assigned_location and not location_coordinates
-                    else "No Vireo-assigned GPS needs to be removed"
-                )
-            ),
+            "after_detail": "No Vireo-assigned GPS needs to be removed",
         }
 
     if change_type == "edit_recipe":

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -326,7 +326,7 @@ function renderSyncPreview() {
     if (data.location_sync_enabled) {
       html += '<div class="sync-review-note"><strong style="color:var(--text-primary);">About location sync:</strong> Location keywords with coordinates are written to XMP as GPS metadata. Their names and hierarchy remain in Vireo.</div>';
     } else {
-      html += '<div class="sync-review-note"><strong style="color:var(--text-primary);">About location sync:</strong> Writing assigned locations to XMP is turned off in Settings. Location keywords stay in Vireo; this check only removes GPS previously written by Vireo.</div>';
+      html += '<div class="sync-review-note"><strong style="color:var(--text-primary);">About location sync:</strong> Location assignments are kept in Vireo. Writing their GPS coordinates to XMP is turned off in Settings; sync only removes GPS previously written by Vireo.</div>';
     }
   }
 

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -447,10 +447,10 @@ def test_sync_preview_describes_location_keyword_as_xmp_delta(
     }
 
 
-def test_sync_preview_explains_when_location_xmp_writes_are_disabled(
+def test_sync_preview_keeps_location_assignment_clear_when_xmp_writes_are_disabled(
     client_with_photo,
 ):
-    """A queued cleanup check must not imply that a location will be written."""
+    """The Vireo assignment stays primary even when XMP GPS is disabled."""
     app, db, photo_id = client_with_photo
     location_id = db.conn.execute(
         "INSERT INTO keywords "
@@ -468,12 +468,12 @@ def test_sync_preview_explains_when_location_xmp_writes_are_disabled(
     assert payload["location_sync_enabled"] is False
     change = payload["photos"][0]["changes"][0]
     assert change["presentation"] == {
-        "field": "XMP location",
-        "action": "unchanged",
+        "field": "Location",
+        "action": "added",
         "before": "No XMP sidecar",
-        "after": "No XMP sidecar",
+        "after": "Tallahassee",
         "after_detail": (
-            "Tallahassee stays in Vireo; writing its GPS to XMP is turned off"
+            "Tallahassee is assigned in Vireo; writing its GPS to XMP is turned off"
         ),
     }
 
@@ -601,6 +601,16 @@ def test_sync_preview_does_not_persist_rating_when_location_lacks_gps(
         for change in response.get_json()["photos"][0]["changes"]
     }
     assert changes["location"]["creates_xmp_sidecar"] is False
+    assert changes["location"]["presentation"] == {
+        "field": "Location",
+        "action": "added",
+        "before": "No XMP sidecar",
+        "after": "Placeholder",
+        "after_detail": (
+            "Placeholder is assigned in Vireo; it has no GPS coordinates "
+            "to write to XMP"
+        ),
+    }
     assert changes["rating"]["presentation"]["action"] == "unchanged"
 
 


### PR DESCRIPTION
## Summary

- Show coordinate-less locations as assignments added in Vireo instead of unchanged XMP metadata.
- Clarify how location assignments behave when GPS writing is disabled and preserve cleanup details for prior Vireo GPS.
- Add API and browser regression coverage for location review presentation.

## Tests

- pytest -q vireo/tests/test_edits_api.py tests/e2e/test_sync_panel.py (73 passed)