### PR TITLE
Show edit confirmations as success toasts

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6297,7 +6297,7 @@ async function redoLast() {
 async function showUndoToast() {
   try {
     var data = await safeFetch('/api/undo/status', {}, { toast: false });
-    if (data.available) showToast(data.description + ' — Ctrl+Z to undo');
+    if (data.available) showToast(data.description + ' — Ctrl+Z to undo', 'success');
   } catch(e) {}
 }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -13413,6 +13413,19 @@ def test_browse_filter_by_collection_guards_degraded_rows():
     )
 
 
+def test_browse_undo_confirmation_uses_success_toast():
+    """Successful edits must not inherit showToast's red error default."""
+    from pathlib import Path
+    src = Path(__file__).parent.parent / "templates" / "browse.html"
+    text = src.read_text(encoding="utf-8")
+    fn_start = text.find("async function showUndoToast")
+    assert fn_start != -1, "showUndoToast function not found"
+    fn_end = text.find("\n}", fn_start)
+    assert fn_end != -1
+    body = text[fn_start:fn_end]
+    assert "showToast(data.description + ' — Ctrl+Z to undo', 'success')" in body
+
+
 def test_review_switch_collection_does_not_silently_widen_scope():
     """When /api/collections/<id>/photos fails, the review page must not fall
     back to `allPredictions.slice()` — that silently widened the scope back


### PR DESCRIPTION
Successful edit confirmations now explicitly use the success toast style, so bulk keyword additions no longer appear as red errors.
The root cause was `showUndoToast` omitting the toast type and inheriting the shared helper's error default.
A regression test guards the success type for future changes.

Validation: `pytest -q vireo/tests/test_app.py::test_browse_undo_confirmation_uses_success_toast vireo/tests/test_app.py::test_templates_jinja_free_except_includes`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Undo confirmations now display with the correct success styling instead of the default error appearance.

- **Tests**
  - Added regression coverage to ensure undo confirmation notifications retain the success toast configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->