### PR TITLE
Update website download links for Vireo 0.30.2

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.30.0';
-const windowsVersion = '0.30.0';
-const linuxVersion = '0.30.0';
+const macosArm64Version = '0.30.2';
+const windowsVersion = '0.30.2';
+const linuxVersion = '0.30.2';
 
 // The Windows 11 public beta ships as the first SignPath-signed build.
 // Until the download link points at that signed build, the older Windows


### PR DESCRIPTION
Automated update of website download links following the Vireo 0.30.2 release. Auto-merges once required checks pass; the website deployment workflow runs on the resulting push to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS, Windows, and Linux download links to release version 0.30.2.
  * Updated the Windows download status to accurately reflect the current public beta availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->