### PR TITLE
Default Life List sorting to A–Z

### DIFF
--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -191,15 +191,16 @@ def test_default_sort_and_numbering_preferences_persist(live_server, page):
     # Fixed numbering preserves the chronological lifer number even though
     # alphabetical order puts the newer robin first.
     expect(page.locator(".lifer-number").first).to_have_text("#2")
-    page.locator("#sortSelect").select_option("newest")
     page.locator("#renumberView").check()
     expect(page.locator(".lifer-number").first).to_have_text("#1")
+    page.locator("#sortSelect").select_option("life-order")
+    expect(page.locator(".species-name").first).to_have_text("Red-tailed Hawk")
 
     page.reload()
     page.locator(".species-card").first.wait_for(state="visible")
-    expect(page.locator("#sortSelect")).to_have_value("newest")
+    expect(page.locator("#sortSelect")).to_have_value("life-order")
     expect(page.locator("#renumberView")).to_be_checked()
-    expect(page.locator(".species-name").first).to_have_text("American Robin")
+    expect(page.locator(".species-name").first).to_have_text("Red-tailed Hawk")
     expect(page.locator(".lifer-number").first).to_have_text("#1")
 
 

--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -180,23 +180,24 @@ def test_lightbox_panel_hides_after_current_photo_rejected(live_server, page):
     expect(panel).to_be_hidden()
 
 
-def test_sort_and_numbering_preferences_persist(live_server, page):
+def test_default_sort_and_numbering_preferences_persist(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/life-list")
     page.locator(".species-card").first.wait_for(state="visible")
 
-    page.locator("#sortSelect").select_option("alpha")
+    expect(page.locator("#sortSelect")).to_have_value("alpha")
     expect(page.locator(".species-name").first).to_have_text("American Robin")
 
     # Fixed numbering preserves the chronological lifer number even though
     # alphabetical order puts the newer robin first.
     expect(page.locator(".lifer-number").first).to_have_text("#2")
+    page.locator("#sortSelect").select_option("newest")
     page.locator("#renumberView").check()
     expect(page.locator(".lifer-number").first).to_have_text("#1")
 
     page.reload()
     page.locator(".species-card").first.wait_for(state="visible")
-    expect(page.locator("#sortSelect")).to_have_value("alpha")
+    expect(page.locator("#sortSelect")).to_have_value("newest")
     expect(page.locator("#renumberView")).to_be_checked()
     expect(page.locator(".species-name").first).to_have_text("American Robin")
     expect(page.locator(".lifer-number").first).to_have_text("#1")

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -160,9 +160,9 @@
   <div class="control-group">
     <label for="sortSelect">Sort</label>
     <select id="sortSelect">
+      <option value="alpha">A&ndash;Z</option>
       <option value="newest">Newest lifer first</option>
       <option value="life-order">Life order (oldest first)</option>
-      <option value="alpha">A&ndash;Z</option>
       <option value="most-photos">Most photos</option>
     </select>
   </div>
@@ -315,7 +315,7 @@ var LIFE_LIST_EXPORT_COLUMNS = {
   ],
 };
 var lifeListExportColumnSelections = {species: null, photos: null};
-var LIFE_LIST_SORTS = ['newest', 'life-order', 'alpha', 'most-photos'];
+var LIFE_LIST_SORTS = ['alpha', 'newest', 'life-order', 'most-photos'];
 var LIFE_LIST_PAGE_SIZE = 100;
 var lifeListLightboxSpecies = null;
 var lifeListLoadPromises = {};
@@ -429,7 +429,7 @@ function sortedSpecies() {
     if (sort === 'alpha') return a.species.localeCompare(b.species);
     if (sort === 'most-photos') return b.photo_count - a.photo_count;
     if (sort === 'life-order') return a.number - b.number;
-    // 'newest' default — by first_seen desc, undated species last so they
+    // 'newest' — by first_seen desc, undated species last so they
     // don't masquerade as the newest lifers (server gives them the highest
     // life-list numbers for stable numbering, so reversing number is wrong).
     var af = a.first_seen, bf = b.first_seen;


### PR DESCRIPTION
Makes A–Z the first and default sorting option on the Life List while continuing to restore users’ saved sort preferences. Updates the browser coverage to verify the alphabetical default as well as persistence after choosing another sort.

Tested with `pytest -q tests/e2e/test_lifelist_add_verify.py::test_default_sort_and_numbering_preferences_persist` (1 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Life List sorting options to present alphabetical order first, followed by newest, life-list order, and most photos.
  * Alphabetical sorting is now the default presentation.

* **Bug Fixes**
  * Improved persistence of sorting and numbering preferences after reloading the Life List.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->