### PR TITLE
Track detected eyes during lightbox navigation

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -62,6 +62,97 @@ def test_browse_lightbox_arrows_navigate(live_server, page):
     expect(counter).to_contain_text(first_filename)
 
 
+def test_lightbox_track_eye_keeps_eye_at_same_screen_position(
+    live_server, page, tmp_path,
+):
+    """Track Eye offsets the next frame so burst inspection stays registered."""
+    db = live_server["db"]
+    folder_path = tmp_path / "eye-track"
+    folder_path.mkdir()
+    folder_id = db.add_folder(str(folder_path), name="eye-track")
+    photo_ids = []
+    for index, eye in enumerate(((0.25, 0.40), (0.75, 0.65)), start=1):
+        filename = f"eye-{index}.png"
+        Image.new("RGB", (1200, 800), (30 * index, 80, 120)).save(
+            folder_path / filename
+        )
+        photo_id = db.add_photo(
+            folder_id=folder_id,
+            filename=filename,
+            extension=".png",
+            file_size=(folder_path / filename).stat().st_size,
+            file_mtime=(folder_path / filename).stat().st_mtime,
+            width=1200,
+            height=800,
+        )
+        db.conn.execute(
+            "UPDATE photos SET eye_x=?, eye_y=?, eye_conf=? WHERE id=?",
+            (eye[0], eye[1], 0.98, photo_id),
+        )
+        photo_ids.append(photo_id)
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate("localStorage.removeItem('vireo.lb.trackEye')")
+    page.evaluate(
+        """photos => openLightbox(photos[0].id, photos[0].filename, photos)""",
+        [
+            {"id": photo_ids[0], "filename": "eye-1.png"},
+            {"id": photo_ids[1], "filename": "eye-2.png"},
+        ],
+    )
+    page.wait_for_function(
+        """photoId => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbPhotoDataByPhoto[String(photoId)] &&
+                img.complete && img.naturalWidth > 0 &&
+                !window._lbVisualTransitionPending;
+        }""",
+        arg=photo_ids[0],
+    )
+    page.evaluate(
+        """() => window._lbApplyViewportState({
+            zoom: 2,
+            centerX: 0.40,
+            centerY: 0.50,
+            oneToOne: false,
+            pending1To1: false,
+        })"""
+    )
+    page.locator("#lightboxTrackEye").click()
+    expect(page.locator("#lightboxTrackEye")).to_have_attribute(
+        "aria-pressed", "true"
+    )
+    assert page.evaluate("localStorage.getItem('vireo.lb.trackEye')") == "1"
+
+    eye_screen_js = """() => {
+        const data = window._lbPhotoDataByPhoto[String(window._lightboxCurrentId)];
+        const metrics = window._lbUpdateLayoutMetrics();
+        const state = window._lbViewportStateFromCurrent();
+        const wrap = document.getElementById('lightboxWrap').getBoundingClientRect();
+        return {
+            x: wrap.left + wrap.width / 2 +
+                (Number(data.eye_x) - state.centerX) * metrics.w * metrics.scale,
+            y: wrap.top + wrap.height / 2 +
+                (Number(data.eye_y) - state.centerY) * metrics.h * metrics.scale,
+        };
+    }"""
+    before = page.evaluate(eye_screen_js)
+
+    page.locator("#lightboxNext").click()
+    page.wait_for_function(
+        """photoId => window._lightboxCurrentId === photoId &&
+            window._lbPhotoDataByPhoto[String(photoId)] &&
+            !window._lbVisualTransitionPending &&
+            window._lbPendingEyeTrack === null""",
+        arg=photo_ids[1],
+    )
+    after = page.evaluate(eye_screen_js)
+
+    assert abs(after["x"] - before["x"]) < 2
+    assert abs(after["y"] - before["y"]) < 2
+
+
 def test_browse_lightbox_same_photo_reopen_does_not_lock_controls(live_server, page):
     """Reopening the visible photo must not wait for a same-src load event."""
     page.route(

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -153,6 +153,39 @@ def test_lightbox_track_eye_keeps_eye_at_same_screen_position(
     assert abs(after["y"] - before["y"]) < 2
 
 
+def test_user_pan_zoom_cancels_pending_eye_track(live_server, page):
+    """Manual pan/zoom before the metadata callback lands must drop the
+    armed eye alignment, otherwise _lbTryApplyPendingEyeTrack later stomps
+    the user's viewport with the previous photo's eye anchor."""
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(
+            body=base64.b64decode(_PNG_1X1), content_type="image/png"
+        ),
+    )
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    state = page.evaluate(
+        """() => {
+            window._lbPendingViewportState = {
+                zoom: 2, centerX: 0.5, centerY: 0.5,
+                oneToOne: false, pending1To1: false,
+            };
+            window._lbPendingEyeTrack = {
+                photoId: 'stale', offsetX: 42, offsetY: 42,
+            };
+            window._lbClearPendingViewportRestore();
+            return {
+                viewport: window._lbPendingViewportState,
+                eyeTrack: window._lbPendingEyeTrack,
+            };
+        }"""
+    )
+
+    assert state == {"viewport": None, "eyeTrack": None}
+
+
 def test_browse_lightbox_same_photo_reopen_does_not_lock_controls(live_server, page):
     """Reopening the visible photo must not wait for a same-src load event."""
     page.route(

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5676,6 +5676,18 @@ function _lbTryApplyPendingEyeTrack(photo) {
   }
   if (!metrics || _lbVisualTransitionPending) return false;
 
+  // A deferred 1:1 snap is still armed — the loader is holding the current
+  // display upscaled while a sharper source (2560/3840 or /original) swap
+  // completes. Applying the viewport here would re-enter
+  // _lbApplyViewportState(), whose one-to-one branch would either clear
+  // _lbPending1To1 (when nativeZoom is known) or leave it armed but whose
+  // trailing _lbScheduleSourceSwap() can retarget back to /full when
+  // /original is unavailable and nativeZoom is not yet known — cancelling
+  // the sharp fallback and leaving the user on a soft view. Wait for the
+  // deferred source swap to land and _lbApplyPendingOneToOneZoom() to
+  // finish before aligning the eye.
+  if (_lbPending1To1) return false;
+
   var state = _lbViewportStateFromCurrent();
   if (!state || _lbZoom <= 1.001 || !metrics.scale) return false;
   state.centerX = point.x - (Number(pending.offsetX) || 0) / (metrics.w * metrics.scale);
@@ -9147,6 +9159,10 @@ function _lbScheduleSourceSwap(targetZoom) {
         // honored — completing with a recentered zoom would make a deferred 1:1
         // jump away from the point the user clicked.
         _lbApplyPendingOneToOneZoom();
+        // Track Eye alignment is deferred while _lbPending1To1 is armed so it
+        // cannot cancel the deferred sharp-source fallback. Re-apply now that
+        // the source has landed and any pending 1:1 has snapped.
+        _lbTryApplyPendingEyeTrack();
         _lbApplyTransform();
       });
       img.src = url;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5641,10 +5641,27 @@ function _lbCaptureEyeTrackingAnchor() {
       ? { offsetX: _lbEyeTrackScreenAnchor.offsetX, offsetY: _lbEyeTrackScreenAnchor.offsetY }
       : null;
   }
-  var point = _lbPhotoEyePoint(_lightboxCurrentId);
+  var photo = _lbPhotoData(_lightboxCurrentId);
+  var eyeKnown = !!(photo && Object.prototype.hasOwnProperty.call(photo, 'eye_x'));
+  var point = _lbPhotoEyePoint(_lightboxCurrentId, photo);
+  var overlaysAvailable = _lbSourceOverlaysAvailable();
+  // If the current photo is known to be unusable for eye alignment — either
+  // its metadata has resolved without an eye, or the active source cannot
+  // align overlays (JPEG pair or geometric edit) — drop any cached anchor
+  // instead of propagating it. Otherwise, after the user pans on this
+  // paused/no-eye frame, _lbTryApplyPendingEyeTrack would apply a prior
+  // photo's anchor on the next eyed photo and jump the viewport to an
+  // unrelated eye position.
+  if ((eyeKnown && !point) || !overlaysAvailable) {
+    _lbEyeTrackScreenAnchor = null;
+    return null;
+  }
   var metrics = _lbUpdateLayoutMetrics();
   var state = _lbViewportStateFromCurrent();
-  if (!point || !metrics || !state || !_lbSourceOverlaysAvailable()) {
+  if (!point || !metrics || !state) {
+    // Truly uncertain state (destination metadata not yet cached or the layout
+    // has not been measured). Reuse the last trustworthy anchor so a later
+    // eyed frame can still align.
     return _lbEyeTrackScreenAnchor
       ? { offsetX: _lbEyeTrackScreenAnchor.offsetX, offsetY: _lbEyeTrackScreenAnchor.offsetY }
       : null;
@@ -6210,9 +6227,17 @@ function _lbApplyTrackEyeState() {
   var hasEye = !!_lbPhotoEyePoint(_lightboxCurrentId, photo);
   var available = hasEye && _lbSourceOverlaysAvailable();
   btn.setAttribute('aria-pressed', _lbTrackEyeEnabled ? 'true' : 'false');
-  btn.textContent = _lbTrackEyeEnabled
-    ? (eyeKnown && !available ? 'Eye Tracking Paused' : 'Tracking Eye')
-    : 'Track Eye';
+  if (_lbTrackEyeEnabled) {
+    if (available) {
+      btn.textContent = 'Tracking Eye';
+    } else if (eyeKnown) {
+      btn.textContent = 'Eye Tracking Paused';
+    } else {
+      btn.textContent = 'Waiting for Eye';
+    }
+  } else {
+    btn.textContent = 'Track Eye';
+  }
   if (_lbTrackEyeEnabled && !available) {
     btn.title = eyeKnown
       ? 'Eye tracking is on but unavailable for this photo'

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5829,10 +5829,16 @@ function _lbClearPendingViewportRestore() {
   // Called from user-driven viewport mutations (wheel/keyboard/click zoom,
   // drag pan) so a still-armed restore carried over by arrow navigation
   // cannot be reapplied by a later async metadata/image-load callback and
-  // stomp the user's manual zoom/pan. Programmatic restore paths
-  // (_lbTryApplyPendingViewportState) own clearing their own state and must
-  // not route through here.
+  // stomp the user's manual zoom/pan. Also drops any deferred eye-tracking
+  // alignment for the same reason: when a destination image finishes
+  // loading before /api/photos/<id> returns, _lbPendingEyeTrack stays
+  // armed until the metadata callback fires _lbTryApplyPendingEyeTrack,
+  // and a user pan/zoom in that window must not be overwritten by the
+  // previous photo's eye anchor. Programmatic restore paths
+  // (_lbTryApplyPendingViewportState, _lbTryApplyPendingEyeTrack) own
+  // clearing their own state and must not route through here.
   _lbPendingViewportState = null;
+  _lbPendingEyeTrack = null;
 }
 
 function _lbTryApplyPendingViewportState() {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5642,26 +5642,19 @@ function _lbCaptureEyeTrackingAnchor() {
       : null;
   }
   var photo = _lbPhotoData(_lightboxCurrentId);
-  var eyeKnown = !!(photo && Object.prototype.hasOwnProperty.call(photo, 'eye_x'));
   var point = _lbPhotoEyePoint(_lightboxCurrentId, photo);
   var overlaysAvailable = _lbSourceOverlaysAvailable();
-  // If the current photo is known to be unusable for eye alignment — either
-  // its metadata has resolved without an eye, or the active source cannot
-  // align overlays (JPEG pair or geometric edit) — drop any cached anchor
-  // instead of propagating it. Otherwise, after the user pans on this
-  // paused/no-eye frame, _lbTryApplyPendingEyeTrack would apply a prior
-  // photo's anchor on the next eyed photo and jump the viewport to an
-  // unrelated eye position.
-  if ((eyeKnown && !point) || !overlaysAvailable) {
-    _lbEyeTrackScreenAnchor = null;
-    return null;
-  }
   var metrics = _lbUpdateLayoutMetrics();
-  var state = _lbViewportStateFromCurrent();
-  if (!point || !metrics || !state) {
-    // Truly uncertain state (destination metadata not yet cached or the layout
-    // has not been measured). Reuse the last trustworthy anchor so a later
-    // eyed frame can still align.
+  var state = point && overlaysAvailable ? _lbViewportStateFromCurrent() : null;
+  if (!point || !overlaysAvailable || !metrics || !state) {
+    // Current frame is unusable for a fresh measurement — either its metadata
+    // has resolved without an eye, the active source cannot align overlays
+    // (JPEG pair or geometric edit), the destination metadata is not yet
+    // cached, or the layout has not been measured. Reuse the last trustworthy
+    // anchor so a later eyed frame can still resume alignment across the
+    // paused sequence. User pan/zoom paths clear the cached anchor via
+    // _lbClearPendingViewportRestore, so a manual viewport change on this
+    // paused frame will not carry a stale eye offset to the next eyed photo.
     return _lbEyeTrackScreenAnchor
       ? { offsetX: _lbEyeTrackScreenAnchor.offsetX, offsetY: _lbEyeTrackScreenAnchor.offsetY }
       : null;
@@ -5834,11 +5827,17 @@ function _lbClearPendingViewportRestore() {
   // loading before /api/photos/<id> returns, _lbPendingEyeTrack stays
   // armed until the metadata callback fires _lbTryApplyPendingEyeTrack,
   // and a user pan/zoom in that window must not be overwritten by the
-  // previous photo's eye anchor. Programmatic restore paths
+  // previous photo's eye anchor. Dropping the cached screen anchor here
+  // — instead of eagerly on every known no-eye frame — lets tracking
+  // resume across an eyed → no-eye → eyed sequence when the user did not
+  // pan or zoom the paused frame, while still preventing a stale offset
+  // from being carried onto the next eyed photo after a manual pan/zoom
+  // on the paused frame. Programmatic restore paths
   // (_lbTryApplyPendingViewportState, _lbTryApplyPendingEyeTrack) own
   // clearing their own state and must not route through here.
   _lbPendingViewportState = null;
   _lbPendingEyeTrack = null;
+  _lbEyeTrackScreenAnchor = null;
 }
 
 function _lbTryApplyPendingViewportState() {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -670,6 +670,11 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   cursor: default;
   text-shadow: none;
 }
+.lb-action-btn[aria-pressed="true"] {
+  color: #ffe066;
+  border-color: rgba(255, 224, 102, 0.84);
+  background: rgba(92, 76, 12, 0.82);
+}
 .lb-action-accent {
   color: #ffe066;
   border-color: rgba(255, 224, 102, 0.84);
@@ -3489,6 +3494,9 @@ async function createWorkspace() {
     <button class="lb-action-btn" id="lightboxToggleEye" onclick="event.stopPropagation(); toggleLightboxEye();" title="Toggle eye marker">
       Hide Eye
     </button>
+    <button class="lb-action-btn" id="lightboxTrackEye" aria-pressed="false" onclick="event.stopPropagation(); toggleLightboxTrackEye();" title="Keep the detected eye in the same screen position while navigating">
+      Track Eye
+    </button>
     <button class="lb-action-btn" id="lightboxToggleInfo" onclick="event.stopPropagation(); toggleLightboxInfo();" title="Toggle filename, counter, and zoom badge">
       Hide Info
     </button>
@@ -3655,6 +3663,8 @@ var _lbFlagPendingByPhoto = {};  // count of in-flight flag writes PER photo; li
 var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated from optimistic page helpers
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
+var _lbPendingEyeTrack = null; // destination alignment waiting for image metadata/layout
+var _lbEyeTrackScreenAnchor = null; // eye offset from viewport center in CSS pixels
 var _lbVisualTransitionPending = false; // keep the outgoing bitmap/transform frozen until the incoming image is decoded
 var _lbDeferredOverlayApply = null; // detections/eye render withheld while _lbVisualTransitionPending; drained when the transition clears
 var _lbAdjacentPreloads = {}; // decoded immediate neighbors, keyed by photo id + source URL
@@ -5621,6 +5631,71 @@ function _lbViewportStateFromCurrent() {
   return state;
 }
 
+function _lbCaptureEyeTrackingAnchor() {
+  if (!_lbTrackEyeEnabled || (_lbZoom <= 1.001 && !_lbPending1To1)) return null;
+  // During rapid navigation the DOM can still contain the outgoing bitmap.
+  // Reuse the last trustworthy screen anchor instead of measuring that bitmap
+  // against the incoming photo id.
+  if (_lbVisualTransitionPending) {
+    return _lbEyeTrackScreenAnchor
+      ? { offsetX: _lbEyeTrackScreenAnchor.offsetX, offsetY: _lbEyeTrackScreenAnchor.offsetY }
+      : null;
+  }
+  var point = _lbPhotoEyePoint(_lightboxCurrentId);
+  var metrics = _lbUpdateLayoutMetrics();
+  var state = _lbViewportStateFromCurrent();
+  if (!point || !metrics || !state || !_lbSourceOverlaysAvailable()) {
+    return _lbEyeTrackScreenAnchor
+      ? { offsetX: _lbEyeTrackScreenAnchor.offsetX, offsetY: _lbEyeTrackScreenAnchor.offsetY }
+      : null;
+  }
+  var anchor = {
+    offsetX: (point.x - state.centerX) * metrics.w * metrics.scale,
+    offsetY: (point.y - state.centerY) * metrics.h * metrics.scale,
+  };
+  _lbEyeTrackScreenAnchor = anchor;
+  return { offsetX: anchor.offsetX, offsetY: anchor.offsetY };
+}
+
+function _lbTryApplyPendingEyeTrack(photo) {
+  var pending = _lbPendingEyeTrack;
+  if (!pending || !_lbTrackEyeEnabled) return false;
+  if (String(pending.photoId) !== String(_lightboxCurrentId)) return false;
+  photo = photo || _lbPhotoData(_lightboxCurrentId);
+  // A missing object means the detail request has not resolved yet. Keep the
+  // alignment armed so its callback can apply it after the image is laid out.
+  // Navigation lists on some pages contain only {id, filename}; those are
+  // also "unknown", not evidence that the destination lacks an eye.
+  if (!photo || !Object.prototype.hasOwnProperty.call(photo, 'eye_x')) return false;
+  var point = _lbPhotoEyePoint(_lightboxCurrentId, photo);
+  var metrics = _lbUpdateLayoutMetrics();
+  if (!point || !_lbSourceOverlaysAvailable()) {
+    _lbPendingEyeTrack = null;
+    _lbApplyTrackEyeState();
+    return false;
+  }
+  if (!metrics || _lbVisualTransitionPending) return false;
+
+  var state = _lbViewportStateFromCurrent();
+  if (!state || _lbZoom <= 1.001 || !metrics.scale) return false;
+  state.centerX = point.x - (Number(pending.offsetX) || 0) / (metrics.w * metrics.scale);
+  state.centerY = point.y - (Number(pending.offsetY) || 0) / (metrics.h * metrics.scale);
+  _lbApplyViewportState(state);
+
+  // Native 1:1 can be learned after the first layout pass. Retain the pending
+  // alignment until then so a later 1:1 snap does not move the eye.
+  if (!state.oneToOne || _lbNativeZoom) {
+    _lbPendingEyeTrack = null;
+  }
+  _lbEyeTrackScreenAnchor = {
+    offsetX: Number(pending.offsetX) || 0,
+    offsetY: Number(pending.offsetY) || 0,
+  };
+  _lbSaveViewportState(_lightboxCurrentId);
+  _lbApplyTrackEyeState();
+  return true;
+}
+
 function _lbSaveViewportState(photoId) {
   if (photoId == null) return null;
   // Mid-navigation the DOM transform still belongs to the outgoing photo but
@@ -5969,6 +6044,7 @@ function _lbPersistBool(key, value) {
 var _lbBoxesVisible = _lbStoredBool('vireo.lb.boxesVisible', false);
 var _lbMasksVisible = _lbStoredBool('vireo.lb.masksVisible', false);
 var _lbEyeVisible = _lbStoredBool('vireo.lb.eyeVisible', false);
+var _lbTrackEyeEnabled = _lbStoredBool('vireo.lb.trackEye', false);
 var _lbInfoVisible = _lbStoredBool('vireo.lb.infoVisible', true);
 var _lbChromeVisible = _lbStoredBool('vireo.lb.chromeVisible', true);
 
@@ -6090,6 +6166,63 @@ function toggleLightboxEye() {
   _lbApplyEyeVisibility();
 }
 
+function _lbPhotoData(photoId) {
+  if (photoId == null) return null;
+  var cached = _lbPhotoDataByPhoto[String(photoId)];
+  if (cached) return cached;
+  return _lightboxPhotoList.find(function(photo) {
+    return String(photo.id) === String(photoId);
+  }) || null;
+}
+
+function _lbPhotoEyePoint(photoId, photo) {
+  photo = photo || _lbPhotoData(photoId);
+  if (!photo || photo.eye_x == null || photo.eye_y == null) return null;
+  var x = Number(photo.eye_x);
+  var y = Number(photo.eye_y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return _lbTransformPointByRecipe(
+    x,
+    y,
+    _lbEditRecipeByPhoto[String(photoId)] || photo.edit_recipe
+  );
+}
+
+function _lbApplyTrackEyeState() {
+  var btn = document.getElementById('lightboxTrackEye');
+  if (!btn) return;
+  var photo = _lbPhotoData(_lightboxCurrentId);
+  var eyeKnown = !!(
+    photo && Object.prototype.hasOwnProperty.call(photo, 'eye_x')
+  );
+  var hasEye = !!_lbPhotoEyePoint(_lightboxCurrentId, photo);
+  var available = hasEye && _lbSourceOverlaysAvailable();
+  btn.setAttribute('aria-pressed', _lbTrackEyeEnabled ? 'true' : 'false');
+  btn.textContent = _lbTrackEyeEnabled
+    ? (eyeKnown && !available ? 'Eye Tracking Paused' : 'Tracking Eye')
+    : 'Track Eye';
+  if (_lbTrackEyeEnabled && !available) {
+    btn.title = eyeKnown
+      ? 'Eye tracking is on but unavailable for this photo'
+      : 'Eye tracking is on; waiting for this photo\'s eye metadata';
+  } else if (!_lbTrackEyeEnabled && !available) {
+    btn.title = 'Turn on eye tracking; it will start when a usable eye keypoint is available';
+  } else {
+    btn.title = _lbTrackEyeEnabled
+      ? 'Keep the detected eye in the same screen position while navigating'
+      : 'Track the detected eye while navigating';
+  }
+}
+
+function toggleLightboxTrackEye() {
+  _lbTrackEyeEnabled = !_lbTrackEyeEnabled;
+  _lbPersistBool('vireo.lb.trackEye', _lbTrackEyeEnabled);
+  _lbPendingEyeTrack = null;
+  _lbEyeTrackScreenAnchor = null;
+  if (_lbTrackEyeEnabled) _lbCaptureEyeTrackingAnchor();
+  _lbApplyTrackEyeState();
+}
+
 /* Species color palette for lightbox bounding boxes */
 var _lbSpeciesColors = {};
 var _lbColorPalette = [
@@ -6138,6 +6271,7 @@ function _lbRenderEyeCrosshair(photo) {
   }
   container.appendChild(marker);
   _lbApplyEyeVisibility();
+  _lbApplyTrackEyeState();
 }
 
 function _lbLoadDetections(photoId) {
@@ -6825,6 +6959,7 @@ function openLightbox(photoId, filename, photoList, options) {
   options = options || {};
   _lbCancelOriginalPreload();
   var fallbackViewportState = options.fallbackViewportState || null;
+  var eyeTrackAnchor = options.eyeTrackAnchor || null;
   _lbFlushPendingAdjustmentSave();
   if (alreadyOpen && _lightboxCurrentId != null) {
     _lbSaveViewportState(_lightboxCurrentId);
@@ -6989,6 +7124,11 @@ function openLightbox(photoId, filename, photoList, options) {
   // a stale edge anchor on the new image — consistent with the pan reset above.
   _lbPending1To1Anchor = null;
   _lbPendingViewportState = restoreViewportState;
+  _lbPendingEyeTrack = (_lbTrackEyeEnabled && eyeTrackAnchor) ? {
+    photoId: photoId,
+    offsetX: Number(eyeTrackAnchor.offsetX) || 0,
+    offsetY: Number(eyeTrackAnchor.offsetY) || 0,
+  } : null;
   _lbOriginalUnavailable = false;
   _lbFullUsesOriginal = null;
   _lbEditRecipe = null;
@@ -7092,6 +7232,7 @@ function openLightbox(photoId, filename, photoList, options) {
       if (!_lbVisualTransitionPending) {
         _lbRecomputeNativeZoom();
         if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
+        _lbTryApplyPendingEyeTrack(data);
         if (_lbCurrentSrcKey === 'full') _lbScheduleOriginalPreload(photoId);
       }
       // Detection boxes, the eye marker, and the mask overlay are children of
@@ -7116,6 +7257,7 @@ function openLightbox(photoId, filename, photoList, options) {
         _lbDeferredOverlayApply = null;
         applyOverlays();
       }
+      _lbApplyTrackEyeState();
     })
     .catch(function() {
       if (_lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
@@ -7155,6 +7297,7 @@ function openLightbox(photoId, filename, photoList, options) {
     } else if (!_lbTryApplyPendingViewportState()) {
       _lbApplyPendingOneToOneZoom();
     }
+    _lbTryApplyPendingEyeTrack();
     _lbApplyTransform();
     _lbFlushDeferredOverlayApply();
     if (typeof window._lbFlushDeferredLightboxLayoutRefresh === 'function') {
@@ -7179,6 +7322,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbSetPhotoTransitionPending(false);
       _lbRecomputeNativeZoom();
       if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
+      _lbTryApplyPendingEyeTrack();
       _lbApplyTransform();
       _lbFlushDeferredOverlayApply();
       if (typeof window._lbFlushDeferredLightboxLayoutRefresh === 'function') {
@@ -7217,6 +7361,7 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbApplyInfoVisibility();
   _lbApplyChromeVisibility();
   _lbApplyEyeVisibility();
+  _lbApplyTrackEyeState();
   _lbApplyMaskToggleButton();
   _lbApplyWildlifeExcludedButton();
 
@@ -7248,10 +7393,12 @@ function lightboxNav(delta) {
     return;
   }
   var currentViewportState = _lbSaveViewportState(_lightboxCurrentId);
+  var eyeTrackAnchor = _lbCaptureEyeTrackingAnchor();
   var next = _lightboxPhotoList[newIdx];
   openLightbox(next.id, next.filename, _lightboxPhotoList, {
     fallbackViewportState: currentViewportState,
-    preserveOneToOne: _lbIsOneToOneZoom()
+    preserveOneToOne: _lbIsOneToOneZoom(),
+    eyeTrackAnchor: eyeTrackAnchor
   });
 }
 
@@ -7529,6 +7676,8 @@ function closeLightbox(e) {
   _lbSetPhotoTransitionPending(false);
   _lbDeferredOverlayApply = null;
   _lbClearPendingViewportRestore();
+  _lbPendingEyeTrack = null;
+  _lbEyeTrackScreenAnchor = null;
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
   _lbCancelOriginalPreload();
@@ -7620,6 +7769,7 @@ function buildLightboxContextMenu(pid) {
   items.push(toggleItem('Detection boxes', _lbBoxesVisible, toggleLightboxBoxes));
   items.push(toggleItem('Mask overlay', _lbMasksVisible, toggleLightboxMasks));
   items.push(toggleItem('Eye marker', _lbEyeVisible, toggleLightboxEye));
+  items.push(toggleItem('Track eye', _lbTrackEyeEnabled, toggleLightboxTrackEye));
   items.push(toggleItem('Filename and counter', _lbInfoVisible, toggleLightboxInfo));
   items.push(toggleItem('Lightbox controls', _lbChromeVisible, toggleLightboxChrome));
   items.push(toggleItem('Wildlife classification', !_lbCurrentWildlifeExcluded, lightboxToggleWildlifeExcluded));


### PR DESCRIPTION
Adds a persistent **Track Eye** lightbox control that keeps the detected eye at the same screen position while moving through zoomed photos. The alignment waits for asynchronous image and eye metadata, preserves the current zoom, and pauses gracefully on photos without a usable eye before resuming on later frames. The control is also available from the lightbox context menu and exposes a clear pressed or paused state. Validated with `pytest -q tests/e2e/test_lightbox_context_menu.py tests/e2e/test_browse_lightbox.py` (49 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Track Eye” option to the lightbox to keep an eye marker’s screen position stable while navigating between photos.
  * Included a toggle button and context-menu action; the setting is remembered for future lightbox sessions and reflects its active state in the UI.
* **Tests**
  * Added an end-to-end regression test that verifies eye screen-position stability across lightbox navigation within a small tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->