### PR TITLE
Stabilize asynchronous browser tests

### DIFF
--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -329,9 +329,13 @@ def test_handoff_hides_misses_when_review_has_collection_scope(
     page.goto(f"{url}/review")
     _wait_bar(page)
     # ``loadCollectionFilter`` populates the dropdown asynchronously —
-    # wait for the option to render before selecting it.
+    # wait for the option to be attached before selecting it. ``<option>``
+    # elements do not have their own rendered box, so Playwright's default
+    # ``visible`` state can never succeed even though the option is ready.
     page.wait_for_selector(
-        f'#collectionFilter option[value="{collection_id}"]', timeout=8000,
+        f'#collectionFilter option[value="{collection_id}"]',
+        state="attached",
+        timeout=8000,
     )
     # Select the collection via Review's dropdown so ``currentCollection``
     # updates through the real switch path (the code under test).

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -867,7 +867,11 @@ def test_exif_suggestion_bails_when_slow_geocode_resolves_after_location_saved(
     inp.fill(saved_text)
     inp.press("Enter")
 
-    expect(page.locator("#locationFilled")).to_be_visible()
+    # This includes the intentional 300 ms Google Places grace period plus
+    # the save request. A full E2E run can leave Chromium briefly starved
+    # after hundreds of browser tests, so use the suite's async-load budget
+    # rather than Playwright's 5 s assertion default.
+    expect(page.locator("#locationFilled")).to_be_visible(timeout=15000)
     expect(page.locator("#locationFilled .filled-place")).to_have_text(saved_text)
     expect(page.locator("#locationEmpty")).to_be_hidden()
     # renderLocationFilled scrubs the suggestion when the filled state


### PR DESCRIPTION
## Summary

Wait for Review collection options to be attached instead of requiring visibility, since option elements do not render independent boxes. Give the delayed free-text location save the full asynchronous test budget so resource-heavy E2E runs do not fail at Playwright’s default timeout. This stabilizes CI without changing application behavior.

## Validation

- Three originally reported tests passed together
- Filter-bar E2E suite: 18 passed
- Lightbox regression: 20 consecutive passes
- Ruff and git diff checks passed