### PR TITLE
Add recent destinations to the Move folder picker

### DIFF
--- a/tests/e2e/test_move_page.py
+++ b/tests/e2e/test_move_page.py
@@ -167,6 +167,40 @@ def test_move_folder_shows_source_while_choosing_destination(live_server, page):
     expect(page.locator("#moveBrowserSourceCount")).to_have_text("(3 photos)")
 
 
+def test_move_folder_browser_navigates_to_recent_destinations(
+    live_server, page, tmp_path
+):
+    import config as cfg
+
+    first = tmp_path / "primary" / "Archive"
+    second = tmp_path / "secondary" / "Archive"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    config = cfg.load()
+    config["ingest"]["recent_destinations"] = [str(first), str(second)]
+    cfg.save(config)
+
+    page.goto(f"{live_server['url']}/move")
+    page.get_by_role("button", name="Browse", exact=True).first.click()
+
+    recents = page.locator("[data-testid='move-browser-recents']")
+    expect(recents).to_be_visible()
+    expect(recents).to_contain_text("primary / Archive")
+    expect(recents).to_contain_text("secondary / Archive")
+
+    page.get_by_role("button", name=f"Go to {second}").click()
+    expect(page.locator("#moveBrowserBreadcrumb")).to_have_text(str(second))
+    expect(page.locator("#moveBrowserModal")).to_have_class(re.compile(r"\bopen\b"))
+
+    page.get_by_role("button", name="Select This Folder").click()
+    expect(page.locator("#quickDestInput")).to_have_value(str(second))
+
+    page.get_by_role("button", name="Browse", exact=True).first.click()
+    expect(
+        page.locator("#moveBrowserRecentList button").first
+    ).to_have_attribute("aria-label", f"Go to {second}")
+
+
 def test_move_folder_prints_full_move_before_submission(live_server, page):
     live_server["db"].update_folder_counts()
     url = live_server["url"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15155,6 +15155,38 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         return jsonify(cfg.load())
 
+    @app.route("/api/recent-destinations", methods=["POST"])
+    def api_recent_destinations_add():
+        """Remember a destination selected in a folder picker."""
+        import config as cfg
+
+        body = request.get_json(silent=True) or {}
+        destination = body.get("path")
+        if not isinstance(destination, str) or not destination:
+            return json_error("path is required", status=400)
+        if not os.path.isabs(destination):
+            return json_error("path must be absolute", status=400)
+
+        # Use a raw read-modify-write so recording this convenience history
+        # neither pins DEFAULTS into config.json nor races settings autosaves.
+        with _settings_write_lock:
+            raw = _read_raw_config_file()
+            ingest = raw.get("ingest")
+            ingest = dict(ingest) if isinstance(ingest, dict) else {}
+            existing = ingest.get("recent_destinations")
+            existing = existing if isinstance(existing, list) else []
+            recents = [
+                item for item in existing
+                if isinstance(item, str) and item and item != destination
+            ]
+            recents.insert(0, destination)
+            recents = recents[:5]
+            ingest["recent_destinations"] = recents
+            raw["ingest"] = ingest
+            cfg.save(raw)
+
+        return jsonify({"ok": True, "recent_destinations": recents})
+
     @app.route("/api/config", methods=["POST"])
     def api_config_set():
         import config as cfg

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -616,6 +616,41 @@ body { padding-bottom: 48px; }
   color: var(--text-primary);
   border-color: var(--accent);
 }
+.browser-recents {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.browser-recents-label {
+  flex: 0 0 auto;
+  padding-top: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.browser-recent-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  min-width: 0;
+}
+.browser-recent-list button {
+  max-width: 190px;
+  overflow: hidden;
+  padding: 4px 8px;
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.browser-recent-list button:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
 .browser-breadcrumb {
   font-size: 12px;
   color: var(--text-secondary);
@@ -874,6 +909,11 @@ body { padding-bottom: 48px; }
       <button onclick="browseTo('__pictures__')">Pictures</button>
       <button onclick="browseTo('__volumes__')">Volumes</button>
     </div>
+    <div class="browser-recents" id="moveBrowserRecents" style="display:none;"
+         data-testid="move-browser-recents">
+      <span class="browser-recents-label">Recent destinations</span>
+      <div class="browser-recent-list" id="moveBrowserRecentList"></div>
+    </div>
     <div class="browser-breadcrumb" id="moveBrowserBreadcrumb"></div>
     <div id="moveBrowserList" style="height:300px;overflow-y:auto;border:1px solid var(--border-primary);border-radius:4px;margin-bottom:12px;"></div>
     <div class="new-folder-row">
@@ -923,6 +963,8 @@ var browserTargetInput = null;
 var browserPath = '';
 var browserHomePath = '';
 var browseSeq = 0;
+var recentDestinations = [];
+var recentDestinationsSeq = 0;
 var confirmCallback = null;
 var editingRuleId = null;
 var quickMoveBusy = false;
@@ -932,6 +974,7 @@ document.addEventListener('DOMContentLoaded', function() {
   loadFolders();
   loadRemoteTargets();
   loadRules();
+  loadRecentDestinations();
 });
 
 /* ---------- Remote (SSH) move targets ---------- */
@@ -2241,6 +2284,81 @@ function closeBrowser() {
   browserTargetInput = null;
 }
 
+function recentDestinationParts(path) {
+  var trimmed = path.replace(/[\\/]+$/, '');
+  return trimmed.split(/[\\/]/).filter(Boolean);
+}
+
+function renderRecentDestinations(paths) {
+  var section = document.getElementById('moveBrowserRecents');
+  var list = document.getElementById('moveBrowserRecentList');
+  if (!section || !list) return;
+
+  var seen = new Set();
+  recentDestinations = (Array.isArray(paths) ? paths : []).filter(function(path) {
+    if (typeof path !== 'string' || !path || seen.has(path)) return false;
+    seen.add(path);
+    return true;
+  }).slice(0, 5);
+
+  var leafCounts = {};
+  recentDestinations.forEach(function(path) {
+    var parts = recentDestinationParts(path);
+    var leaf = parts[parts.length - 1] || path;
+    leafCounts[leaf] = (leafCounts[leaf] || 0) + 1;
+  });
+
+  list.replaceChildren();
+  recentDestinations.forEach(function(path) {
+    var parts = recentDestinationParts(path);
+    var leaf = parts[parts.length - 1] || path;
+    var label = leaf;
+    if (leafCounts[leaf] > 1 && parts.length > 1) {
+      label = parts[parts.length - 2] + ' / ' + leaf;
+    }
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.title = path;
+    button.setAttribute('aria-label', 'Go to ' + path);
+    button.addEventListener('click', function() { browseTo(path); });
+    list.appendChild(button);
+  });
+  section.style.display = recentDestinations.length ? '' : 'none';
+}
+
+async function loadRecentDestinations() {
+  var seq = ++recentDestinationsSeq;
+  try {
+    var cfg = await safeFetch('/api/config', undefined, {toast: false});
+    if (seq !== recentDestinationsSeq) return;
+    var ingest = cfg && cfg.ingest;
+    renderRecentDestinations(ingest && ingest.recent_destinations);
+  } catch (e) {
+    if (seq === recentDestinationsSeq) renderRecentDestinations([]);
+  }
+}
+
+async function rememberRecentDestination(path) {
+  var seq = ++recentDestinationsSeq;
+  renderRecentDestinations(
+    [path].concat(recentDestinations.filter(function(item) { return item !== path; }))
+  );
+  try {
+    var data = await safeFetch('/api/recent-destinations', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({path: path}),
+    }, {toast: false});
+    if (seq === recentDestinationsSeq && data && Array.isArray(data.recent_destinations)) {
+      renderRecentDestinations(data.recent_destinations);
+    }
+  } catch (e) {
+    // The shortcut is a convenience; a settings write failure must not
+    // prevent the selected destination from being used for this move.
+  }
+}
+
 async function browseTo(path) {
   // Stamp each browse so a slow initial fetch can't clobber a later
   // shortcut click. Without this, opening the modal with a prefilled
@@ -2326,8 +2444,10 @@ function renderBrowserList(data, opts) {
 
 function selectBrowserFolder() {
   if (!browserTargetInput || !browserPath) return;
-  document.getElementById(browserTargetInput).value = browserPath;
+  var selectedPath = browserPath;
+  document.getElementById(browserTargetInput).value = selectedPath;
   closeBrowser();
+  rememberRecentDestination(selectedPath);
   // Trigger any button state updates
   updateQuickMoveBtn();
   updatePhotoSelectionUI();

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -338,6 +338,7 @@ POST         /api/predictions/<int:pred_id>/reviewed
 POST         /api/predictions/group/apply
 POST         /api/preview-cache/clear
 POST         /api/processes
+POST         /api/recent-destinations
 POST         /api/redo
 POST         /api/remote-targets/test
 POST         /api/report-issue

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -116,6 +116,44 @@ def test_move_page_windows_parent_preserves_drive_root(app_and_db):
     assert "parent += '\\\\'" in html
 
 
+def test_recent_destinations_add_reorders_deduplicates_and_limits(
+    app_and_db, tmp_path
+):
+    import config as cfg
+
+    app, _ = app_and_db
+    client = app.test_client()
+    destinations = [str(tmp_path / f"archive-{i}") for i in range(6)]
+
+    for destination in destinations:
+        resp = client.post("/api/recent-destinations", json={"path": destination})
+        assert resp.status_code == 200
+
+    recents = cfg.load()["ingest"]["recent_destinations"]
+    assert recents == list(reversed(destinations[1:]))
+
+    resp = client.post(
+        "/api/recent-destinations", json={"path": destinations[2]}
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["recent_destinations"] == [
+        destinations[2],
+        destinations[5],
+        destinations[4],
+        destinations[3],
+        destinations[1],
+    ]
+
+
+def test_recent_destinations_rejects_relative_path(app_and_db):
+    app, _ = app_and_db
+    resp = app.test_client().post(
+        "/api/recent-destinations", json={"path": "relative/archive"}
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "path must be absolute"
+
+
 def test_move_photos_job_starts(app_and_db, tmp_path):
     """POST /api/jobs/move-photos starts a job."""
     app, db = app_and_db


### PR DESCRIPTION
Adds up to five recent destination shortcuts beneath the Move folder browser’s standard locations, with one-click navigation and disambiguated labels for duplicate folder names.

Selecting a folder promotes it to the front of the shared destination history through a race-safe persistence endpoint, while stale UI requests are ignored so newer choices win.

Validated with `pytest -q vireo/tests/test_move_api.py tests/e2e/test_move_page.py` (53 passed).