### PR TITLE
Prevent large map views from freezing

### DIFF
--- a/tests/e2e/test_map_deep_link.py
+++ b/tests/e2e/test_map_deep_link.py
@@ -26,9 +26,24 @@ window.L = {
   },
   markerClusterGroup: function() {
     var layers = [];
+    window.__mapMarkerBatchSizes = [];
     return {
-      addLayer: function(marker) { layers.push(marker); return this; },
-      clearLayers: function() { layers = []; return this; },
+      addLayer: function(marker) {
+        layers.push(marker);
+        window.__mapMarkerCount = layers.length;
+        return this;
+      },
+      addLayers: function(markers) {
+        window.__mapMarkerBatchSizes.push(markers.length);
+        layers = layers.concat(markers);
+        window.__mapMarkerCount = layers.length;
+        return this;
+      },
+      clearLayers: function() {
+        layers = [];
+        window.__mapMarkerCount = 0;
+        return this;
+      },
       getBounds: function() { return [[0, 0], [1, 1]]; },
       zoomToShowLayer: function(marker, cb) {
         window.__zoomedToMarker = marker.getLatLng();
@@ -168,3 +183,64 @@ def test_map_photo_id_deep_link_is_one_shot_for_later_filters(live_server, page)
 
     expect(page.locator("#mapStatus")).to_contain_text("Showing 1 of 2 geolocated photos")
     expect(page.locator("#mapStatus")).not_to_contain_text("No map location found")
+
+
+def test_large_map_renders_in_bounded_batches_and_virtualizes_sidebar(
+    live_server, page
+):
+    """Large libraries must not monopolize or exhaust the browser main thread."""
+    photo_count = 2500
+    matching_count = 5000
+    photos = [
+        {
+            "id": index + 1,
+            "filename": f"photo-{index + 1}.jpg",
+            "latitude": 37.0 + (index % 100) / 1000,
+            "longitude": -122.0 - (index % 100) / 1000,
+            "timestamp": "2026-01-01T12:00:00",
+            "rating": 0,
+            "species": None,
+            "coord_source": "exif",
+            "keyword_location_name": None,
+            "folder_id": 1,
+            "edit_recipe": None,
+        }
+        for index in range(photo_count)
+    ]
+    payload = {
+        "photos": photos,
+        "total_filtered": matching_count,
+        "total_rendered": photo_count,
+        "render_limit": photo_count,
+        "truncated": True,
+        "total_photos": matching_count,
+        "total_geolocated": matching_count,
+        "total_without_coordinates": 0,
+    }
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.route("**/api/photos/geo**", lambda route: route.fulfill(json=payload))
+    page.goto(f"{live_server['url']}/map")
+
+    page.wait_for_function(
+        "count => window.__mapMarkerCount === count",
+        arg=photo_count,
+        timeout=15_000,
+    )
+    expect(page.locator("#mapStatus")).to_contain_text(
+        f"Showing {photo_count} of {matching_count} matching photos"
+    )
+    expect(page.locator("#mapStatus")).to_contain_text("refine the filters")
+
+    batch_sizes = page.evaluate("window.__mapMarkerBatchSizes")
+    assert len(batch_sizes) > 1
+    assert max(batch_sizes) <= 100
+
+    # The scroll area represents all results, but only the visible window and
+    # a small overscan are materialized (and allowed to request thumbnails).
+    rendered_cards = page.locator(".sidebar-card").count()
+    assert rendered_cards < 50
+    assert rendered_cards < photo_count
+
+    page.locator("#sidebarList").evaluate("el => { el.scrollTop = el.scrollHeight; }")
+    expect(page.locator(f".sidebar-card[data-id='{photo_count}']")).to_be_visible()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -124,6 +124,11 @@ log = logging.getLogger(__name__)
 # and leave the process in the wrong mode mid-probe.
 _WIN_ERROR_MODE_LOCK = threading.Lock()
 
+# A Leaflet marker is substantially heavier than its JSON source row. Keep a
+# hard ceiling as a final safety net for very large libraries; the Map UI
+# clearly reports truncation and lets users narrow the shared filters.
+MAP_RENDER_PHOTO_LIMIT = 10_000
+
 
 # Stable ordering and labels for the palette + nav rendering.
 # The `id` is the nav-id used in `tabs`; `href` is the canonical
@@ -6800,6 +6805,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_photos_geo():
         db = _get_db()
         folder_id = request.args.get("folder_id", None, type=int)
+        focus_photo_id = request.args.get("photo_id", None, type=int)
         try:
             rules = _request_rules_arg()
             visual = _request_visual_arg()
@@ -6841,12 +6847,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         total_without_coordinates = db.count_photos_without_coordinates()
         total_geolocated = total_photos - total_without_coordinates
 
-        photo_dicts = [dict(p) for p in photos]
+        total_filtered = len(photos)
+        visible_photos = list(photos[:MAP_RENDER_PHOTO_LIMIT])
+        # A deep-linked photo must remain reachable even when it falls beyond
+        # the safety ceiling in the default date ordering. Replace the last
+        # visible row rather than exceeding the bound.
+        if (
+            focus_photo_id is not None
+            and visible_photos
+            and all(p["id"] != focus_photo_id for p in visible_photos)
+        ):
+            focused = next((p for p in photos if p["id"] == focus_photo_id), None)
+            if focused is not None:
+                visible_photos[-1] = focused
+
+        photo_dicts = [dict(p) for p in visible_photos]
         _attach_edit_recipes(db, photo_dicts)
 
         response = {
             "photos": photo_dicts,
-            "total_filtered": len(photos),
+            "total_filtered": total_filtered,
+            "total_rendered": len(photo_dicts),
+            "render_limit": MAP_RENDER_PHOTO_LIMIT,
+            "truncated": total_filtered > len(photo_dicts),
             "total_photos": total_photos,
             "total_geolocated": total_geolocated,
             "total_without_coordinates": total_without_coordinates,

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -83,10 +83,23 @@ body { padding-bottom: 36px; }
 .sidebar-card {
   display: flex;
   gap: 8px;
+  box-sizing: border-box;
+  height: 69px;
   padding: 6px 10px;
   border-bottom: 1px solid var(--border, #1a4a5a);
   cursor: pointer;
   transition: background 0.15s;
+}
+
+.sidebar-virtual-spacer {
+  position: relative;
+  width: 100%;
+}
+
+.sidebar-virtual-spacer .sidebar-card {
+  position: absolute;
+  left: 0;
+  right: 0;
 }
 
 .sidebar-card:hover {
@@ -419,6 +432,17 @@ function formatDate(ts) {
 /* ── State for bi-directional sync ── */
 var photoMarkers = {};  /* photo id -> marker */
 var activePhotoId = null;
+/* Keep both kinds of map work bounded. Leaflet clustering is efficient once
+ * markers exist, but creating thousands of markers in one JavaScript turn
+ * still blocks navigation and animation. Likewise, a sidebar DOM node (and
+ * thumbnail) for every result can exhaust the webview on large libraries. */
+var MAP_RENDER_BATCH_SIZE = 100;
+var SIDEBAR_CARD_HEIGHT = 69;
+var SIDEBAR_OVERSCAN = 8;
+var sidebarPhotos = [];
+var sidebarPhotoIndexes = {};
+var sidebarSpacer = null;
+var sidebarRenderFrame = null;
 var requestedPhotoId = (function() {
   var raw = new URLSearchParams(window.location.search).get('photo_id');
   if (!raw) return null;
@@ -434,9 +458,17 @@ function setActiveCard(photoId) {
   activePhotoId = photoId;
   if (photoId !== null) {
     var card = document.querySelector('.sidebar-card[data-id="' + photoId + '"]');
+    if (!card && Object.prototype.hasOwnProperty.call(sidebarPhotoIndexes, photoId)) {
+      var list = document.getElementById('sidebarList');
+      list.scrollTop = Math.max(0,
+        sidebarPhotoIndexes[photoId] * SIDEBAR_CARD_HEIGHT
+          - Math.floor(list.clientHeight / 2));
+      renderSidebarWindow();
+      card = document.querySelector('.sidebar-card[data-id="' + photoId + '"]');
+    }
     if (card) {
       card.classList.add('active');
-      card.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      card.scrollIntoView({ block: 'nearest' });
     }
   }
 }
@@ -459,16 +491,13 @@ function photoThumbnailUrl(p) {
     : '/thumbnails/' + p.id + '.jpg';
 }
 
-/* ── Sidebar rendering ── */
-function renderSidebar(photos) {
-  var list = document.getElementById('sidebarList');
-  list.innerHTML = '';
-  document.getElementById('sidebarHeader').textContent = photos.length + ' photo' + (photos.length !== 1 ? 's' : '');
-
-  photos.forEach(function(p) {
+/* ── Virtualized sidebar rendering ── */
+function makeSidebarCard(p, index) {
     var card = document.createElement('div');
     card.className = 'sidebar-card';
+    if (p.id === activePhotoId) card.classList.add('active');
     card.setAttribute('data-id', p.id);
+    card.style.top = (index * SIDEBAR_CARD_HEIGHT) + 'px';
 
     var thumbSrc = photoThumbnailUrl(p);
     var color = getSpeciesColor(p.species);
@@ -478,7 +507,7 @@ function renderSidebar(photos) {
       : '';
 
     card.innerHTML =
-      (thumbSrc ? '<img src="' + escapeAttr(thumbSrc) + '" alt="" onerror="this.style.visibility=\'hidden\'">' : '<div style="width:56px;height:56px;background:var(--bg-tertiary,#14374E);border-radius:4px;flex-shrink:0"></div>')
+      (thumbSrc ? '<img src="' + escapeAttr(thumbSrc) + '" alt="" loading="lazy" decoding="async" onerror="this.style.visibility=\'hidden\'">' : '<div style="width:56px;height:56px;background:var(--bg-tertiary,#14374E);border-radius:4px;flex-shrink:0"></div>')
       + '<div class="card-info">'
       + '<div class="card-filename">' + escapeHtml(p.filename) + '</div>'
       + speciesHtml
@@ -489,9 +518,53 @@ function renderSidebar(photos) {
       openPhotoMarker(p.id);
     });
 
-    list.appendChild(card);
-  });
+    return card;
 }
+
+function renderSidebarWindow() {
+  if (!sidebarSpacer) return;
+  var list = document.getElementById('sidebarList');
+  var visibleCount = Math.max(1, Math.ceil(list.clientHeight / SIDEBAR_CARD_HEIGHT));
+  var start = Math.max(0,
+    Math.floor(list.scrollTop / SIDEBAR_CARD_HEIGHT) - SIDEBAR_OVERSCAN);
+  var end = Math.min(sidebarPhotos.length,
+    start + visibleCount + SIDEBAR_OVERSCAN * 2);
+  var fragment = document.createDocumentFragment();
+
+  for (var i = start; i < end; i++) {
+    fragment.appendChild(makeSidebarCard(sidebarPhotos[i], i));
+  }
+  sidebarSpacer.replaceChildren(fragment);
+}
+
+function renderSidebar(photos) {
+  var list = document.getElementById('sidebarList');
+  list.innerHTML = '';
+  list.scrollTop = 0;
+  sidebarPhotos = photos;
+  sidebarPhotoIndexes = {};
+  photos.forEach(function(p, index) { sidebarPhotoIndexes[p.id] = index; });
+  document.getElementById('sidebarHeader').textContent = photos.length + ' photo' + (photos.length !== 1 ? 's' : '');
+
+  if (photos.length === 0) {
+    sidebarSpacer = null;
+    return;
+  }
+
+  sidebarSpacer = document.createElement('div');
+  sidebarSpacer.className = 'sidebar-virtual-spacer';
+  sidebarSpacer.style.height = (photos.length * SIDEBAR_CARD_HEIGHT) + 'px';
+  list.appendChild(sidebarSpacer);
+  renderSidebarWindow();
+}
+
+document.getElementById('sidebarList').addEventListener('scroll', function() {
+  if (sidebarRenderFrame !== null) return;
+  sidebarRenderFrame = requestAnimationFrame(function() {
+    sidebarRenderFrame = null;
+    renderSidebarWindow();
+  });
+});
 
 /* ── Cluster preview ── */
 var clusterPreviewEl = document.getElementById('clusterPreview');
@@ -541,6 +614,74 @@ markers.on('clusterclick', hideClusterPreview);
  * current rules. */
 var _loadPhotosEpoch = 0;
 
+function nextMapRenderFrame() {
+  return new Promise(function(resolve) { requestAnimationFrame(resolve); });
+}
+
+function makePhotoMarker(p) {
+  var thumbSrc = photoThumbnailUrl(p);
+  var imgTag = thumbSrc
+    ? '<img src="' + escapeAttr(thumbSrc) + '" alt="" loading="lazy" decoding="async" onerror="this.style.display=\'none\'">'
+    : '';
+  var speciesLine = p.species
+    ? '<div class="popup-species">' + escapeHtml(p.species) + '</div>'
+    : '';
+
+  var provenanceLine = '';
+  if (p.coord_source === 'keyword' && p.keyword_location_name) {
+    provenanceLine = '<div class="popup-provenance">\u{1F4CD} from assigned location: '
+      + escapeHtml(p.keyword_location_name) + '</div>';
+  } else if (p.coord_source === 'exif') {
+    provenanceLine = '<div class="popup-provenance">\u{1F4CD} from EXIF GPS</div>';
+  }
+
+  var popup = '<div class="photo-popup">'
+    + imgTag
+    + '<div class="popup-title">' + escapeHtml(p.filename) + '</div>'
+    + '<div class="popup-meta">' + escapeHtml(formatDate(p.timestamp)) + ' ' + buildStars(p.rating) + '</div>'
+    + speciesLine
+    + '<a class="popup-link" href="/browse?photo_id=' + p.id + '">View in Browse &rarr;</a>'
+    + provenanceLine
+    + '</div>';
+
+  var marker = L.marker([p.latitude, p.longitude], {
+    icon: makeCircleIcon(getSpeciesColor(p.species)),
+  });
+  marker.bindPopup(popup);
+  marker._photoData = p;
+  marker.on('click', function() { setActiveCard(p.id); });
+  return marker;
+}
+
+async function renderPhotoMarkers(photos, epoch) {
+  for (var offset = 0; offset < photos.length; offset += MAP_RENDER_BATCH_SIZE) {
+    if (epoch !== _loadPhotosEpoch) return false;
+    var end = Math.min(offset + MAP_RENDER_BATCH_SIZE, photos.length);
+    var markerBatch = [];
+
+    for (var i = offset; i < end; i++) {
+      var p = photos[i];
+      var marker = makePhotoMarker(p);
+      photoMarkers[p.id] = marker;
+      markerBatch.push(marker);
+    }
+
+    /* addLayers() lets MarkerCluster process a bounded batch together. The
+     * old one-at-a-time addLayer() loop caused its clustering/layout work to
+     * monopolize the UI thread for large libraries. */
+    if (markers.addLayers) {
+      markers.addLayers(markerBatch);
+    } else {
+      markerBatch.forEach(function(marker) { markers.addLayer(marker); });
+    }
+
+    document.getElementById('mapStatus').textContent =
+      'Plotting ' + end + ' of ' + photos.length + ' photos\u2026';
+    if (end < photos.length) await nextMapRenderFrame();
+  }
+  return epoch === _loadPhotosEpoch;
+}
+
 /* ── Load photos ── */
 async function loadPhotos() {
   var myEpoch = ++_loadPhotosEpoch;
@@ -560,6 +701,7 @@ async function loadPhotos() {
     var visual = VireoFilter.getVisual ? VireoFilter.getVisual() : null;
     if (visual) params.set('visual', JSON.stringify(visual));
   }
+  if (focusPhotoId !== null) params.set('photo_id', focusPhotoId);
 
   var qs = params.toString();
   var url = '/api/photos/geo' + (qs ? '?' + qs : '');
@@ -600,48 +742,9 @@ async function loadPhotos() {
 
     assignSpeciesColors(data.photos);
     legendControl.update(speciesColorMap);
-
-    data.photos.forEach(function(p) {
-      var thumbSrc = photoThumbnailUrl(p);
-      var imgTag = thumbSrc
-        ? '<img src="' + escapeAttr(thumbSrc) + '" alt="" onerror="this.style.display=\'none\'">'
-        : '';
-      var speciesLine = p.species
-        ? '<div class="popup-species">' + escapeHtml(p.species) + '</div>'
-        : '';
-
-      var provenanceLine = '';
-      if (p.coord_source === 'keyword' && p.keyword_location_name) {
-        provenanceLine = '<div class="popup-provenance">\u{1F4CD} from assigned location: '
-          + escapeHtml(p.keyword_location_name) + '</div>';
-      } else if (p.coord_source === 'exif') {
-        provenanceLine = '<div class="popup-provenance">\u{1F4CD} from EXIF GPS</div>';
-      }
-
-      var popup = '<div class="photo-popup">'
-        + imgTag
-        + '<div class="popup-title">' + escapeHtml(p.filename) + '</div>'
-        + '<div class="popup-meta">' + escapeHtml(formatDate(p.timestamp)) + ' ' + buildStars(p.rating) + '</div>'
-        + speciesLine
-        + '<a class="popup-link" href="/browse?photo_id=' + p.id + '">View in Browse &rarr;</a>'
-        + provenanceLine
-        + '</div>';
-
-      var color = getSpeciesColor(p.species);
-      var marker = L.marker([p.latitude, p.longitude], { icon: makeCircleIcon(color) });
-      marker.bindPopup(popup);
-      marker._photoData = p;
-
-      marker.on('click', function() {
-        setActiveCard(p.id);
-      });
-
-      photoMarkers[p.id] = marker;
-      markers.addLayer(marker);
-    });
-
-    map.fitBounds(markers.getBounds(), { padding: [30, 30] });
     renderSidebar(data.photos);
+    if (!await renderPhotoMarkers(data.photos, myEpoch)) return;
+    map.fitBounds(markers.getBounds(), { padding: [30, 30] });
     if (focusPhotoId !== null) {
       if (!openPhotoMarker(focusPhotoId)) {
         document.getElementById('mapStatus').textContent =
@@ -657,7 +760,15 @@ async function loadPhotos() {
     var pct = totalPhotos > 0 ? Math.round((totalGeolocated / totalPhotos) * 100) : 0;
 
     var statusEl = document.getElementById('mapStatus');
-    var parts = ['Showing ' + totalFiltered + ' of ' + totalGeolocated + ' geolocated photos'];
+    var parts;
+    if (data.truncated) {
+      parts = [
+        'Showing ' + data.photos.length + ' of ' + totalFiltered + ' matching photos',
+        'Map display is limited to ' + data.render_limit + ' photos; refine the filters to see omitted results',
+      ];
+    } else {
+      parts = ['Showing ' + totalFiltered + ' of ' + totalGeolocated + ' geolocated photos'];
+    }
     parts.push(pct + '% map coverage');
     if (missingCoordinates > 0) {
       parts.push('<a href="/browse?location_status=none">' + missingCoordinates + ' without coordinates</a>');

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1123,6 +1123,35 @@ def test_api_photos_geo_empty(app_and_db):
     assert data['total_filtered'] == 0
 
 
+def test_api_photos_geo_caps_payload_and_preserves_focused_photo(
+    app_and_db, monkeypatch
+):
+    """The map payload has a hard ceiling without breaking deep links."""
+    import app as app_module
+
+    app, db = app_and_db
+    photos = db.get_photos(sort="name")
+    for index, photo in enumerate(photos):
+        db.conn.execute(
+            "UPDATE photos SET latitude=?, longitude=? WHERE id=?",
+            (37.0 + index, -122.0 - index, photo["id"]),
+        )
+    db.conn.commit()
+    monkeypatch.setattr(app_module, "MAP_RENDER_PHOTO_LIMIT", 2)
+
+    focus_id = photos[-1]["id"]
+    response = app.test_client().get(f"/api/photos/geo?photo_id={focus_id}")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["total_filtered"] == 3
+    assert data["total_rendered"] == 2
+    assert data["render_limit"] == 2
+    assert data["truncated"] is True
+    assert len(data["photos"]) == 2
+    assert focus_id in {photo["id"] for photo in data["photos"]}
+
+
 def test_api_photos_geo_includes_gps_stats(app_and_db):
     """GET /api/photos/geo response includes consistent global GPS stats."""
     app, db = app_and_db


### PR DESCRIPTION
Large map libraries previously created every Leaflet marker, popup, sidebar card, thumbnail, and event handler synchronously, which could monopolize the webview main thread. This change renders markers in bounded batches, virtualizes the sidebar, and caps map payloads at 10,000 photos with a clear filter-refinement notice while preserving deep-linked photos. Regression coverage exercises a 2,500-photo browser payload, the server-side ceiling, focused-photo behavior, filter handoff, and map navigation. Validation: Ruff, `git diff --check`, commit hooks, and 16 focused backend/browser tests passed.