### PR TITLE
Prevent release workflow from blanking download versions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -785,10 +785,16 @@ jobs:
         id: version
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo "ver=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+            RAW_VERSION="${GITHUB_REF#refs/tags/}"
           else
-            echo "ver=${{ github.event.inputs.tag_name }}" | sed 's/^v//' >> "$GITHUB_OUTPUT"
+            RAW_VERSION="${{ github.event.inputs.tag_name }}"
           fi
+          VERSION="${RAW_VERSION#v}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::Cannot update website download links without a release version"
+            exit 1
+          fi
+          echo "ver=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update download links for successful platforms
         run: |

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -8,6 +8,14 @@ import json
 import re
 import sys
 
+SEMVER_PATTERN = re.compile(
+    r"(?:0|[1-9]\d*)\."
+    r"(?:0|[1-9]\d*)\."
+    r"(?:0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+)
+
 
 def update_json_file(path, version):
     """Update the 'version' field in a JSON file."""
@@ -112,7 +120,11 @@ def main():
         print(f"Usage: {sys.argv[0]} <version> [--include-website] [--platform LABEL]")
         sys.exit(1)
 
-    version = positional[0].lstrip("v")
+    version = positional[0].removeprefix("v")
+    if not SEMVER_PATTERN.fullmatch(version):
+        print(f"Invalid version: {positional[0]!r}", file=sys.stderr)
+        sys.exit(1)
+
     if platform_flags:
         path = "website/src/pages/download.astro"
         for plat in platform_flags:

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -74,3 +74,28 @@ def test_sync_version_strips_v_prefix(version_files, monkeypatch):
         (version_files / "src-tauri" / "tauri.conf.json").read_text()
     )
     assert tauri_conf["version"] == "2.0.0-beta.1"
+
+
+@pytest.mark.parametrize("version", ["", "v", "not-a-version"])
+def test_sync_version_rejects_invalid_version_without_writing(version_files, version):
+    """Invalid versions must fail before any manifest or website is changed."""
+    original_contents = {
+        path.relative_to(version_files): path.read_text()
+        for path in version_files.rglob("*")
+        if path.is_file()
+    }
+
+    script = str(REPO_ROOT / "scripts" / "sync_version.py")
+    result = subprocess.run(
+        [sys.executable, script, version, "--include-website"],
+        cwd=version_files,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Invalid version" in result.stderr
+    assert all(
+        (version_files / path).read_text() == contents
+        for path, contents in original_contents.items()
+    )


### PR DESCRIPTION
## Summary

Fix version output parsing in the release workflow so manually dispatched releases publish the actual version instead of an empty string.
Reject empty or malformed semantic versions before `sync_version.py` writes any files, with regression coverage for the failure cases.
This prevents generated website download links and labels from becoming blank again.

## Validation

- `pytest -q tests/test_sync_version.py`
- `actionlint -ignore SC2012 -ignore SC2046 .github/workflows/build-release.yml`
- `npm run build` in `website/`
