### PR TITLE
Sort life-list names with leading ʻokina under A

### DIFF
--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -202,6 +202,35 @@ def test_sort_and_numbering_preferences_persist(live_server, page):
     expect(page.locator(".lifer-number").first).to_have_text("#1")
 
 
+def test_alphabetical_sort_ignores_leading_okina(live_server, page):
+    db = live_server["db"]
+    folder_id = live_server["data"]["folders"][0]
+
+    for i, species in enumerate(("Hutton's vireo", "\u02bbapapane", "Java sparrow")):
+        keyword_id = db.add_keyword(species, is_species=True)
+        photo_id = db.add_photo(
+            folder_id=folder_id,
+            filename=f"okina-sort-{i}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=200.0 + i,
+            timestamp=f"2024-07-{i + 1:02d}T09:00:00",
+        )
+        db.tag_photo(photo_id, keyword_id)
+
+    page.goto(f"{live_server['url']}/life-list")
+    page.locator(".species-card").first.wait_for(state="visible")
+    page.locator("#sortSelect").select_option("alpha")
+
+    expect(page.locator(".species-name")).to_have_text([
+        "American Robin",
+        "\u02bbApapane",
+        "Hutton's vireo",
+        "Java Sparrow",
+        "Red-tailed Hawk",
+    ])
+
+
 def test_taxonomic_group_and_identification_level_filters(live_server, page):
     db = live_server["db"]
     folder_id = live_server["data"]["folders"][0]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2701,6 +2701,21 @@ def _strftime_template_can_render(template_component, target):
         return True
 
 
+_LIFE_LIST_LEADING_APOSTROPHE_RE = re.compile(
+    r"^['`´ʹʻʼ‘’‛]+"
+)
+
+
+def _life_list_alphabetical_key(name):
+    """Sort key that ignores a leading Hawaiian ʻokina or apostrophe variant.
+
+    Kept in sync with ``lifeListAlphabeticalName`` in ``life_list.html`` so
+    server-side lifer numbering ties break under the same letter the client
+    displays the species under.
+    """
+    return _LIFE_LIST_LEADING_APOSTROPHE_RE.sub("", str(name or "")).lower()
+
+
 def create_app(db_path, thumb_cache_dir=None, api_token=None):
     """Create the Flask app for the Vireo photo browser.
 
@@ -11652,6 +11667,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         species_entries.sort(key=lambda e: (
             e["first_seen"] is None,
             e["first_seen"] or "",
+            _life_list_alphabetical_key(e["species"]),
             e["species"].lower(),
         ))
         for i, e in enumerate(species_entries, start=1):

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -422,23 +422,38 @@ function populateLifeListTaxonomyFilters() {
   replaceSelectOptions(document.getElementById('identificationRankSelect'), rankOptions);
 }
 
+function lifeListAlphabeticalName(name) {
+  // In an English-oriented common-name list, a leading Hawaiian ʻokina is
+  // ignored for alphabetization even though it remains part of the displayed
+  // spelling. Include common apostrophe substitutes so imported variants sort
+  // consistently with the proper U+02BB character.
+  return String(name || '').replace(/^[\u0027\u02BB\u02BC\u2018\u2019]+/, '');
+}
+
+function compareLifeListSpeciesAlphabetically(a, b) {
+  var aName = String(a.species || '');
+  var bName = String(b.species || '');
+  return lifeListAlphabeticalName(aName).localeCompare(lifeListAlphabeticalName(bName))
+    || aName.localeCompare(bName);
+}
+
 function sortedSpecies() {
   var sort = document.getElementById('sortSelect').value;
   var list = (currentData.species || []).slice();
   list.sort(function(a, b) {
-    if (sort === 'alpha') return a.species.localeCompare(b.species);
+    if (sort === 'alpha') return compareLifeListSpeciesAlphabetically(a, b);
     if (sort === 'most-photos') return b.photo_count - a.photo_count;
     if (sort === 'life-order') return a.number - b.number;
     // 'newest' default — by first_seen desc, undated species last so they
     // don't masquerade as the newest lifers (server gives them the highest
     // life-list numbers for stable numbering, so reversing number is wrong).
     var af = a.first_seen, bf = b.first_seen;
-    if (!af && !bf) return a.species.localeCompare(b.species);
+    if (!af && !bf) return compareLifeListSpeciesAlphabetically(a, b);
     if (!af) return 1;
     if (!bf) return -1;
     if (af < bf) return 1;
     if (af > bf) return -1;
-    return a.species.localeCompare(b.species);
+    return compareLifeListSpeciesAlphabetically(a, b);
   });
   return list;
 }

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -427,7 +427,7 @@ function lifeListAlphabeticalName(name) {
   // ignored for alphabetization even though it remains part of the displayed
   // spelling. Include common apostrophe substitutes so imported variants sort
   // consistently with the proper U+02BB character.
-  return String(name || '').replace(/^[\u0027\u02BB\u02BC\u2018\u2019]+/, '');
+  return String(name || '').replace(/^[\u0027\u0060\u00B4\u02B9\u02BB\u02BC\u2018\u2019\u201B]+/, '');
 }
 
 function compareLifeListSpeciesAlphabetically(a, b) {

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -1439,3 +1439,58 @@ def test_life_list_bucket_survives_root_repair_spelling_drift(tmp_path, monkeypa
     assert {p["id"] for p in single_data["photos"]} == {pid_hier, pid_root}
 
     db.close()
+
+
+def test_life_list_alphabetical_key_ignores_apostrophe_variants():
+    """Server-side sort key strips the same leading apostrophe variants
+    the client's ``lifeListAlphabeticalName`` does, so lifer numbering
+    tie-breaks agree with what the alphabetical view renders."""
+    from app import _life_list_alphabetical_key
+
+    for prefix in ("ʻ", "ʼ", "'", "`", "´", "ʹ", "‘", "’", "‛"):
+        assert (
+            _life_list_alphabetical_key(prefix + "Apapane") == "apapane"
+        ), f"prefix {prefix!r} (U+{ord(prefix):04X}) should be stripped"
+    assert _life_list_alphabetical_key("Hutton's Vireo") == "hutton's vireo"
+    assert _life_list_alphabetical_key("") == ""
+    assert _life_list_alphabetical_key(None) == ""
+
+
+def test_life_list_numbering_places_okina_species_under_a(life_app):
+    """When ``first_seen`` ties (or both species are undated), lifer
+    numbering must sort ``ʻApapane`` under A rather than after H, matching
+    the client-side alphabetical view. Regression for the Codex review on
+    PR #1366."""
+    app, db, ids = life_app
+
+    apapane_kw = db.add_keyword("ʻApapane", is_species=True)
+    hutton_kw = db.add_keyword("Hutton's Vireo", is_species=True)
+    # Identical timestamps make the numbering tuple fall through to the
+    # alphabetical tie-breaker, isolating the behavior under test.
+    for filename, kw in (("apapane1.jpg", apapane_kw),
+                         ("hutton1.jpg", hutton_kw)):
+        pid = db.add_photo(
+            folder_id=ids["folder"],
+            filename=filename,
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=100.0,
+            timestamp="2022-01-01T00:00:00",
+        )
+        db.tag_photo(pid, kw)
+    db.conn.commit()
+
+    data = _get_life_list(app)
+    by_lower = {e["species"].lower(): e for e in data["species"]}
+    # ``add_keyword`` title-cases species names, so the stored form is
+    # ``Hutton'S Vireo``; compare case-insensitively to keep the test
+    # focused on numbering rather than the casing heuristic.
+    apapane = by_lower["ʻapapane"]
+    hutton = by_lower["hutton's vireo"]
+    assert apapane["first_seen"] == hutton["first_seen"], (
+        "test setup should tie first_seen so numbering falls to the name key"
+    )
+    assert apapane["number"] < hutton["number"], (
+        f"ʻApapane (#{apapane['number']}) must sort under A ahead of "
+        f"Hutton's Vireo (#{hutton['number']})"
+    )


### PR DESCRIPTION
Sorts life-list common names with a leading ʻokina or common apostrophe substitute by their base English name while preserving the displayed spelling. The same comparator now handles the explicit A–Z view and alphabetical date tie-breaks. This fixes the default `localeCompare()` behavior that placed `ʻApapane` between H and J, and adds an end-to-end regression test. Validation: `pytest -q tests/e2e/test_lifelist_add_verify.py` (11 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alphabetical sorting in the Life List to correctly ignore leading apostrophe and okina characters in species names.
  - Added consistent tie-breaking for species names with equivalent normalized forms.

- **Tests**
  - Added end-to-end coverage verifying the corrected ordering for species names beginning with an okina.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->