### PR TITLE
Standardize filters on the Misses page

### DIFF
--- a/docs/plans/2026-07-19-universal-filters-plan.md
+++ b/docs/plans/2026-07-19-universal-filters-plan.md
@@ -150,18 +150,19 @@ Nothing user-visible changes in this phase.
 ### Phase 5 outcome — residual legacy surface (documented, deliberate)
 
 The callerless legacy filter branches were deleted (summary, calendar,
-geo, text-search scope, browse/init). Three holdouts keep the legacy
+geo, text-search scope, browse/init). Three compatibility paths keep the legacy
 params on `/api/photos`, `/api/photos/ids`, and the
 `get_photos`/`get_photo_ids`/`count_filtered_photos` trio:
 
-- the Misses page's page-local filter UI (`misses.html` →
-  `_miss_filter_photo_ids`) — a future candidate for filter-bar adoption;
+- the Misses API's scalar-param shim for old bookmarks and callers (the page
+  itself now sends the universal rule tree and visual clause);
 - the photo editor's keyword search (`photo_editor.html`);
 - bulk "fetch everything" pipeline callers (`per_page=999999`, no filter
   kwargs).
 
-These are shims in the plan's sense: thin, tested, and no longer
-duplicated anywhere else.
+The Misses page adopted the shared filter bar after Phase 5. These remaining
+paths are shims in the plan's sense: thin, tested, and no longer duplicated
+anywhere else.
 
 ## Review-cycle regressions to guard (from prototype PR #1319)
 

--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -280,6 +280,78 @@ def test_handoff_hides_misses_when_source_has_folder_scope(live_server, page):
     ).count() == 1
 
 
+def test_handoff_hides_misses_when_source_has_dashboard_collection_scope(
+    live_server, page,
+):
+    """Companion to the folder-scope guard: a dashboard-composed collection
+    (?dashboard_scope=1&collection_id=...) also lives outside ``state.root``,
+    so the same handoff-payload leak would drop the collection restriction
+    on the way to Misses. Hide Misses when Browse reports that scope too
+    (CodeRabbit review r3627968187)."""
+    import json
+
+    db = live_server["db"]
+    rules = json.dumps([{"field": "extension", "op": "is", "value": ".jpg"}])
+    collection_id = db.add_collection("All JPGs", rules)
+
+    url = live_server["url"]
+    page.goto(f"{url}/browse?collection_id={collection_id}&dashboard_scope=1")
+    _wait_bar(page)
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
+
+    page.click(".vf-handoff")
+    page.wait_for_selector(".vf-handoff-menu button", timeout=8000)
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/misses"]'
+    ).count() == 0
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/map"]'
+    ).count() == 1
+
+
+def test_handoff_hides_misses_when_review_has_collection_scope(
+    live_server, page,
+):
+    """Review keeps ``currentCollection`` outside the filter tree and
+    passes it separately as ``collection_id`` to /api/predictions. Without
+    a ``getScope`` on Review's ``VireoFilter.init``, the handoff guard
+    could not see this scope and would offer Misses under a Review-
+    collection view — landing on workspace-wide misses matching the chip,
+    with bulk reject/recompute enabled against photos outside the source
+    collection (Codex review r3627997828)."""
+    import json
+
+    db = live_server["db"]
+    rules = json.dumps([{"field": "extension", "op": "is", "value": ".jpg"}])
+    collection_id = db.add_collection("All JPGs", rules)
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    _wait_bar(page)
+    # ``loadCollectionFilter`` populates the dropdown asynchronously —
+    # wait for the option to render before selecting it.
+    page.wait_for_selector(
+        f'#collectionFilter option[value="{collection_id}"]', timeout=8000,
+    )
+    # Select the collection via Review's dropdown so ``currentCollection``
+    # updates through the real switch path (the code under test).
+    page.select_option("#collectionFilter", str(collection_id))
+    page.wait_for_function(
+        "currentCollection === '" + str(collection_id) + "'", timeout=8000,
+    )
+    # A rule is required to reveal the handoff button.
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
+
+    page.click(".vf-handoff")
+    page.wait_for_selector(".vf-handoff-menu button", timeout=8000)
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/misses"]'
+    ).count() == 0
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/map"]'
+    ).count() == 1
+
+
 def test_handoff_shows_misses_when_source_has_no_external_scope(
     live_server, page,
 ):

--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -223,3 +223,59 @@ def test_handoff_hides_misses_for_rejected_flag(live_server, page):
     assert page.locator(
         '.vf-handoff-menu [data-handoff-path="/map"]'
     ).count() == 1
+
+
+def test_handoff_to_misses_strips_rejected_flag(live_server, page):
+    """A cross-page handoff payload that pins Flag=Rejected must not
+    smuggle that rule into Misses: /api/misses excludes rejected rows
+    server-side, so an unsanitized payload would render an always-empty
+    grid (Codex review r3627389228). Simulates the URL a Browse handoff
+    button would produce; the guard fires no matter which source built it.
+    """
+    import json
+    from urllib.parse import quote
+
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"]
+    with db.conn:
+        db.conn.executemany(
+            "UPDATE photos SET miss_no_subject=1, miss_computed_at='2026-04-22' "
+            "WHERE id=?",
+            [(photo_id,) for photo_id in photo_ids],
+        )
+
+    payload = quote(json.dumps({
+        "root": {
+            "mode": "all",
+            "rules": [{"field": "flag", "op": "is", "value": "rejected"}],
+        },
+        "visual": None,
+    }))
+    page.goto(f"{live_server['url']}/misses?filters={payload}")
+    _wait_bar(page)
+
+    # The rejected clause was dropped, not adopted: the full Misses grid
+    # renders instead of an empty result.
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent").lower()
+    assert "rejected" not in chips
+    assert _total(page) == 5
+
+
+def test_misses_legacy_flag_query_strips_rejected(live_server, page):
+    """``?flag=rejected`` on Misses would otherwise install a rule Misses
+    hides from its own controls, so it must be dropped the same way as
+    the handoff payload (Codex review r3627389228)."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"]
+    with db.conn:
+        db.conn.executemany(
+            "UPDATE photos SET miss_no_subject=1, miss_computed_at='2026-04-22' "
+            "WHERE id=?",
+            [(photo_id,) for photo_id in photo_ids],
+        )
+
+    page.goto(live_server["url"] + "/misses?flag=rejected")
+    _wait_bar(page)
+    chips = page.evaluate("document.querySelector('.vf-chips').textContent").lower()
+    assert "rejected" not in chips
+    assert _total(page) == 5

--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -112,6 +112,29 @@ def test_misses_page_hides_rejected_flag_filter(live_server, page):
     ).count() == 0
 
 
+def test_enum_field_is_unavailable_when_page_excludes_every_value(
+    live_server, page,
+):
+    def leave_only_rejected_flag(route):
+        response = route.fetch()
+        body = response.json()
+        flag = next(field for field in body["fields"] if field["key"] == "flag")
+        flag["values"] = ["rejected"]
+        route.fulfill(response=response, json=body)
+
+    page.route("**/api/filters/fields", leave_only_rejected_flag)
+    page.goto(live_server["url"] + "/misses")
+    _wait_bar(page)
+
+    page.click(".vf-filters-btn")
+    expect_flag_buttons = page.locator(".vf-quick-flags button")
+    for index in range(expect_flag_buttons.count()):
+        assert expect_flag_buttons.nth(index).is_hidden()
+    page.click(".vf-add-filter")
+    page.fill(".vf-field-search", "flag")
+    assert page.locator('[data-add-field="flag"]').count() == 0
+
+
 def test_browse_picker_hides_review_only_fields(live_server, page):
     page.goto(live_server["url"] + "/browse")
     _wait_bar(page)
@@ -185,3 +208,18 @@ def test_handoff_carries_expression_to_map(live_server, page):
     assert "hawk" in chips
     assert "Plottable locations" in page.inner_text(".vf-scope-chip")
     assert _total(page) == 1
+
+
+def test_handoff_hides_misses_for_rejected_flag(live_server, page):
+    page.goto(live_server["url"] + "/browse")
+    _wait_bar(page)
+    page.evaluate("VireoFilter.addRule('flag', 'is', 'rejected')")
+
+    page.click(".vf-handoff")
+    page.wait_for_selector(".vf-handoff-menu button", timeout=8000)
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/misses"]'
+    ).count() == 0
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/map"]'
+    ).count() == 1

--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -255,6 +255,48 @@ def test_handoff_keeps_misses_for_compatible_rejected_rules(
     ).count() == 1
 
 
+def test_handoff_hides_misses_when_source_has_folder_scope(live_server, page):
+    """A source page with an external scope (Browse sidebar folder,
+    dashboard collection) that lives outside ``state.root`` would lose
+    that scope when the handoff payload — ``{root, visual}`` only — lands
+    on Misses; bulk reject/recompute would then act workspace-wide on
+    photos beyond the source scope. Hide Misses when the source reports
+    such a scope (Codex review r3627693288)."""
+    url = live_server["url"]
+    folder_id = live_server["data"]["folders"][0]
+    page.goto(f"{url}/browse?folder_id={folder_id}")
+    _wait_bar(page)
+    # A rule is required to reveal the handoff button.
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
+
+    page.click(".vf-handoff")
+    page.wait_for_selector(".vf-handoff-menu button", timeout=8000)
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/misses"]'
+    ).count() == 0
+    # Non-destructive targets remain — this is a Misses-specific guard.
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/map"]'
+    ).count() == 1
+
+
+def test_handoff_shows_misses_when_source_has_no_external_scope(
+    live_server, page,
+):
+    """Sanity check the guard doesn't hide Misses when there is no
+    external folder/collection scope to lose on handoff."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    _wait_bar(page)
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
+
+    page.click(".vf-handoff")
+    page.wait_for_selector(".vf-handoff-menu button", timeout=8000)
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/misses"]'
+    ).count() == 1
+
+
 def test_handoff_to_misses_strips_rejected_flag(live_server, page):
     """A cross-page handoff payload that pins Flag=Rejected must not
     smuggle that rule into Misses: /api/misses excludes rejected rows

--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -1,4 +1,4 @@
-"""E2E: universal filter bar on Map, Review, and Duplicates (Phase 4),
+"""E2E: universal filter bar on Map, Review, Duplicates, and Misses,
 plus the cross-page "Open results in…" handoff.
 
 Seed data (conftest): 3 hawk photos in /photos/park, 2 robins in
@@ -50,7 +50,7 @@ def test_map_page_uses_filter_bar(live_server, page):
 def test_review_page_uses_filter_bar(live_server, page):
     page.goto(live_server["url"] + "/review")
     _wait_bar(page)
-    assert "Pending predictions" in page.inner_text(".vf-scope-chip")
+    assert "Review · Predictions" in page.inner_text(".vf-scope-chip")
     page.wait_for_selector(".pred-card, .grid .card, #grid > *", timeout=15000)
     before = page.evaluate("predictions.length")
     assert before == 5
@@ -67,6 +67,34 @@ def test_review_page_uses_filter_bar(live_server, page):
     page.click(".vf-add-filter")
     page.fill(".vf-field-search", "prediction status")
     page.wait_for_selector('[data-add-field="prediction_status"]', timeout=8000)
+
+
+def test_misses_page_uses_filter_bar(live_server, page):
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"]
+    with db.conn:
+        db.conn.executemany(
+            "UPDATE photos SET miss_no_subject=1, miss_computed_at='2026-04-22' "
+            "WHERE id=?",
+            [(photo_id,) for photo_id in photo_ids],
+        )
+
+    page.goto(live_server["url"] + "/misses")
+    _wait_bar(page)
+    assert "Misses · Detected misses" in page.inner_text(".vf-scope-chip")
+    assert _total(page) == 5
+
+    search = page.locator(".vf-search input")
+    search.fill("robin")
+    search.press("Enter")
+    page.wait_for_function(
+        "document.querySelector('.vf-total strong').textContent === '2'",
+        timeout=8000,
+    )
+    assert page.locator("[data-testid^='miss-card-no_subject-']").count() == 2
+
+    page.click(".vf-handoff")
+    page.wait_for_selector('.vf-handoff-menu [data-handoff-path="/browse"]')
 
 
 def test_browse_picker_hides_review_only_fields(live_server, page):

--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -6,6 +6,8 @@ Seed data (conftest): 3 hawk photos in /photos/park, 2 robins in
 photo has a pending prediction.
 """
 
+import pytest
+
 
 def _wait_bar(page):
     page.wait_for_selector("#vireoFilterBar", timeout=15000)
@@ -210,10 +212,17 @@ def test_handoff_carries_expression_to_map(live_server, page):
     assert _total(page) == 1
 
 
-def test_handoff_hides_misses_for_rejected_flag(live_server, page):
+@pytest.mark.parametrize(
+    ("op", "value"),
+    [("is", "rejected"), ("in", ["rejected"])],
+)
+def test_handoff_hides_misses_for_rejected_flag(live_server, page, op, value):
     page.goto(live_server["url"] + "/browse")
     _wait_bar(page)
-    page.evaluate("VireoFilter.addRule('flag', 'is', 'rejected')")
+    page.evaluate(
+        "([op, value]) => VireoFilter.addRule('flag', op, value)",
+        [op, value],
+    )
 
     page.click(".vf-handoff")
     page.wait_for_selector(".vf-handoff-menu button", timeout=8000)
@@ -222,6 +231,27 @@ def test_handoff_hides_misses_for_rejected_flag(live_server, page):
     ).count() == 0
     assert page.locator(
         '.vf-handoff-menu [data-handoff-path="/map"]'
+    ).count() == 1
+
+
+@pytest.mark.parametrize(
+    ("op", "value"),
+    [("is not", "rejected"), ("in", ["rejected", "flagged"])],
+)
+def test_handoff_keeps_misses_for_compatible_rejected_rules(
+    live_server, page, op, value,
+):
+    page.goto(live_server["url"] + "/browse")
+    _wait_bar(page)
+    page.evaluate(
+        "([op, value]) => VireoFilter.addRule('flag', op, value)",
+        [op, value],
+    )
+
+    page.click(".vf-handoff")
+    page.wait_for_selector(".vf-handoff-menu button", timeout=8000)
+    assert page.locator(
+        '.vf-handoff-menu [data-handoff-path="/misses"]'
     ).count() == 1
 
 

--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -97,6 +97,21 @@ def test_misses_page_uses_filter_bar(live_server, page):
     page.wait_for_selector('.vf-handoff-menu [data-handoff-path="/browse"]')
 
 
+def test_misses_page_hides_rejected_flag_filter(live_server, page):
+    page.goto(live_server["url"] + "/misses")
+    _wait_bar(page)
+
+    page.click(".vf-filters-btn")
+    assert page.locator('.vf-quick-flags [data-flag="rejected"]').is_hidden()
+
+    page.click(".vf-add-filter")
+    page.fill(".vf-field-search", "flag")
+    page.click('[data-add-field="flag"]')
+    assert page.locator(
+        '.vf-enum-pill[data-value="rejected"]'
+    ).count() == 0
+
+
 def test_browse_picker_hides_review_only_fields(live_server, page):
     page.goto(live_server["url"] + "/browse")
     _wait_bar(page)

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -108,6 +108,64 @@ def test_missing_folder_deep_link_fails_closed(live_server, page):
     expect(page.locator("#missRecomputeBtn")).to_be_disabled()
 
 
+def test_unresolved_scope_freezes_preview_controls(live_server, page):
+    """When a deep link fails closed, moving a threshold slider must not
+    fire /api/misses/preview and repopulate the grid with photos outside
+    the unresolved scope. The whole tuning group (sliders, save-defaults,
+    reset, Recompute) stays disabled until the user edits the filter bar
+    and the replacement scope loads."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses?collection_id=999999")
+    expect(page.locator("#scopeBanner")).to_be_visible()
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
+    for control_id in (
+        "missCfgDetectorFloor",
+        "missCfgNoSubject",
+        "missCfgClassifierRescue",
+        "missCfgBboxMin",
+        "missCfgOofRatio",
+        "missSaveDefaults",
+        "missRecomputeBtn",
+        "missResetPreviewBtn",
+    ):
+        expect(page.locator(f"#{control_id}")).to_be_disabled()
+
+    # Any /api/misses/preview call while the scope is unresolved would widen
+    # results to every miss outside the failed scope; track and assert none
+    # fire even if a slider input is dispatched programmatically.
+    page.evaluate("""() => {
+      window.previewCalls = 0;
+      const realFetch = window.fetch.bind(window);
+      window.fetch = (url, options) => {
+        if (String(url).includes('/api/misses/preview')) window.previewCalls++;
+        return realFetch(url, options);
+      };
+    }""")
+    page.locator("#missCfgNoSubject").evaluate("""el => {
+      el.value = String(Number(el.value) + 1);
+      el.dispatchEvent(new Event('input', {bubbles: true}));
+    }""")
+    page.wait_for_timeout(400)
+    assert page.evaluate("window.previewCalls") == 0
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
+
+    # Editing the filter bar replaces the failed scope; once the follow-up
+    # load succeeds, the tuning controls become interactive again.
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    for control_id in (
+        "missCfgDetectorFloor",
+        "missSaveDefaults",
+        "missRecomputeBtn",
+        "missResetPreviewBtn",
+    ):
+        expect(page.locator(f"#{control_id}")).to_be_enabled()
+
+
 def test_collections_fetch_failure_fails_closed(live_server, page):
     """If /api/collections itself errors, the deep-link resolver must fail
     closed rather than treating the empty list as "no collection matches"

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -181,8 +181,12 @@ def test_filter_bootstrap_failure_keeps_requested_scope_closed(
         ("missing_rules", "%7B%22root%22%3A%7B%22mode%22%3A%22all%22%7D%7D"),
         # Non-JSON garbage.
         ("garbage", "not-a-json-object"),
+        # Empty ``?filters=`` — ``URLSearchParams.get`` returns ``""``,
+        # which is falsy but still carries a required handoff scope
+        # (Codex review r3627816534).
+        ("empty_string", ""),
     ],
-    ids=["truncated_json", "missing_rules", "garbage"],
+    ids=["truncated_json", "missing_rules", "garbage", "empty_string"],
 )
 def test_malformed_misses_handoff_filters_fails_closed(
     live_server, page, label, bad_payload,

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -79,7 +79,7 @@ def test_missing_collection_deep_link_fails_closed(live_server, page):
     pids = live_server["data"]["photos"]
     _seed_misses(db, pids, "no_subject")
 
-    page.goto(f"{url}/misses?collection_id=999999")
+    page.goto(f"{url}/misses?collection_id=999999&since=2026-01-01")
     expect(page.locator("#scopeBanner")).to_be_visible()
     expect(page.locator("#scopeBanner")).to_contain_text("999999")
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
@@ -88,7 +88,10 @@ def test_missing_collection_deep_link_fails_closed(live_server, page):
     # Editing the filter bar clears the fail-closed guard and loads normally.
     page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
-    expect(page.locator("#scopeBanner")).to_be_hidden()
+    expect(page.locator("#scopeBanner")).to_contain_text(
+        "Showing only the current pipeline run"
+    )
+    expect(page.locator("#missRecomputeBtn")).to_be_enabled()
 
 
 def test_missing_folder_deep_link_fails_closed(live_server, page):

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -54,17 +54,16 @@ def test_collection_and_rating_filters_limit_visible_misses(live_server, page):
         json.dumps([{"field": "photo_ids", "value": pids[:3]}]),
     )
 
-    page.goto(f"{url}/misses")
+    page.goto(f"{url}/misses?collection_id={collection_id}")
     page.locator("[data-testid^='miss-card-no_subject-']").first.wait_for(
         state="visible", timeout=3000,
     )
-    page.locator("#missCollectionFilter").select_option(str(collection_id))
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(3)
     assert f"collection_id={collection_id}" in page.url
 
     # The shared E2E fixture gives the first hawk four stars; the other two
     # have no rating, so composing filters should leave exactly that miss.
-    page.locator("#missRatingFilter").select_option("4")
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
     expect(
         page.locator(f"[data-testid='miss-card-no_subject-{pids[0]}']")
@@ -98,7 +97,7 @@ def test_filter_change_ignores_older_threshold_preview(live_server, page):
     }""")
     page.wait_for_function("window.releaseHeldPreview != null")
 
-    page.locator("#missRatingFilter").select_option("4")
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
     page.evaluate("window.releaseHeldPreview()")
     page.wait_for_timeout(400)
@@ -140,7 +139,7 @@ def test_filter_change_ignores_older_recompute_response(live_server, page):
     page.locator("#missRecomputeBtn").click()
     page.wait_for_function("window.releaseHeldRecompute != null")
 
-    page.locator("#missRatingFilter").select_option("4")
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
     calls_before_release = page.evaluate(
         "window.missesFetchCalls.filter(u => u.startsWith('/api/misses') && !u.includes('/recompute') && !u.includes('/preview')).length"
@@ -180,7 +179,7 @@ def test_bulk_reject_uses_filters_that_rendered_visible_cards(live_server, page)
         return realFetch(url, options);
       };
     }""")
-    page.locator("#missRatingFilter").select_option("")
+    page.evaluate("VireoFilter.removeField('rating')")
     page.wait_for_function("window.releaseHeldFilterLoad != null")
 
     page.once("dialog", lambda dialog: dialog.accept())
@@ -211,7 +210,7 @@ def test_recompute_uses_filters_that_rendered_visible_cards(live_server, page):
         return realFetch(url, options);
       };
     }""")
-    page.locator("#missRatingFilter").select_option("")
+    page.evaluate("VireoFilter.removeField('rating')")
     page.wait_for_function("window.releaseHeldFilterLoad != null")
 
     page.locator("#missRecomputeBtn").click()
@@ -238,7 +237,9 @@ def test_initial_recompute_uses_url_filters_before_grid_loads(live_server, page)
       const realFetch = window.fetch.bind(window);
       let held = false;
       window.fetch = (url, options) => {
-        if (!held && String(url).includes('/api/misses?rating_min=4')) {
+        const parsed = new URL(String(url), window.location.origin);
+        const body = options && options.body ? JSON.parse(options.body) : {};
+        if (!held && parsed.pathname === '/api/misses' && body.rules) {
           held = true;
           return new Promise(resolve => {
             window.releaseInitialMissesLoad = () => realFetch(url, options).then(resolve);
@@ -256,7 +257,12 @@ def test_initial_recompute_uses_url_filters_before_grid_loads(live_server, page)
     expect(page.locator("#missRecomputeBtn")).to_be_enabled()
     page.locator("#missRecomputeBtn").click()
     page.wait_for_function("window.initialRecomputeBody != null")
-    assert page.evaluate("window.initialRecomputeBody.rating_min") == "4"
+    assert page.evaluate("""() => {
+      const rules = window.initialRecomputeBody.rules;
+      const leaves = Array.isArray(rules) ? rules : (rules.rules || []);
+      const rating = leaves.find(rule => rule.field === 'rating');
+      return rating && rating.op === '>=' && rating.value === 4;
+    }""")
     page.evaluate("window.releaseInitialMissesLoad()")
 
 

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -7,6 +7,7 @@ selection. Double-click opens the shared lightbox.
 import json
 import time
 
+import pytest
 from playwright.sync_api import expect
 
 
@@ -104,6 +105,28 @@ def test_missing_folder_deep_link_fails_closed(live_server, page):
     page.goto(f"{url}/misses?folder_id=999999")
     expect(page.locator("#scopeBanner")).to_be_visible()
     expect(page.locator("#scopeBanner")).to_contain_text("999999")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
+    expect(page.locator("#missRecomputeBtn")).to_be_disabled()
+
+
+@pytest.mark.parametrize("scope_key", ["collection_id", "folder_id"])
+def test_malformed_legacy_scope_id_fails_closed(live_server, page, scope_key):
+    """A numeric prefix must not resolve a malformed legacy scope id."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+    if scope_key == "collection_id":
+        scope_id = db.add_collection(
+            "Hawk review",
+            json.dumps([{"field": "photo_ids", "value": pids[:3]}]),
+        )
+    else:
+        scope_id = live_server["data"]["folders"][0]
+
+    page.goto(f"{url}/misses?{scope_key}={scope_id}junk")
+    expect(page.locator("#scopeBanner")).to_be_visible()
+    expect(page.locator("#scopeBanner")).to_contain_text(f"Invalid ?{scope_key}")
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
     expect(page.locator("#missRecomputeBtn")).to_be_disabled()
 

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -6,6 +6,7 @@ selection. Double-click opens the shared lightbox.
 """
 import json
 import time
+from urllib.parse import quote
 
 import pytest
 from playwright.sync_api import expect
@@ -131,11 +132,11 @@ def test_malformed_legacy_scope_id_fails_closed(live_server, page, scope_key):
     expect(page.locator("#missRecomputeBtn")).to_be_disabled()
 
 
-@pytest.mark.parametrize("scope_key", ["collection_id", "folder_id"])
-def test_filter_bootstrap_failure_keeps_legacy_scope_closed(
+@pytest.mark.parametrize("scope_key", ["collection_id", "folder_id", "filters"])
+def test_filter_bootstrap_failure_keeps_requested_scope_closed(
     live_server, page, scope_key,
 ):
-    """A filter registry failure must not bypass a legacy URL scope."""
+    """A filter registry failure must not bypass a scoped URL."""
     url = live_server["url"]
     db = live_server["db"]
     pids = live_server["data"]["photos"]
@@ -145,8 +146,16 @@ def test_filter_bootstrap_failure_keeps_legacy_scope_closed(
             "Hawk review",
             json.dumps([{"field": "photo_ids", "value": pids[:3]}]),
         )
-    else:
+    elif scope_key == "folder_id":
         scope_id = live_server["data"]["folders"][0]
+    else:
+        scope_id = quote(json.dumps({
+            "root": {
+                "mode": "all",
+                "rules": [{"field": "rating", "op": ">=", "value": 4}],
+            },
+            "visual": None,
+        }))
 
     page.route(
         "**/api/filters/fields",
@@ -156,7 +165,7 @@ def test_filter_bootstrap_failure_keeps_legacy_scope_closed(
 
     expect(page.locator("#scopeBanner")).to_be_visible()
     expect(page.locator("#scopeBanner")).to_contain_text(
-        "Could not initialize filters"
+        "Could not initialize the requested filters"
     )
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
     expect(page.locator("#missRecomputeBtn")).to_be_disabled()

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -70,6 +70,71 @@ def test_collection_and_rating_filters_limit_visible_misses(live_server, page):
     ).to_be_visible()
 
 
+def test_missing_collection_deep_link_fails_closed(live_server, page):
+    """A ?collection_id=<gone> deep link must not silently widen to every
+    miss in the workspace — bulk reject/recompute would otherwise operate
+    on photos the user never scoped."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses?collection_id=999999")
+    expect(page.locator("#scopeBanner")).to_be_visible()
+    expect(page.locator("#scopeBanner")).to_contain_text("999999")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
+    expect(page.locator("#missRecomputeBtn")).to_be_disabled()
+
+    # Editing the filter bar clears the fail-closed guard and loads normally.
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    expect(page.locator("#scopeBanner")).to_be_hidden()
+
+
+def test_missing_folder_deep_link_fails_closed(live_server, page):
+    """A ?folder_id=<gone> deep link must not silently widen to every miss."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses?folder_id=999999")
+    expect(page.locator("#scopeBanner")).to_be_visible()
+    expect(page.locator("#scopeBanner")).to_contain_text("999999")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
+    expect(page.locator("#missRecomputeBtn")).to_be_disabled()
+
+
+def test_collections_fetch_failure_fails_closed(live_server, page):
+    """If /api/collections itself errors, the deep-link resolver must fail
+    closed rather than treating the empty list as "no collection matches"
+    and dropping the scope."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+    collection_id = db.add_collection(
+        "Hawk review",
+        json.dumps([{"field": "photo_ids", "value": pids[:3]}]),
+    )
+
+    page.add_init_script("""(() => {
+      const realFetch = window.fetch.bind(window);
+      window.fetch = (url, options) => {
+        if (String(url).includes('/api/collections')
+            && !String(url).includes('/api/collections/')) {
+          return Promise.resolve(new Response('boom', {status: 500}));
+        }
+        return realFetch(url, options);
+      };
+    })()""")
+
+    page.goto(f"{url}/misses?collection_id={collection_id}")
+    expect(page.locator("#scopeBanner")).to_be_visible()
+    expect(page.locator("#scopeBanner")).to_contain_text("Could not load collections")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
+
+
 def test_filter_change_ignores_older_threshold_preview(live_server, page):
     url = live_server["url"]
     db = live_server["db"]

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -171,6 +171,44 @@ def test_filter_bootstrap_failure_keeps_requested_scope_closed(
     expect(page.locator("#missRecomputeBtn")).to_be_disabled()
 
 
+@pytest.mark.parametrize(
+    ("label", "bad_payload"),
+    [
+        # Truncated JSON (URL cut off mid-array).
+        ("truncated_json",
+         "%7B%22root%22%3A%7B%22mode%22%3A%22all%22%2C%22rules%22%3A%5B"),
+        # Well-formed JSON with the wrong shape (missing ``root.rules``).
+        ("missing_rules", "%7B%22root%22%3A%7B%22mode%22%3A%22all%22%7D%7D"),
+        # Non-JSON garbage.
+        ("garbage", "not-a-json-object"),
+    ],
+    ids=["truncated_json", "missing_rules", "garbage"],
+)
+def test_malformed_misses_handoff_filters_fails_closed(
+    live_server, page, label, bad_payload,
+):
+    """A present-but-invalid ``filters=...`` handoff payload on /misses
+    must not silently fall through to legacy params or persisted filters.
+    ``VireoFilter.init`` rejects on any malformed payload and the page
+    installs the fail-closed banner so bulk reject/recompute cannot
+    escape the intended handoff scope (Codex review r3627693292)."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses?filters={bad_payload}")
+
+    expect(page.locator("#scopeBanner")).to_be_visible()
+    expect(page.locator("#scopeBanner")).to_contain_text(
+        "Could not initialize the requested filters"
+    )
+    expect(
+        page.locator("[data-testid^='miss-card-no_subject-']")
+    ).to_have_count(0)
+    expect(page.locator("#missRecomputeBtn")).to_be_disabled()
+
+
 def test_unresolved_scope_freezes_preview_controls(live_server, page):
     """When a deep link fails closed, moving a threshold slider must not
     fire /api/misses/preview and repopulate the grid with photos outside

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -166,6 +166,59 @@ def test_unresolved_scope_freezes_preview_controls(live_server, page):
         expect(page.locator(f"#{control_id}")).to_be_enabled()
 
 
+def test_scope_recovery_stays_frozen_until_replacement_load(live_server, page):
+    """A late config response must not re-enable tuning while the request
+    that replaces an unresolved deep-link scope is still in flight."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.add_init_script("""(() => {
+      const realFetch = window.fetch.bind(window);
+      window.previewCalls = 0;
+      window.recomputeCalls = 0;
+      window.fetch = (url, options) => {
+        const value = String(url);
+        if (value === '/api/misses/config') {
+          return realFetch(url, options).then(response => new Promise(resolve => {
+            window.releaseHeldConfig = () => resolve(response);
+          }));
+        }
+        if (value === '/api/misses') {
+          return realFetch(url, options).then(response => new Promise(resolve => {
+            window.releaseHeldMisses = () => resolve(response);
+          }));
+        }
+        if (value.includes('/api/misses/preview')) window.previewCalls++;
+        if (value.includes('/api/misses/recompute')) window.recomputeCalls++;
+        return realFetch(url, options);
+      };
+    })()""")
+
+    page.goto(f"{url}/misses?collection_id=999999")
+    expect(page.locator("#scopeBanner")).to_be_visible()
+    page.wait_for_function("window.releaseHeldConfig != null")
+
+    page.evaluate("VireoFilter.addRule('rating', '>=', 4)")
+    page.wait_for_function("window.releaseHeldMisses != null")
+    page.evaluate("window.releaseHeldConfig()")
+    page.wait_for_function("window.missConfigLoaded === true")
+
+    # Config is ready, but the replacement filters are not yet applied.
+    expect(page.locator("#missRecomputeBtn")).to_be_disabled()
+    expect(page.locator("#missCfgNoSubject")).to_be_disabled()
+    page.evaluate("previewMisses(); recomputeMisses()")
+    page.wait_for_timeout(100)
+    assert page.evaluate("window.previewCalls") == 0
+    assert page.evaluate("window.recomputeCalls") == 0
+
+    page.evaluate("window.releaseHeldMisses()")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    expect(page.locator("#missRecomputeBtn")).to_be_enabled()
+    expect(page.locator("#missCfgNoSubject")).to_be_enabled()
+
+
 def test_collections_fetch_failure_fails_closed(live_server, page):
     """If /api/collections itself errors, the deep-link resolver must fail
     closed rather than treating the empty list as "no collection matches"

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -131,6 +131,37 @@ def test_malformed_legacy_scope_id_fails_closed(live_server, page, scope_key):
     expect(page.locator("#missRecomputeBtn")).to_be_disabled()
 
 
+@pytest.mark.parametrize("scope_key", ["collection_id", "folder_id"])
+def test_filter_bootstrap_failure_keeps_legacy_scope_closed(
+    live_server, page, scope_key,
+):
+    """A filter registry failure must not bypass a legacy URL scope."""
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+    if scope_key == "collection_id":
+        scope_id = db.add_collection(
+            "Hawk review",
+            json.dumps([{"field": "photo_ids", "value": pids[:3]}]),
+        )
+    else:
+        scope_id = live_server["data"]["folders"][0]
+
+    page.route(
+        "**/api/filters/fields",
+        lambda route: route.fulfill(status=500, body="registry unavailable"),
+    )
+    page.goto(f"{url}/misses?{scope_key}={scope_id}")
+
+    expect(page.locator("#scopeBanner")).to_be_visible()
+    expect(page.locator("#scopeBanner")).to_contain_text(
+        "Could not initialize filters"
+    )
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(0)
+    expect(page.locator("#missRecomputeBtn")).to_be_disabled()
+
+
 def test_unresolved_scope_freezes_preview_controls(live_server, page):
     """When a deep link fails closed, moving a threshold slider must not
     fire /api/misses/preview and repopulate the grid with photos outside

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14557,6 +14557,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         rules_raw = value("rules")
         visual_raw = value("visual")
         if rules_raw is not None or visual_raw is not None:
+            collection_ids = None
+            if collection_id is not None:
+                # Validate before rules/visual resolution so both paths can
+                # safely use the collection as their candidate scope while
+                # preserving the friendlier legacy error messages.
+                valid = {c["id"]: c for c in db.get_collections()}
+                if collection_id not in valid:
+                    raise ValueError("collection not found")
+                if valid[collection_id]["visual_json"] is not None:
+                    raise ValueError(
+                        "visual collections have no rules-only expansion; "
+                        "open the collection from Browse instead"
+                    )
+                collection_ids = db.collection_photo_ids(collection_id)
             try:
                 rules = (
                     json.loads(rules_raw)
@@ -14578,24 +14592,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             visual_info = None
             photo_ids = None
             if visual is not None:
-                visual_info, ordered_ids, _ = _resolve_visual(db, rules, visual)
+                visual_info, ordered_ids, _ = _resolve_visual(
+                    db, rules, visual, collection_id=collection_id,
+                )
                 if ordered_ids is not None:
                     photo_ids = set(ordered_ids)
             if photo_ids is None and rules:
-                photo_ids = set(db.query_photo_ids(rules))
+                photo_ids = set(db.query_photo_ids(
+                    rules, collection_id=collection_id,
+                ))
 
             # ``collection_id`` can still accompany the universal expression
             # for compatibility with an old composed Misses deep link.
             if collection_id is not None:
-                valid = {c["id"]: c for c in db.get_collections()}
-                if collection_id not in valid:
-                    raise ValueError("collection not found")
-                if valid[collection_id]["visual_json"] is not None:
-                    raise ValueError(
-                        "visual collections have no rules-only expansion; "
-                        "open the collection from Browse instead"
-                    )
-                collection_ids = db.collection_photo_ids(collection_id)
                 photo_ids = (
                     collection_ids
                     if photo_ids is None
@@ -14693,7 +14702,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )]
             _attach_species_representatives(db, photos)
             _attach_edit_recipes(db, photos)
-            return jsonify({"photos": photos, "category": category})
+            response = {"photos": photos, "category": category}
+            if visual_info is not None:
+                response["visual"] = visual_info
+            return jsonify(response)
         grouped = {
             "no_subject": db.list_misses(category="no_subject", since=since, photo_ids=photo_ids),
             "clipped":    db.list_misses(category="clipped", since=since, photo_ids=photo_ids),

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10659,8 +10659,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     d["can_add_photos"] = False
             # ``has_visual`` lets clients that funnel a collection through
             # the legacy rules-only path (``/api/collections/<id>/photos``,
-            # ``/photo-ids``, pipeline/misses ``collection_id``) hide or
-            # disable visual collections in their pickers. Those paths
+            # ``/photo-ids``, pipeline/Misses ``collection_id`` callers) hide,
+            # disable, or reject visual collections. Those paths
             # evaluate ``rules`` only — a visual-only collection would
             # otherwise silently widen the scope to every metadata match.
             # Browse opens the same collection into the filter bar, where
@@ -10908,7 +10908,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         The consumers that call ``db.get_collection_photos`` /
         ``collection_photo_ids`` (pipeline stages, sharpness/cull/classify/
-        regroup/masks jobs, predictions-compare, misses filter, import
+        regroup/masks jobs, predictions-compare, the Misses legacy API, import
         preview) evaluate ``rules`` only. A visual-only collection would
         otherwise silently scope those runs to every metadata-matching
         photo instead of the visually-matched subset — the fix Codex
@@ -14523,7 +14523,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return grouped
 
     def _miss_filter_photo_ids(db, values):
-        """Resolve Misses-page filters to an intersected workspace photo set."""
+        """Resolve Misses-page filters to an intersected workspace photo set.
+
+        The Misses UI sends the shared filter bar's ``rules``/``visual``
+        expression.  The legacy scalar parameters remain accepted for old
+        bookmarks and API callers, but are no longer emitted by the page.
+
+        Returns ``(photo_ids, visual_info)``.  ``photo_ids=None`` means the
+        full active-workspace scope; ``visual_info`` mirrors
+        ``/api/photos/query`` so the shared bar can surface visual-search
+        fallback states instead of silently widening the result set.
+        """
         def value(name):
             raw = values.get(name)
             return None if raw in (None, "") else raw
@@ -14543,6 +14553,56 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return parsed
 
         collection_id = integer("collection_id", minimum=1)
+
+        rules_raw = value("rules")
+        visual_raw = value("visual")
+        if rules_raw is not None or visual_raw is not None:
+            try:
+                rules = (
+                    json.loads(rules_raw)
+                    if isinstance(rules_raw, str)
+                    else rules_raw
+                )
+                visual_value = (
+                    json.loads(visual_raw)
+                    if isinstance(visual_raw, str)
+                    else visual_raw
+                )
+            except (TypeError, json.JSONDecodeError) as exc:
+                raise ValueError("rules and visual must be valid JSON") from exc
+
+            if rules is None:
+                rules = []
+            rules = _inject_active_visual_model(rules)
+            visual = _validate_visual_arg(visual_value)
+            visual_info = None
+            photo_ids = None
+            if visual is not None:
+                visual_info, ordered_ids, _ = _resolve_visual(db, rules, visual)
+                if ordered_ids is not None:
+                    photo_ids = set(ordered_ids)
+            if photo_ids is None and rules:
+                photo_ids = set(db.query_photo_ids(rules))
+
+            # ``collection_id`` can still accompany the universal expression
+            # for compatibility with an old composed Misses deep link.
+            if collection_id is not None:
+                valid = {c["id"]: c for c in db.get_collections()}
+                if collection_id not in valid:
+                    raise ValueError("collection not found")
+                if valid[collection_id]["visual_json"] is not None:
+                    raise ValueError(
+                        "visual collections have no rules-only expansion; "
+                        "open the collection from Browse instead"
+                    )
+                collection_ids = db.collection_photo_ids(collection_id)
+                photo_ids = (
+                    collection_ids
+                    if photo_ids is None
+                    else photo_ids & collection_ids
+                )
+            return photo_ids, visual_info
+
         folder_id = integer("folder_id", minimum=1)
         rating_min = integer("rating_min", minimum=1, maximum=5)
         keyword = value("keyword")
@@ -14582,9 +14642,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if collection_id is not None:
             # ``collection_photo_ids`` (like ``get_collection_photos``)
             # evaluates ``rules`` only. Refuse a visual-only collection
-            # here so the Misses page does not silently widen its scope
-            # to every metadata match — the picker filter is the primary
-            # gate; this is defense-in-depth for API callers.
+            # here so a legacy Misses API caller does not silently widen its
+            # scope to every metadata match. The shared-bar page sends the
+            # collection's rules + visual clause instead of collection_id.
             valid = {c["id"]: c for c in db.get_collections()}
             if collection_id not in valid:
                 raise ValueError("collection not found")
@@ -14599,22 +14659,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if photo_ids is None
                 else photo_ids & collection_ids
             )
-        return photo_ids
+        return photo_ids, None
 
-    @app.route("/api/misses")
+    @app.route("/api/misses", methods=["GET", "POST"])
     def api_misses():
         """Return photos flagged as misses.
 
-        With no query string, returns a dict with all three categories.
-        With ``?category=X``, returns {"photos": [...], "category": X}.
-        ``?since=<iso-ts>`` restricts results to photos whose
-        miss_computed_at >= since (used by the pipeline-review step).
+        GET retains the legacy scalar query parameters for bookmarks and API
+        callers. POST accepts the shared filter bar's rule/visual payload,
+        avoiding URL-size limits for large saved collections. With a category,
+        returns {"photos": [...], "category": X}; otherwise returns all three
+        category lists. ``since`` restricts results to photos whose
+        miss_computed_at >= the supplied timestamp.
         """
         db = _get_db()
-        category = request.args.get("category")
-        since = request.args.get("since") or None
+        if request.method == "POST":
+            values = request.get_json(silent=True)
+            if not isinstance(values, dict):
+                return json_error("request body must be a JSON object", 400)
+        else:
+            values = request.args
+        category = values.get("category")
+        since = values.get("since") or None
         try:
-            photo_ids = _miss_filter_photo_ids(db, request.args)
+            photo_ids, visual_info = _miss_filter_photo_ids(db, values)
         except ValueError as e:
             return json_error(str(e), 400)
         if category is not None:
@@ -14631,7 +14699,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "clipped":    db.list_misses(category="clipped", since=since, photo_ids=photo_ids),
             "oof":        db.list_misses(category="oof", since=since, photo_ids=photo_ids),
         }
-        return jsonify(_attach_miss_edit_recipes(db, grouped))
+        grouped = _attach_miss_edit_recipes(db, grouped)
+        if visual_info is not None:
+            grouped["visual"] = visual_info
+        return jsonify(grouped)
 
     @app.route("/api/misses/preview", methods=["POST"])
     def api_misses_preview():
@@ -14647,7 +14718,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except ValueError as e:
             return json_error(str(e))
         try:
-            photo_ids = _miss_filter_photo_ids(db, body)
+            photo_ids, visual_info = _miss_filter_photo_ids(db, body)
         except ValueError as e:
             return json_error(str(e), 400)
         grouped = preview_misses_for_workspace(
@@ -14657,6 +14728,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         _attach_miss_edit_recipes(db, grouped)
         grouped["config"] = values
         grouped["preview"] = True
+        if visual_info is not None:
+            grouped["visual"] = visual_info
         return jsonify(grouped)
 
     @app.route("/api/misses/recompute", methods=["POST"])
@@ -14673,7 +14746,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except ValueError as e:
             return json_error(str(e))
         try:
-            photo_ids = _miss_filter_photo_ids(db, body)
+            photo_ids, visual_info = _miss_filter_photo_ids(db, body)
         except ValueError as e:
             return json_error(str(e), 400)
 
@@ -14693,6 +14766,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         grouped["config"] = values
         grouped["updated"] = updated
         grouped["saved_defaults"] = body.get("save_defaults") is True
+        if visual_info is not None:
+            grouped["visual"] = visual_info
         return jsonify(grouped)
 
     @app.route("/api/misses/reject", methods=["POST"])
@@ -14717,7 +14792,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if category not in ("no_subject", "clipped", "oof"):
             return jsonify({"error": "invalid category"}), 400
         try:
-            photo_ids = _miss_filter_photo_ids(db, body)
+            photo_ids, _ = _miss_filter_photo_ids(db, body)
         except ValueError as e:
             return json_error(str(e), 400)
         affected = db.bulk_reject_miss_category(

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -52,6 +52,7 @@
     scopeLocked: true,
     fields: null,          // registry from /api/filters/fields (key -> spec)
     fieldOrder: [],
+    excludedValues: {},    // page-specific enum values hidden from filter controls
     onChange: null,
     getContextRules: null, // page-supplied rules ANDed outside the user tree
     getScope: null,        // page-supplied {folder_id, collection_id} for /api/filters/values
@@ -119,6 +120,18 @@
     return spec.ops[0];
   }
 
+  function fieldSpec(field) {
+    const spec = state.fields[field];
+    const excluded = state.excludedValues[field] || [];
+    if (!spec || !spec.values || !excluded.length) return spec;
+    return { ...spec, values: spec.values.filter((value) => !excluded.includes(value)) };
+  }
+
+  function fieldValueAvailable(field, value) {
+    const spec = fieldSpec(field);
+    return !spec || !spec.values || spec.values.includes(value);
+  }
+
   function defaultValue(spec, op) {
     if (op === 'recent') return { n: 12, unit: 'months' };
     if (op === 'between') {
@@ -155,7 +168,7 @@
   }
 
   function makeRule(field, op, value) {
-    const spec = state.fields[field];
+    const spec = fieldSpec(field);
     const resolvedOp = op || defaultOp(spec);
     return { field, op: resolvedOp, value: value == null ? defaultValue(spec, resolvedOp) : value };
   }
@@ -697,6 +710,7 @@
   }
 
   function toggleQuickEnum(field, value) {
+    if (!fieldValueAvailable(field, value)) return;
     mutate(() => {
       const idx = state.root.rules.findIndex((n) => !isGroup(n) && n.field === field);
       if (idx < 0) { state.root.rules.unshift(makeRule(field, 'in', [value])); return; }
@@ -720,7 +734,10 @@
       btn.classList.toggle('active', Boolean(rating && Number(rating.value) >= Number(btn.dataset.rating)));
     });
     const flags = quickEnumValues('flag');
-    $$('.vf-quick-flags button').forEach((btn) => btn.classList.toggle('active', flags.includes(btn.dataset.flag)));
+    $$('.vf-quick-flags button').forEach((btn) => {
+      btn.hidden = !fieldValueAvailable('flag', btn.dataset.flag);
+      btn.classList.toggle('active', flags.includes(btn.dataset.flag));
+    });
     const colors = quickEnumValues('color_label');
     $$('.vf-quick-colors button').forEach((btn) => btn.classList.toggle('active', colors.includes(btn.dataset.color)));
   }
@@ -786,7 +803,7 @@
         </div>
       </div>`;
     }
-    const spec = state.fields[node.field] || { label: node.field, type: 'text', ops: ['is'] };
+    const spec = fieldSpec(node.field) || { label: node.field, type: 'text', ops: ['is'] };
     const fieldOptions = state.fieldOrder.filter((key) =>
       fieldAvailable(state.fields[key]) || key === node.field).map((key) =>
       `<option value="${key}" ${key === node.field ? 'selected' : ''}>${esc(state.fields[key].label)}</option>`).join('');
@@ -931,10 +948,10 @@
         if (action === 'mode') node.mode = target.value;
         return;
       }
-      const spec = state.fields[node.field];
+      const spec = fieldSpec(node.field);
       if (action === 'field') {
         node.field = target.value;
-        const next = state.fields[node.field];
+        const next = fieldSpec(node.field);
         node.op = defaultOp(next);
         node.value = defaultValue(next, node.op);
         delete node.case;
@@ -1349,6 +1366,7 @@
       state.getContextRules = options.getContextRules || null;
       state.getScope = options.getScope || null;
       state.onCollectionSaved = options.onCollectionSaved || null;
+      state.excludedValues = options.excludedValues || {};
       rootEl = typeof options.root === 'string' ? document.querySelector(options.root) : options.root;
       if (!rootEl) return Promise.reject(new Error('VireoFilter: missing root element'));
       return loadRegistry().then(() => {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -138,9 +138,9 @@
       if (spec.type === 'date') return ['2025-01-01', new Date().toISOString().slice(0, 10)];
       return [0, 100];
     }
-    if (op === 'in' || op === 'not_in') return spec.values ? [spec.values[0]] : [];
+    if (op === 'in' || op === 'not_in') return spec.values && spec.values.length ? [spec.values[0]] : [];
     if (spec.type === 'boolean') return 1;
-    if (spec.type === 'enum') return (spec.values || [''])[0];
+    if (spec.type === 'enum') return spec.values && spec.values.length ? spec.values[0] : '';
     if (spec.type === 'rating') return 3;
     if (spec.type === 'number') return 0;
     if (spec.type === 'date') return new Date().toISOString().slice(0, 10);
@@ -162,7 +162,9 @@
     }
     if (Array.isArray(prev)) return prev.length ? prev[0] : defaultValue(spec, op);
     if (prev && typeof prev === 'object') return defaultValue(spec, op);
-    if (spec.type === 'enum' && spec.values && !spec.values.includes(prev)) return spec.values[0];
+    if (spec.type === 'enum' && spec.values && !spec.values.includes(prev)) {
+      return spec.values.length ? spec.values[0] : '';
+    }
     if (prev == null || prev === '') return defaultValue(spec, op);
     return prev;
   }
@@ -805,7 +807,7 @@
     }
     const spec = fieldSpec(node.field) || { label: node.field, type: 'text', ops: ['is'] };
     const fieldOptions = state.fieldOrder.filter((key) =>
-      fieldAvailable(state.fields[key]) || key === node.field).map((key) =>
+      fieldAvailable(key) || key === node.field).map((key) =>
       `<option value="${key}" ${key === node.field ? 'selected' : ''}>${esc(state.fields[key].label)}</option>`).join('');
     const opOptions = spec.ops.map((op) =>
       `<option value="${esc(op)}" ${op === node.op ? 'selected' : ''}>${esc(OP_LABELS[op] || op)}</option>`).join('');
@@ -913,7 +915,10 @@
     if (shouldOpen) renderRules();
   }
 
-  function fieldAvailable(spec) {
+  function fieldAvailable(field) {
+    const spec = fieldSpec(field);
+    if (!spec) return false;
+    if (spec.type === 'enum' && Array.isArray(spec.values) && !spec.values.length) return false;
     return !spec.pages || spec.pages.includes(state.page);
   }
 
@@ -921,8 +926,8 @@
     const needle = String(query || '').trim().toLowerCase();
     const byCategory = new Map();
     state.fieldOrder.forEach((key) => {
-      const spec = state.fields[key];
-      if (!fieldAvailable(spec)) return;
+      const spec = fieldSpec(key);
+      if (!fieldAvailable(key)) return;
       if (needle && !`${spec.label} ${spec.category}`.toLowerCase().includes(needle)) return;
       if (!byCategory.has(spec.category)) byCategory.set(spec.category, []);
       byCategory.get(spec.category).push([key, spec]);
@@ -1335,6 +1340,20 @@
     ['duplicates', '/duplicates', 'Duplicates', 'Adds: duplicate groups scope'],
     ['misses', '/misses', 'Misses', 'Adds: detected misses scope'],
   ];
+  const HANDOFF_EXCLUDED_VALUES = {
+    misses: { flag: ['rejected'] },
+  };
+
+  function handoffPageAvailable(page) {
+    const exclusions = HANDOFF_EXCLUDED_VALUES[page];
+    if (!exclusions) return true;
+    return !allLeaves(state.root).some((rule) => {
+      const excluded = exclusions[rule.field];
+      if (!excluded) return false;
+      const values = Array.isArray(rule.value) ? rule.value : [rule.value];
+      return values.some((value) => excluded.includes(value));
+    });
+  }
 
   function renderHandoff() {
     const btn = $('.vf-handoff');
@@ -1345,7 +1364,8 @@
   function openHandoffMenu() {
     const menu = $('.vf-handoff-menu');
     if (!menu.hidden) { menu.hidden = true; return; }
-    menu.innerHTML = HANDOFF_PAGES.filter(([key]) => key !== state.page).map(([key, path, label, detail]) =>
+    menu.innerHTML = HANDOFF_PAGES.filter(([key]) =>
+      key !== state.page && handoffPageAvailable(key)).map(([key, path, label, detail]) =>
       `<button type="button" data-handoff-path="${path}"><span>${label}</span><small>${esc(detail)}</small></button>`).join('');
     menu.hidden = false;
   }

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1391,8 +1391,11 @@
     return !allLeaves(state.root).some((rule) => {
       const excluded = exclusions[rule.field];
       if (!excluded) return false;
-      const values = Array.isArray(rule.value) ? rule.value : [rule.value];
-      return values.some((value) => excluded.includes(value));
+      if (rule.op === 'is') return excluded.includes(rule.value);
+      if (rule.op === 'in' && Array.isArray(rule.value)) {
+        return rule.value.every((value) => excluded.includes(value));
+      }
+      return false;
     });
   }
 

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -132,6 +132,44 @@
     return !spec || !spec.values || spec.values.includes(value);
   }
 
+  // Strip excluded enum values out of a rule tree so a cross-page handoff
+  // (or a legacy deep link) can't smuggle in a value the current page hides
+  // from its own controls. Misses excludes ``flag=rejected`` because
+  // ``/api/misses`` filters those rows out server-side; without this a
+  // "Flag = Rejected" expression composed on Browse and handed to Misses
+  // would render an always-empty grid (Codex review r3627389228).
+  //
+  // The rewrite is minimal: values the server excludes are dropped from
+  // ``is``/``in`` clauses (leaves become no-ops rather than always-false
+  // matchers); ``is not``/``not_in`` stay untouched because the excluded
+  // value is already false by the page scope, so they are harmless. An
+  // ``in`` rule left with no values, or a group left with no rules, is
+  // pruned so we never send an empty ``in [] → false`` clause.
+  function sanitizeExcludedValues(node) {
+    if (!node) return null;
+    if (isGroup(node)) {
+      const rules = node.rules.map(sanitizeExcludedValues).filter((n) => n);
+      if (!rules.length) return null;
+      return { ...node, rules };
+    }
+    const excluded = state.excludedValues[node.field];
+    if (!excluded || !excluded.length) return node;
+    if (node.op === 'is') return excluded.includes(node.value) ? null : node;
+    if (node.op === 'in' && Array.isArray(node.value)) {
+      const values = node.value.filter((v) => !excluded.includes(v));
+      if (!values.length) return null;
+      if (values.length === node.value.length) return node;
+      return { ...node, value: values };
+    }
+    return node;
+  }
+
+  function sanitizeRoot(root) {
+    if (!root || !Array.isArray(root.rules)) return { mode: 'all', rules: [] };
+    const cleaned = sanitizeExcludedValues(root);
+    return cleaned || { mode: root.mode || 'all', rules: [] };
+  }
+
   function defaultValue(spec, op) {
     if (op === 'recent') return { n: 12, unit: 'months' };
     if (op === 'between') {
@@ -432,7 +470,10 @@
       const uiState = parseUiState(ws.ui_state);
       const saved = uiState.universal_filters && uiState.universal_filters[state.page];
       if (saved && saved.root && Array.isArray(saved.root.rules)) {
-        state.root = saved.root;
+        // Persisted state predates the current excludedValues config in
+        // some cases (e.g. a page tightens its excluded set); keep the
+        // guarantee that hidden values never reach the rule tree.
+        state.root = sanitizeRoot(saved.root);
         state.muted = Boolean(saved.muted);
         state.visual = (
           saved.visual && typeof saved.visual.prompt === 'string' && saved.visual.prompt
@@ -1398,7 +1439,10 @@
           try {
             const payload = JSON.parse(handoffRaw);
             if (payload && payload.root && Array.isArray(payload.root.rules)) {
-              state.root = payload.root;
+              // Strip page-excluded values before adopting the payload so
+              // a Browse expression like ``flag=rejected`` doesn't render
+              // an empty Misses grid when handed off.
+              state.root = sanitizeRoot(payload.root);
               // Reconstruct the visual clause from the allowed fields
               // rather than trusting the parsed URL payload — an invalid
               // ``strength`` (or an unknown extra key) would otherwise
@@ -1415,6 +1459,10 @@
           } catch (e) { /* malformed handoff param — fall through */ }
         }
         if (!fromUrl) fromUrl = applyLegacyParams(urlParams);
+        // ``applyLegacyParams`` builds rules directly from raw URL params
+        // (e.g. ``?flag=rejected`` on Misses) and would otherwise bypass
+        // the excluded-value guard.
+        if (fromUrl) state.root = sanitizeRoot(state.root);
         const finish = () => {
           state.ready = true;
           render();

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1452,8 +1452,15 @@
         installEvents();
         const urlParams = new URLSearchParams(window.location.search);
         let fromUrl = false;
-        const handoffRaw = urlParams.get('filters');
-        if (handoffRaw) {
+        // Use ``has`` rather than truthiness: ``/misses?filters=`` (or
+        // ``?filters``) hands back an empty string, which is falsy but
+        // still carries the caller's intent to constrain the page. Falling
+        // through to legacy params or persisted state would silently widen
+        // the destination — on Misses, that re-exposes bulk reject and
+        // recompute to photos outside the intended handoff scope
+        // (Codex review r3627816534).
+        if (urlParams.has('filters')) {
+          const handoffRaw = urlParams.get('filters');
           let payload = null;
           try { payload = JSON.parse(handoffRaw); }
           catch (e) { payload = null; }

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1,4 +1,4 @@
-/* Universal photo filter bar — shared across Browse/Map/Review/Duplicates.
+/* Universal photo filter bar — shared across Browse/Map/Review/Duplicates/Misses.
  *
  * Owns the filter expression (a smart-collection rule tree, the same JSON
  * collections store), its UI (quick search, chips, popover with quick
@@ -1314,8 +1314,9 @@
   const HANDOFF_PAGES = [
     ['browse', '/browse', 'Browse', 'Workspace · All available photos'],
     ['map', '/map', 'Map', 'Adds: plottable locations scope'],
-    ['review', '/review', 'Review', 'Adds: pending predictions scope'],
+    ['review', '/review', 'Review', 'Adds: predictions scope'],
     ['duplicates', '/duplicates', 'Duplicates', 'Adds: duplicate groups scope'],
+    ['misses', '/misses', 'Misses', 'Adds: detected misses scope'],
   ];
 
   function renderHandoff() {

--- a/vireo/static/vireo-filter.js
+++ b/vireo/static/vireo-filter.js
@@ -1386,6 +1386,21 @@
   };
 
   function handoffPageAvailable(page) {
+    // Misses has bulk reject/recompute over the whole result set. The
+    // handoff payload serializes only ``state.root``/``state.visual`` —
+    // it drops any external scope the source page keeps outside the
+    // filter tree (Browse sidebar folder, dashboard collection). Hand
+    // off from ``folder A ∩ hawk`` → Misses would otherwise widen to
+    // every ``hawk`` miss in the workspace and expose them to bulk
+    // actions the user never asked for. Hide Misses whenever the source
+    // exposes an external scope; the user can navigate manually if they
+    // really want the workspace-wide view.
+    if (page === 'misses' && state.getScope) {
+      const scope = state.getScope();
+      if (scope && (scope.folder_id != null || scope.collection_id != null)) {
+        return false;
+      }
+    }
     const exclusions = HANDOFF_EXCLUDED_VALUES[page];
     if (!exclusions) return true;
     return !allLeaves(state.root).some((rule) => {
@@ -1439,27 +1454,36 @@
         let fromUrl = false;
         const handoffRaw = urlParams.get('filters');
         if (handoffRaw) {
-          try {
-            const payload = JSON.parse(handoffRaw);
-            if (payload && payload.root && Array.isArray(payload.root.rules)) {
-              // Strip page-excluded values before adopting the payload so
-              // a Browse expression like ``flag=rejected`` doesn't render
-              // an empty Misses grid when handed off.
-              state.root = sanitizeRoot(payload.root);
-              // Reconstruct the visual clause from the allowed fields
-              // rather than trusting the parsed URL payload — an invalid
-              // ``strength`` (or an unknown extra key) would otherwise
-              // ride through to ``/api/photos/query`` and 500 the request.
-              // Mirrors ``restorePersisted()``.
-              state.visual = (
-                payload.visual && typeof payload.visual.prompt === 'string' && payload.visual.prompt
-              ) ? { prompt: payload.visual.prompt,
-                    strength: ['broad', 'balanced', 'strict'].includes(payload.visual.strength)
-                      ? payload.visual.strength : 'balanced' }
-                : null;
-              fromUrl = true;
-            }
-          } catch (e) { /* malformed handoff param — fall through */ }
+          let payload = null;
+          try { payload = JSON.parse(handoffRaw); }
+          catch (e) { payload = null; }
+          if (payload && payload.root && Array.isArray(payload.root.rules)) {
+            // Strip page-excluded values before adopting the payload so
+            // a Browse expression like ``flag=rejected`` doesn't render
+            // an empty Misses grid when handed off.
+            state.root = sanitizeRoot(payload.root);
+            // Reconstruct the visual clause from the allowed fields
+            // rather than trusting the parsed URL payload — an invalid
+            // ``strength`` (or an unknown extra key) would otherwise
+            // ride through to ``/api/photos/query`` and 500 the request.
+            // Mirrors ``restorePersisted()``.
+            state.visual = (
+              payload.visual && typeof payload.visual.prompt === 'string' && payload.visual.prompt
+            ) ? { prompt: payload.visual.prompt,
+                  strength: ['broad', 'balanced', 'strict'].includes(payload.visual.strength)
+                    ? payload.visual.strength : 'balanced' }
+              : null;
+            fromUrl = true;
+          } else {
+            // A present-but-invalid handoff payload (truncated URL, bad
+            // JSON, missing ``root.rules``) must not fall through to
+            // legacy params or persisted state — that would silently
+            // widen the page beyond the intended handoff scope and, on
+            // Misses, expose bulk reject/recompute to unrelated photos.
+            // Reject init so the destination page can install its
+            // fail-closed banner (see misses.html bootstrap catch).
+            throw new Error('VireoFilter: invalid filters handoff payload');
+          }
         }
         if (!fromUrl) fromUrl = applyLegacyParams(urlParams);
         // ``applyLegacyParams`` builds rules directly from raw URL params

--- a/vireo/templates/_filterbar.html
+++ b/vireo/templates/_filterbar.html
@@ -1,5 +1,5 @@
-<!-- Universal photo filter bar (shared: Browse now, Map/Review/Duplicates in
-     Phase 4). Markup + scoped styles; behavior in /static/vireo-filter.js.
+<!-- Universal photo filter bar shared by photo-result pages. Markup + scoped
+     styles; behavior in /static/vireo-filter.js.
      Pages include this, then call VireoFilter.init({...}).
      Design: docs/plans/2026-07-19-universal-filters-design.md -->
 <div id="vireoFilterBar" class="vf-bar">

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -19,36 +19,6 @@ body { padding-bottom: 36px; }
   height: calc(100vh - 44px);
 }
 
-.map-filters {
-  display: flex;
-  gap: 8px;
-  padding: 8px 12px;
-  background: var(--bg-secondary, #0a2a3a);
-  border-bottom: 1px solid var(--border, #1a4a5a);
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.map-filters label {
-  font-size: 12px;
-  color: var(--text-secondary, #B0CCCC);
-}
-
-.map-filters select,
-.map-filters input {
-  font-size: 12px;
-  padding: 4px 6px;
-  background: var(--bg-primary, #061a24);
-  color: var(--text-primary, #E0F0F0);
-  border: 1px solid var(--border, #1a4a5a);
-  border-radius: 4px;
-}
-
-.map-filters input[type="text"] { width: 120px; }
-.map-filters input[type="date"] { width: 130px; }
-.map-filters .search-control { width: 190px; }
-.map-filters .search-control input[type="text"] { width: auto; border-radius: 4px 0 0 4px; }
-
 .map-body {
   display: flex;
   flex: 1;

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1975,14 +1975,15 @@ VireoFilter.init({
 }).then(loadMisses).catch(function() {
   initializingMissFilters = false;
   var current = new URL(window.location.href).searchParams;
-  if (current.has('collection_id') || current.has('folder_id')) {
+  if (current.has('collection_id') || current.has('folder_id') ||
+      current.has('filters')) {
     // If the shared registry/bootstrap fails, applyLegacyMissScopes() never
     // gets a chance to translate the legacy URL into universal rules. Keep
     // the page closed instead of loading the default empty expression, which
     // would expose every miss to bulk actions outside the requested scope.
     noteLegacyScopeError(
-      'Could not initialize filters to resolve this collection or folder ' +
-      'deep link. Showing no misses so bulk actions stay within the requested scope.'
+      'Could not initialize the requested filters. Showing no misses so ' +
+      'bulk actions stay within the requested scope.'
     );
   }
   loadMissConfig().then(loadMisses);

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -300,33 +300,19 @@
     border: 1px solid var(--border-primary);
     border-radius: 6px;
   }
-  .misses-filters {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
+  .misses-filterbar {
     margin: 0 0 12px;
     padding: 10px 12px;
     background: var(--bg-secondary);
     border: 1px solid var(--border-primary);
     border-radius: 6px;
   }
-  .misses-filters input,
-  .misses-filters select,
-  .misses-filters button {
-    min-height: 30px;
-    border: 1px solid var(--border-secondary);
-    border-radius: 4px;
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    padding: 5px 8px;
+  .misses-scope-reset {
+    margin: -4px 0 12px;
     font-size: 12px;
+    color: var(--text-secondary);
   }
-  .misses-filters input[type="search"] { flex: 1 1 220px; min-width: 160px; }
-  .misses-filters input[type="date"] { width: 130px; }
-  .misses-filters button { cursor: pointer; color: var(--text-secondary); }
-  .misses-filters button:hover { border-color: var(--accent); color: var(--text-primary); }
-  .misses-filter-label { font-size: 11px; color: var(--text-secondary); }
+  .misses-scope-reset a { color: var(--accent); }
   .misses-tuning-head {
     display: flex;
     align-items: center;
@@ -432,45 +418,11 @@
     </button>
   </div>
 
-  <div id="scopeBanner" style="display:none;padding:8px 12px;margin-bottom:12px;
-       background:var(--bg-tertiary);border:1px solid var(--border-primary);
-       border-radius:4px;font-size:12px;color:var(--text-secondary);">
-    Showing misses from the current pipeline run.
-    <a href="/misses" style="color:var(--accent);margin-left:8px;">Show all</a>
+  <div class="misses-filterbar">
+    {% include '_filterbar.html' %}
   </div>
-
-  <div class="misses-filters" aria-label="Miss filters">
-    <select id="missCollectionFilter" onchange="applyMissFilters()" title="Filter by collection">
-      <option value="">All collections</option>
-    </select>
-    <select id="missFolderFilter" onchange="applyMissFilters()" title="Filter by folder and its subfolders">
-      <option value="">All folders</option>
-    </select>
-    <input id="missSearchFilter" type="search" placeholder="Search keywords or filenames..."
-           autocomplete="off" oninput="scheduleMissFilter()"
-           onkeydown="if(event.key==='Enter'){event.preventDefault();applyMissFilters();}">
-    <select id="missRatingFilter" onchange="applyMissFilters()" title="Minimum star rating">
-      <option value="">Any rating</option>
-      <option value="1">1+ stars</option><option value="2">2+ stars</option>
-      <option value="3">3+ stars</option><option value="4">4+ stars</option>
-      <option value="5">5 stars</option>
-    </select>
-    <select id="missFlagFilter" onchange="applyMissFilters()" title="Filter by pick status">
-      <option value="">Any pick status</option>
-      <option value="none">Unflagged</option>
-      <option value="flagged">Picks</option>
-    </select>
-    <select id="missColorFilter" onchange="applyMissFilters()" title="Filter by color label">
-      <option value="">Any color</option>
-      <option value="red">Red</option><option value="yellow">Yellow</option>
-      <option value="green">Green</option><option value="blue">Blue</option>
-      <option value="purple">Purple</option>
-    </select>
-    <span class="misses-filter-label">Captured</span>
-    <input id="missDateFrom" type="date" onchange="applyMissFilters()" title="Captured from">
-    <span class="misses-filter-label">to</span>
-    <input id="missDateTo" type="date" onchange="applyMissFilters()" title="Captured through">
-    <button type="button" onclick="clearMissFilters()">Clear filters</button>
+  <div class="misses-scope-reset" id="scopeBanner" hidden>
+    Showing only the current pipeline run. <a href="/misses">Show all misses</a>
   </div>
 
   <div class="misses-tuning" id="missesTuning">
@@ -559,19 +511,9 @@ var missLightboxCurrent = null;
 // sections accumulates them all. The focused card doubles as the anchor for
 // shift-click range selection (range stays within the clicked category).
 var selection = new Set();
-var missFilterTimer = null;
 var missLoadRequestId = 0;
-var appliedMissFilters = new URLSearchParams();
-var MISS_FILTER_FIELDS = {
-  collection_id: 'missCollectionFilter',
-  folder_id: 'missFolderFilter',
-  keyword: 'missSearchFilter',
-  rating_min: 'missRatingFilter',
-  flag: 'missFlagFilter',
-  color_label: 'missColorFilter',
-  date_from: 'missDateFrom',
-  date_to: 'missDateTo',
-};
+var appliedMissFilters = { rules: [], visual: null };
+var initializingMissFilters = true;
 var MISS_TUNING_CONTROL_IDS = [
   'missCfgDetectorFloor',
   'missCfgNoSubject',
@@ -637,104 +579,125 @@ function getSinceParam() {
   } catch (e) { return null; }
 }
 
-function missFilterParams() {
-  var params = new URLSearchParams();
-  Object.keys(MISS_FILTER_FIELDS).forEach(function(key) {
-    var el = document.getElementById(MISS_FILTER_FIELDS[key]);
-    var value = el ? String(el.value || '').trim() : '';
-    if (value) params.set(key, value);
-  });
-  return params;
+function cloneMissFilterPayload(payload) {
+  return JSON.parse(JSON.stringify(payload || { rules: [], visual: null }));
 }
 
-function addFilterParamsToBody(body, params) {
-  params.forEach(function(value, key) { body[key] = value; });
+function missFilterPayload() {
+  var rules = [];
+  var visual = null;
+  if (window.VireoFilter && VireoFilter.getRules) {
+    rules = VireoFilter.getRules();
+    visual = VireoFilter.getVisual ? VireoFilter.getVisual() : null;
+  }
+  return { rules: rules || [], visual: visual || null };
+}
+
+function addFilterPayloadToBody(body, payload) {
+  body.rules = payload.rules || [];
+  if (payload.visual) body.visual = payload.visual;
   return body;
 }
 
-function addMissFiltersToBody(body) {
-  return addFilterParamsToBody(body, missFilterParams());
-}
-
 function addAppliedMissFiltersToBody(body) {
-  return addFilterParamsToBody(body, appliedMissFilters);
+  return addFilterPayloadToBody(body, appliedMissFilters);
 }
 
-function syncMissFilterUrl() {
-  var url = new URL(window.location.href);
-  Object.keys(MISS_FILTER_FIELDS).forEach(function(key) { url.searchParams.delete(key); });
-  missFilterParams().forEach(function(value, key) { url.searchParams.set(key, value); });
-  window.history.replaceState({}, '', url.pathname + (url.searchParams.toString() ? '?' + url.searchParams.toString() : ''));
+function sameMissFilterPayload(a, b) {
+  return JSON.stringify(a || {}) === JSON.stringify(b || {});
+}
+
+function missRulesContainField(node, field) {
+  if (Array.isArray(node)) {
+    return node.some(function(child) { return missRulesContainField(child, field); });
+  }
+  if (!node || typeof node !== 'object') return false;
+  if (node.field === field) return true;
+  return Array.isArray(node.rules) && node.rules.some(function(child) {
+    return missRulesContainField(child, field);
+  });
 }
 
 function applyMissFilters() {
-  if (missFilterTimer) clearTimeout(missFilterTimer);
-  missFilterTimer = null;
+  if (initializingMissFilters) return;
   invalidateMissPreview();
-  syncMissFilterUrl();
   selection.clear();
   focusedCategory = null;
   focusedIndex = -1;
   loadMisses();
 }
 
-function scheduleMissFilter() {
-  if (missFilterTimer) clearTimeout(missFilterTimer);
-  missFilterTimer = setTimeout(applyMissFilters, 250);
+function normalizedRuleRoot(raw) {
+  if (Array.isArray(raw)) return { mode: 'all', rules: raw };
+  if (raw && Array.isArray(raw.rules)) return raw;
+  return { mode: 'all', rules: [] };
 }
 
-function clearMissFilters() {
-  Object.keys(MISS_FILTER_FIELDS).forEach(function(key) {
-    var el = document.getElementById(MISS_FILTER_FIELDS[key]);
-    if (el) el.value = '';
-  });
-  applyMissFilters();
+function appendRuleRoot(target, source) {
+  var root = normalizedRuleRoot(source);
+  if (!root.rules.length) return;
+  if ((root.mode || 'all') === 'all') {
+    root.rules.forEach(function(rule) { target.rules.push(rule); });
+  } else {
+    target.rules.push(root);
+  }
 }
 
-async function initMissFilters() {
+async function applyLegacyMissScopes() {
   var current = new URL(window.location.href).searchParams;
-  var results = await Promise.all([
-    fetch('/api/collections').then(function(r) { return r.ok ? r.json() : []; }).catch(function() { return []; }),
-    fetch('/api/folders').then(function(r) { return r.ok ? r.json() : []; }).catch(function() { return []; }),
-  ]);
-  var collectionSelect = document.getElementById('missCollectionFilter');
-  (results[0] || []).forEach(function(c) {
-    var option = document.createElement('option');
-    option.value = c.id;
-    if (c.has_visual) {
-      // Misses filter consumes the collection via
-      // collection_photo_ids, which is rules-only — a visual
-      // collection would silently expand the filter to every
-      // metadata match. Server 400s the request too.
-      option.disabled = true;
-      option.textContent = c.name + ' (visual — open in Browse)';
-      option.title = 'Visual collections can only be used from Browse, where the filter bar resolves the visual-search clause.';
-    } else {
-      option.textContent = c.name + (c.photo_count == null ? '' : ' (' + c.photo_count + ')');
-      option.disabled = !!c.count_error;
+  var collectionId = parseInt(current.get('collection_id'), 10);
+  var folderId = parseInt(current.get('folder_id'), 10);
+  if (isNaN(collectionId) && isNaN(folderId)) return;
+
+  var legacyFilterKeys = [
+    'rating_min', 'flag', 'color_label', 'date_from', 'date_to', 'keyword',
+    'filters',
+  ];
+  var keepCompiledUrlRules = legacyFilterKeys.some(function(key) {
+    return current.has(key);
+  });
+  var combined = { mode: 'all', rules: [] };
+  if (keepCompiledUrlRules) appendRuleRoot(combined, VireoFilter.getUserRules());
+  // A plain folder/collection deep link overrides restored page state. Keep a
+  // visual clause only when it came from this URL's handoff payload; a visual
+  // collection below supplies its own clause explicitly.
+  var visual = keepCompiledUrlRules && VireoFilter.getVisual
+    ? VireoFilter.getVisual()
+    : null;
+
+  var requests = [];
+  requests.push(
+    isNaN(collectionId)
+      ? Promise.resolve([])
+      : fetch('/api/collections').then(function(r) { return r.ok ? r.json() : []; })
+          .catch(function() { return []; })
+  );
+  requests.push(
+    isNaN(folderId)
+      ? Promise.resolve([])
+      : fetch('/api/folders').then(function(r) { return r.ok ? r.json() : []; })
+          .catch(function() { return []; })
+  );
+  var results = await Promise.all(requests);
+
+  if (!isNaN(collectionId)) {
+    var collection = (results[0] || []).find(function(c) { return c.id === collectionId; });
+    if (collection && !collection.count_error) {
+      try { appendRuleRoot(combined, JSON.parse(collection.rules || '[]')); } catch (e) {}
+      try {
+        if (collection.visual_json) visual = JSON.parse(collection.visual_json);
+      } catch (e) {}
     }
-    collectionSelect.appendChild(option);
-  });
-  var folderSelect = document.getElementById('missFolderFilter');
-  (results[1] || []).slice().sort(function(a, b) {
-    return String(a.path || a.name || '').localeCompare(String(b.path || b.name || ''));
-  }).forEach(function(f) {
-    var option = document.createElement('option');
-    option.value = f.id;
-    option.textContent = f.path || f.name || ('Folder ' + f.id);
-    folderSelect.appendChild(option);
-  });
-  Object.keys(MISS_FILTER_FIELDS).forEach(function(key) {
-    var el = document.getElementById(MISS_FILTER_FIELDS[key]);
-    if (el && current.has(key)) el.value = current.get(key);
-  });
-  // Seed the applied-filters snapshot from the URL so recompute/bulk reject
-  // scope to the URL-requested review set if the user clicks before the first
-  // /api/misses response applies (e.g. /misses?rating_min=4). Without this,
-  // loadMissConfig() enables the Recompute button while appliedMissFilters is
-  // still empty, and an early click POSTs an unfiltered recompute that flags
-  // photos outside the URL scope.
-  appliedMissFilters = missFilterParams();
+  }
+  if (!isNaN(folderId)) {
+    var folder = (results[1] || []).find(function(f) { return f.id === folderId; });
+    if (folder) {
+      combined.rules.push({
+        field: 'folder', op: 'under', value: folder.path || folder.name || '',
+      });
+    }
+  }
+  VireoFilter.loadExpression(combined, visual, { reason: 'legacyScopeLoaded' });
 }
 
 function setMissTuningStatus(text) {
@@ -855,9 +818,9 @@ async function previewMisses() {
   }
   var requestId = ++previewRequestId;
   missLoadRequestId++;
-  var requestedFilters = missFilterParams();
+  var requestedFilters = missFilterPayload();
   var body = collectMissThresholds();
-  addFilterParamsToBody(body, requestedFilters);
+  addFilterPayloadToBody(body, requestedFilters);
   var since = getSinceParam();
   if (since) body.since = since;
   setMissTuningStatus('Previewing...');
@@ -870,7 +833,7 @@ async function previewMisses() {
     if (!r.ok) throw new Error('http ' + r.status);
     var data = await r.json();
     if (requestId !== previewRequestId) return;
-    appliedMissFilters = new URLSearchParams(requestedFilters.toString());
+    appliedMissFilters = cloneMissFilterPayload(requestedFilters);
     previewActive = true;
     previewPayload = data;
     applyMissesPayload(data);
@@ -888,9 +851,9 @@ async function recomputeMisses() {
   var btn = document.getElementById('missRecomputeBtn');
   // Recompute the photos that produced the cards the user is looking at.
   // Live controls may already represent a newer filter whose load is pending.
-  var requestedFilters = new URLSearchParams(appliedMissFilters.toString());
+  var requestedFilters = cloneMissFilterPayload(appliedMissFilters);
   var body = collectMissThresholds();
-  addFilterParamsToBody(body, requestedFilters);
+  addFilterPayloadToBody(body, requestedFilters);
   var since = getSinceParam();
   if (since) body.since = since;
   body.save_defaults = !!document.getElementById('missSaveDefaults').checked;
@@ -915,7 +878,7 @@ async function recomputeMisses() {
       loadMisses();
       return;
     }
-    if (missFilterParams().toString() !== requestedFilters.toString()) {
+    if (!sameMissFilterPayload(missFilterPayload(), requestedFilters)) {
       if (data.config && data.saved_defaults) {
         missConfig = data.config;
         originalMissConfig = Object.assign({}, data.config);
@@ -924,7 +887,7 @@ async function recomputeMisses() {
       loadMisses();
       return;
     }
-    appliedMissFilters = new URLSearchParams(requestedFilters.toString());
+    appliedMissFilters = cloneMissFilterPayload(requestedFilters);
     previewActive = false;
     previewPayload = null;
     applyMissesPayload(data);
@@ -965,6 +928,12 @@ function applyMissesPayload(data) {
   selection.forEach(function(id) {
     if (!present.has(id)) selection.delete(id);
   });
+  if (window.VireoFilter && VireoFilter.setResultTotal) {
+    VireoFilter.setResultTotal(present.size);
+  }
+  if (window.VireoFilter && VireoFilter.setVisualInfo) {
+    VireoFilter.setVisualInfo(data.visual || null);
+  }
   render();
 }
 
@@ -972,10 +941,8 @@ function applyMissesPayload(data) {
 async function loadMisses() {
   var requestId = ++missLoadRequestId;
   var since = getSinceParam();
-  if (since) {
-    var b = document.getElementById('scopeBanner');
-    if (b) b.style.display = '';
-  }
+  var b = document.getElementById('scopeBanner');
+  if (b) b.hidden = !since;
   if (previewActive) {
     // Re-derive from the preview endpoint with the live slider values
     // instead of replaying a cached payload that a mutating action may
@@ -983,11 +950,14 @@ async function loadMisses() {
     await previewMisses();
     return;
   }
-  var requestedFilters = missFilterParams();
-  var params = new URLSearchParams(requestedFilters.toString());
-  if (since) params.set('since', since);
-  var url = '/api/misses' + (params.toString() ? '?' + params.toString() : '');
-  var r = await fetch(url);
+  var requestedFilters = missFilterPayload();
+  var body = addFilterPayloadToBody({}, requestedFilters);
+  if (since) body.since = since;
+  var r = await fetch('/api/misses', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
   if (requestId !== missLoadRequestId) return;
   if (!r.ok) {
     document.getElementById('missesRoot').innerHTML =
@@ -996,7 +966,7 @@ async function loadMisses() {
   }
   var data = await r.json();
   if (requestId !== missLoadRequestId) return;
-  appliedMissFilters = new URLSearchParams(requestedFilters.toString());
+  appliedMissFilters = cloneMissFilterPayload(requestedFilters);
   applyMissesPayload(data);
 }
 
@@ -1297,7 +1267,7 @@ function _clearMissRepresentativeStateIfIneligible(photoIds, flag) {
  * disappear on the next loadMisses() (list_misses excludes flag='rejected').
  */
 function refreshAppliedFlagFilter() {
-  if (appliedMissFilters.has('flag')) loadMisses();
+  if (missRulesContainField(appliedMissFilters.rules, 'flag')) loadMisses();
 }
 
 async function flagFocusedMiss(photoId, flag) {
@@ -1824,9 +1794,27 @@ document.addEventListener('lightbox:flagchanged', function(e) {
 
 /* ---------- Boot ---------- */
 installMissSliderHandlers();
-initMissFilters().then(function() {
+var missSince = getSinceParam();
+VireoFilter.init({
+  page: 'misses',
+  root: document.getElementById('vireoFilterBar'),
+  scopeLabel: missSince
+    ? 'Misses \u00b7 Current pipeline run'
+    : 'Misses \u00b7 Detected misses',
+  onChange: applyMissFilters,
+}).then(function() {
+  return applyLegacyMissScopes();
+}).then(function() {
+  // Seed the applied-expression snapshot before threshold controls become
+  // enabled. An immediate Recompute therefore scopes to the expression that
+  // produced the initial grid, including legacy deep links and handoffs.
+  appliedMissFilters = cloneMissFilterPayload(missFilterPayload());
+  initializingMissFilters = false;
   return loadMissConfig();
-}).then(loadMisses);
+}).then(loadMisses).catch(function() {
+  initializingMissFilters = false;
+  loadMissConfig().then(loadMisses);
+});
 </script>
 
 </body>

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1974,6 +1974,17 @@ VireoFilter.init({
   return loadMissConfig();
 }).then(loadMisses).catch(function() {
   initializingMissFilters = false;
+  var current = new URL(window.location.href).searchParams;
+  if (current.has('collection_id') || current.has('folder_id')) {
+    // If the shared registry/bootstrap fails, applyLegacyMissScopes() never
+    // gets a chance to translate the legacy URL into universal rules. Keep
+    // the page closed instead of loading the default empty expression, which
+    // would expose every miss to bulk actions outside the requested scope.
+    noteLegacyScopeError(
+      'Could not initialize filters to resolve this collection or folder ' +
+      'deep link. Showing no misses so bulk actions stay within the requested scope.'
+    );
+  }
   loadMissConfig().then(loadMisses);
 });
 </script>

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1801,6 +1801,7 @@ VireoFilter.init({
   scopeLabel: missSince
     ? 'Misses \u00b7 Current pipeline run'
     : 'Misses \u00b7 Detected misses',
+  excludedValues: { flag: ['rejected'] },
   onChange: applyMissFilters,
 }).then(function() {
   return applyLegacyMissScopes();

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -701,11 +701,29 @@ function renderMissScopeBanner() {
   b.hidden = !message;
 }
 
+function parseLegacyScopeParam(params, key) {
+  if (!params.has(key)) return { present: false, valid: true, value: null };
+  var raw = params.get(key);
+  var normalized = String(raw == null ? '' : raw).trim();
+  if (!/^[+-]?\d+$/.test(normalized)) {
+    return { present: true, valid: false, value: null, raw: raw };
+  }
+  var value = Number(normalized);
+  if (!Number.isSafeInteger(value)) {
+    return { present: true, valid: false, value: null, raw: raw };
+  }
+  return { present: true, valid: true, value: value, raw: raw };
+}
+
 async function applyLegacyMissScopes() {
   var current = new URL(window.location.href).searchParams;
-  var collectionId = parseInt(current.get('collection_id'), 10);
-  var folderId = parseInt(current.get('folder_id'), 10);
-  if (isNaN(collectionId) && isNaN(folderId)) return;
+  var collectionParam = parseLegacyScopeParam(current, 'collection_id');
+  var folderParam = parseLegacyScopeParam(current, 'folder_id');
+  if (!collectionParam.present && !folderParam.present) return;
+  var collectionId = collectionParam.present && collectionParam.valid
+    ? collectionParam.value : NaN;
+  var folderId = folderParam.present && folderParam.valid
+    ? folderParam.value : NaN;
 
   var legacyFilterKeys = [
     'rating_min', 'flag', 'color_label', 'date_from', 'date_to', 'keyword',
@@ -722,6 +740,19 @@ async function applyLegacyMissScopes() {
   var visual = keepCompiledUrlRules && VireoFilter.getVisual
     ? VireoFilter.getVisual()
     : null;
+
+  if (!collectionParam.valid) {
+    noteLegacyScopeError(
+      'Invalid ?collection_id=' + collectionParam.raw + ' deep link. ' +
+      'Showing no misses so bulk actions do not touch the wrong collection.'
+    );
+  }
+  if (!folderParam.valid) {
+    noteLegacyScopeError(
+      'Invalid ?folder_id=' + folderParam.raw + ' deep link. ' +
+      'Showing no misses so bulk actions do not touch the wrong folder.'
+    );
+  }
 
   // Track fetch failures separately from empty responses: a failed
   // /api/collections must fail closed instead of being treated as an

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -514,6 +514,14 @@ var selection = new Set();
 var missLoadRequestId = 0;
 var appliedMissFilters = { rules: [], visual: null };
 var initializingMissFilters = true;
+// Set when a ?collection_id=/?folder_id= deep link points at a scope we can't
+// resolve at boot (deleted collection/folder, degraded collection, or a
+// /api/collections|/api/folders fetch failure). Skipping the missing rule
+// silently would widen the initial /api/misses POST to the entire workspace,
+// and bulk reject/recompute would then operate on photos the user never
+// scoped. Fail closed instead: render an empty grid with an explanatory
+// banner and block recompute until the user edits the filter bar.
+var legacyScopeError = null;
 var MISS_TUNING_CONTROL_IDS = [
   'missCfgDetectorFloor',
   'missCfgNoSubject',
@@ -620,11 +628,26 @@ function missRulesContainField(node, field) {
 
 function applyMissFilters() {
   if (initializingMissFilters) return;
+  // A user-driven filter change replaces the unresolved deep-link scope with
+  // whatever they typed, so the fail-closed guard no longer applies.
+  clearLegacyScopeError();
   invalidateMissPreview();
   selection.clear();
   focusedCategory = null;
   focusedIndex = -1;
   loadMisses();
+}
+
+function clearLegacyScopeError() {
+  if (!legacyScopeError) return;
+  legacyScopeError = null;
+  var b = document.getElementById('scopeBanner');
+  if (b) {
+    b.hidden = true;
+    b.textContent = '';
+  }
+  // Recompute stays disabled until loadMissConfig re-enables it via its
+  // normal control-enablement path; don't force it on here.
 }
 
 function normalizedRuleRoot(raw) {
@@ -641,6 +664,28 @@ function appendRuleRoot(target, source) {
   } else {
     target.rules.push(root);
   }
+}
+
+function noteLegacyScopeError(message) {
+  // Append when multiple deep-link params fail (e.g. a link with both a
+  // missing collection and a missing folder) so the banner surfaces both.
+  legacyScopeError = legacyScopeError
+    ? legacyScopeError + ' ' + message
+    : message;
+  if (typeof showToast === 'function') showToast(message, 'error');
+  var b = document.getElementById('scopeBanner');
+  if (b) {
+    // Rebuild via textContent + a fresh anchor node so a collection name
+    // that contains HTML metacharacters can't inject markup into the page.
+    b.textContent = legacyScopeError + ' ';
+    var reset = document.createElement('a');
+    reset.href = '/misses';
+    reset.textContent = 'Show all misses';
+    b.appendChild(reset);
+    b.hidden = false;
+  }
+  var recomputeBtn = document.getElementById('missRecomputeBtn');
+  if (recomputeBtn) recomputeBtn.disabled = true;
 }
 
 async function applyLegacyMissScopes() {
@@ -665,36 +710,77 @@ async function applyLegacyMissScopes() {
     ? VireoFilter.getVisual()
     : null;
 
+  // Track fetch failures separately from empty responses: a failed
+  // /api/collections must fail closed instead of being treated as an
+  // empty list (which would silently drop the collection rule and load
+  // every miss in the workspace).
+  var collectionsFetchFailed = false;
+  var foldersFetchFailed = false;
   var requests = [];
   requests.push(
     isNaN(collectionId)
       ? Promise.resolve([])
-      : fetch('/api/collections').then(function(r) { return r.ok ? r.json() : []; })
-          .catch(function() { return []; })
+      : fetch('/api/collections').then(function(r) {
+          if (!r.ok) { collectionsFetchFailed = true; return []; }
+          return r.json();
+        }).catch(function() { collectionsFetchFailed = true; return []; })
   );
   requests.push(
     isNaN(folderId)
       ? Promise.resolve([])
-      : fetch('/api/folders').then(function(r) { return r.ok ? r.json() : []; })
-          .catch(function() { return []; })
+      : fetch('/api/folders').then(function(r) {
+          if (!r.ok) { foldersFetchFailed = true; return []; }
+          return r.json();
+        }).catch(function() { foldersFetchFailed = true; return []; })
   );
   var results = await Promise.all(requests);
 
   if (!isNaN(collectionId)) {
-    var collection = (results[0] || []).find(function(c) { return c.id === collectionId; });
-    if (collection && !collection.count_error) {
-      try { appendRuleRoot(combined, JSON.parse(collection.rules || '[]')); } catch (e) {}
-      try {
-        if (collection.visual_json) visual = JSON.parse(collection.visual_json);
-      } catch (e) {}
+    if (collectionsFetchFailed) {
+      noteLegacyScopeError(
+        'Could not load collections to resolve the ?collection_id=' +
+        collectionId + ' deep link. Showing no misses to avoid ' +
+        'bulk-rejecting the whole workspace.'
+      );
+    } else {
+      var collection = (results[0] || []).find(function(c) { return c.id === collectionId; });
+      if (!collection) {
+        noteLegacyScopeError(
+          'Collection #' + collectionId + ' is missing or was deleted. ' +
+          'Showing no misses so bulk actions do not touch the whole workspace.'
+        );
+      } else if (collection.count_error) {
+        noteLegacyScopeError(
+          'Collection "' + (collection.name || ('#' + collectionId)) +
+          '" is degraded (' + collection.count_error + '). ' +
+          'Showing no misses so bulk actions do not touch the whole workspace.'
+        );
+      } else {
+        try { appendRuleRoot(combined, JSON.parse(collection.rules || '[]')); } catch (e) {}
+        try {
+          if (collection.visual_json) visual = JSON.parse(collection.visual_json);
+        } catch (e) {}
+      }
     }
   }
   if (!isNaN(folderId)) {
-    var folder = (results[1] || []).find(function(f) { return f.id === folderId; });
-    if (folder) {
-      combined.rules.push({
-        field: 'folder', op: 'under', value: folder.path || folder.name || '',
-      });
+    if (foldersFetchFailed) {
+      noteLegacyScopeError(
+        'Could not load folders to resolve the ?folder_id=' + folderId +
+        ' deep link. Showing no misses to avoid bulk-rejecting the whole workspace.'
+      );
+    } else {
+      var folder = (results[1] || []).find(function(f) { return f.id === folderId; });
+      if (folder) {
+        combined.rules.push({
+          field: 'folder', op: 'under', value: folder.path || folder.name || '',
+        });
+      } else {
+        noteLegacyScopeError(
+          'Folder #' + folderId + ' is missing or was removed. ' +
+          'Showing no misses so bulk actions do not touch the whole workspace.'
+        );
+      }
     }
   }
   VireoFilter.loadExpression(combined, visual, { reason: 'legacyScopeLoaded' });
@@ -942,7 +1028,21 @@ async function loadMisses() {
   var requestId = ++missLoadRequestId;
   var since = getSinceParam();
   var b = document.getElementById('scopeBanner');
-  if (b) b.hidden = !since;
+  // The scope banner doubles as the deep-link error surface; only reset it
+  // to the ``since`` label when we're not currently reporting a failure.
+  if (b && !legacyScopeError) b.hidden = !since;
+  if (legacyScopeError) {
+    // Deep link couldn't be resolved: render an empty grid so bulk reject
+    // and recompute have nothing to accidentally widen to. The applied
+    // filter snapshot stays empty; a subsequent user filter edit calls
+    // clearLegacyScopeError() and loadMisses() again with the new scope.
+    missesData = { no_subject: [], clipped: [], oof: [] };
+    appliedMissFilters = cloneMissFilterPayload(missFilterPayload());
+    render();
+    var recomputeBtn = document.getElementById('missRecomputeBtn');
+    if (recomputeBtn) recomputeBtn.disabled = true;
+    return;
+  }
   if (previewActive) {
     // Re-derive from the preview endpoint with the live slider values
     // instead of replaying a cached payload that a mutating action may

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -899,7 +899,9 @@ async function loadMissConfig() {
     // Keep the tuning group frozen when a fail-closed scope is in effect;
     // loadMisses() will re-enable it once a user-supplied replacement
     // filter loads successfully.
-    if (!legacyScopeError) setMissTuningDisabled(false);
+    if (!legacyScopeError && !legacyScopeRecoveryPending) {
+      setMissTuningDisabled(false);
+    }
     setMissTuningStatus('Preview uses current sliders');
   } catch (e) {
     setMissTuningStatus('Thresholds unavailable');
@@ -908,7 +910,7 @@ async function loadMissConfig() {
 
 function scheduleMissPreview() {
   if (!missConfigLoaded) return;
-  if (legacyScopeError) return;
+  if (legacyScopeError || legacyScopeRecoveryPending) return;
   if (previewTimer) clearTimeout(previewTimer);
   previewTimer = setTimeout(previewMisses, 250);
 }
@@ -919,7 +921,7 @@ async function previewMisses() {
   // unresolved, but any caller that reaches here anyway must not POST the
   // empty rule payload to /api/misses/preview and repopulate the grid with
   // photos outside the user's scope.
-  if (legacyScopeError) return;
+  if (legacyScopeError || legacyScopeRecoveryPending) return;
   if (previewTimer) {
     clearTimeout(previewTimer);
     previewTimer = null;
@@ -954,7 +956,7 @@ async function previewMisses() {
 
 async function recomputeMisses() {
   if (!missConfigLoaded) return;
-  if (legacyScopeError) return;
+  if (legacyScopeError || legacyScopeRecoveryPending) return;
   invalidateMissPreview();
   var requestId = ++missLoadRequestId;
   var btn = document.getElementById('missRecomputeBtn');
@@ -1010,13 +1012,15 @@ async function recomputeMisses() {
     setMissTuningStatus('Recompute failed');
     if (typeof showToast === 'function') showToast('Recompute failed', 'error');
   } finally {
-    if (btn && missConfigLoaded) btn.disabled = false;
+    if (btn && missConfigLoaded && !legacyScopeError && !legacyScopeRecoveryPending) {
+      btn.disabled = false;
+    }
   }
 }
 
 function resetMissThresholds() {
   if (!missConfigLoaded || !originalMissConfig) return;
-  if (legacyScopeError) return;
+  if (legacyScopeError || legacyScopeRecoveryPending) return;
   invalidateMissPreview();
   setMissSliders(originalMissConfig);
   previewActive = false;

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -642,9 +642,11 @@ function applyMissFilters() {
 function clearLegacyScopeError() {
   if (!legacyScopeError) return;
   legacyScopeError = null;
-  // Keep Recompute disabled until the replacement expression has loaded.
-  // Re-enabling it here would briefly let a fast click recompute the empty
-  // fail-closed snapshot (effectively the whole workspace).
+  // Keep the tuning controls (sliders, save-defaults, reset, Recompute)
+  // disabled until the replacement expression has loaded. Re-enabling them
+  // here would briefly let a slider nudge preview — or a fast Recompute
+  // click — operate on the empty fail-closed snapshot, which the preview
+  // endpoint would widen back to the whole workspace.
   legacyScopeRecoveryPending = true;
   renderMissScopeBanner();
 }
@@ -673,8 +675,12 @@ function noteLegacyScopeError(message) {
     : message;
   if (typeof showToast === 'function') showToast(message, 'error');
   renderMissScopeBanner();
-  var recomputeBtn = document.getElementById('missRecomputeBtn');
-  if (recomputeBtn) recomputeBtn.disabled = true;
+  // Freeze the whole tuning group — not just Recompute. Preview and reset
+  // still call /api/misses/preview with the current (empty) rules, which
+  // widens results to every miss outside the unresolved scope; card and
+  // selection handlers on that grid could then mutate photos the user
+  // never scoped. Sliders re-enable once a replacement scope loads.
+  setMissTuningDisabled(true);
 }
 
 function renderMissScopeBanner() {
@@ -890,7 +896,10 @@ async function loadMissConfig() {
     originalMissConfig = Object.assign({}, missConfig);
     setMissSliders(missConfig);
     missConfigLoaded = true;
-    setMissTuningDisabled(false);
+    // Keep the tuning group frozen when a fail-closed scope is in effect;
+    // loadMisses() will re-enable it once a user-supplied replacement
+    // filter loads successfully.
+    if (!legacyScopeError) setMissTuningDisabled(false);
     setMissTuningStatus('Preview uses current sliders');
   } catch (e) {
     setMissTuningStatus('Thresholds unavailable');
@@ -899,12 +908,18 @@ async function loadMissConfig() {
 
 function scheduleMissPreview() {
   if (!missConfigLoaded) return;
+  if (legacyScopeError) return;
   if (previewTimer) clearTimeout(previewTimer);
   previewTimer = setTimeout(previewMisses, 250);
 }
 
 async function previewMisses() {
   if (!missConfigLoaded) return;
+  // Defense in depth: sliders are disabled while a deep-link scope is
+  // unresolved, but any caller that reaches here anyway must not POST the
+  // empty rule payload to /api/misses/preview and repopulate the grid with
+  // photos outside the user's scope.
+  if (legacyScopeError) return;
   if (previewTimer) {
     clearTimeout(previewTimer);
     previewTimer = null;
@@ -939,6 +954,7 @@ async function previewMisses() {
 
 async function recomputeMisses() {
   if (!missConfigLoaded) return;
+  if (legacyScopeError) return;
   invalidateMissPreview();
   var requestId = ++missLoadRequestId;
   var btn = document.getElementById('missRecomputeBtn');
@@ -1000,6 +1016,7 @@ async function recomputeMisses() {
 
 function resetMissThresholds() {
   if (!missConfigLoaded || !originalMissConfig) return;
+  if (legacyScopeError) return;
   invalidateMissPreview();
   setMissSliders(originalMissConfig);
   previewActive = false;
@@ -1074,8 +1091,7 @@ async function loadMisses() {
   applyMissesPayload(data);
   if (legacyScopeRecoveryPending) {
     legacyScopeRecoveryPending = false;
-    var recomputeBtn = document.getElementById('missRecomputeBtn');
-    if (recomputeBtn && missConfigLoaded) recomputeBtn.disabled = false;
+    if (missConfigLoaded) setMissTuningDisabled(false);
   }
 }
 

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -522,6 +522,7 @@ var initializingMissFilters = true;
 // scoped. Fail closed instead: render an empty grid with an explanatory
 // banner and block recompute until the user edits the filter bar.
 var legacyScopeError = null;
+var legacyScopeRecoveryPending = false;
 var MISS_TUNING_CONTROL_IDS = [
   'missCfgDetectorFloor',
   'missCfgNoSubject',
@@ -641,13 +642,11 @@ function applyMissFilters() {
 function clearLegacyScopeError() {
   if (!legacyScopeError) return;
   legacyScopeError = null;
-  var b = document.getElementById('scopeBanner');
-  if (b) {
-    b.hidden = true;
-    b.textContent = '';
-  }
-  // Recompute stays disabled until loadMissConfig re-enables it via its
-  // normal control-enablement path; don't force it on here.
+  // Keep Recompute disabled until the replacement expression has loaded.
+  // Re-enabling it here would briefly let a fast click recompute the empty
+  // fail-closed snapshot (effectively the whole workspace).
+  legacyScopeRecoveryPending = true;
+  renderMissScopeBanner();
 }
 
 function normalizedRuleRoot(raw) {
@@ -673,19 +672,27 @@ function noteLegacyScopeError(message) {
     ? legacyScopeError + ' ' + message
     : message;
   if (typeof showToast === 'function') showToast(message, 'error');
+  renderMissScopeBanner();
+  var recomputeBtn = document.getElementById('missRecomputeBtn');
+  if (recomputeBtn) recomputeBtn.disabled = true;
+}
+
+function renderMissScopeBanner() {
   var b = document.getElementById('scopeBanner');
-  if (b) {
-    // Rebuild via textContent + a fresh anchor node so a collection name
-    // that contains HTML metacharacters can't inject markup into the page.
-    b.textContent = legacyScopeError + ' ';
+  if (!b) return;
+  var since = getSinceParam();
+  var message = legacyScopeError || (since
+    ? 'Showing only the current pipeline run.'
+    : '');
+  b.textContent = message ? message + ' ' : '';
+  if (message) {
+    // Build the link as a node so collection names and API errors remain text.
     var reset = document.createElement('a');
     reset.href = '/misses';
     reset.textContent = 'Show all misses';
     b.appendChild(reset);
-    b.hidden = false;
   }
-  var recomputeBtn = document.getElementById('missRecomputeBtn');
-  if (recomputeBtn) recomputeBtn.disabled = true;
+  b.hidden = !message;
 }
 
 async function applyLegacyMissScopes() {
@@ -1027,10 +1034,7 @@ function applyMissesPayload(data) {
 async function loadMisses() {
   var requestId = ++missLoadRequestId;
   var since = getSinceParam();
-  var b = document.getElementById('scopeBanner');
-  // The scope banner doubles as the deep-link error surface; only reset it
-  // to the ``since`` label when we're not currently reporting a failure.
-  if (b && !legacyScopeError) b.hidden = !since;
+  renderMissScopeBanner();
   if (legacyScopeError) {
     // Deep link couldn't be resolved: render an empty grid so bulk reject
     // and recompute have nothing to accidentally widen to. The applied
@@ -1068,6 +1072,11 @@ async function loadMisses() {
   if (requestId !== missLoadRequestId) return;
   appliedMissFilters = cloneMissFilterPayload(requestedFilters);
   applyMissesPayload(data);
+  if (legacyScopeRecoveryPending) {
+    legacyScopeRecoveryPending = false;
+    var recomputeBtn = document.getElementById('missRecomputeBtn');
+    if (recomputeBtn && missConfigLoaded) recomputeBtn.disabled = false;
+  }
 }
 
 function render() {

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1016,6 +1016,23 @@ VireoFilter.init({
   root: document.getElementById('vireoFilterBar'),
   scopeLabel: 'Review \u00b7 Predictions',
   onChange: loadPredictions,
+  // Review keeps its collection scope outside the filter tree and passes
+  // it separately as ``collection_id`` on /api/predictions. The Misses
+  // handoff payload only serializes ``state.root``/``state.visual``, so
+  // without exposing this scope the handoff menu would offer Misses under
+  // a Review-collection view and land on workspace-wide misses matching
+  // the chip \u2014 with bulk reject/recompute enabled against photos
+  // outside the source collection (Codex review r3627997828).
+  getScope: function() {
+    if (currentCollection === 'all') {
+      return { folder_id: null, collection_id: null };
+    }
+    var collId = parseInt(currentCollection, 10);
+    return {
+      folder_id: null,
+      collection_id: isNaN(collId) ? null : collId,
+    };
+  },
 }).then(function() {
   // Restored/deep-linked filters weren't part of the first fetch above.
   if (VireoFilter.hasFilters()) loadPredictions();

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1014,7 +1014,7 @@ loadCollectionFilter();
 VireoFilter.init({
   page: 'review',
   root: document.getElementById('vireoFilterBar'),
-  scopeLabel: 'Review \u00b7 Pending predictions',
+  scopeLabel: 'Review \u00b7 Predictions',
   onChange: loadPredictions,
 }).then(function() {
   // Restored/deep-linked filters weren't part of the first fetch above.

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -79,7 +79,6 @@ GET          /api/location-review/saved-suggestions
 GET          /api/logs/recent
 GET          /api/logs/stream
 GET          /api/masks/<int:pid>/<variant>.png
-GET          /api/misses
 GET          /api/misses/config
 GET          /api/models
 GET          /api/models/pipeline
@@ -194,6 +193,7 @@ GET          /variants
 GET          /welcome
 GET          /workspace
 GET,POST     /api/edit-presets
+GET,POST     /api/misses
 GET,POST     /api/pipeline/config
 PATCH        /api/settings/global
 PATCH        /api/settings/workspace

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -99,6 +99,24 @@ def test_api_misses_filter_by_category(client, db_with_misses):
     assert len(data["photos"]) == 1
 
 
+def test_api_misses_category_preserves_visual_info(
+    client, db_with_misses, monkeypatch,
+):
+    import models
+
+    monkeypatch.setattr(models, "get_active_model", lambda: None)
+    r = client.post("/api/misses", json={
+        "category": "clipped",
+        "rules": [],
+        "visual": {"prompt": "bird", "strength": "balanced"},
+    })
+
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["category"] == "clipped"
+    assert data["visual"]["status"] == "no_model"
+
+
 def test_api_misses_filters_by_collection_and_browse_attributes(
     client, db_with_misses,
 ):
@@ -146,6 +164,54 @@ def test_api_misses_accepts_universal_filter_rules(client, db_with_misses):
     assert data["no_subject"] == []
     assert [p["id"] for p in data["clipped"]] == [ids["clipped"]]
     assert data["oof"] == []
+
+
+def test_api_misses_forwards_collection_to_rule_and_visual_queries(
+    client, db_with_misses, monkeypatch,
+):
+    import models
+
+    _, db, ids = db_with_misses
+    collection_id = db.add_collection(
+        "One miss",
+        json.dumps([{
+            "field": "photo_ids",
+            "value": [ids["clipped"]],
+        }]),
+    )
+    original = type(db).query_photo_ids
+    seen_collection_ids = []
+
+    def tracked_query_photo_ids(self, rules, *args, **kwargs):
+        seen_collection_ids.append(kwargs.get("collection_id"))
+        return original(self, rules, *args, **kwargs)
+
+    monkeypatch.setattr(type(db), "query_photo_ids", tracked_query_photo_ids)
+    r = client.post("/api/misses", json={
+        "collection_id": collection_id,
+        "rules": [{"field": "rating", "op": ">=", "value": 0}],
+    })
+
+    assert r.status_code == 200
+    assert collection_id in seen_collection_ids
+    assert [p["id"] for p in r.get_json()["clipped"]] == [ids["clipped"]]
+
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "name": "test-model",
+        "model_type": "bioclip",
+        "model_str": "test-model",
+    })
+    visual = client.post("/api/misses", json={
+        "collection_id": collection_id,
+        "rules": [],
+        "visual": {"prompt": "bird", "strength": "balanced"},
+    })
+
+    assert visual.status_code == 200
+    visual_info = visual.get_json()["visual"]
+    assert visual_info["status"] == "no_embeddings"
+    assert visual_info["candidates"] == 1
+    assert seen_collection_ids.count(collection_id) >= 2
 
 
 def test_api_misses_actions_accept_universal_filter_rules(

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -127,6 +127,64 @@ def test_api_misses_filters_by_collection_and_browse_attributes(
     assert data["oof"] == []
 
 
+def test_api_misses_accepts_universal_filter_rules(client, db_with_misses):
+    _, db, ids = db_with_misses
+    db.update_photo_rating(ids["no_subject"], 2)
+    db.update_photo_rating(ids["clipped"], 5)
+    rules = {
+        "mode": "all",
+        "rules": [
+            {"field": "rating", "op": ">=", "value": 4},
+            {"field": "filename", "op": "contains", "value": "clip"},
+        ],
+    }
+
+    r = client.post("/api/misses", json={"rules": rules})
+
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["no_subject"] == []
+    assert [p["id"] for p in data["clipped"]] == [ids["clipped"]]
+    assert data["oof"] == []
+
+
+def test_api_misses_actions_accept_universal_filter_rules(
+    client, db_with_misses,
+):
+    _, db, ids = db_with_misses
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1 WHERE id=?", (ids["no_subject"],)
+    )
+    db.conn.commit()
+    rules = {
+        "mode": "all",
+        "rules": [{"field": "photo_ids", "op": "in", "value": [ids["clipped"]]}],
+    }
+
+    reject = client.post(
+        "/api/misses/reject",
+        data=json.dumps({"category": "clipped", "rules": rules}),
+        content_type="application/json",
+    )
+
+    assert reject.status_code == 200
+    assert reject.get_json()["rejected"] == 1
+    assert db.get_photo(ids["clipped"])["flag"] == "rejected"
+    assert db.get_photo(ids["no_subject"])["flag"] != "rejected"
+
+
+def test_api_misses_rejects_malformed_universal_rules(client):
+    r = client.get("/api/misses", query_string={"rules": "not-json"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "rules and visual must be valid JSON"
+
+
+def test_api_misses_post_requires_object_body(client):
+    r = client.post("/api/misses", json=[])
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "request body must be a JSON object"
+
+
 def test_api_misses_reject_and_recompute_honor_collection_filter(
     client, db_with_misses,
 ):
@@ -505,14 +563,11 @@ def test_api_misses_since_restricts_to_recent_run(client, db_with_misses):
 
 
 def test_api_misses_rejects_visual_collection(client, db_with_misses):
-    """The Misses page filter funnels ``collection_id`` through
-    ``collection_photo_ids``, which evaluates ``rules`` only. A visual
-    collection would silently widen the miss scope to every metadata
-    match instead of the visually-matched subset — Codex review
-    r3620423210 on PR #1343 flagged the equivalent risk for
-    ``/api/collections/<id>/photos``; the misses filter has the same
-    boundary. Reject with 400 so the front-end picker (which disables
-    the same options) has a defense-in-depth backstop.
+    """The legacy Misses ``collection_id`` shim evaluates ``rules`` only.
+
+    A visual collection would silently widen the miss scope to every metadata
+    match instead of the visually matched subset. The shared-bar page sends
+    rules + visual directly, but old API callers still need this boundary.
     """
     _, db, _ = db_with_misses
     visual_cid = db.add_collection(


### PR DESCRIPTION
Standardizes the Misses page on the shared universal filter bar, including persisted rule and visual filters, saved-collection/deep-link compatibility, accurate unique-photo totals, and cross-page handoff.
Preserves Misses-specific threshold controls, current-run scope, and action/race safety while adding a POST query path for rule trees too large for URLs and retaining legacy GET compatibility.
Corrects the Review scope label, removes obsolete Map filter CSS and stale Phase 4 comments, and updates the implementation plan and route contract.
Validation: 26 Misses API/route-contract tests, 40 relevant browser tests, 14 shared query/filter API tests, plus Python/JavaScript syntax and diff checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the universal filter bar to the Misses page, including cross-page handoff to Misses.
  * Added support for universal filter payloads (rules + visual) across Misses preview, recompute, and bulk actions.
  * Updated handoff logic to account for excluded/unavailable filter values.
* **Bug Fixes**
  * Strengthened fail-closed behavior for unresolved/invalid legacy scopes and sanitization of rejected-flag filters.
  * Prevented unavailable enum values from appearing in filter controls.
  * Updated Review scope label.
* **Tests**
  * Expanded end-to-end and API test coverage for Misses universal filtering, deep links, handoff sanitization, and validation.
* **Documentation**
  * Refreshed Phase 5 legacy filter documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->