### PR TITLE
Stop recycled photo rowids from inheriting the old photo's cached images

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3385,6 +3385,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         variant,
                         exc_info=True,
                     )
+            # ``<pid>_regen.jpg`` / ``<pid>_raw_regen.jpg`` /
+            # ``<pid>_jpeg_regen.jpg`` are the sidecars ``serve_thumbnail``
+            # falls back to when the default couldn't be unlinked (a
+            # persistent lock). Without this pass, editing the recipe
+            # while the default stays locked leaves the sidecar carrying
+            # the pre-edit pixels; the freshness gate there compares
+            # against the unchanged source mtime and re-serves them.
+            for stem in (f"{pid}", f"{pid}_raw", f"{pid}_jpeg"):
+                sidecar = os.path.join(thumb_dir, f"{stem}_regen.jpg")
+                try:
+                    if os.path.exists(sidecar):
+                        os.remove(sidecar)
+                except OSError:
+                    log.warning(
+                        "Failed to remove stale regeneration sidecar %s",
+                        sidecar,
+                        exc_info=True,
+                    )
             if clear_thumb_path:
                 db.conn.execute(
                     "UPDATE photos SET thumb_path = NULL WHERE id = ?", (pid,),
@@ -30451,6 +30469,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 live_source_path=image_path, folder_path=folder["path"],
             )
         )
+        # Preserve the resolved RAW path before the RAW-failure branch
+        # below rewrites ``image_path`` to the companion. The display
+        # cache-hit check on the next request reconstructs both live
+        # sources and pegs against their max, so passing only the
+        # companion into ``_peg_display_cache_mtime`` would fail the
+        # gate whenever the RAW is newer and re-extract on every hit.
+        raw_source_path = image_path
         if has_current_raw_failure:
             if (
                 resolved_ext in RAW_EXTENSIONS
@@ -30536,9 +30561,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     # (clock skew, archives that preserve future
                     # timestamps), and every request re-decodes the RAW
                     # and companion. Peg to the same max the check
-                    # consults.
+                    # consults. Use ``raw_source_path`` — the RAW resolved
+                    # before the has_current_raw_failure branch rewrote
+                    # ``image_path`` to the companion — so a newer RAW
+                    # mtime doesn't fail the gate and re-extract on every
+                    # hit.
                     _peg_display_cache_mtime(
-                        wc_abs, (image_path, companion_for_extraction),
+                        wc_abs, (raw_source_path, companion_for_extraction),
                     )
                 return extracted
             finally:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3198,27 +3198,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     _invalid_preview_cache_paths = set()
 
+    # Canonical definitions live in preview_cache so the recycled-rowid
+    # purge (which runs in the scanner, outside this app factory) writes
+    # the same marker _serve_preview's lazy-adoption branch consults.
     def _ensure_preview_cache_invalidations_table(db):
-        db.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS preview_cache_invalidations (
-                photo_id INTEGER NOT NULL,
-                size INTEGER NOT NULL,
-                PRIMARY KEY (photo_id, size),
-                FOREIGN KEY (photo_id) REFERENCES photos(id) ON DELETE CASCADE
-            )
-            """,
-        )
+        from preview_cache import ensure_preview_cache_invalidations_table
+        ensure_preview_cache_invalidations_table(db)
 
     def _mark_preview_cache_invalid(db, photo_id, size, *, commit=True):
-        _ensure_preview_cache_invalidations_table(db)
-        db.conn.execute(
-            "INSERT OR IGNORE INTO preview_cache_invalidations (photo_id, size) "
-            "VALUES (?, ?)",
-            (photo_id, size),
-        )
-        if commit:
-            db.conn.commit()
+        from preview_cache import mark_preview_cache_invalid
+        mark_preview_cache_invalid(db, photo_id, size, commit=commit)
 
     def _clear_preview_cache_invalid(db, photo_id, size, *, commit=True):
         _ensure_preview_cache_invalidations_table(db)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24783,6 +24783,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             f"{photo_id}_{pair_source}.jpg" if pair_source else filename
         )
         thumb_path = os.path.join(thumb_dir, cache_filename)
+        # Set when a locked stale thumbnail forces regeneration to the
+        # ``<id>_regen.jpg`` sidecar; the real ``<id>.jpg`` stays stale.
+        served_from_regen_sidecar = False
         try:
             selected_source_mtime = (
                 os.path.getmtime(pair_source_path)
@@ -24841,6 +24844,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # the delete cleanup already sweep it.
                 stem, ext = os.path.splitext(cache_filename)
                 cache_filename = f"{stem}_regen{ext}"
+                served_from_regen_sidecar = True
                 thumb_path = os.path.join(thumb_dir, cache_filename)
                 log.warning(
                     "Could not unlink stale thumbnail %s; regenerating to "
@@ -25090,7 +25094,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Persist on-disk presence so the dashboard's coverage query
         # (`thumb_path IS NOT NULL`) reflects this regeneration. Stored
         # value is the bare filename, matching ``thumbnails.generate_all``.
-        if not pair_source:
+        #
+        # Skipped when we fell back to the ``_regen`` sidecar: the real
+        # ``<id>.jpg`` is still the previous owner's locked, stale file.
+        # Recording it as done would tell the coverage dashboard and
+        # ``backfill_thumb_paths`` this photo has a valid thumbnail, so
+        # nothing would regenerate it once the lock clears — a pill
+        # claiming work is finished when the next run would not be a
+        # no-op is exactly what CORE_PHILOSOPHY forbids. Leaving the
+        # column NULL keeps the photo in the "needs a thumbnail" set,
+        # which is the truth.
+        if not pair_source and not served_from_regen_sidecar:
             try:
                 db.conn.execute(
                     "UPDATE photos SET thumb_path=? WHERE id=?",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -27728,6 +27728,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             result["detection_conf"] = None
         return jsonify(result)
 
+    def _mask_file_is_db_backed(filename, mask_path):
+        """Whether a mask file on disk is actually this photo's.
+
+        ``masks/<id>.png`` and ``masks/<id>.<variant>.png`` are keyed by
+        bare photo id, and ``photos.id`` recycles freed rowids, so file
+        existence alone does not mean the file belongs to the photo now
+        holding that id. ``photo_masks`` rows cascade away with the photo,
+        so requiring one is what distinguishes "this photo's mask" from
+        "a mask the previous owner of this rowid left behind" — and unlike
+        a timestamp check it can't be fooled by a stale file that happens
+        to be newer than the new photo's source.
+
+        Files whose name doesn't start with a photo id aren't id-keyed and
+        are served as before.
+        """
+        m = re.match(r"^(\d+)[._]", filename)
+        if not m:
+            return True
+        pid = int(m.group(1))
+        db = _get_db()
+        real = os.path.realpath(mask_path)
+        for row in db.conn.execute(
+            "SELECT path FROM photo_masks WHERE photo_id = ?", (pid,)
+        ):
+            if row["path"] and os.path.realpath(row["path"]) == real:
+                return True
+        row = db.conn.execute(
+            "SELECT mask_path FROM photos WHERE id = ?", (pid,)
+        ).fetchone()
+        return bool(
+            row and row["mask_path"]
+            and os.path.realpath(row["mask_path"]) == real
+        )
+
     @app.route("/masks/<filename>")
     def serve_mask(filename):
         """Serve mask PNG files.
@@ -27741,7 +27775,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         masks_dir = os.path.join(os.path.dirname(db_path), "masks")
         mask_path = os.path.join(masks_dir, filename)
-        if os.path.exists(mask_path):
+        if os.path.exists(mask_path) and _mask_file_is_db_backed(
+            filename, mask_path,
+        ):
             return send_from_directory(masks_dir, filename)
 
         m = re.match(r"^(\d+)\.png$", filename)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3264,6 +3264,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             vireo_dir, "originals", f"{photo['id']}_{cache_key}.jpg",
         )
 
+    def _peg_render_mtime_to_source(cache_path, photo):
+        """Align a freshly written render's mtime to the photo's source.
+
+        ``_prepared_full_resolution_render`` rejects renders whose mtime
+        predates ``photos.file_mtime``. Renders are written with the wall
+        clock, so a source whose ``file_mtime`` is in the *future* — clock
+        skew on the machine that wrote it, archives that preserve future
+        timestamps — would fail that gate immediately and re-render on
+        every single request. ``serve_thumbnail`` already documents and
+        guards this exact trap; the cost here is a full-resolution decode
+        plus edit pipeline per request, so it matters more.
+        """
+        source_mtime = photo["file_mtime"] if photo is not None else None
+        if source_mtime is None:
+            return
+        with contextlib.suppress(OSError, TypeError, ValueError):
+            os.utime(cache_path, (float(source_mtime), float(source_mtime)))
+
     def _prepared_full_resolution_render(
         vireo_dir, photo, recipe, file_state=None,
     ):
@@ -30316,6 +30334,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             try:
                 img.save(tmp_path, format="JPEG", quality=quality)
                 os.replace(tmp_path, cache_path)
+                _peg_render_mtime_to_source(cache_path, photo)
             except Exception:
                 with contextlib.suppress(OSError):
                     os.unlink(tmp_path)
@@ -30665,6 +30684,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             img.save(tmp_path, format="JPEG", quality=quality)
             os.replace(tmp_path, cache_path)
+            _peg_render_mtime_to_source(cache_path, photo)
         except Exception:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24857,11 +24857,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     or sidecar_mtime >= selected_source_mtime
                 ):
                     return _send_cached(thumb_dir, cache_filename)
-                # Fall through: the regen path below now targets the
-                # sidecar, so a stale sidecar is overwritten too.
-                with contextlib.suppress(OSError):
-                    if sidecar_mtime is not None:
+                # A stale sidecar has to go before we fall through, for
+                # the same reason as the original: ``generate_thumbnail``
+                # short-circuits on an existing destination, so leaving it
+                # would return the previous owner's pixels and the
+                # ``os.utime(result, ...)`` below would then mark them
+                # fresh forever.
+                if sidecar_mtime is not None:
+                    with contextlib.suppress(OSError):
                         os.remove(thumb_path)
+                    if os.path.exists(thumb_path):
+                        # Both the real thumbnail and the sidecar are
+                        # stale and undeletable, so there is nowhere in
+                        # the cache we can safely write. Every remaining
+                        # option would serve another photo's pixels;
+                        # answer honestly instead. The next request
+                        # retries both unlinks.
+                        log.error(
+                            "Photo %s has a stale thumbnail and a stale "
+                            "regeneration sidecar, neither of which could "
+                            "be removed (%s). Serving no thumbnail rather "
+                            "than the previous owner's pixels; clear the "
+                            "cache in Settings > Storage to recover.",
+                            photo_id, thumb_path,
+                        )
+                        return "", 404
 
         # Self-heal path: regenerate on miss (or stale) when the photo
         # still exists.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3273,6 +3273,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             if not os.path.isfile(cache_path) or os.path.getsize(cache_path) <= 0:
                 return None
+            # Same freshness gate ``serve_thumbnail`` uses. The signature
+            # hash already covers the normal invalidation case (a scan that
+            # updates ``file_mtime`` computes a different cache path), so
+            # this check is a no-op for legitimate renders — their mtime is
+            # the write time, which is by definition ``>= file_mtime``.
+            # It exists to reject a *surviving* render left over when a
+            # rowid is recycled and the new photo's signature happens to
+            # collide with a previous owner's: ``purge_cached_files_for_
+            # recycled_id`` backdates any undeletable survivor to mtime 0,
+            # and without this check ``/original`` would happily send the
+            # previous owner's pixels since the existence-and-size probe
+            # can't distinguish them from a fresh render.
+            source_mtime = photo["file_mtime"]
+            if (
+                source_mtime is not None
+                and os.path.getmtime(cache_path) < float(source_mtime)
+            ):
+                return None
         except OSError:
             return None
         return cache_path

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24824,19 +24824,44 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             try:
                 os.remove(thumb_path)
             except OSError:
-                # If we can't unlink the stale file (Windows lock,
-                # permissions, antivirus quarantine), do NOT proceed to
-                # regen+utime: ``generate_thumbnail`` would short-circuit
-                # on the existing file and the subsequent ``os.utime``
-                # below would mark the stale image as fresh forever.
-                # Serve what's on disk this once and leave the mtime
-                # alone — next request will retry the unlink.
+                # We can't unlink the stale file (Windows lock,
+                # permissions, antivirus quarantine) and we must not
+                # regenerate over it: ``generate_thumbnail`` would
+                # short-circuit on the existing file and the ``os.utime``
+                # below would then mark the stale image fresh forever.
+                #
+                # Serving it is not an option either. This branch fires
+                # for recycled rowids, so those pixels belong to a
+                # *different photo* — and if the lock persists, every
+                # subsequent request serves them too. Showing another
+                # bird is worse than showing nothing.
+                #
+                # Regenerate to a sidecar and serve that instead. The
+                # ``{photo_id}_*`` shape means the recycled-id purge and
+                # the delete cleanup already sweep it.
+                stem, ext = os.path.splitext(cache_filename)
+                cache_filename = f"{stem}_regen{ext}"
+                thumb_path = os.path.join(thumb_dir, cache_filename)
                 log.warning(
-                    "Could not unlink stale thumbnail %s; serving stale "
-                    "file once. Next request will retry the unlink.",
-                    thumb_path, exc_info=True,
+                    "Could not unlink stale thumbnail %s; regenerating to "
+                    "%s rather than serving the previous owner's pixels.",
+                    os.path.join(thumb_dir, f"{stem}{ext}"), cache_filename,
+                    exc_info=True,
                 )
-                return _send_cached(thumb_dir, cache_filename)
+                try:
+                    sidecar_mtime = os.path.getmtime(thumb_path)
+                except FileNotFoundError:
+                    sidecar_mtime = None
+                if sidecar_mtime is not None and (
+                    selected_source_mtime is None
+                    or sidecar_mtime >= selected_source_mtime
+                ):
+                    return _send_cached(thumb_dir, cache_filename)
+                # Fall through: the regen path below now targets the
+                # sidecar, so a stale sidecar is overwritten too.
+                with contextlib.suppress(OSError):
+                    if sidecar_mtime is not None:
+                        os.remove(thumb_path)
 
         # Self-heal path: regenerate on miss (or stale) when the photo
         # still exists.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -25003,6 +25003,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 _recipe_source_dimensions(photo)
                                 if render_recipe else None
                             ),
+                            # Must match the primary call's target: when a
+                            # locked stale thumbnail redirected us to the
+                            # sidecar, generating to the default
+                            # ``<id>.jpg`` would short-circuit on that
+                            # locked file and the os.utime below would pin
+                            # the previous owner's pixels as fresh.
+                            cache_name=cache_filename,
                         )
                         if result:
                             source = companion_abs
@@ -25021,6 +25028,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     cfg.load().get("thumbnail_quality", 85),
                     render_recipe,
                     vireo_dir,
+                    cache_name=cache_filename,
                 )
                 if result:
                     source = result

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24728,7 +24728,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         next insert. Combined with delete paths that don't unlink cached
         files (``audit.remove_orphans``, folder consolidation in
         ``Database.consolidate_folders``, companion-pair dedup in
-        ``scanner._merge_companion_pair``), a JPEG at ``<id>.jpg`` can
+        ``scanner._pair_raw_jpeg_companions``), a JPEG at ``<id>.jpg`` can
         outlive its original photo and then be served as the thumbnail
         for an entirely different photo that later inherits that ID.
         Compare the cached file's mtime against the photo's

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3275,12 +3275,54 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         every single request. ``serve_thumbnail`` already documents and
         guards this exact trap; the cost here is a full-resolution decode
         plus edit pipeline per request, so it matters more.
+
+        Use this for *signature-keyed* prepared renders only — the
+        signature already encodes the recipe and edit-math version, so
+        pegging to ``photos.file_mtime`` alone is enough. For the unedited
+        RAW display cache, use :func:`_peg_display_cache_mtime` instead;
+        that cache-hit check compares the file against
+        ``max(mtime(source), mtime(companion))``, so pegging to the row's
+        ``file_mtime`` here would fail the check on every request when a
+        paired companion has a later mtime than the RAW row.
         """
         source_mtime = photo["file_mtime"] if photo is not None else None
         if source_mtime is None:
             return
         with contextlib.suppress(OSError, TypeError, ValueError):
             os.utime(cache_path, (float(source_mtime), float(source_mtime)))
+
+    def _peg_display_cache_mtime(cache_path, source_paths):
+        """Align an unedited RAW display cache's mtime to its own hit check.
+
+        ``/photos/<id>/original`` decides the display cache is fresh when
+        its mtime is ``>= max(mtime(image_path), mtime(companion))``.
+        Renders are written with the wall clock, so if either live source
+        has a *future* mtime — clock skew, archives that preserve future
+        timestamps — the just-written cache fails the check the instant
+        it lands and every request re-decodes the RAW plus the companion
+        JPEG. And even without clock skew, pegging the display cache to
+        ``photos.file_mtime`` (the row's stored mtime for the RAW) would
+        fail the check whenever a paired companion JPEG has a later
+        filesystem mtime than the RAW row does, which is the common shape
+        for a fresh camera dump touched by any post-import step.
+
+        Peg to the same max the cache-hit check consults so a valid
+        render satisfies its own gate. Best-effort: a failed ``utime``
+        only costs the next request a re-render.
+        """
+        mtimes = []
+        for path in source_paths:
+            if not path:
+                continue
+            try:
+                mtimes.append(os.path.getmtime(path))
+            except OSError:
+                continue
+        if not mtimes:
+            return
+        peg = max(mtimes)
+        with contextlib.suppress(OSError, TypeError, ValueError):
+            os.utime(cache_path, (peg, peg))
 
     def _prepared_full_resolution_render(
         vireo_dir, photo, recipe, file_state=None,
@@ -30487,6 +30529,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if extracted and tmp_path:
                     os.replace(tmp_path, wc_abs)
                     tmp_path = None
+                    # The display cache-hit check compares against
+                    # ``max(mtime(image_path), mtime(companion))``.
+                    # Leaving wall-clock mtime here fails that check
+                    # whenever either live source has a future mtime
+                    # (clock skew, archives that preserve future
+                    # timestamps), and every request re-decodes the RAW
+                    # and companion. Peg to the same max the check
+                    # consults.
+                    _peg_display_cache_mtime(
+                        wc_abs, (image_path, companion_for_extraction),
+                    )
                 return extracted
             finally:
                 if tmp_path:
@@ -30684,7 +30737,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             img.save(tmp_path, format="JPEG", quality=quality)
             os.replace(tmp_path, cache_path)
-            _peg_render_mtime_to_source(cache_path, photo)
+            if primary_is_raw:
+                # The unedited RAW display cache-hit check compares
+                # against ``max(mtime(image_path), mtime(companion))``.
+                # Pegging to ``photo['file_mtime']`` alone (as the
+                # signature-keyed prepared render does) would fail that
+                # check on every request when the paired companion is
+                # newer than the RAW row.
+                _peg_display_cache_mtime(
+                    cache_path, (image_path, companion_for_extraction),
+                )
+            else:
+                _peg_render_mtime_to_source(cache_path, photo)
         except Exception:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -261,11 +261,12 @@ def transfer_snapshots(vireo_dir, old_photo_id, new_photo_id):
     Byte-identical snapshots for the same ref hash to the same file name,
     so ``os.replace`` on a pre-existing destination is safe (same content).
 
-    Returns ``{"moved": [refs], "failed": [refs]}``. ``load_snapshot``
-    only ever builds ``snapshot_path(vireo_dir, photo_id, ref)``, so a
-    snapshot left under the *old* id is unreachable no matter what — the
-    render disables the local pass indefinitely. That makes a silent
-    failure here invisible, so:
+    Returns ``{"moved": [refs], "failed": [refs], "enumerate_failed":
+    bool}``. ``load_snapshot`` only ever builds
+    ``snapshot_path(vireo_dir, photo_id, ref)``, so a snapshot left under
+    the *old* id is unreachable no matter what — the render disables the
+    local pass indefinitely. That makes a silent failure here invisible,
+    so:
 
     * ``os.replace`` failing (typically a locked source on Windows) falls
       back to ``shutil.copy2`` + best-effort unlink. The copy is what
@@ -274,13 +275,30 @@ def transfer_snapshots(vireo_dir, old_photo_id, new_photo_id):
     * Anything still unrecoverable is reported in ``failed`` so the
       caller can say so out loud instead of rendering a silently
       degraded image (CORE_PHILOSOPHY: no black boxes).
+    * If ``os.listdir`` itself raises (transient EIO, ACL change on
+      ``edit-masks/``), the individual refs are unknown but the outcome
+      is the same as ``failed``: every snapshot stays under the old id
+      and every affected local pass renders without its mask.
+      ``enumerate_failed`` surfaces that so the caller can log it rather
+      than let the exception vanish into the deferred-action guard.
     """
     directory = edit_masks_dir(vireo_dir)
-    result = {"moved": [], "failed": []}
+    result = {"moved": [], "failed": [], "enumerate_failed": False}
     if not os.path.isdir(directory):
         return result
     prefix = f"{int(old_photo_id)}."
-    for name in os.listdir(directory):
+    try:
+        names = os.listdir(directory)
+    except OSError:
+        log.warning(
+            "Could not enumerate edit-masks directory %s while moving "
+            "snapshots from photo %s to %s; any local adjustments will "
+            "render without their mask until the snapshots are recreated",
+            directory, old_photo_id, new_photo_id, exc_info=True,
+        )
+        result["enumerate_failed"] = True
+        return result
+    for name in names:
         if not name.startswith(prefix):
             continue
         match = _SNAPSHOT_FILE_RE.match(name)

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import tempfile
 import time
 
@@ -259,10 +260,25 @@ def transfer_snapshots(vireo_dir, old_photo_id, new_photo_id):
 
     Byte-identical snapshots for the same ref hash to the same file name,
     so ``os.replace`` on a pre-existing destination is safe (same content).
+
+    Returns ``{"moved": [refs], "failed": [refs]}``. ``load_snapshot``
+    only ever builds ``snapshot_path(vireo_dir, photo_id, ref)``, so a
+    snapshot left under the *old* id is unreachable no matter what — the
+    render disables the local pass indefinitely. That makes a silent
+    failure here invisible, so:
+
+    * ``os.replace`` failing (typically a locked source on Windows) falls
+      back to ``shutil.copy2`` + best-effort unlink. The copy is what
+      actually restores the local pass; leaving the original behind is
+      harmless because ``gc_edit_masks`` reaps by ref, not by id.
+    * Anything still unrecoverable is reported in ``failed`` so the
+      caller can say so out loud instead of rendering a silently
+      degraded image (CORE_PHILOSOPHY: no black boxes).
     """
     directory = edit_masks_dir(vireo_dir)
+    result = {"moved": [], "failed": []}
     if not os.path.isdir(directory):
-        return
+        return result
     prefix = f"{int(old_photo_id)}."
     for name in os.listdir(directory):
         if not name.startswith(prefix):
@@ -270,15 +286,33 @@ def transfer_snapshots(vireo_dir, old_photo_id, new_photo_id):
         match = _SNAPSHOT_FILE_RE.match(name)
         if not match or int(match.group(1)) != int(old_photo_id):
             continue
+        ref = match.group(2)
         src = os.path.join(directory, name)
-        dst = snapshot_path(vireo_dir, int(new_photo_id), match.group(2))
+        dst = snapshot_path(vireo_dir, int(new_photo_id), ref)
         try:
             os.replace(src, dst)
         except OSError:
             log.warning(
-                "Could not transfer edit-mask snapshot %s -> %s",
+                "Could not rename edit-mask snapshot %s -> %s; trying a copy",
                 src, dst, exc_info=True,
             )
+            try:
+                shutil.copy2(src, dst)
+            except OSError:
+                log.warning(
+                    "Could not copy edit-mask snapshot %s -> %s either; "
+                    "the local adjustment for photo %s will render "
+                    "without its mask until the snapshot is recreated",
+                    src, dst, new_photo_id, exc_info=True,
+                )
+                result["failed"].append(ref)
+                continue
+            # The copy already restored the local pass; the leftover
+            # source is only clutter, and gc_edit_masks reaps by ref.
+            with contextlib.suppress(OSError):
+                os.remove(src)
+        result["moved"].append(ref)
+    return result
 
 
 def _referenced_refs(db):

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -48,6 +48,7 @@ def cleanup_cached_files_for_deleted_photos(
     originals_dir = os.path.join(vireo_dir, "originals")
     masks_dir = os.path.join(vireo_dir, "masks")
     external_dng_dir = os.path.join(vireo_dir, "external-dng")
+    external_edits_dir = os.path.join(vireo_dir, "external-edits")
     # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
     # The FK cascade drops the offline_originals row when the photo is
     # deleted, so we lose the exact stored paths — glob by photo id to
@@ -161,6 +162,23 @@ def cleanup_cached_files_for_deleted_photos(
                     "— will be reclaimed by Clear Cache: %s",
                     orphan, e,
                 )
+        # ``external-edits/<pid>.jpg`` is the render handed to an external
+        # editor, and ``<pid>.json`` is its cache key — recipe, source path,
+        # source mtime, edit-math version. No photo id or content hash, so a
+        # recycled id re-imported at the same path with a preserved mtime and
+        # the same recipe matches the previous owner's metadata and the old
+        # render gets handed to the editor.
+        for name in (f"{pid}.jpg", f"{pid}.json"):
+            handoff = os.path.join(external_edits_dir, name)
+            if os.path.isfile(handoff):
+                try:
+                    os.remove(handoff)
+                except OSError as e:
+                    log.warning(
+                        "Failed to remove external-edit handoff %s after "
+                        "photo delete — will be reclaimed by Clear Cache: %s",
+                        handoff, e,
+                    )
         # ``external-dng/<pid>/<stem>.dng`` caches DNG conversions per
         # photo id for the Nikon-HE-NEF external-editor path. The
         # freshness check there is source-mtime-based, so a recycled id
@@ -196,6 +214,7 @@ def _recycled_id_probe_paths(thumb_cache_dir, photo_id, vireo_dir=None):
         os.path.join(vireo_dir, "previews", f"{photo_id}.jpg"),
         os.path.join(vireo_dir, "originals", f"{photo_id}.display.jpg"),
         os.path.join(vireo_dir, "masks", f"{photo_id}.png"),
+        os.path.join(vireo_dir, "external-edits", f"{photo_id}.jpg"),
         # ``external-dng/<pid>/`` is a per-photo-id *directory* rather than
         # a file — ``os.path.exists`` returns True for directories, so
         # the same machinery covers it. The batch index's directory sweep
@@ -229,6 +248,7 @@ def _recycled_id_probe_patterns(thumb_cache_dir, photo_id, vireo_dir=None):
         os.path.join(vireo_dir, "previews", f"{photo_id}_*.jpg"),
         os.path.join(vireo_dir, "originals", f"{photo_id}_*.jpg"),
         os.path.join(vireo_dir, "masks", f"{photo_id}.*.png"),
+        os.path.join(vireo_dir, "external-edits", f"{photo_id}.json"),
         os.path.join(vireo_dir, "offline", "originals", f"{photo_id}.*"),
         os.path.join(vireo_dir, "offline", "xmp", f"{photo_id}.*"),
         os.path.join(vireo_dir, "offline", "companions", f"{photo_id}.*"),
@@ -268,6 +288,7 @@ def _derivative_dirs(thumb_cache_dir, vireo_dir=None):
         os.path.join(vireo_dir, "working"),
         os.path.join(vireo_dir, "originals"),
         os.path.join(vireo_dir, "masks"),
+        os.path.join(vireo_dir, "external-edits"),
         os.path.join(vireo_dir, "offline", "originals"),
         os.path.join(vireo_dir, "offline", "xmp"),
         os.path.join(vireo_dir, "offline", "companions"),

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -348,10 +348,11 @@ def purge_cached_files_for_recycled_id(
     photo's pixels: the Life List card for a gull renders whatever bird
     used to own that row.
 
-    Delete paths are supposed to unlink these files, but several
-    (``Database._merge_into_existing``, ``scanner._merge_companion_pair``,
-    ``audit.remove_orphans``) drop photo rows with raw SQL and leave the
-    cache behind, and any unlink that fails leaves an orphan too. Rather
+    Delete paths are supposed to unlink these files, but the surface
+    area is wide — ``Database._merge_into_existing``,
+    ``scanner._pair_raw_jpeg_companions``, ``audit.remove_orphans`` and
+    other raw-SQL drops each need to remember every id-keyed derivative
+    family, and any unlink that fails leaves an orphan behind. Rather
     than trusting every delete site, ingest re-checks at the one moment
     the collision can actually happen — when a brand-new row claims a
     rowid.

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -415,8 +415,20 @@ def mark_preview_cache_invalid(db, photo_id, size, *, commit=True):
         db.conn.commit()
 
 
-def _preview_size_from_path(path, photo_id):
-    """Parse ``previews/<id>_<size>.jpg`` -> ``size``, else ``None``."""
+def _preview_size_from_path(path, photo_id, preview_dir=None):
+    """Parse ``previews/<id>_<size>.jpg`` -> ``size``, else ``None``.
+
+    ``preview_dir`` gates the match on the file actually living in
+    ``previews/``. The name shape alone is ambiguous: a prepared render at
+    ``originals/<id>_2048.jpg`` parses identically and would earn a durable
+    ``preview_cache_invalidations`` row for a preview size that was never
+    cached, permanently suppressing adoption of a preview that does get
+    written later.
+    """
+    if preview_dir is not None and os.path.normpath(
+        os.path.dirname(path)
+    ) != os.path.normpath(preview_dir):
+        return None
     name = os.path.basename(path)
     stem, ext = os.path.splitext(name)
     if ext.lower() != ".jpg":
@@ -537,28 +549,51 @@ def purge_cached_files_for_recycled_id(
         thumb_cache_dir, photo_id, vireo_dir,
     )
     if survivors:
+        preview_dir = os.path.join(
+            vireo_dir or os.path.dirname(thumb_cache_dir), "previews",
+        )
+        external_edits_dir = os.path.join(
+            vireo_dir or os.path.dirname(thumb_cache_dir), "external-edits",
+        )
         unfixable = []
         for path in survivors:
+            backdated = True
             try:
                 os.utime(path, (0, 0))
             except OSError:
+                backdated = False
+
+            size = _preview_size_from_path(path, photo_id, preview_dir)
+            if size is not None:
+                # Previews are the one family where the marker, not the
+                # mtime, is what keeps the adoption branch off the file —
+                # so attempt it even when the backdate failed. Doing this
+                # only on the backdate's success path (as an earlier
+                # revision did) left a readable survivor adoptable.
+                if db is None:
+                    unfixable.append(path)
+                    continue
+                try:
+                    mark_preview_cache_invalid(db, photo_id, size)
+                except Exception:
+                    log.warning(
+                        "Could not mark surviving preview %s invalid", path,
+                        exc_info=True,
+                    )
+                    unfixable.append(path)
+                continue
+
+            if os.path.normpath(os.path.dirname(path)) == os.path.normpath(
+                external_edits_dir
+            ):
+                # ``_external_edit_handoff_path`` compares the JSON's
+                # {recipe, source_path, source_mtime, edit_math_version}
+                # and never stats either file, so a backdate here changes
+                # nothing. Nothing short of removing them helps.
                 unfixable.append(path)
                 continue
-            size = _preview_size_from_path(path, photo_id)
-            if size is None:
-                continue
-            if db is None:
-                # No handle to write the marker, and mtime alone won't
-                # keep the adoption branch off it.
-                unfixable.append(path)
-                continue
-            try:
-                mark_preview_cache_invalid(db, photo_id, size)
-            except Exception:
-                log.warning(
-                    "Could not mark surviving preview %s invalid", path,
-                    exc_info=True,
-                )
+
+            if not backdated:
                 unfixable.append(path)
         if unfixable:
             log.error(

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -361,6 +361,52 @@ class RecycledIdIndex:
         return photo_id in self._ids
 
 
+def ensure_preview_cache_invalidations_table(db):
+    """Create the durable "do not adopt this preview" marker table.
+
+    Shared home for the marker `app.py`'s ``_serve_preview`` consults.
+    Backdating a preview file does nothing: the lazy-adoption branch there
+    tests ``os.path.exists(cache_path)`` with no mtime comparison, so an
+    on-disk preview that outlived its owner gets adopted and re-registered
+    verbatim. Only this row keeps it out.
+    """
+    db.conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS preview_cache_invalidations (
+            photo_id INTEGER NOT NULL,
+            size INTEGER NOT NULL,
+            PRIMARY KEY (photo_id, size),
+            FOREIGN KEY (photo_id) REFERENCES photos(id) ON DELETE CASCADE
+        )
+        """,
+    )
+
+
+def mark_preview_cache_invalid(db, photo_id, size, *, commit=True):
+    """Record that ``(photo_id, size)``'s on-disk preview must not be adopted."""
+    ensure_preview_cache_invalidations_table(db)
+    db.conn.execute(
+        "INSERT OR IGNORE INTO preview_cache_invalidations (photo_id, size) "
+        "VALUES (?, ?)",
+        (photo_id, size),
+    )
+    if commit:
+        db.conn.commit()
+
+
+def _preview_size_from_path(path, photo_id):
+    """Parse ``previews/<id>_<size>.jpg`` -> ``size``, else ``None``."""
+    name = os.path.basename(path)
+    stem, ext = os.path.splitext(name)
+    if ext.lower() != ".jpg":
+        return None
+    prefix = f"{photo_id}_"
+    if not stem.startswith(prefix):
+        return None
+    suffix = stem[len(prefix):]
+    return int(suffix) if suffix.isdigit() else None
+
+
 def _surviving_derivative_paths(thumb_cache_dir, photo_id, vireo_dir=None):
     """Concrete surviving derivative **files** for ``photo_id``.
 
@@ -399,7 +445,7 @@ def _surviving_derivative_paths(thumb_cache_dir, photo_id, vireo_dir=None):
 
 
 def purge_cached_files_for_recycled_id(
-    thumb_cache_dir, photo_id, id_index=None, vireo_dir=None,
+    thumb_cache_dir, photo_id, id_index=None, vireo_dir=None, db=None,
 ):
     """Drop any cached derivative left over from a previous owner of ``photo_id``.
 
@@ -459,6 +505,13 @@ def purge_cached_files_for_recycled_id(
     # deletion isn't (the lock blocks unlink, not utime), so this recovers
     # the common case; when even that fails we say so instead of leaving a
     # silent wrong-pixels bug.
+    #
+    # Backdating is not enough for *previews*, though: ``_serve_preview``'s
+    # lazy-adoption branch tests ``os.path.exists(cache_path)`` with no
+    # mtime comparison, so a surviving ``previews/<id>_<size>.jpg`` would
+    # be adopted and re-registered verbatim. Those need the durable
+    # ``preview_cache_invalidations`` marker, which that branch does
+    # honour. Requires a ``db``; callers in the ingest path have one.
     survivors = _surviving_derivative_paths(
         thumb_cache_dir, photo_id, vireo_dir,
     )
@@ -468,6 +521,23 @@ def purge_cached_files_for_recycled_id(
             try:
                 os.utime(path, (0, 0))
             except OSError:
+                unfixable.append(path)
+                continue
+            size = _preview_size_from_path(path, photo_id)
+            if size is None:
+                continue
+            if db is None:
+                # No handle to write the marker, and mtime alone won't
+                # keep the adoption branch off it.
+                unfixable.append(path)
+                continue
+            try:
+                mark_preview_cache_invalid(db, photo_id, size)
+            except Exception:
+                log.warning(
+                    "Could not mark surviving preview %s invalid", path,
+                    exc_info=True,
+                )
                 unfixable.append(path)
         if unfixable:
             log.error(

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -343,6 +343,24 @@ class RecycledIdIndex:
         return photo_id in self._ids
 
 
+def _surviving_derivative_paths(thumb_cache_dir, photo_id):
+    """Concrete derivative paths for ``photo_id`` still on disk.
+
+    Post-purge audit for :func:`purge_cached_files_for_recycled_id` — the
+    probe helpers answer "does anything exist?" and short-circuit, but
+    here we need the full list so each survivor can be dealt with.
+    """
+    paths = [
+        p for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id)
+        if os.path.exists(p)
+    ]
+    for pattern in _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
+        paths.extend(_glob.glob(pattern))
+    # dict.fromkeys: de-dupe (a bare name can match a variant pattern too)
+    # while keeping a stable order for the log message.
+    return list(dict.fromkeys(paths))
+
+
 def purge_cached_files_for_recycled_id(
     thumb_cache_dir, photo_id, id_index=None,
 ):
@@ -390,6 +408,41 @@ def purge_cached_files_for_recycled_id(
     cleanup_cached_files_for_deleted_photos(
         thumb_cache_dir, [{"photo_id": photo_id}],
     )
+    # ``cleanup_cached_files_for_deleted_photos`` logs and continues when an
+    # unlink fails (locked file on Windows, a momentarily unwritable
+    # directory), so "we ran the purge" is not the same as "the stale
+    # pixels are gone". Returning True unconditionally would let the scan
+    # commit a recycled row while the previous owner's thumbnail is still
+    # servable — and the request path's mtime guard can't catch it, since
+    # a recently generated thumbnail beats an old capture's file_mtime.
+    # Re-probe, and for anything left behind, backdate its mtime so that
+    # guard *does* reject it. Timestamps are usually still writable when
+    # deletion isn't (the lock blocks unlink, not utime), so this recovers
+    # the common case; when even that fails we say so instead of leaving a
+    # silent wrong-pixels bug.
+    survivors = _surviving_derivative_paths(thumb_cache_dir, photo_id)
+    if survivors:
+        unfixable = []
+        for path in survivors:
+            try:
+                os.utime(path, (0, 0))
+            except OSError:
+                unfixable.append(path)
+        if unfixable:
+            log.error(
+                "Photo %s reused a freed rowid but %d cached derivative(s) "
+                "could not be removed or invalidated: %s. Until they are "
+                "cleared (Settings > Storage > Clear cache), this photo may "
+                "render the previous owner's pixels.",
+                photo_id, len(unfixable), ", ".join(unfixable),
+            )
+        else:
+            log.warning(
+                "Photo %s reused a freed rowid; %d cached derivative(s) "
+                "survived deletion but were backdated so the freshness "
+                "guard regenerates them: %s",
+                photo_id, len(survivors), ", ".join(survivors),
+            )
     return True
 
 

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -38,7 +38,6 @@ def cleanup_cached_files_for_deleted_photos(
     working_dir = os.path.join(vireo_dir, "working")
     originals_dir = os.path.join(vireo_dir, "originals")
     masks_dir = os.path.join(vireo_dir, "masks")
-    edit_masks_dir = os.path.join(vireo_dir, "edit-masks")
     external_dng_dir = os.path.join(vireo_dir, "external-dng")
     # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
     # The FK cascade drops the offline_originals row when the photo is
@@ -122,23 +121,37 @@ def cleanup_cached_files_for_deleted_photos(
                         orphan, e,
                     )
         # Subject masks (``masks/{pid}.png``, ``masks/{pid}.{variant}.png``)
-        # and local-adjustment snapshots (``edit-masks/{pid}.{ref}.png``)
         # are id-keyed like everything above. photos.mask_path goes away
         # with the row, so a leftover file is invisible to the DB but is
         # picked back up by any photo that later inherits the id — the
-        # renderer would apply another photo's mask to the local pass.
-        for d in (masks_dir, edit_masks_dir):
-            for orphan in _glob.glob(os.path.join(d, f"{pid}.png")) + _glob.glob(
-                os.path.join(d, f"{pid}.*.png")
-            ):
-                try:
-                    os.remove(orphan)
-                except OSError as e:
-                    log.warning(
-                        "Failed to remove mask file %s after photo delete "
-                        "— will be reclaimed by Clear Cache: %s",
-                        orphan, e,
-                    )
+        # pipeline would score the new photo against another photo's mask.
+        #
+        # ``edit-masks/{pid}.{ref}.png`` is deliberately NOT purged here.
+        # Those snapshots are content-addressed: the filename carries a
+        # photo id, but ``load_snapshot`` only reads one when the photo's
+        # own recipe names that ``ref``, and a ref is a hash of the mask
+        # bytes. A recycled id therefore can't surface a previous owner's
+        # snapshot — a brand-new photo has no local section at all, and a
+        # ref match would mean byte-identical masks. Deleting them by id
+        # only creates a data-loss window: ``transfer_snapshots`` swallows
+        # OSError when a rename fails (locked destination on Windows), so
+        # an id-keyed purge in the companion-merge path would destroy the
+        # sole remaining copy of a snapshot whose recipe has already been
+        # reassigned to the primary, silently disabling that local
+        # adjustment forever. ``local_masks.gc_edit_masks`` owns this
+        # directory instead and reaps by ref — the correct key — with a
+        # grace period and a re-stat guard.
+        for orphan in _glob.glob(
+            os.path.join(masks_dir, f"{pid}.png")
+        ) + _glob.glob(os.path.join(masks_dir, f"{pid}.*.png")):
+            try:
+                os.remove(orphan)
+            except OSError as e:
+                log.warning(
+                    "Failed to remove mask file %s after photo delete "
+                    "— will be reclaimed by Clear Cache: %s",
+                    orphan, e,
+                )
         # ``external-dng/<pid>/<stem>.dng`` caches DNG conversions per
         # photo id for the Nikon-HE-NEF external-editor path. The
         # freshness check there is source-mtime-based, so a recycled id
@@ -190,8 +203,7 @@ def _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
     the standard shape written by ``scanner._extract_previews``), source-
     specific thumbnails (``thumbnails/7_raw.jpg`` / ``7_jpeg.jpg``),
     prepared full-res renders (``originals/7_1920.jpg``), model-scoped
-    subject masks (``masks/7.sam2-large.png``), edit-mask snapshots
-    (``edit-masks/7.abcdef012345.png``), and offline originals
+    subject masks (``masks/7.sam2-large.png``), and offline originals
     (``offline/originals/7.NEF``). Every one of these is unlinked by
     ``cleanup_cached_files_for_deleted_photos`` on the delete side, so
     the *probe* must also see them or the purge silently returns without
@@ -208,8 +220,6 @@ def _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
         os.path.join(vireo_dir, "previews", f"{photo_id}_*.jpg"),
         os.path.join(vireo_dir, "originals", f"{photo_id}_*.jpg"),
         os.path.join(vireo_dir, "masks", f"{photo_id}.*.png"),
-        os.path.join(vireo_dir, "edit-masks", f"{photo_id}.png"),
-        os.path.join(vireo_dir, "edit-masks", f"{photo_id}.*.png"),
         os.path.join(vireo_dir, "offline", "originals", f"{photo_id}.*"),
         os.path.join(vireo_dir, "offline", "xmp", f"{photo_id}.*"),
         os.path.join(vireo_dir, "offline", "companions", f"{photo_id}.*"),
@@ -247,7 +257,6 @@ def _derivative_dirs(thumb_cache_dir):
         os.path.join(vireo_dir, "working"),
         os.path.join(vireo_dir, "originals"),
         os.path.join(vireo_dir, "masks"),
-        os.path.join(vireo_dir, "edit-masks"),
         os.path.join(vireo_dir, "offline", "originals"),
         os.path.join(vireo_dir, "offline", "xmp"),
         os.path.join(vireo_dir, "offline", "companions"),

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -36,6 +36,8 @@ def cleanup_cached_files_for_deleted_photos(
     preview_dir = os.path.join(vireo_dir, "previews")
     working_dir = os.path.join(vireo_dir, "working")
     originals_dir = os.path.join(vireo_dir, "originals")
+    masks_dir = os.path.join(vireo_dir, "masks")
+    edit_masks_dir = os.path.join(vireo_dir, "edit-masks")
     # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
     # The FK cascade drops the offline_originals row when the photo is
     # deleted, so we lose the exact stored paths — glob by photo id to
@@ -117,8 +119,87 @@ def cleanup_cached_files_for_deleted_photos(
                         "Cache: %s",
                         orphan, e,
                     )
+        # Subject masks (``masks/{pid}.png``, ``masks/{pid}.{variant}.png``)
+        # and local-adjustment snapshots (``edit-masks/{pid}.{ref}.png``)
+        # are id-keyed like everything above. photos.mask_path goes away
+        # with the row, so a leftover file is invisible to the DB but is
+        # picked back up by any photo that later inherits the id — the
+        # renderer would apply another photo's mask to the local pass.
+        for d in (masks_dir, edit_masks_dir):
+            for orphan in _glob.glob(os.path.join(d, f"{pid}.png")) + _glob.glob(
+                os.path.join(d, f"{pid}.*.png")
+            ):
+                try:
+                    os.remove(orphan)
+                except OSError as e:
+                    log.warning(
+                        "Failed to remove mask file %s after photo delete "
+                        "— will be reclaimed by Clear Cache: %s",
+                        orphan, e,
+                    )
         if progress_callback:
             progress_callback(idx, total, f.get("filename") or str(pid))
+
+
+def _recycled_id_probe_paths(thumb_cache_dir, photo_id):
+    """One exact (non-globbed) path per id-keyed derivative family.
+
+    Used as a cheap existence probe before the full globbing purge — see
+    ``purge_cached_files_for_recycled_id``.
+    """
+    vireo_dir = os.path.dirname(thumb_cache_dir)
+    return (
+        os.path.join(thumb_cache_dir, f"{photo_id}.jpg"),
+        os.path.join(vireo_dir, "working", f"{photo_id}.jpg"),
+        os.path.join(vireo_dir, "previews", f"{photo_id}.jpg"),
+        os.path.join(vireo_dir, "originals", f"{photo_id}.display.jpg"),
+        os.path.join(vireo_dir, "masks", f"{photo_id}.png"),
+    )
+
+
+def purge_cached_files_for_recycled_id(thumb_cache_dir, photo_id):
+    """Drop any cached derivative left over from a previous owner of ``photo_id``.
+
+    ``photos.id`` is ``INTEGER PRIMARY KEY`` *without* ``AUTOINCREMENT``,
+    so SQLite hands the next insert ``max(rowid) + 1`` — the ids freed by
+    deleting the highest-numbered rows get handed straight back out. Every
+    derivative in ``~/.vireo`` is keyed by bare photo id
+    (``thumbnails/<id>.jpg``, ``working/<id>.jpg``, ``masks/<id>.png``, …),
+    so a new photo that inherits a freed id silently adopts the *previous*
+    photo's pixels: the Life List card for a gull renders whatever bird
+    used to own that row.
+
+    Delete paths are supposed to unlink these files, but several
+    (``Database._merge_into_existing``, ``scanner._merge_companion_pair``,
+    ``audit.remove_orphans``) drop photo rows with raw SQL and leave the
+    cache behind, and any unlink that fails leaves an orphan too. Rather
+    than trusting every delete site, ingest re-checks at the one moment
+    the collision can actually happen — when a brand-new row claims a
+    rowid.
+
+    Returns ``True`` when something was purged. The caller uses that to
+    schedule the batched untracked-preview sweep, which is too expensive
+    to run per-photo.
+
+    The probe is 5 ``stat`` calls; only ids that actually collide pay for
+    the globbing purge, so a first scan of a fresh library adds ~nothing.
+    """
+    if not thumb_cache_dir:
+        return False
+    if not any(
+        os.path.exists(p)
+        for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id)
+    ):
+        return False
+    log.info(
+        "Photo %s reused a freed rowid with cached derivatives still on "
+        "disk — purging them so the new photo renders its own pixels",
+        photo_id,
+    )
+    cleanup_cached_files_for_deleted_photos(
+        thumb_cache_dir, [{"photo_id": photo_id}],
+    )
+    return True
 
 
 def evict_if_over_quota(db, vireo_dir):

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -275,7 +275,9 @@ def _recycled_id_probe_patterns(thumb_cache_dir, photo_id, vireo_dir=None):
     )
 
 
-def _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id, vireo_dir=None):
+def _recycled_id_has_stale_derivative(
+    thumb_cache_dir, photo_id, vireo_dir=None, unreadable_dirs=None,
+):
     """True when *any* id-keyed derivative for ``photo_id`` still exists.
 
     Exact paths (cheap ``stat``) first; falls through to variant globs
@@ -287,13 +289,29 @@ def _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id, vireo_dir=None)
     per-photo across a populated cache is O(new photos × cached files):
     measured at 117 ms per miss against a 76k-thumbnail library, i.e.
     ~10 minutes of pure ``scandir`` for a 5000-photo import.
+
+    ``unreadable_dirs`` lets ``RecycledIdIndex`` pass through the set of
+    directories its own sweep couldn't enumerate. Variant patterns
+    targeting those dirs would silently miss under ``glob.iglob`` (same
+    ``scandir`` that already failed), so treat their presence as
+    "unknown, assume a derivative exists" and return True — the purge is
+    the conservative move; a spurious purge is cheap, a skipped one
+    silently serves the previous owner's pixels.
     """
     for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id, vireo_dir):
         if os.path.exists(p):
             return True
+    unreadable = set()
+    if unreadable_dirs:
+        unreadable = {os.path.normpath(d) for d in unreadable_dirs}
     for pattern in _recycled_id_probe_patterns(
         thumb_cache_dir, photo_id, vireo_dir,
     ):
+        if unreadable and os.path.normpath(os.path.dirname(pattern)) in unreadable:
+            # The batch sweep couldn't enumerate this directory, so
+            # ``glob.iglob`` would fail too. Assume a variant may be
+            # hiding there and force the purge.
+            return True
         if next(_glob.iglob(pattern), None) is not None:
             return True
     return False
@@ -367,6 +385,7 @@ class RecycledIdIndex:
         self._vireo_dir = vireo_dir or os.path.dirname(thumb_cache_dir)
         self._ids = None
         self._incomplete = False
+        self._unreadable_dirs = set()
 
     def _sweep(self, directory):
         """Return the ids seen in ``directory`` or ``None`` if unreadable.
@@ -375,6 +394,11 @@ class RecycledIdIndex:
         derivatives yet). Any other ``OSError`` — permissions, EIO — is
         an *unknown*, not an empty; the caller records the incomplete
         sweep and the per-id probe covers it later.
+
+        The iterator itself can also raise (a network-backed cache
+        losing the mount mid-walk, an ACL change between ``scandir`` and
+        the first ``__next__``). Catch that too so an unrelated
+        directory failure doesn't abort the whole index build.
         """
         try:
             entries = os.scandir(directory)
@@ -391,22 +415,33 @@ class RecycledIdIndex:
             )
             return None
         found = set()
-        with entries:
-            for entry in entries:
-                photo_id = _leading_photo_id(entry.name)
-                if photo_id is not None:
-                    found.add(photo_id)
+        try:
+            with entries:
+                for entry in entries:
+                    photo_id = _leading_photo_id(entry.name)
+                    if photo_id is not None:
+                        found.add(photo_id)
+        except OSError as e:
+            log.warning(
+                "Iterating derivative directory %s raised %s partway "
+                "through recycled-rowid detection; treating as unreadable "
+                "so the batch index falls back to the exact-path probe",
+                directory, e,
+            )
+            return None
         return found
 
     def _build(self):
         ids = set()
         incomplete = False
+        unreadable = set()
         for directory in _derivative_dirs(
             self._thumb_cache_dir, self._vireo_dir,
         ):
             seen = self._sweep(directory)
             if seen is None:
                 incomplete = True
+                unreadable.add(os.path.normpath(directory))
             else:
                 ids.update(seen)
         # ``external-dng/`` isn't in ``_derivative_dirs`` because its
@@ -429,12 +464,24 @@ class RecycledIdIndex:
             )
             entries = None
             incomplete = True
+            unreadable.add(os.path.normpath(external_dng))
         if entries is not None:
-            with entries:
-                for entry in entries:
-                    if entry.name.isdigit():
-                        ids.add(int(entry.name))
+            try:
+                with entries:
+                    for entry in entries:
+                        if entry.name.isdigit():
+                            ids.add(int(entry.name))
+            except OSError as e:
+                log.warning(
+                    "Iterating %s raised %s partway through recycled-"
+                    "rowid detection; treating as unreadable so the "
+                    "batch index falls back to the exact-path probe",
+                    external_dng, e,
+                )
+                incomplete = True
+                unreadable.add(os.path.normpath(external_dng))
         self._incomplete = incomplete
+        self._unreadable_dirs = unreadable
         log.info(
             "Indexed %d photo ids with cached derivatives for "
             "recycled-rowid detection%s", len(ids),
@@ -454,9 +501,14 @@ class RecycledIdIndex:
             # exact-path probe, which uses ``os.path.exists`` on specific
             # files and works even when the containing directory is
             # execute-only but not readable — the shape of a permissions
-            # gap that trips ``scandir`` but not ``stat``.
+            # gap that trips ``scandir`` but not ``stat``. Variant globs
+            # rely on ``scandir`` too, so pass the unreadable-directory
+            # set through: the probe treats variants in those dirs as
+            # "unknown, assume present" and forces the purge rather than
+            # silently serving another photo's pixels.
             return _recycled_id_has_stale_derivative(
                 self._thumb_cache_dir, photo_id, self._vireo_dir,
+                unreadable_dirs=self._unreadable_dirs,
             )
         return False
 

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 def cleanup_cached_files_for_deleted_photos(
-    thumb_cache_dir, files, progress_callback=None,
+    thumb_cache_dir, files, progress_callback=None, vireo_dir=None,
 ):
     """Remove thumbnail, preview, working-copy, and display files for deleted photos.
 
@@ -32,8 +32,17 @@ def cleanup_cached_files_for_deleted_photos(
     remains on disk as an orphan because the cascade has already removed
     the preview_cache row. "Clear cache" in Settings recovers by globbing
     the directory.
+
+    ``--db`` and ``--thumb-dir`` are independently configurable, so
+    ``thumb_cache_dir`` is not necessarily ``<vireo_dir>/thumbnails`` —
+    ``audit.import_untracked`` takes both separately for exactly this
+    reason. Callers that know the real cache root must pass ``vireo_dir``;
+    every other family (previews, working copies, masks, offline, DNG)
+    lives under it, and guessing ``dirname(thumb_cache_dir)`` would look
+    for them beside the thumbnails instead. The fallback keeps the
+    conventional layout working for callers that only have one path.
     """
-    vireo_dir = os.path.dirname(thumb_cache_dir)
+    vireo_dir = vireo_dir or os.path.dirname(thumb_cache_dir)
     preview_dir = os.path.join(vireo_dir, "previews")
     working_dir = os.path.join(vireo_dir, "working")
     originals_dir = os.path.join(vireo_dir, "originals")
@@ -172,7 +181,7 @@ def cleanup_cached_files_for_deleted_photos(
             progress_callback(idx, total, f.get("filename") or str(pid))
 
 
-def _recycled_id_probe_paths(thumb_cache_dir, photo_id):
+def _recycled_id_probe_paths(thumb_cache_dir, photo_id, vireo_dir=None):
     """One exact (non-globbed) path per id-keyed derivative family.
 
     Used as a cheap existence probe before the full globbing purge — see
@@ -180,7 +189,7 @@ def _recycled_id_probe_paths(thumb_cache_dir, photo_id):
     id, no variant suffix) names — the variant patterns are covered by
     ``_recycled_id_probe_patterns``.
     """
-    vireo_dir = os.path.dirname(thumb_cache_dir)
+    vireo_dir = vireo_dir or os.path.dirname(thumb_cache_dir)
     return (
         os.path.join(thumb_cache_dir, f"{photo_id}.jpg"),
         os.path.join(vireo_dir, "working", f"{photo_id}.jpg"),
@@ -195,7 +204,7 @@ def _recycled_id_probe_paths(thumb_cache_dir, photo_id):
     )
 
 
-def _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
+def _recycled_id_probe_patterns(thumb_cache_dir, photo_id, vireo_dir=None):
     """Glob patterns covering the id-keyed derivative *variants*.
 
     The exact-path probe above misses the common case where a family
@@ -214,7 +223,7 @@ def _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
     pattern short-circuits at the first hit — a fresh library pays only
     the ``os.scandir`` open on each empty derivative dir.
     """
-    vireo_dir = os.path.dirname(thumb_cache_dir)
+    vireo_dir = vireo_dir or os.path.dirname(thumb_cache_dir)
     return (
         os.path.join(thumb_cache_dir, f"{photo_id}_*.jpg"),
         os.path.join(vireo_dir, "previews", f"{photo_id}_*.jpg"),
@@ -226,7 +235,7 @@ def _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
     )
 
 
-def _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
+def _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id, vireo_dir=None):
     """True when *any* id-keyed derivative for ``photo_id`` still exists.
 
     Exact paths (cheap ``stat``) first; falls through to variant globs
@@ -239,18 +248,20 @@ def _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
     measured at 117 ms per miss against a 76k-thumbnail library, i.e.
     ~10 minutes of pure ``scandir`` for a 5000-photo import.
     """
-    for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id):
+    for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id, vireo_dir):
         if os.path.exists(p):
             return True
-    for pattern in _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
+    for pattern in _recycled_id_probe_patterns(
+        thumb_cache_dir, photo_id, vireo_dir,
+    ):
         if next(_glob.iglob(pattern), None) is not None:
             return True
     return False
 
 
-def _derivative_dirs(thumb_cache_dir):
+def _derivative_dirs(thumb_cache_dir, vireo_dir=None):
     """Every directory that stores files keyed by bare photo id."""
-    vireo_dir = os.path.dirname(thumb_cache_dir)
+    vireo_dir = vireo_dir or os.path.dirname(thumb_cache_dir)
     return (
         thumb_cache_dir,
         os.path.join(vireo_dir, "previews"),
@@ -298,13 +309,19 @@ class RecycledIdIndex:
     ids collided.
     """
 
-    def __init__(self, thumb_cache_dir):
+    def __init__(self, thumb_cache_dir, vireo_dir=None):
         self._thumb_cache_dir = thumb_cache_dir
+        # --db and --thumb-dir are independent, so the other derivative
+        # dirs are not necessarily siblings of the thumbnails. Callers
+        # that know the real cache root pass it explicitly.
+        self._vireo_dir = vireo_dir or os.path.dirname(thumb_cache_dir)
         self._ids = None
 
     def _build(self):
         ids = set()
-        for directory in _derivative_dirs(self._thumb_cache_dir):
+        for directory in _derivative_dirs(
+            self._thumb_cache_dir, self._vireo_dir,
+        ):
             try:
                 entries = os.scandir(directory)
             except OSError:
@@ -321,9 +338,10 @@ class RecycledIdIndex:
         # registering as id 4, and loosening it for the file-based
         # families to accept EOL would break that guard. Handle
         # external-dng in its own sweep instead.
-        vireo_dir = os.path.dirname(self._thumb_cache_dir)
         try:
-            entries = os.scandir(os.path.join(vireo_dir, "external-dng"))
+            entries = os.scandir(
+                os.path.join(self._vireo_dir, "external-dng")
+            )
         except OSError:
             entries = None
         if entries is not None:
@@ -343,26 +361,45 @@ class RecycledIdIndex:
         return photo_id in self._ids
 
 
-def _surviving_derivative_paths(thumb_cache_dir, photo_id):
-    """Concrete derivative paths for ``photo_id`` still on disk.
+def _surviving_derivative_paths(thumb_cache_dir, photo_id, vireo_dir=None):
+    """Concrete surviving derivative **files** for ``photo_id``.
 
     Post-purge audit for :func:`purge_cached_files_for_recycled_id` — the
     probe helpers answer "does anything exist?" and short-circuit, but
     here we need the full list so each survivor can be dealt with.
+
+    Directories are expanded into the files they contain rather than
+    returned as-is. ``external-dng/<id>/`` is a per-id directory, and the
+    freshness check that consumes it (``app.py``'s external-editor path)
+    stats the *DNG file*, not its parent — so backdating the directory
+    would leave the child's recent mtime intact and the caller would
+    report a successful invalidation that invalidates nothing.
     """
     paths = [
-        p for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id)
+        p for p in _recycled_id_probe_paths(
+            thumb_cache_dir, photo_id, vireo_dir,
+        )
         if os.path.exists(p)
     ]
-    for pattern in _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
+    for pattern in _recycled_id_probe_patterns(
+        thumb_cache_dir, photo_id, vireo_dir,
+    ):
         paths.extend(_glob.glob(pattern))
+
+    files = []
+    for path in paths:
+        if not os.path.isdir(path):
+            files.append(path)
+            continue
+        for root, _dirs, names in os.walk(path):
+            files.extend(os.path.join(root, name) for name in names)
     # dict.fromkeys: de-dupe (a bare name can match a variant pattern too)
     # while keeping a stable order for the log message.
-    return list(dict.fromkeys(paths))
+    return list(dict.fromkeys(files))
 
 
 def purge_cached_files_for_recycled_id(
-    thumb_cache_dir, photo_id, id_index=None,
+    thumb_cache_dir, photo_id, id_index=None, vireo_dir=None,
 ):
     """Drop any cached derivative left over from a previous owner of ``photo_id``.
 
@@ -398,7 +435,9 @@ def purge_cached_files_for_recycled_id(
     if id_index is not None:
         if photo_id not in id_index:
             return False
-    elif not _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
+    elif not _recycled_id_has_stale_derivative(
+        thumb_cache_dir, photo_id, vireo_dir,
+    ):
         return False
     log.info(
         "Photo %s reused a freed rowid with cached derivatives still on "
@@ -406,7 +445,7 @@ def purge_cached_files_for_recycled_id(
         photo_id,
     )
     cleanup_cached_files_for_deleted_photos(
-        thumb_cache_dir, [{"photo_id": photo_id}],
+        thumb_cache_dir, [{"photo_id": photo_id}], vireo_dir=vireo_dir,
     )
     # ``cleanup_cached_files_for_deleted_photos`` logs and continues when an
     # unlink fails (locked file on Windows, a momentarily unwritable
@@ -420,7 +459,9 @@ def purge_cached_files_for_recycled_id(
     # deletion isn't (the lock blocks unlink, not utime), so this recovers
     # the common case; when even that fails we say so instead of leaving a
     # silent wrong-pixels bug.
-    survivors = _surviving_derivative_paths(thumb_cache_dir, photo_id)
+    survivors = _surviving_derivative_paths(
+        thumb_cache_dir, photo_id, vireo_dir,
+    )
     if survivors:
         unfixable = []
         for path in survivors:

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -145,7 +145,9 @@ def _recycled_id_probe_paths(thumb_cache_dir, photo_id):
     """One exact (non-globbed) path per id-keyed derivative family.
 
     Used as a cheap existence probe before the full globbing purge — see
-    ``purge_cached_files_for_recycled_id``.
+    ``purge_cached_files_for_recycled_id``. These are the "legacy" (bare
+    id, no variant suffix) names — the variant patterns are covered by
+    ``_recycled_id_probe_patterns``.
     """
     vireo_dir = os.path.dirname(thumb_cache_dir)
     return (
@@ -155,6 +157,56 @@ def _recycled_id_probe_paths(thumb_cache_dir, photo_id):
         os.path.join(vireo_dir, "originals", f"{photo_id}.display.jpg"),
         os.path.join(vireo_dir, "masks", f"{photo_id}.png"),
     )
+
+
+def _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
+    """Glob patterns covering the id-keyed derivative *variants*.
+
+    The exact-path probe above misses the common case where a family
+    exists only in a variant form: sized previews (``previews/7_1920.jpg``,
+    the standard shape written by ``scanner._extract_previews``), source-
+    specific thumbnails (``thumbnails/7_raw.jpg`` / ``7_jpeg.jpg``),
+    prepared full-res renders (``originals/7_1920.jpg``), model-scoped
+    subject masks (``masks/7.sam2-large.png``), edit-mask snapshots
+    (``edit-masks/7.abcdef012345.png``), and offline originals
+    (``offline/originals/7.NEF``). Every one of these is unlinked by
+    ``cleanup_cached_files_for_deleted_photos`` on the delete side, so
+    the *probe* must also see them or the purge silently returns without
+    firing and the new photo serves the previous owner's pixels through
+    the request paths' lazy-adoption shortcuts.
+
+    Callers use ``glob.iglob(pattern)`` with ``next(..., None)`` so each
+    pattern short-circuits at the first hit — a fresh library pays only
+    the ``os.scandir`` open on each empty derivative dir.
+    """
+    vireo_dir = os.path.dirname(thumb_cache_dir)
+    return (
+        os.path.join(thumb_cache_dir, f"{photo_id}_*.jpg"),
+        os.path.join(vireo_dir, "previews", f"{photo_id}_*.jpg"),
+        os.path.join(vireo_dir, "originals", f"{photo_id}_*.jpg"),
+        os.path.join(vireo_dir, "masks", f"{photo_id}.*.png"),
+        os.path.join(vireo_dir, "edit-masks", f"{photo_id}.png"),
+        os.path.join(vireo_dir, "edit-masks", f"{photo_id}.*.png"),
+        os.path.join(vireo_dir, "offline", "originals", f"{photo_id}.*"),
+        os.path.join(vireo_dir, "offline", "xmp", f"{photo_id}.*"),
+        os.path.join(vireo_dir, "offline", "companions", f"{photo_id}.*"),
+    )
+
+
+def _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
+    """True when *any* id-keyed derivative for ``photo_id`` still exists.
+
+    Exact paths (cheap ``stat``) first; falls through to variant globs
+    only if none of the legacy names matched — so a fresh library's
+    collision-free path stays at N stats and never enumerates directories.
+    """
+    for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id):
+        if os.path.exists(p):
+            return True
+    for pattern in _recycled_id_probe_patterns(thumb_cache_dir, photo_id):
+        if next(_glob.iglob(pattern), None) is not None:
+            return True
+    return False
 
 
 def purge_cached_files_for_recycled_id(thumb_cache_dir, photo_id):
@@ -181,15 +233,14 @@ def purge_cached_files_for_recycled_id(thumb_cache_dir, photo_id):
     schedule the batched untracked-preview sweep, which is too expensive
     to run per-photo.
 
-    The probe is 5 ``stat`` calls; only ids that actually collide pay for
-    the globbing purge, so a first scan of a fresh library adds ~nothing.
+    The probe is a handful of ``stat`` calls plus, only when none hit,
+    a lazy ``glob.iglob`` per variant family that short-circuits on the
+    first match. Only ids that actually collide pay for the full purge,
+    so a first scan of a fresh library adds ~nothing.
     """
     if not thumb_cache_dir:
         return False
-    if not any(
-        os.path.exists(p)
-        for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id)
-    ):
+    if not _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
         return False
     log.info(
         "Photo %s reused a freed rowid with cached derivatives still on "

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -197,8 +197,14 @@ def _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
     """True when *any* id-keyed derivative for ``photo_id`` still exists.
 
     Exact paths (cheap ``stat``) first; falls through to variant globs
-    only if none of the legacy names matched — so a fresh library's
-    collision-free path stays at N stats and never enumerates directories.
+    only if none of the legacy names matched.
+
+    Single-id probe — for the *batch* case (ingest, which asks this once
+    per inserted photo) use :class:`RecycledIdIndex` instead. The variant
+    globs enumerate a whole directory when they don't match, so asking
+    per-photo across a populated cache is O(new photos × cached files):
+    measured at 117 ms per miss against a 76k-thumbnail library, i.e.
+    ~10 minutes of pure ``scandir`` for a 5000-photo import.
     """
     for p in _recycled_id_probe_paths(thumb_cache_dir, photo_id):
         if os.path.exists(p):
@@ -209,7 +215,88 @@ def _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
     return False
 
 
-def purge_cached_files_for_recycled_id(thumb_cache_dir, photo_id):
+def _derivative_dirs(thumb_cache_dir):
+    """Every directory that stores files keyed by bare photo id."""
+    vireo_dir = os.path.dirname(thumb_cache_dir)
+    return (
+        thumb_cache_dir,
+        os.path.join(vireo_dir, "previews"),
+        os.path.join(vireo_dir, "working"),
+        os.path.join(vireo_dir, "originals"),
+        os.path.join(vireo_dir, "masks"),
+        os.path.join(vireo_dir, "edit-masks"),
+        os.path.join(vireo_dir, "offline", "originals"),
+        os.path.join(vireo_dir, "offline", "xmp"),
+        os.path.join(vireo_dir, "offline", "companions"),
+    )
+
+
+def _leading_photo_id(name):
+    """Parse the photo id a derivative filename is keyed by, or ``None``.
+
+    Every derivative name is the bare id followed by ``.`` or ``_`` and
+    then a suffix / variant: ``4.jpg``, ``4_1920.jpg``, ``4.display.jpg``,
+    ``4.sam2-large.png``, ``4.NEF``. Requiring that separator is what
+    stops ``40.jpg`` from registering as id 4.
+    """
+    digits = 0
+    while digits < len(name) and name[digits].isdigit():
+        digits += 1
+    if not digits or digits == len(name) or name[digits] not in "._":
+        return None
+    return int(name[:digits])
+
+
+class RecycledIdIndex:
+    """The set of photo ids that already have a cached derivative on disk.
+
+    Ingest needs the same question answered once per inserted photo, and
+    the per-id probe answers it by enumerating directories — see
+    :func:`_recycled_id_has_stale_derivative` for the measured cost. One
+    ``scandir`` per derivative directory answers it for every id at once,
+    so a scan pays O(cached files) total instead of per photo. Mirrors
+    the batching in ``scanner._sweep_untracked_previews_for_photos``,
+    which exists for exactly this reason.
+
+    Built lazily on first query, so a scan that inserts nothing never
+    touches the filesystem. The snapshot is deliberately taken before
+    ingest generates any derivative of its own: working copies and
+    previews are extracted at the end of ``scan()``, and those belong to
+    the new rows — a live re-read would see them and wrongly conclude the
+    ids collided.
+    """
+
+    def __init__(self, thumb_cache_dir):
+        self._thumb_cache_dir = thumb_cache_dir
+        self._ids = None
+
+    def _build(self):
+        ids = set()
+        for directory in _derivative_dirs(self._thumb_cache_dir):
+            try:
+                entries = os.scandir(directory)
+            except OSError:
+                continue  # dir absent on a fresh install, or unreadable
+            with entries:
+                for entry in entries:
+                    photo_id = _leading_photo_id(entry.name)
+                    if photo_id is not None:
+                        ids.add(photo_id)
+        log.info(
+            "Indexed %d photo ids with cached derivatives for "
+            "recycled-rowid detection", len(ids),
+        )
+        return ids
+
+    def __contains__(self, photo_id):
+        if self._ids is None:
+            self._ids = self._build()
+        return photo_id in self._ids
+
+
+def purge_cached_files_for_recycled_id(
+    thumb_cache_dir, photo_id, id_index=None,
+):
     """Drop any cached derivative left over from a previous owner of ``photo_id``.
 
     ``photos.id`` is ``INTEGER PRIMARY KEY`` *without* ``AUTOINCREMENT``,
@@ -233,14 +320,17 @@ def purge_cached_files_for_recycled_id(thumb_cache_dir, photo_id):
     schedule the batched untracked-preview sweep, which is too expensive
     to run per-photo.
 
-    The probe is a handful of ``stat`` calls plus, only when none hit,
-    a lazy ``glob.iglob`` per variant family that short-circuits on the
-    first match. Only ids that actually collide pay for the full purge,
-    so a first scan of a fresh library adds ~nothing.
+    Pass a :class:`RecycledIdIndex` as ``id_index`` when calling this in a
+    loop (ingest does): the probe becomes an O(1) set lookup against one
+    ``scandir`` per derivative directory instead of a per-photo directory
+    enumeration. Without it, falls back to the single-id probe.
     """
     if not thumb_cache_dir:
         return False
-    if not _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
+    if id_index is not None:
+        if photo_id not in id_index:
+            return False
+    elif not _recycled_id_has_stale_derivative(thumb_cache_dir, photo_id):
         return False
     log.info(
         "Photo %s reused a freed rowid with cached derivatives still on "

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -328,6 +328,14 @@ class RecycledIdIndex:
     previews are extracted at the end of ``scan()``, and those belong to
     the new rows — a live re-read would see them and wrongly conclude the
     ids collided.
+
+    If any derivative directory can't be enumerated (execute-only but
+    unreadable, transient EIO, ACL quirk), the index remembers that and
+    falls back to the exact-path per-id probe for every lookup. Treating
+    ``scandir`` failure as "directory is empty" would silently teach the
+    purge to skip recycled ids whose only surviving derivative lives
+    there — and the exact-path probe (``os.path.exists``) still works on
+    execute-only directories, so the fallback recovers that case.
     """
 
     def __init__(self, thumb_cache_dir, vireo_dir=None):
@@ -337,21 +345,49 @@ class RecycledIdIndex:
         # that know the real cache root pass it explicitly.
         self._vireo_dir = vireo_dir or os.path.dirname(thumb_cache_dir)
         self._ids = None
+        self._incomplete = False
+
+    def _sweep(self, directory):
+        """Return the ids seen in ``directory`` or ``None`` if unreadable.
+
+        ``FileNotFoundError`` is genuinely empty (fresh install, no
+        derivatives yet). Any other ``OSError`` — permissions, EIO — is
+        an *unknown*, not an empty; the caller records the incomplete
+        sweep and the per-id probe covers it later.
+        """
+        try:
+            entries = os.scandir(directory)
+        except FileNotFoundError:
+            return set()
+        except OSError as e:
+            log.warning(
+                "Could not enumerate derivative directory %s for "
+                "recycled-rowid detection (%s); the batch index will "
+                "fall back to the exact-path probe for every lookup so "
+                "recycled ids whose only surviving cached file lives "
+                "here are still purged",
+                directory, e,
+            )
+            return None
+        found = set()
+        with entries:
+            for entry in entries:
+                photo_id = _leading_photo_id(entry.name)
+                if photo_id is not None:
+                    found.add(photo_id)
+        return found
 
     def _build(self):
         ids = set()
+        incomplete = False
         for directory in _derivative_dirs(
             self._thumb_cache_dir, self._vireo_dir,
         ):
-            try:
-                entries = os.scandir(directory)
-            except OSError:
-                continue  # dir absent on a fresh install, or unreadable
-            with entries:
-                for entry in entries:
-                    photo_id = _leading_photo_id(entry.name)
-                    if photo_id is not None:
-                        ids.add(photo_id)
+            seen = self._sweep(directory)
+            if seen is None:
+                incomplete = True
+            else:
+                ids.update(seen)
         # ``external-dng/`` isn't in ``_derivative_dirs`` because its
         # entries are per-id *subdirectories* named with bare digits
         # (``external-dng/42/``) — ``_leading_photo_id`` intentionally
@@ -359,27 +395,49 @@ class RecycledIdIndex:
         # registering as id 4, and loosening it for the file-based
         # families to accept EOL would break that guard. Handle
         # external-dng in its own sweep instead.
+        external_dng = os.path.join(self._vireo_dir, "external-dng")
         try:
-            entries = os.scandir(
-                os.path.join(self._vireo_dir, "external-dng")
-            )
-        except OSError:
+            entries = os.scandir(external_dng)
+        except FileNotFoundError:
             entries = None
+        except OSError as e:
+            log.warning(
+                "Could not enumerate %s for recycled-rowid detection "
+                "(%s); the batch index will fall back to the exact-path "
+                "probe for every lookup", external_dng, e,
+            )
+            entries = None
+            incomplete = True
         if entries is not None:
             with entries:
                 for entry in entries:
                     if entry.name.isdigit():
                         ids.add(int(entry.name))
+        self._incomplete = incomplete
         log.info(
             "Indexed %d photo ids with cached derivatives for "
-            "recycled-rowid detection", len(ids),
+            "recycled-rowid detection%s", len(ids),
+            " (incomplete — some directories were unreadable)"
+            if incomplete else "",
         )
         return ids
 
     def __contains__(self, photo_id):
         if self._ids is None:
             self._ids = self._build()
-        return photo_id in self._ids
+        if photo_id in self._ids:
+            return True
+        if self._incomplete:
+            # One of the derivative dirs couldn't be enumerated, so its
+            # absence from ``self._ids`` proves nothing. Fall back to the
+            # exact-path probe, which uses ``os.path.exists`` on specific
+            # files and works even when the containing directory is
+            # execute-only but not readable — the shape of a permissions
+            # gap that trips ``scandir`` but not ``stat``.
+            return _recycled_id_has_stale_derivative(
+                self._thumb_cache_dir, photo_id, self._vireo_dir,
+            )
+        return False
 
 
 def ensure_preview_cache_invalidations_table(db):

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -10,6 +10,7 @@ the loop in two modules.
 import glob as _glob
 import logging
 import os
+import shutil
 
 log = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ def cleanup_cached_files_for_deleted_photos(
     originals_dir = os.path.join(vireo_dir, "originals")
     masks_dir = os.path.join(vireo_dir, "masks")
     edit_masks_dir = os.path.join(vireo_dir, "edit-masks")
+    external_dng_dir = os.path.join(vireo_dir, "external-dng")
     # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
     # The FK cascade drops the offline_originals row when the photo is
     # deleted, so we lose the exact stored paths — glob by photo id to
@@ -137,6 +139,22 @@ def cleanup_cached_files_for_deleted_photos(
                         "— will be reclaimed by Clear Cache: %s",
                         orphan, e,
                     )
+        # ``external-dng/<pid>/<stem>.dng`` caches DNG conversions per
+        # photo id for the Nikon-HE-NEF external-editor path. The
+        # freshness check there is source-mtime-based, so a recycled id
+        # with the same basename and older source would silently reuse
+        # the previous owner's DNG. Wipe the whole per-id directory.
+        pid_external_dng = os.path.join(external_dng_dir, str(pid))
+        if os.path.isdir(pid_external_dng):
+            try:
+                shutil.rmtree(pid_external_dng)
+            except OSError as e:
+                log.warning(
+                    "Failed to remove external-dng cache directory %s "
+                    "after photo delete — will be reclaimed by Clear "
+                    "Cache: %s",
+                    pid_external_dng, e,
+                )
         if progress_callback:
             progress_callback(idx, total, f.get("filename") or str(pid))
 
@@ -156,6 +174,11 @@ def _recycled_id_probe_paths(thumb_cache_dir, photo_id):
         os.path.join(vireo_dir, "previews", f"{photo_id}.jpg"),
         os.path.join(vireo_dir, "originals", f"{photo_id}.display.jpg"),
         os.path.join(vireo_dir, "masks", f"{photo_id}.png"),
+        # ``external-dng/<pid>/`` is a per-photo-id *directory* rather than
+        # a file — ``os.path.exists`` returns True for directories, so
+        # the same machinery covers it. The batch index's directory sweep
+        # (``RecycledIdIndex._build``) also enumerates its subdirectories.
+        os.path.join(vireo_dir, "external-dng", str(photo_id)),
     )
 
 
@@ -282,6 +305,23 @@ class RecycledIdIndex:
                     photo_id = _leading_photo_id(entry.name)
                     if photo_id is not None:
                         ids.add(photo_id)
+        # ``external-dng/`` isn't in ``_derivative_dirs`` because its
+        # entries are per-id *subdirectories* named with bare digits
+        # (``external-dng/42/``) — ``_leading_photo_id`` intentionally
+        # requires a ``.``/``_`` terminator to keep ``40.jpg`` from
+        # registering as id 4, and loosening it for the file-based
+        # families to accept EOL would break that guard. Handle
+        # external-dng in its own sweep instead.
+        vireo_dir = os.path.dirname(self._thumb_cache_dir)
+        try:
+            entries = os.scandir(os.path.join(vireo_dir, "external-dng"))
+        except OSError:
+            entries = None
+        if entries is not None:
+            with entries:
+                for entry in entries:
+                    if entry.name.isdigit():
+                        ids.add(int(entry.name))
         log.info(
             "Indexed %d photo ids with cached derivatives for "
             "recycled-rowid detection", len(ids),

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -49,6 +49,7 @@ def cleanup_cached_files_for_deleted_photos(
     masks_dir = os.path.join(vireo_dir, "masks")
     external_dng_dir = os.path.join(vireo_dir, "external-dng")
     external_edits_dir = os.path.join(vireo_dir, "external-edits")
+    inat_uploads_dir = os.path.join(vireo_dir, "inat-uploads")
     # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
     # The FK cascade drops the offline_originals row when the photo is
     # deleted, so we lose the exact stored paths — glob by photo id to
@@ -179,6 +180,23 @@ def cleanup_cached_files_for_deleted_photos(
                         "photo delete — will be reclaimed by Clear Cache: %s",
                         handoff, e,
                     )
+        # ``inat-uploads/<pid>.jpg`` is the analogous handoff to iNaturalist,
+        # and ``<pid>.json`` caches the same {recipe, source_path,
+        # source_mtime, edit_math_version} envelope. Same failure mode:
+        # ``_inat_upload_photo_path`` never checks the file mtime, so a
+        # recycled id imported at the same path/mtime with the same recipe
+        # would ship the previous owner's pixels to iNaturalist.
+        for name in (f"{pid}.jpg", f"{pid}.json"):
+            handoff = os.path.join(inat_uploads_dir, name)
+            if os.path.isfile(handoff):
+                try:
+                    os.remove(handoff)
+                except OSError as e:
+                    log.warning(
+                        "Failed to remove iNat upload handoff %s after "
+                        "photo delete — will be reclaimed by Clear Cache: %s",
+                        handoff, e,
+                    )
         # ``external-dng/<pid>/<stem>.dng`` caches DNG conversions per
         # photo id for the Nikon-HE-NEF external-editor path. The
         # freshness check there is source-mtime-based, so a recycled id
@@ -215,6 +233,7 @@ def _recycled_id_probe_paths(thumb_cache_dir, photo_id, vireo_dir=None):
         os.path.join(vireo_dir, "originals", f"{photo_id}.display.jpg"),
         os.path.join(vireo_dir, "masks", f"{photo_id}.png"),
         os.path.join(vireo_dir, "external-edits", f"{photo_id}.jpg"),
+        os.path.join(vireo_dir, "inat-uploads", f"{photo_id}.jpg"),
         # ``external-dng/<pid>/`` is a per-photo-id *directory* rather than
         # a file — ``os.path.exists`` returns True for directories, so
         # the same machinery covers it. The batch index's directory sweep
@@ -249,6 +268,7 @@ def _recycled_id_probe_patterns(thumb_cache_dir, photo_id, vireo_dir=None):
         os.path.join(vireo_dir, "originals", f"{photo_id}_*.jpg"),
         os.path.join(vireo_dir, "masks", f"{photo_id}.*.png"),
         os.path.join(vireo_dir, "external-edits", f"{photo_id}.json"),
+        os.path.join(vireo_dir, "inat-uploads", f"{photo_id}.json"),
         os.path.join(vireo_dir, "offline", "originals", f"{photo_id}.*"),
         os.path.join(vireo_dir, "offline", "xmp", f"{photo_id}.*"),
         os.path.join(vireo_dir, "offline", "companions", f"{photo_id}.*"),
@@ -289,6 +309,7 @@ def _derivative_dirs(thumb_cache_dir, vireo_dir=None):
         os.path.join(vireo_dir, "originals"),
         os.path.join(vireo_dir, "masks"),
         os.path.join(vireo_dir, "external-edits"),
+        os.path.join(vireo_dir, "inat-uploads"),
         os.path.join(vireo_dir, "offline", "originals"),
         os.path.join(vireo_dir, "offline", "xmp"),
         os.path.join(vireo_dir, "offline", "companions"),
@@ -537,6 +558,7 @@ def _surviving_derivative_paths(thumb_cache_dir, photo_id, vireo_dir=None):
 
 def purge_cached_files_for_recycled_id(
     thumb_cache_dir, photo_id, id_index=None, vireo_dir=None, db=None,
+    file_mtime=None,
 ):
     """Drop any cached derivative left over from a previous owner of ``photo_id``.
 
@@ -566,6 +588,17 @@ def purge_cached_files_for_recycled_id(
     loop (ingest does): the probe becomes an O(1) set lookup against one
     ``scandir`` per derivative directory instead of a per-photo directory
     enumeration. Without it, falls back to the single-id probe.
+
+    ``file_mtime`` is the new photo's source ``photos.file_mtime``. It
+    picks the timestamp we backdate undeletable survivors to: the
+    ``serve_thumbnail`` / prepared-render / external-DNG freshness gates
+    all compare ``cached_mtime >= source_mtime``, so a survivor pinned to
+    ``file_mtime - 1`` is provably rejected regardless of what the source
+    mtime happens to be. When ``file_mtime`` is unavailable (older
+    single-id callers) we fall back to ``0``, which works for any source
+    with a positive mtime — the case the reviewer specifically flagged is
+    a source at or below the Unix epoch, and callers on the ingest path
+    do have ``file_mtime`` in hand.
     """
     if not thumb_cache_dir:
         return False
@@ -607,17 +640,31 @@ def purge_cached_files_for_recycled_id(
         thumb_cache_dir, photo_id, vireo_dir,
     )
     if survivors:
-        preview_dir = os.path.join(
-            vireo_dir or os.path.dirname(thumb_cache_dir), "previews",
-        )
-        external_edits_dir = os.path.join(
-            vireo_dir or os.path.dirname(thumb_cache_dir), "external-edits",
-        )
+        base_dir = vireo_dir or os.path.dirname(thumb_cache_dir)
+        preview_dir = os.path.join(base_dir, "previews")
+        external_edits_dir = os.path.join(base_dir, "external-edits")
+        inat_uploads_dir = os.path.join(base_dir, "inat-uploads")
+        # ``serve_thumbnail`` / ``_prepared_full_resolution_render`` / the
+        # external-DNG gate all treat ``cached_mtime >= source_mtime`` as
+        # fresh. Backdating to a hard-coded ``0`` fails when the new
+        # photo's source is itself at or below the Unix epoch (an archive
+        # that preserved an epoch or negative filesystem timestamp) — the
+        # survivor's mtime then still matches or exceeds ``file_mtime`` and
+        # the guard waves the previous owner's pixels through. Anchor the
+        # sentinel to the new photo's source instead so the comparison is
+        # provably false regardless of what value ``file_mtime`` takes.
+        if file_mtime is not None:
+            try:
+                backdate_target = float(file_mtime) - 1.0
+            except (TypeError, ValueError):
+                backdate_target = 0.0
+        else:
+            backdate_target = 0.0
         unfixable = []
         for path in survivors:
             backdated = True
             try:
-                os.utime(path, (0, 0))
+                os.utime(path, (backdate_target, backdate_target))
             except OSError:
                 backdated = False
 
@@ -641,12 +688,14 @@ def purge_cached_files_for_recycled_id(
                     unfixable.append(path)
                 continue
 
-            if os.path.normpath(os.path.dirname(path)) == os.path.normpath(
-                external_edits_dir
+            parent = os.path.normpath(os.path.dirname(path))
+            if parent == os.path.normpath(external_edits_dir) or parent == (
+                os.path.normpath(inat_uploads_dir)
             ):
-                # ``_external_edit_handoff_path`` compares the JSON's
+                # ``_external_edit_handoff_path`` and
+                # ``_inat_upload_photo_path`` compare the JSON's
                 # {recipe, source_path, source_mtime, edit_math_version}
-                # and never stats either file, so a backdate here changes
+                # and never stat either file, so a backdate here changes
                 # nothing. Nothing short of removing them helps.
                 unfixable.append(path)
                 continue

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -28,6 +28,7 @@ from keyword_normalization import keyword_match_key
 from metadata import EXIF_SUMMARY_COLUMNS, exif_summary_columns, extract_metadata
 from PIL import Image
 from preview_cache import (
+    RecycledIdIndex,
     cleanup_cached_files_for_deleted_photos,
     purge_cached_files_for_recycled_id,
 )
@@ -1835,6 +1836,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # so the untracked-preview sweep can run once as a batch instead of
     # per-photo (avoids O(N × M) directory walks on large rescans).
     invalidated_photo_ids: set[int] = set()
+    # Photo IDs that already own cached derivative files, for the
+    # recycled-rowid check on insert. Snapshotted once (lazily, on the
+    # first insert) for the same batching reason as the sweep above.
+    recycled_id_index = RecycledIdIndex(
+        thumb_cache_dir or (
+            os.path.join(vireo_dir, "thumbnails") if vireo_dir else ""
+        )
+    )
     scoped_paths = {str(root_path)}
     if restrict_dirs is not None:
         scoped_paths.update(str(d) for d in restrict_dirs)
@@ -2209,14 +2218,16 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             # A brand-new row may have claimed a *recycled* rowid (see
             # ``purge_cached_files_for_recycled_id``). Cached derivatives
             # from the id's previous owner would otherwise be served as
-            # this photo's — a wrong-bird Life List card. Cheap stat probe
-            # per insert; only actual collisions do real work.
+            # this photo's — a wrong-bird Life List card. The index makes
+            # this an O(1) set lookup per insert; only ids that actually
+            # collide do real work.
             if (
                 not row_already_existed
                 and vireo_dir
                 and purge_cached_files_for_recycled_id(
                     thumb_cache_dir or os.path.join(vireo_dir, "thumbnails"),
                     photo_id,
+                    id_index=recycled_id_index,
                 )
             ):
                 invalidated_photo_ids.add(photo_id)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -2247,6 +2247,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     id_index=recycled_id_index,
                     vireo_dir=vireo_dir,
                     db=db,
+                    file_mtime=file_mtime,
                 )
             ):
                 invalidated_photo_ids.add(photo_id)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -27,6 +27,10 @@ from image_loader import (
 from keyword_normalization import keyword_match_key
 from metadata import EXIF_SUMMARY_COLUMNS, exif_summary_columns, extract_metadata
 from PIL import Image
+from preview_cache import (
+    cleanup_cached_files_for_deleted_photos,
+    purge_cached_files_for_recycled_id,
+)
 from render_source import exif_orientation as _exif_orientation_from_data
 from render_source import is_undersized
 from xmp import read_hierarchical_keywords, read_keywords
@@ -587,6 +591,15 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
         # Remove keyword associations then the duplicate JPEG record
         db.conn.execute("DELETE FROM photo_keywords WHERE photo_id = ?", (companion["id"],))
         db.conn.execute("DELETE FROM photos WHERE id = ?", (companion["id"],))
+        # The companion's rowid is now free for SQLite to hand to the next
+        # insert. Unlink its derivatives here so the next photo to inherit
+        # the id can't adopt the companion's thumbnail / working copy /
+        # masks (see ``purge_cached_files_for_recycled_id``).
+        if vireo_dir:
+            cleanup_cached_files_for_deleted_photos(
+                thumb_cache_dir or os.path.join(vireo_dir, "thumbnails"),
+                [{"photo_id": companion["id"]}],
+            )
 
     commit_with_retry(db.conn)
 
@@ -2083,10 +2096,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 longitude = exif_group.get("GPSLongitude")
 
             # Pre-check: capture prior content identity AND whether the
-            # row existed before add_photo touches it. Brand-new rows
-            # have no derived caches to flush — skipping invalidation
-            # for them avoids O(N) wasted UPDATE + commit round-trips on
-            # large initial scans.
+            # row existed before add_photo touches it. Existing rows take
+            # the content-change invalidation below; brand-new rows take
+            # the cheaper recycled-rowid probe right after the insert, so
+            # a large initial scan doesn't pay for O(N) UPDATE + commit
+            # round-trips it has no reason to make.
             existing_row = db.conn.execute(
                 "SELECT file_hash, flag FROM photos WHERE folder_id = ? AND filename = ?",
                 (folder_id, image_path.name),
@@ -2118,6 +2132,21 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 width=width,
                 height=height,
             )
+
+            # A brand-new row may have claimed a *recycled* rowid (see
+            # ``purge_cached_files_for_recycled_id``). Cached derivatives
+            # from the id's previous owner would otherwise be served as
+            # this photo's — a wrong-bird Life List card. Cheap stat probe
+            # per insert; only actual collisions do real work.
+            if (
+                not row_already_existed
+                and vireo_dir
+                and purge_cached_files_for_recycled_id(
+                    thumb_cache_dir or os.path.join(vireo_dir, "thumbnails"),
+                    photo_id,
+                )
+            ):
+                invalidated_photo_ids.add(photo_id)
 
             # Update metadata columns (also fixes existing photos that were
             # inserted before ExifTool metadata was available)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -2246,6 +2246,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     photo_id,
                     id_index=recycled_id_index,
                     vireo_dir=vireo_dir,
+                    db=db,
                 )
             ):
                 invalidated_photo_ids.add(photo_id)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -293,6 +293,17 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
         base = os.path.splitext(row["filename"])[0]
         groups[(row["folder_id"], base)].append(dict(row))
 
+    # Filesystem changes are collected here and executed only after
+    # commit_with_retry succeeds. All pairs share one transaction, so a
+    # failure on any later iteration (or on the commit itself) rolls back
+    # every companion row that was DELETEd earlier — but any files we'd
+    # already unlinked inline are gone for good, leaving the restored
+    # companion rows pointing at missing thumbnails, working copies,
+    # masks, offline originals, and moved mask snapshots. Deferring gives
+    # us "all DB changes durable, then all FS changes" — commit failure
+    # aborts both halves.
+    post_commit_fs_actions = []
+
     for (_folder_id, _base), members in groups.items():
         if len(members) < 2:
             continue
@@ -396,20 +407,33 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
             # An unedited RAW display cache may have been rendered before the
             # camera JPEG was paired. File mtimes cannot tell which source
             # produced that cache, so discard it when the companion changes.
-            _invalidate_raw_display_cache(vireo_dir, primary["id"])
-            thumb_dir = thumb_cache_dir or os.path.join(vireo_dir, "thumbnails")
-            jpeg_variant = os.path.join(
-                thumb_dir, f"{primary['id']}_jpeg.jpg",
+            # Deferred to post-commit: if this pair's DB changes roll back
+            # (because a later iteration or the final commit fails), the
+            # primary's companion_path stays NULL and there's no reason to
+            # have invalidated its display cache — the RAW render is still
+            # valid.
+            _primary_id = primary["id"]
+            _thumb_dir = thumb_cache_dir or os.path.join(
+                vireo_dir, "thumbnails",
             )
-            try:
-                if os.path.exists(jpeg_variant):
-                    os.remove(jpeg_variant)
-            except OSError:
-                log.debug(
-                    "Could not delete stale companion thumbnail %s",
-                    jpeg_variant,
-                    exc_info=True,
-                )
+            _vireo_dir = vireo_dir
+
+            def _invalidate_primary_variants(
+                pid=_primary_id, td=_thumb_dir, vd=_vireo_dir,
+            ):
+                _invalidate_raw_display_cache(vd, pid)
+                jpeg_variant = os.path.join(td, f"{pid}_jpeg.jpg")
+                try:
+                    if os.path.exists(jpeg_variant):
+                        os.remove(jpeg_variant)
+                except OSError:
+                    log.debug(
+                        "Could not delete stale companion thumbnail %s",
+                        jpeg_variant,
+                        exc_info=True,
+                    )
+
+            post_commit_fs_actions.append(_invalidate_primary_variants)
 
         # Transfer detections (and their cascaded predictions) from companion to primary.
         # Detection IDs are content-addressed on (photo_id, detector_model, box,
@@ -573,12 +597,27 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
                 # (photo_id, ref); the transferred recipe now points at
                 # primary["id"], so the files must move with it or every
                 # render silently disables the local pass.
-                from local_masks import transfer_snapshots
-                transfer_snapshots(vireo_dir, companion["id"], primary["id"])
-                _invalidate_derived_caches(
-                    db, vireo_dir, primary["id"],
-                    thumb_cache_dir=thumb_cache_dir,
-                )
+                # Deferred to post-commit: transfer_snapshots MOVES files
+                # and _invalidate_derived_caches DELETES them. Running
+                # either before the transaction is durable risks moving
+                # the companion's snapshots onto the primary and then
+                # rolling back the recipe transfer — the render would
+                # then load snapshots the DB no longer knows about.
+                _primary_id = primary["id"]
+                _companion_id = companion["id"]
+                _tcd = thumb_cache_dir
+                _vd = vireo_dir
+
+                def _apply_recipe_transfer_fs(
+                    pid=_primary_id, cid=_companion_id, tcd=_tcd, vd=_vd,
+                ):
+                    from local_masks import transfer_snapshots
+                    transfer_snapshots(vd, cid, pid)
+                    _invalidate_derived_caches(
+                        db, vd, pid, thumb_cache_dir=tcd,
+                    )
+
+                post_commit_fs_actions.append(_apply_recipe_transfer_fs)
             else:
                 db.conn.execute(
                     "UPDATE photos SET thumb_path = NULL WHERE id = ?",
@@ -592,16 +631,50 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
         db.conn.execute("DELETE FROM photo_keywords WHERE photo_id = ?", (companion["id"],))
         db.conn.execute("DELETE FROM photos WHERE id = ?", (companion["id"],))
         # The companion's rowid is now free for SQLite to hand to the next
-        # insert. Unlink its derivatives here so the next photo to inherit
-        # the id can't adopt the companion's thumbnail / working copy /
-        # masks (see ``purge_cached_files_for_recycled_id``).
+        # insert. Its derivatives must be unlinked so the next photo to
+        # inherit the id can't adopt the companion's thumbnail / working
+        # copy / masks (see ``purge_cached_files_for_recycled_id``).
+        # Deferred to post-commit: unlinking inline and then losing this
+        # pair's DELETE to a later rollback would leave a restored
+        # companion row pointing at gone-from-disk derivatives, and none
+        # of ``purge_cached_files_for_recycled_id``'s protections would
+        # help — the rowid is still occupied by that restored row, not
+        # available for reuse.
         if vireo_dir:
-            cleanup_cached_files_for_deleted_photos(
-                thumb_cache_dir or os.path.join(vireo_dir, "thumbnails"),
-                [{"photo_id": companion["id"]}],
+            _companion_id = companion["id"]
+            _thumb_dir_for_companion = thumb_cache_dir or os.path.join(
+                vireo_dir, "thumbnails",
             )
 
+            def _cleanup_companion(
+                cid=_companion_id, td=_thumb_dir_for_companion,
+            ):
+                cleanup_cached_files_for_deleted_photos(
+                    td, [{"photo_id": cid}],
+                )
+
+            post_commit_fs_actions.append(_cleanup_companion)
+
     commit_with_retry(db.conn)
+    # DB state is durable now. Run the collected filesystem operations —
+    # any exception here is per-action so a single failing unlink doesn't
+    # skip the rest, and the recycled-id purge on the next insert would
+    # eventually recover anything we missed.
+    for action in post_commit_fs_actions:
+        try:
+            action()
+        except Exception:
+            log.exception(
+                "Deferred filesystem cleanup after raw+JPEG pairing "
+                "failed; may leave stale derivative files that the "
+                "recycled-id purge or Clear Cache will reclaim later",
+            )
+    # ``_invalidate_derived_caches`` inside a deferred action issues DB
+    # updates (clears thumb_path / working_copy_path, drops preview_cache
+    # rows). Those auto-opened a new transaction; commit it so the state
+    # is durable and doesn't leak into the caller's next write.
+    if db.conn.in_transaction:
+        commit_with_retry(db.conn)
 
 
 def _invalidate_raw_display_cache(vireo_dir, photo_id):

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -664,9 +664,10 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
 
             def _cleanup_companion(
                 cid=_companion_id, td=_thumb_dir_for_companion,
+                vd=vireo_dir,
             ):
                 cleanup_cached_files_for_deleted_photos(
-                    td, [{"photo_id": cid}],
+                    td, [{"photo_id": cid}], vireo_dir=vd,
                 )
 
             post_commit_fs_actions.append(_cleanup_companion)
@@ -1857,7 +1858,8 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     recycled_id_index = RecycledIdIndex(
         thumb_cache_dir or (
             os.path.join(vireo_dir, "thumbnails") if vireo_dir else ""
-        )
+        ),
+        vireo_dir=vireo_dir,
     )
     scoped_paths = {str(root_path)}
     if restrict_dirs is not None:
@@ -2243,6 +2245,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     thumb_cache_dir or os.path.join(vireo_dir, "thumbnails"),
                     photo_id,
                     id_index=recycled_id_index,
+                    vireo_dir=vireo_dir,
                 )
             ):
                 invalidated_photo_ids.add(photo_id)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -613,7 +613,22 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
                     pid=_primary_id, cid=_companion_id, tcd=_tcd, vd=_vd,
                 ):
                     from local_masks import transfer_snapshots
-                    transfer_snapshots(vd, cid, pid)
+                    # transfer_snapshots falls back to a copy when the
+                    # rename fails, so ``failed`` means the snapshot is
+                    # genuinely unreachable — ``load_snapshot`` only ever
+                    # builds snapshot_path(vireo_dir, pid, ref), so the
+                    # local pass for those refs renders without its mask.
+                    # Say so rather than degrading the image silently.
+                    transferred = transfer_snapshots(vd, cid, pid)
+                    if transferred["failed"]:
+                        log.warning(
+                            "Pairing moved photo %s's edit recipe to %s but "
+                            "could not relocate %d local-mask snapshot(s) "
+                            "(refs %s); those local adjustments will render "
+                            "without their mask until recreated",
+                            cid, pid, len(transferred["failed"]),
+                            ", ".join(transferred["failed"]),
+                        )
                     _invalidate_derived_caches(
                         db, vd, pid, thumb_cache_dir=tcd,
                     )

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -629,6 +629,24 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
                             cid, pid, len(transferred["failed"]),
                             ", ".join(transferred["failed"]),
                         )
+                    if transferred.get("enumerate_failed"):
+                        # ``os.listdir(edit-masks/)`` failed, so the snapshot
+                        # refs are unknown. The recipe has been transferred
+                        # to the primary and load_snapshot always builds
+                        # ``snapshot_path(vireo_dir, primary_id, ref)`` — any
+                        # snapshot still under the companion's id is
+                        # unreachable, and the local pass renders without
+                        # its mask until the snapshot is recreated. Say so
+                        # (CORE_PHILOSOPHY: no black boxes) instead of
+                        # letting the exception vanish into the deferred-
+                        # action guard.
+                        log.warning(
+                            "Pairing moved photo %s's edit recipe to %s but "
+                            "could not enumerate edit-masks/ to move any "
+                            "snapshots; every affected local adjustment will "
+                            "render without its mask until recreated",
+                            cid, pid,
+                        )
                     _invalidate_derived_caches(
                         db, vd, pid, thumb_cache_dir=tcd,
                     )

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -1684,3 +1684,46 @@ def test_history_isolated_between_workspaces(app_and_db):
     ws1 = db.conn.execute("SELECT id FROM workspaces WHERE name = 'Default'").fetchone()['id']
     db.set_active_workspace(ws1)
     assert len(db.get_edit_history()) == 1
+
+
+def test_set_edit_recipe_removes_regeneration_sidecar(app_and_db, tmp_path):
+    """A recipe edit must clear ``<pid>_regen.jpg`` too.
+
+    When the default thumbnail can't be unlinked (Windows lock,
+    antivirus, permissions blip), ``serve_thumbnail`` falls back to a
+    ``<pid>_regen.jpg`` sidecar. Editing the recipe without also
+    invalidating the sidecar leaves it carrying the pre-edit pixels:
+    the freshness gate compares against the unchanged source mtime and
+    re-serves the sidecar indefinitely. The invalidation must sweep the
+    sidecar the same way it sweeps ``<pid>.jpg``.
+    """
+    app, db = app_and_db
+    photos = db.get_photos()
+    pid = photos[0]['id']
+    thumb_dir = app.config["THUMB_CACHE_DIR"]
+
+    # Simulate the state after serve_thumbnail regenerated to a sidecar
+    # because the default was locked.
+    sidecar = os.path.join(thumb_dir, f"{pid}_regen.jpg")
+    with open(sidecar, "wb") as fh:
+        fh.write(b"pre-edit sidecar pixels")
+    raw_sidecar = os.path.join(thumb_dir, f"{pid}_raw_regen.jpg")
+    with open(raw_sidecar, "wb") as fh:
+        fh.write(b"pre-edit paired sidecar")
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/edit-recipe",
+        json={"recipe": {"exposure": 0.5}},
+    )
+
+    assert resp.status_code == 200
+    assert not os.path.exists(sidecar), (
+        f"{pid}_regen.jpg survived the recipe-edit invalidation; if "
+        "the default thumbnail is locked, the next request would "
+        "keep serving pre-edit pixels through the sidecar path"
+    )
+    assert not os.path.exists(raw_sidecar), (
+        f"{pid}_raw_regen.jpg survived the recipe-edit invalidation; "
+        "paired-source sidecars need the same sweep as the default"
+    )

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -9033,20 +9033,57 @@ def test_legacy_serve_mask_404_when_no_active_variant(app_and_db):
     assert resp.status_code == 404
 
 
-def test_legacy_serve_mask_direct_file_still_served(app_and_db):
-    """A literal ``{pid}.png`` on disk (legacy backfill) is served as-is."""
+def test_legacy_serve_mask_direct_file_served_when_db_backed(app_and_db):
+    """A literal ``{pid}.png`` is served when a ``photo_masks`` row owns it."""
+    import os as _os
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    masks_dir = _os.path.join(_os.path.dirname(db._db_path), "masks")
+    _os.makedirs(masks_dir, exist_ok=True)
+    mask_file = _os.path.join(masks_dir, f"{pid}.png")
+    with open(mask_file, "wb") as fh:
+        fh.write(b"LEGACYDIRECT")
+    db.upsert_photo_mask(
+        photo_id=pid, variant="legacy", path=mask_file,
+        detector_model="md", prompt_x=0, prompt_y=0, prompt_w=0, prompt_h=0,
+    )
+
+    client = app.test_client()
+    resp = client.get(f"/masks/{pid}.png")
+    assert resp.status_code == 200
+    assert resp.data == b"LEGACYDIRECT"
+
+
+def test_serve_mask_404s_a_file_no_db_row_claims(app_and_db):
+    """An id-keyed mask with no DB row behind it must not be served.
+
+    ``masks/<id>.png`` is keyed by bare photo id and ``photos.id`` recycles
+    freed rowids, so existence alone doesn't mean the file belongs to the
+    photo now holding that id — and ``photo_masks`` rows cascade away with
+    the deleted photo, which is exactly what makes their absence the
+    signal. Serving on existence let the inspect overlay show the previous
+    owner's mask indefinitely; an mtime check can't catch it either, since
+    a recently written mask beats an old capture's source timestamp.
+
+    This tightens the old "legacy backfill is served as-is" contract. On
+    the real library that contract was protecting stale data: of 916
+    unreferenced bare mask files, 915 belonged to dead photo ids and one
+    to a live photo.
+    """
     import os as _os
     app, db = app_and_db
     pid = db.get_photos()[0]["id"]
     masks_dir = _os.path.join(_os.path.dirname(db._db_path), "masks")
     _os.makedirs(masks_dir, exist_ok=True)
     with open(_os.path.join(masks_dir, f"{pid}.png"), "wb") as fh:
-        fh.write(b"LEGACYDIRECT")
+        fh.write(b"PREVIOUS-TENANT-MASK")
 
     client = app.test_client()
     resp = client.get(f"/masks/{pid}.png")
-    assert resp.status_code == 200
-    assert resp.data == b"LEGACYDIRECT"
+    assert resp.status_code == 404, (
+        "a mask file no DB row claims was served; a recycled rowid would "
+        "show the previous owner's mask in the inspect overlay"
+    )
 
 
 def test_api_serve_mask_rejects_path_outside_masks_dir(app_and_db, tmp_path):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1758,6 +1758,107 @@ def test_unedited_raw_original_uses_camera_display_cache_not_working_copy(
     assert db.get_photo(photo_id)["working_copy_path"] == f"working/{photo_id}.jpg"
 
 
+def test_unedited_raw_display_cache_survives_when_companion_is_newer_than_raw_row(
+    app_and_db, monkeypatch, tmp_path,
+):
+    """The written display cache must satisfy its own hit check.
+
+    ``/photos/<id>/original`` treats ``originals/<id>.display.jpg`` as a
+    hit only when its mtime is ``>= max(mtime(image_path), mtime(companion))``.
+    Pegging the cache to ``photos.file_mtime`` (the row's stored RAW
+    mtime) would fail that check whenever a paired companion JPEG has a
+    later filesystem mtime than the RAW row does — the common shape for
+    any post-import step that touches the JPEG — and every request would
+    re-decode the RAW plus the companion again.
+
+    Verify that a second request reuses the cache when the companion is
+    newer than the RAW row's stored mtime.
+    """
+    import io
+    import time
+
+    import image_loader
+    from PIL import Image
+
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.get_photos()[0]
+    photo_id = photo["id"]
+
+    source_dir = tmp_path / "raw-source"
+    source_dir.mkdir()
+    raw_path = source_dir / "DSC_0001.NEF"
+    raw_path.write_bytes(b"fake raw")
+    companion_path = source_dir / "DSC_0001.JPG"
+    Image.new("RGB", (800, 600), (200, 50, 50)).save(
+        str(companion_path), "JPEG",
+    )
+
+    raw_mtime = os.path.getmtime(str(raw_path))
+    # Companion is deliberately newer than the RAW row's file_mtime — the
+    # exact case that codex flagged. Also ensure the RAW row's stored
+    # mtime is behind the companion's actual filesystem mtime.
+    later = raw_mtime + 3600
+    os.utime(str(companion_path), (later, later))
+
+    db.conn.execute(
+        "UPDATE folders SET path=? WHERE id=?",
+        (str(source_dir), photo["folder_id"]),
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='DSC_0001.NEF', extension='.nef',
+               width=800, height=600,
+               companion_path='DSC_0001.JPG',
+               file_mtime=?
+           WHERE id=?""",
+        (raw_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    calls = []
+
+    def camera_extract(source, output, **kwargs):
+        calls.append((os.fspath(source), os.fspath(output), kwargs))
+        Image.new("RGB", (800, 600), (220, 220, 220)).save(output, "JPEG")
+        return True
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", camera_extract)
+
+    first = client.get(f"/photos/{photo_id}/original")
+    assert first.status_code == 200
+    assert len(calls) == 1
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    display_path = os.path.join(
+        vireo_dir, "originals", f"{photo_id}.display.jpg",
+    )
+    assert os.path.exists(display_path)
+    display_mtime = os.path.getmtime(display_path)
+
+    # The core defect: the just-written cache must satisfy its own
+    # hit check. If it doesn't, the second request re-extracts.
+    max_source_mtime = max(
+        os.path.getmtime(str(raw_path)),
+        os.path.getmtime(str(companion_path)),
+    )
+    assert display_mtime >= max_source_mtime, (
+        f"display cache mtime {display_mtime} is behind max source "
+        f"mtime {max_source_mtime}; every /original request will "
+        "re-decode the RAW plus companion"
+    )
+
+    second = client.get(f"/photos/{photo_id}/original")
+    assert second.status_code == 200
+    assert len(calls) == 1, (
+        "second /original request re-extracted instead of reusing the "
+        "display cache — the peg to the RAW row's mtime made the cache "
+        "fail its own hit check under a newer companion"
+    )
+    with Image.open(io.BytesIO(second.data)) as rendered:
+        assert rendered.getpixel((0, 0))[0] > 200
+
+
 def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(
     app_and_db, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1775,7 +1775,6 @@ def test_unedited_raw_display_cache_survives_when_companion_is_newer_than_raw_ro
     newer than the RAW row's stored mtime.
     """
     import io
-    import time
 
     import image_loader
     from PIL import Image

--- a/vireo/tests/test_prepare_full_resolution.py
+++ b/vireo/tests/test_prepare_full_resolution.py
@@ -331,6 +331,11 @@ def test_prepared_render_rejected_when_mtime_predates_source(client_with_photo):
     # Prime the cache: the first request writes the prepared render.
     primed = client.get(f"/photos/{photo_id}/original")
     assert primed.status_code == 200
+    # Release the WSGI file wrapper's handle on ``cache_path`` before we
+    # try to overwrite it below. On Windows, ``send_file``'s underlying
+    # handle is held until the response is closed, and ``os.replace`` on
+    # the second request would then fail with ``WinError 5``.
+    primed.close()
 
     vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
     originals_dir = os.path.join(vireo_dir, "originals")

--- a/vireo/tests/test_prepare_full_resolution.py
+++ b/vireo/tests/test_prepare_full_resolution.py
@@ -298,3 +298,65 @@ def test_photo_cache_cleanup_removes_prepared_render(tmp_path):
     )
 
     assert not rendered.exists()
+
+
+def test_prepared_render_rejected_when_mtime_predates_source(client_with_photo):
+    """A stale ``originals/<id>_<sig>.jpg`` must not serve the previous
+    owner's pixels after a recycled-rowid purge failed to delete it.
+
+    ``purge_cached_files_for_recycled_id`` backdates any undeletable
+    ``originals/<id>_<sig>.jpg`` survivor to mtime 0 when the recycled row
+    inherits its previous owner's cached derivative. That is a no-op
+    unless ``_prepared_full_resolution_render`` refuses to serve files
+    whose mtime is older than the photo's ``file_mtime`` — the existence-
+    and-size probe alone can't distinguish a backdated survivor from a
+    fresh render, and ``/photos/<id>/original`` would happily send the
+    stale JPEG.
+
+    Prime the render endpoint, replace the cached JPEG with recognisable
+    sentinel bytes, backdate its mtime, and confirm the next request
+    re-renders (returning a valid JPEG whose bytes differ from the
+    sentinel).
+    """
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    # An edit recipe is what routes ``/original`` through the render-and-
+    # cache path (``_full_resolution_render_path``). Without one, the
+    # endpoint just streams the raw source file — nothing lands in
+    # ``originals/`` and there's no signature-keyed cache to invalidate.
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    # Prime the cache: the first request writes the prepared render.
+    primed = client.get(f"/photos/{photo_id}/original")
+    assert primed.status_code == 200
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    originals_dir = os.path.join(vireo_dir, "originals")
+    cached_names = [
+        name for name in os.listdir(originals_dir)
+        if name.startswith(f"{photo_id}_") and name.endswith(".jpg")
+    ]
+    assert len(cached_names) == 1, cached_names
+    cache_path = os.path.join(originals_dir, cached_names[0])
+
+    # Replace with sentinel bytes and backdate to a mtime before the
+    # photo's file_mtime — the shape of a survivor that ``os.utime((0, 0))``
+    # from ``purge_cached_files_for_recycled_id`` leaves behind when it
+    # couldn't unlink the file.
+    sentinel = b"NOT A VALID JPEG, previous owner's leftover render"
+    with open(cache_path, "wb") as fh:
+        fh.write(sentinel)
+    os.utime(cache_path, (0, 0))
+
+    resp = client.get(f"/photos/{photo_id}/original")
+    assert resp.status_code == 200
+    assert resp.data != sentinel, (
+        "``/original`` served the backdated survivor verbatim; on a "
+        "recycled rowid that would be the previous owner's pixels"
+    )
+    # And the endpoint must have written a *new* JPEG (either overwriting
+    # the sentinel path or a fresh sibling), whose mtime is newer than
+    # the backdated survivor's — the freshness guard's inverse.
+    with Image.open(io.BytesIO(resp.data)) as fresh:
+        assert fresh.format == "JPEG"

--- a/vireo/tests/test_prepare_full_resolution.py
+++ b/vireo/tests/test_prepare_full_resolution.py
@@ -1,5 +1,6 @@
 import io
 import os
+import time
 
 from PIL import Image
 from wait import wait_for_job_via_client
@@ -360,3 +361,56 @@ def test_prepared_render_rejected_when_mtime_predates_source(client_with_photo):
     # the backdated survivor's — the freshness guard's inverse.
     with Image.open(io.BytesIO(resp.data)) as fresh:
         assert fresh.format == "JPEG"
+
+
+def test_prepared_render_not_regenerated_every_request_for_future_mtime(
+    client_with_photo,
+):
+    """A future-dated source must not cause a re-render on every request.
+
+    ``_prepared_full_resolution_render`` rejects renders whose mtime
+    predates ``photos.file_mtime``. Renders are written with the wall
+    clock, so a source whose ``file_mtime`` is in the future — clock skew
+    on the writing machine, archives that preserve future timestamps —
+    fails that gate the instant it's written, and every request pays a
+    full-resolution decode plus the edit pipeline again.
+
+    ``serve_thumbnail`` documents and guards this exact trap for the much
+    cheaper thumbnail path; the render path needs the same mtime peg.
+    """
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    # Put the source's mtime well ahead of the wall clock.
+    future = time.time() + 86400
+    db.conn.execute(
+        "UPDATE photos SET file_mtime=? WHERE id=?", (future, photo_id),
+    )
+    db.conn.commit()
+
+    assert client.get(f"/photos/{photo_id}/original").status_code == 200
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    originals_dir = os.path.join(vireo_dir, "originals")
+    cached = [
+        name for name in os.listdir(originals_dir)
+        if name.startswith(f"{photo_id}_") and name.endswith(".jpg")
+    ]
+    assert len(cached) == 1, cached
+    cache_path = os.path.join(originals_dir, cached[0])
+
+    # The cached render must satisfy its own freshness gate, or the next
+    # request re-renders from scratch.
+    assert os.path.getmtime(cache_path) >= future, (
+        "the just-written render already fails the freshness gate, so "
+        "every request re-renders at full resolution"
+    )
+
+    # Prove it: a second request must reuse the cache rather than rewrite.
+    before = os.path.getmtime(cache_path)
+    assert client.get(f"/photos/{photo_id}/original").status_code == 200
+    assert os.path.getmtime(cache_path) == before, (
+        "the second request rewrote the prepared render instead of "
+        "serving the cached one"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4706,9 +4706,137 @@ def test_recycled_id_index_falls_back_to_per_id_probe_when_dir_unreadable(
         "empty; recycled id 7 would skip the purge and the new photo "
         "would inherit the previous owner's mask"
     )
-    # An id with no cached derivative anywhere must still be reported
-    # absent — the fallback probe returns False, not a blanket True.
-    assert 12345 not in index
+    # An id whose variant patterns don't touch the unreadable directory
+    # must still be reported absent — the fallback only conservatively
+    # says True when a variant *could* be hiding in a dir the sweep
+    # couldn't enumerate. Point the probe at a fresh library where every
+    # derivative dir except masks/ is missing (FileNotFoundError, treated
+    # as genuinely empty), then verify the id isn't blanket-forced true.
+    fresh_vireo = tmp_path / "vireo-fresh"
+    fresh_thumbs = fresh_vireo / "thumbnails"
+    fresh_thumbs.mkdir(parents=True)
+    fresh_index = RecycledIdIndex(
+        str(fresh_thumbs), vireo_dir=str(fresh_vireo),
+    )
+    assert 12345 not in fresh_index, (
+        "fallback returned a blanket True for a fresh library where no "
+        "directory is unreadable; the probe should say False"
+    )
+
+
+def test_recycled_id_index_probe_forces_purge_for_variant_in_unreadable_dir(
+    tmp_path, monkeypatch,
+):
+    """A variant-only derivative in an unreadable directory must still trip.
+
+    Only the exact-path probe (``os.path.exists``) survives when a
+    directory is execute-only but not readable. The variant globs
+    (``previews/<id>_*.jpg``, ``masks/<id>.*.png``) still call
+    ``scandir`` under the hood, so if the fallback trusted their
+    "no match" answer, a variant-only derivative in that directory
+    would slip through and the recycled id would silently serve the
+    previous owner's pixels.
+    """
+    import preview_cache
+    from preview_cache import RecycledIdIndex
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    previews_dir = vireo_dir / "previews"
+    previews_dir.mkdir()
+
+    # id 9's ONLY surviving derivative is a variant preview — the
+    # exact-path probe (``previews/9.jpg``) won't see it, and the
+    # variant glob would need to enumerate a directory the sweep just
+    # reported unreadable.
+    (previews_dir / "9_1920.jpg").write_bytes(b"previous owner's preview")
+
+    real_scandir = preview_cache.os.scandir
+    unreadable = os.path.normpath(str(previews_dir))
+
+    def scandir_denied(path):
+        if os.path.normpath(str(path)) == unreadable:
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_scandir(path)
+
+    monkeypatch.setattr(preview_cache.os, "scandir", scandir_denied)
+
+    real_iglob = preview_cache._glob.iglob
+
+    def iglob_denied(pattern, *args, **kwargs):
+        if os.path.normpath(os.path.dirname(pattern)) == unreadable:
+            # glob.iglob against an unreadable directory silently
+            # returns no matches under scandir failure — same class of
+            # failure the fallback is meant to guard against.
+            return iter(())
+        return real_iglob(pattern, *args, **kwargs)
+
+    monkeypatch.setattr(preview_cache._glob, "iglob", iglob_denied)
+
+    index = RecycledIdIndex(str(thumb_dir), vireo_dir=str(vireo_dir))
+
+    assert 9 in index, (
+        "fallback probe missed a variant-only preview in an unreadable "
+        "directory; recycled id 9 would skip the purge and the new "
+        "photo would inherit the previous owner's preview"
+    )
+
+
+def test_recycled_id_index_sweep_survives_iterator_error(tmp_path, monkeypatch):
+    """OSError raised while iterating scandir must not abort the build.
+
+    ``os.scandir`` succeeds but iterating the entries can still raise
+    (network-backed cache losing the mount mid-walk, ACL change between
+    the open and the first ``__next__``). Without the iterator guard,
+    the whole ``_build`` aborts and every subsequent lookup wrongly
+    reports the id absent — recycled ids skip the purge and their
+    replacements silently serve the previous owner's pixels.
+    """
+    import preview_cache
+    from preview_cache import RecycledIdIndex
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    masks_dir = vireo_dir / "masks"
+    masks_dir.mkdir()
+    (masks_dir / "13.png").write_bytes(b"stale mask")
+
+    real_scandir = preview_cache.os.scandir
+    unreadable = os.path.normpath(str(masks_dir))
+
+    class ExplodingIterator:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def __enter__(self):
+            self._wrapped.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._wrapped.__exit__(*args)
+
+        def __iter__(self):
+            raise OSError("simulated mid-iteration failure")
+
+    def scandir_explodes(path):
+        result = real_scandir(path)
+        if os.path.normpath(str(path)) == unreadable:
+            return ExplodingIterator(result)
+        return result
+
+    monkeypatch.setattr(preview_cache.os, "scandir", scandir_explodes)
+
+    index = RecycledIdIndex(str(thumb_dir), vireo_dir=str(vireo_dir))
+
+    # The build must not raise — the sweep should catch the iteration
+    # failure and mark the index incomplete. The exact-path fallback
+    # then still finds id 13 via ``os.path.exists``.
+    assert 13 in index, (
+        "sweep didn't recover from an iteration OSError; the whole "
+        "batch index aborted and recycled id 13 would skip the purge"
+    )
 
 
 def test_recycled_id_index_indexes_external_dng_subdirectories(tmp_path):
@@ -4814,6 +4942,36 @@ def test_transfer_snapshots_reports_unrecoverable_refs(tmp_path):
 
     assert result["failed"] == [ref]
     assert result["moved"] == []
+
+
+def test_transfer_snapshots_reports_enumerate_failure(tmp_path, monkeypatch):
+    """``os.listdir`` failing on ``edit-masks/`` must surface as a flag.
+
+    Without the flag, the raised ``OSError`` is caught by the deferred-
+    action loop in scanner._pair_raw_jpeg_companions after the recipe
+    has already been committed to the primary. Every affected local
+    adjustment renders without its mask indefinitely, and the caller
+    can't say so because the exception vanished before ``failed`` got
+    populated.
+    """
+    import local_masks
+
+    vireo_dir = str(tmp_path / "vireo")
+    _seed_edit_mask_snapshot(vireo_dir, 55)
+
+    def boom(path):
+        raise PermissionError(13, "Permission denied", path)
+
+    monkeypatch.setattr(local_masks.os, "listdir", boom)
+
+    result = local_masks.transfer_snapshots(vireo_dir, 55, 66)
+
+    assert result["enumerate_failed"] is True, (
+        "os.listdir failure did not surface as enumerate_failed; the "
+        "caller can't warn the user about masks left under the old id"
+    )
+    assert result["moved"] == []
+    assert result["failed"] == []
 
 
 def test_delete_photos_cleanup_leaves_edit_mask_snapshots_to_gc(tmp_path):

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4647,6 +4647,64 @@ def test_recycled_id_index_does_not_confuse_id_prefixes(tmp_path):
     assert 0 not in index
 
 
+def test_recycled_id_index_falls_back_to_per_id_probe_when_dir_unreadable(
+    tmp_path, monkeypatch,
+):
+    """A derivative directory that can't be enumerated must not be
+    silently treated as empty.
+
+    ``scandir`` fails on directories that are execute-only but not
+    readable (a permissions gap, transient EIO, ACL quirk). Treating
+    that as "no cached files for any id" makes the batch index drop
+    every recycled id whose only surviving derivative lives there — and
+    ``purge_cached_files_for_recycled_id`` short-circuits on the index,
+    so a subsequent request lazily adopts the previous owner's pixels.
+
+    The exact-path probe (``os.path.exists``) works even on execute-only
+    directories, so falling back to it for uncertain lookups recovers the
+    common case (id-keyed exact filenames like ``masks/<id>.png`` or the
+    legacy ``previews/<id>.jpg``). Verify the fallback fires when
+    ``scandir`` raises.
+    """
+    from preview_cache import RecycledIdIndex
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    masks_dir = vireo_dir / "masks"
+    masks_dir.mkdir()
+
+    # Only surviving derivative for id 7 is its subject mask. If the
+    # index treated an unreadable masks/ as empty, ``7 in index`` would
+    # return False and the purge would be skipped — the recycled RAW
+    # would then get another photo's mask applied to the local pass.
+    stale = masks_dir / "7.png"
+    stale.write_bytes(b"previous owner's mask")
+
+    import preview_cache
+
+    real_scandir = preview_cache.os.scandir
+    unreadable_dir = os.path.normpath(str(masks_dir))
+
+    def scandir_denied(path):
+        if os.path.normpath(str(path)) == unreadable_dir:
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_scandir(path)
+
+    monkeypatch.setattr(preview_cache.os, "scandir", scandir_denied)
+
+    index = RecycledIdIndex(str(thumb_dir), vireo_dir=str(vireo_dir))
+
+    assert 7 in index, (
+        "batch index treated an unreadable derivative directory as "
+        "empty; recycled id 7 would skip the purge and the new photo "
+        "would inherit the previous owner's mask"
+    )
+    # An id with no cached derivative anywhere must still be reported
+    # absent — the fallback probe returns False, not a blanket True.
+    assert 12345 not in index
+
+
 def test_recycled_id_index_indexes_external_dng_subdirectories(tmp_path):
     """The Nikon-HE-NEF DNG cache lives at ``external-dng/<pid>/`` — the
     entries are bare-digit *directory* names rather than files with a

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4673,22 +4673,19 @@ def test_recycled_id_index_indexes_external_dng_subdirectories(tmp_path):
     )
 
 
-def test_pairing_keeps_companion_snapshot_when_transfer_fails(tmp_path, monkeypatch):
-    """A failed snapshot rename must not lose the only copy.
+def test_pairing_recovers_snapshot_when_rename_fails(tmp_path, monkeypatch):
+    """A failed snapshot rename must still leave the mask reachable.
 
-    ``local_masks.transfer_snapshots`` catches ``OSError`` and returns
-    normally (a locked destination on Windows, a permissions blip), so the
-    source ``edit-masks/<companion_id>.<ref>.png`` stays put. The recipe row
-    has *already* been reassigned to the primary by then, so if the
-    companion cleanup deleted edit-mask snapshots by photo id it would
-    destroy the sole remaining copy — ``load_snapshot`` misses, and that
-    local adjustment is silently disabled forever with nothing to recover.
-
-    Snapshots are content-addressed, so the id-keyed purge has no business
-    in that directory at all; ``gc_edit_masks`` reaps by ref instead.
+    ``transfer_snapshots`` catches ``OSError`` from ``os.replace`` (a locked
+    source on Windows, a permissions blip). The recipe row has already been
+    reassigned to the primary by then, and ``load_snapshot`` only ever
+    builds ``snapshot_path(vireo_dir, primary_id, ref)`` — so merely leaving
+    the old-id file in place doesn't help: every render still disables the
+    local pass. The copy fallback is what actually recovers it.
     """
     import local_masks
     from db import Database
+    from local_masks import snapshot_path
     from scanner import _pair_raw_jpeg_companions
 
     img_dir = tmp_path / "photos"
@@ -4702,19 +4699,18 @@ def test_pairing_keeps_companion_snapshot_when_transfer_fails(tmp_path, monkeypa
         folder_id=fid, filename="IMG_004.jpg", extension=".jpg",
         file_size=1000, file_mtime=1.0,
     )
-    db.add_photo(
+    raw_id = db.add_photo(
         folder_id=fid, filename="IMG_004.cr3", extension=".cr3",
         file_size=2000, file_mtime=1.0,
     )
     # A recipe on the JPEG is what makes pairing transfer the row (and the
     # snapshot files) over to the RAW primary.
     db.set_photo_edit_recipe(jpeg_id, {"rotation": 90})
-    snapshot = _seed_edit_mask_snapshot(vireo_dir, jpeg_id)
+    ref = "abcdef012345"
+    _seed_edit_mask_snapshot(vireo_dir, jpeg_id, ref)
 
-    # Simulate the rename failing the way it does on a locked destination:
-    # transfer_snapshots logs and returns, leaving the source in place.
     def _failing_replace(src, dst):
-        raise OSError("simulated locked destination")
+        raise OSError("simulated locked source")
 
     monkeypatch.setattr(local_masks.os, "replace", _failing_replace)
 
@@ -4722,11 +4718,38 @@ def test_pairing_keeps_companion_snapshot_when_transfer_fails(tmp_path, monkeypa
         db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
     )
 
-    assert os.path.exists(snapshot), (
-        "companion's local-mask snapshot was deleted after its rename "
-        "failed; the recipe now points at the primary id, so this was the "
-        "only copy and the local adjustment is unrecoverable"
+    assert os.path.exists(snapshot_path(vireo_dir, raw_id, ref)), (
+        "snapshot never reached the primary id after the rename failed; "
+        "load_snapshot builds the path from the primary id, so the local "
+        "adjustment renders without its mask"
     )
+
+
+def test_transfer_snapshots_reports_unrecoverable_refs(tmp_path):
+    """When neither rename nor copy works, the caller must be told.
+
+    A silently-degraded render is exactly the black box CORE_PHILOSOPHY
+    forbids — the mask is gone and the image just looks different.
+    """
+    import local_masks
+
+    vireo_dir = str(tmp_path / "vireo")
+    ref = "abcdef012345"
+    _seed_edit_mask_snapshot(vireo_dir, 11, ref)
+
+    def _boom(*args, **kwargs):
+        raise OSError("simulated failure")
+
+    local_masks.os.replace, real_replace = _boom, local_masks.os.replace
+    local_masks.shutil.copy2, real_copy = _boom, local_masks.shutil.copy2
+    try:
+        result = local_masks.transfer_snapshots(vireo_dir, 11, 22)
+    finally:
+        local_masks.os.replace = real_replace
+        local_masks.shutil.copy2 = real_copy
+
+    assert result["failed"] == [ref]
+    assert result["moved"] == []
 
 
 def test_delete_photos_cleanup_leaves_edit_mask_snapshots_to_gc(tmp_path):
@@ -4760,4 +4783,47 @@ def test_delete_photos_cleanup_leaves_edit_mask_snapshots_to_gc(tmp_path):
     )
     assert os.path.exists(snapshot), (
         "content-addressed edit-mask snapshot must be left to gc_edit_masks"
+    )
+
+
+def test_recycled_id_purge_backdates_derivatives_it_could_not_delete(tmp_path):
+    """"Ran the purge" is not the same as "the stale pixels are gone".
+
+    ``cleanup_cached_files_for_deleted_photos`` logs and continues when an
+    unlink fails (locked file on Windows, momentarily unwritable dir), so a
+    purge that reports success can still leave the previous owner's
+    thumbnail servable — and ``serve_thumbnail``'s mtime guard won't catch
+    it, because a recently generated thumbnail beats an old capture's
+    ``file_mtime``. Backdating the survivor makes that existing guard do
+    the right thing.
+    """
+    import preview_cache
+    from preview_cache import purge_cached_files_for_recycled_id
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    stuck = thumb_dir / "88.jpg"
+    stuck.write_bytes(b"previous-tenant")
+    # Recent mtime — exactly the case the freshness guard would wave through.
+    os.utime(stuck, (2_000_000_000, 2_000_000_000))
+
+    real_remove = os.remove
+
+    def _locked_remove(path, *args, **kwargs):
+        if os.path.normpath(str(path)) == os.path.normpath(str(stuck)):
+            raise OSError("simulated Windows lock")
+        return real_remove(path, *args, **kwargs)
+
+    preview_cache.os.remove = _locked_remove
+    try:
+        purged = purge_cached_files_for_recycled_id(str(thumb_dir), 88)
+    finally:
+        preview_cache.os.remove = real_remove
+
+    assert purged is True
+    assert stuck.exists(), "test setup failed to simulate an undeletable file"
+    assert os.path.getmtime(stuck) == 0, (
+        "undeletable stale derivative kept its recent mtime, so the "
+        "freshness guard would serve the previous owner's pixels"
     )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -5008,3 +5008,120 @@ def test_recycled_id_purge_clears_external_edit_handoffs(tmp_path):
         "external-edit cache metadata outlived its photo; it is what makes "
         "the stale render look valid"
     )
+
+
+def test_preview_marker_written_even_when_backdating_fails(tmp_path):
+    """For previews the marker matters more than the mtime.
+
+    ``_serve_preview``'s lazy-adoption branch never compares mtimes, so a
+    readable surviving preview is adoptable regardless of its timestamp —
+    only the durable ``preview_cache_invalidations`` row keeps it out. An
+    earlier revision attempted the marker only on the backdate's success
+    path, so a survivor whose ``utime`` also failed stayed adoptable.
+    """
+    import preview_cache
+    from db import Database
+    from preview_cache import purge_cached_files_for_recycled_id
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path / "photos"), name="photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="gull.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    survivor = vireo_dir / "previews" / f"{pid}_1920.jpg"
+    survivor.parent.mkdir(parents=True)
+    survivor.write_bytes(b"previous-tenant-preview")
+
+    real_remove, real_utime = preview_cache.os.remove, preview_cache.os.utime
+
+    def locked_remove(path, *a, **k):
+        if os.path.normpath(str(path)) == os.path.normpath(str(survivor)):
+            raise OSError("locked")
+        return real_remove(path, *a, **k)
+
+    def locked_utime(path, *a, **k):
+        if os.path.normpath(str(path)) == os.path.normpath(str(survivor)):
+            raise OSError("locked")
+        return real_utime(path, *a, **k)
+
+    preview_cache.os.remove, preview_cache.os.utime = locked_remove, locked_utime
+    try:
+        purge_cached_files_for_recycled_id(
+            str(thumb_dir), pid, vireo_dir=str(vireo_dir), db=db,
+        )
+    finally:
+        preview_cache.os.remove, preview_cache.os.utime = real_remove, real_utime
+
+    row = db.conn.execute(
+        "SELECT 1 FROM preview_cache_invalidations WHERE photo_id=? AND size=?",
+        (pid, 1920),
+    ).fetchone()
+    assert row is not None, (
+        "no invalidation marker was written because the backdate failed "
+        "first; _serve_preview would adopt the previous owner's preview"
+    )
+
+
+def test_prepared_render_survivor_does_not_get_a_preview_marker(tmp_path):
+    """``originals/<id>_2048.jpg`` is not a preview.
+
+    The name shape is identical to a sized preview, so a name-only parse
+    earns the photo a durable ``preview_cache_invalidations`` row for a
+    size that was never cached — which would then suppress adoption of a
+    preview that legitimately gets written later.
+    """
+    from db import Database
+    from preview_cache import (
+        ensure_preview_cache_invalidations_table,
+        purge_cached_files_for_recycled_id,
+    )
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path / "photos"), name="photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="gull.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    # Create the table up front so an empty result means "no marker was
+    # written", not "the purge never touched this family".
+    ensure_preview_cache_invalidations_table(db)
+    render = vireo_dir / "originals" / f"{pid}_2048.jpg"
+    render.parent.mkdir(parents=True)
+    render.write_bytes(b"prepared-render")
+
+    # Lock it so it actually becomes a *survivor* — otherwise the purge
+    # just deletes it and the marker logic is never reached.
+    import preview_cache
+
+    real_remove = preview_cache.os.remove
+
+    def locked_remove(path, *a, **k):
+        if os.path.normpath(str(path)) == os.path.normpath(str(render)):
+            raise OSError("locked")
+        return real_remove(path, *a, **k)
+
+    preview_cache.os.remove = locked_remove
+    try:
+        purge_cached_files_for_recycled_id(
+            str(thumb_dir), pid, vireo_dir=str(vireo_dir), db=db,
+        )
+    finally:
+        preview_cache.os.remove = real_remove
+
+    assert render.exists(), "test setup failed to make the render survive"
+
+    rows = db.conn.execute(
+        "SELECT size FROM preview_cache_invalidations WHERE photo_id=?", (pid,)
+    ).fetchall()
+    assert not rows, (
+        f"a prepared render earned bogus preview invalidation rows: {rows}"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4827,3 +4827,86 @@ def test_recycled_id_purge_backdates_derivatives_it_could_not_delete(tmp_path):
         "undeletable stale derivative kept its recent mtime, so the "
         "freshness guard would serve the previous owner's pixels"
     )
+
+
+def test_recycled_id_purge_honors_a_thumb_dir_outside_vireo_dir(tmp_path):
+    """``--db`` and ``--thumb-dir`` are independent paths.
+
+    ``audit.import_untracked`` takes ``vireo_dir`` and ``thumb_cache_dir``
+    separately for exactly this reason. Deriving the cache root as
+    ``dirname(thumb_cache_dir)`` would look for previews, working copies,
+    masks, offline files, and DNGs beside the *thumbnails* — so under a
+    split layout none of them are detected or purged, and a recycled id
+    keeps serving the previous owner's pixels from every family except
+    thumbnails.
+    """
+    from preview_cache import (
+        RecycledIdIndex,
+        purge_cached_files_for_recycled_id,
+    )
+
+    vireo_dir = tmp_path / "data"
+    thumb_dir = tmp_path / "elsewhere" / "thumbs"   # NOT vireo_dir/thumbnails
+    thumb_dir.mkdir(parents=True)
+    (thumb_dir / "55.jpg").write_bytes(b"stale-thumb")
+    working = vireo_dir / "working" / "55.jpg"
+    working.parent.mkdir(parents=True)
+    working.write_bytes(b"stale-working")
+    preview = vireo_dir / "previews" / "55_1920.jpg"
+    preview.parent.mkdir(parents=True)
+    preview.write_bytes(b"stale-preview")
+
+    index = RecycledIdIndex(str(thumb_dir), vireo_dir=str(vireo_dir))
+    assert 55 in index, "index missed derivatives under a split layout"
+
+    assert purge_cached_files_for_recycled_id(
+        str(thumb_dir), 55, vireo_dir=str(vireo_dir),
+    )
+
+    assert not (thumb_dir / "55.jpg").exists()
+    assert not working.exists(), (
+        "working copy under the real vireo_dir survived; the purge looked "
+        "beside the thumbnails instead"
+    )
+    assert not preview.exists(), "sized preview under the real vireo_dir survived"
+
+
+def test_recycled_id_purge_backdates_files_inside_an_undeletable_dng_dir(
+    tmp_path,
+):
+    """Backdating a directory does nothing for the file inside it.
+
+    ``external-dng/<id>/`` is a per-id *directory*, but the external-editor
+    freshness check stats the DNG **file** (``cached_mtime >= source_mtime``).
+    If ``rmtree`` fails and we backdate only the directory, the purge reports
+    a successful invalidation while a recycled RAW with the same stem can
+    still be handed the previous owner's DNG.
+    """
+    import preview_cache
+    from preview_cache import purge_cached_files_for_recycled_id
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    dng_dir = vireo_dir / "external-dng" / "99"
+    dng_dir.mkdir(parents=True)
+    dng = dng_dir / "DSC_0001.dng"
+    dng.write_bytes(b"previous-tenant-conversion")
+    os.utime(dng, (2_000_000_000, 2_000_000_000))
+
+    def _locked_rmtree(path, *args, **kwargs):
+        raise OSError("simulated locked DNG")
+
+    real_rmtree = preview_cache.shutil.rmtree
+    preview_cache.shutil.rmtree = _locked_rmtree
+    try:
+        purge_cached_files_for_recycled_id(str(thumb_dir), 99)
+    finally:
+        preview_cache.shutil.rmtree = real_rmtree
+
+    assert dng.exists(), "test setup failed to simulate an undeletable DNG"
+    assert os.path.getmtime(dng) == 0, (
+        "the DNG inside the undeletable directory kept its recent mtime, so "
+        "the external-editor freshness check would hand Darktable the "
+        "previous owner's conversion"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4403,3 +4403,142 @@ def test_pairing_purges_the_merged_companion_derived_caches(tmp_path):
         assert not os.path.exists(path), (
             f"merged companion's {name} cache outlived its photo row"
         )
+
+
+def test_scan_purges_variant_only_caches_when_new_photo_reuses_a_freed_rowid(
+    tmp_path,
+):
+    """The recycled-id probe must catch derivative families that only exist
+    in a variant form (no legacy exact-name file).
+
+    Sized preview files (``previews/{id}_1920.jpg``) are the standard shape
+    written by the preview stage; source-specific thumbnails
+    (``thumbnails/{id}_raw.jpg``), variant subject masks, and edit-mask
+    snapshots have the same "no bare-name counterpart" property. A probe
+    that only checks the legacy exact names returns False for these, skips
+    the purge, and the request paths' lazy-adoption shortcuts then serve
+    the previous owner's pixels as if they were the new photo's.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['gull.jpg']})
+    vireo_dir = str(tmp_path / "vireo")
+    thumb_dir = os.path.join(vireo_dir, "thumbnails")
+
+    db = Database(str(tmp_path / "test.db"))
+    placeholder_folder = db.add_folder(str(tmp_path / "gone"), name="gone")
+    doomed_id = db.add_photo(
+        folder_id=placeholder_folder, filename="munia.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    db.conn.execute("DELETE FROM photos WHERE id = ?", (doomed_id,))
+    db.conn.commit()
+
+    # Seed ONLY variant-form derivatives — no bare-name legacy files.
+    variant_paths = {
+        "sized_preview": os.path.join(
+            vireo_dir, "previews", f"{doomed_id}_1920.jpg",
+        ),
+        "raw_thumbnail_variant": os.path.join(
+            thumb_dir, f"{doomed_id}_raw.jpg",
+        ),
+        "prepared_render": os.path.join(
+            vireo_dir, "originals", f"{doomed_id}_2048.jpg",
+        ),
+        "variant_mask": os.path.join(
+            vireo_dir, "masks", f"{doomed_id}.sam2-large.png",
+        ),
+        "edit_mask_snapshot": os.path.join(
+            vireo_dir, "edit-masks", f"{doomed_id}.abcdef012345.png",
+        ),
+        "offline_original": os.path.join(
+            vireo_dir, "offline", "originals", f"{doomed_id}.NEF",
+        ),
+    }
+    for path in variant_paths.values():
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as fh:
+            fh.write(b"previous-tenant")
+
+    scan(root, db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
+         skip_working_copies=True)
+
+    new_id = db.conn.execute(
+        "SELECT id FROM photos WHERE filename = 'gull.jpg'"
+    ).fetchone()["id"]
+    assert new_id == doomed_id, (
+        "test setup no longer reproduces rowid reuse; SQLite handed out "
+        f"{new_id} instead of {doomed_id}"
+    )
+    for name, path in variant_paths.items():
+        assert not os.path.exists(path), (
+            f"variant-only {name} cache survived the recycled-id purge and "
+            f"would be served as photo {new_id}'s pixels"
+        )
+
+
+def test_pairing_defers_companion_file_cleanup_until_commit_succeeds(
+    tmp_path, monkeypatch,
+):
+    """If ``commit_with_retry`` raises, the transaction rolls back — every
+    companion row that had been DELETEd earlier in the loop comes back.
+    Any files we'd already unlinked inline would then leave those restored
+    rows pointing at gone-from-disk thumbnails / working copies / masks
+    / offline originals.
+
+    Simulate the failure by monkeypatching ``commit_with_retry`` inside
+    scanner to raise, then assert that the companion row is still present
+    AND its cached derivatives are all still on disk.
+    """
+    import scanner
+    from db import Database
+    from scanner import _pair_raw_jpeg_companions
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+    vireo_dir = str(tmp_path / "vireo")
+    thumb_dir = os.path.join(vireo_dir, "thumbnails")
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(img_dir), name="photos")
+    jpeg_id = db.add_photo(
+        folder_id=fid, filename="IMG_003.jpg", extension=".jpg",
+        file_size=1000, file_mtime=1.0,
+    )
+    db.add_photo(
+        folder_id=fid, filename="IMG_003.cr3", extension=".cr3",
+        file_size=2000, file_mtime=1.0,
+    )
+    db.conn.commit()
+
+    seeded = _seed_derivative_files(vireo_dir, thumb_dir, jpeg_id)
+
+    def _boom(_conn):
+        raise RuntimeError("simulated commit failure")
+
+    monkeypatch.setattr(scanner, "commit_with_retry", _boom)
+
+    with pytest.raises(RuntimeError, match="simulated commit failure"):
+        _pair_raw_jpeg_companions(
+            db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
+        )
+
+    # Force a rollback of the aborted transaction (mirroring what the
+    # scan orchestrator does when a partial pair-up raises) so the
+    # visibility check below sees post-rollback state.
+    db.conn.rollback()
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) AS n FROM photos WHERE id = ?", (jpeg_id,)
+    ).fetchone()["n"] == 1, (
+        "companion row should have been restored by the transaction "
+        "rollback after commit failure"
+    )
+    for name, path in seeded.items():
+        assert os.path.exists(path), (
+            f"companion's {name} cache was deleted before the commit "
+            "succeeded, leaving the restored companion row pointing at a "
+            "missing file"
+        )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4373,7 +4373,7 @@ def test_scan_leaves_derived_caches_alone_for_rows_it_did_not_create(
 def test_pairing_purges_the_merged_companion_derived_caches(tmp_path):
     """Folding a JPEG companion into its RAW frees the companion's rowid.
 
-    ``_merge_companion_pair`` deletes the companion photo row with raw
+    ``_pair_raw_jpeg_companions`` deletes the companion photo row with raw
     SQL. Without unlinking its derivatives, the next photo to inherit that
     id adopts the companion's thumbnail.
     """

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4969,3 +4969,42 @@ def test_recycled_id_purge_marks_surviving_previews_uncacheable(tmp_path):
         "surviving preview was only backdated; _serve_preview would still "
         "adopt it and serve the previous owner's pixels"
     )
+
+
+def test_recycled_id_purge_clears_external_edit_handoffs(tmp_path):
+    """The external-editor handoff render is id-keyed and must be purged.
+
+    ``external-edits/<id>.jpg`` is the render handed to an external editor
+    and ``<id>.json`` is its cache key — recipe, source path, source mtime,
+    edit-math version. None of those is a photo id or a content hash, so a
+    recycled id re-imported at the same path with a preserved mtime and the
+    same recipe matches the previous owner's metadata, and the editor is
+    handed the previous owner's pixels.
+    """
+    from preview_cache import (
+        RecycledIdIndex,
+        purge_cached_files_for_recycled_id,
+    )
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    handoff_dir = vireo_dir / "external-edits"
+    handoff_dir.mkdir()
+    render = handoff_dir / "77.jpg"
+    meta = handoff_dir / "77.json"
+    render.write_bytes(b"previous-tenant-render")
+    meta.write_text('{"recipe": "", "source_mtime": 1.0}')
+
+    index = RecycledIdIndex(str(thumb_dir), vireo_dir=str(vireo_dir))
+    assert 77 in index, "index missed an external-edit handoff"
+
+    assert purge_cached_files_for_recycled_id(
+        str(thumb_dir), 77, vireo_dir=str(vireo_dir),
+    )
+
+    assert not render.exists(), "external-edit render outlived its photo"
+    assert not meta.exists(), (
+        "external-edit cache metadata outlived its photo; it is what makes "
+        "the stale render look valid"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4243,3 +4243,163 @@ def test_scan_recursive_raises_permission_error_without_callback(
     db = Database(str(tmp_path / "test.db"))
     with pytest.raises(PermissionError):
         scan(root, db)
+
+
+# ---------------------------------------------------------------------------
+# Recycled rowid → stale derived caches
+# ---------------------------------------------------------------------------
+
+
+def _seed_derivative_files(vireo_dir, thumb_dir, photo_id, marker=b"previous-tenant"):
+    """Write one file per id-keyed derivative family for ``photo_id``."""
+    paths = {
+        "thumb": os.path.join(thumb_dir, f"{photo_id}.jpg"),
+        "thumb_variant": os.path.join(thumb_dir, f"{photo_id}_raw.jpg"),
+        "working": os.path.join(vireo_dir, "working", f"{photo_id}.jpg"),
+        "preview": os.path.join(vireo_dir, "previews", f"{photo_id}_1920.jpg"),
+        "display": os.path.join(
+            vireo_dir, "originals", f"{photo_id}.display.jpg"
+        ),
+        "mask": os.path.join(vireo_dir, "masks", f"{photo_id}.png"),
+        "mask_variant": os.path.join(
+            vireo_dir, "masks", f"{photo_id}.sam2-large.png"
+        ),
+        "edit_mask": os.path.join(
+            vireo_dir, "edit-masks", f"{photo_id}.abcdef012345.png"
+        ),
+    }
+    for path in paths.values():
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as fh:
+            fh.write(marker)
+    return paths
+
+
+def test_scan_purges_derived_caches_when_new_photo_reuses_a_freed_rowid(
+    tmp_path,
+):
+    """A new photo that inherits a freed rowid must not inherit its cache.
+
+    ``photos.id`` is INTEGER PRIMARY KEY without AUTOINCREMENT, so SQLite
+    hands the next insert ``max(rowid) + 1`` — delete the highest-numbered
+    rows and those ids come straight back. Every derivative in ``~/.vireo``
+    is keyed by bare photo id, so if a delete path left the files behind
+    (several drop photo rows with raw SQL and do), the next photo to claim
+    the id renders the *previous* photo's pixels — the wrong bird on a
+    Life List card. Ingest is the one place the collision is observable,
+    so it re-checks there.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['gull.jpg']})
+    vireo_dir = str(tmp_path / "vireo")
+    thumb_dir = os.path.join(vireo_dir, "thumbnails")
+
+    db = Database(str(tmp_path / "test.db"))
+    # Claim (and free) a rowid so the real scan's insert reuses it.
+    placeholder_folder = db.add_folder(str(tmp_path / "gone"), name="gone")
+    doomed_id = db.add_photo(
+        folder_id=placeholder_folder, filename="munia.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    db.conn.execute("DELETE FROM photos WHERE id = ?", (doomed_id,))
+    db.conn.commit()
+
+    seeded = _seed_derivative_files(vireo_dir, thumb_dir, doomed_id)
+
+    scan(root, db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
+         skip_working_copies=True)
+
+    new_id = db.conn.execute(
+        "SELECT id FROM photos WHERE filename = 'gull.jpg'"
+    ).fetchone()["id"]
+    assert new_id == doomed_id, (
+        "test setup no longer reproduces rowid reuse; SQLite handed out "
+        f"{new_id} instead of {doomed_id}"
+    )
+    for name, path in seeded.items():
+        assert not os.path.exists(path), (
+            f"{name} cache from the freed rowid's previous owner survived "
+            f"the insert and would be served as photo {new_id}'s"
+        )
+
+
+def test_scan_leaves_derived_caches_alone_for_rows_it_did_not_create(
+    tmp_path,
+):
+    """The recycled-id purge must not fire on a plain rescan.
+
+    Re-scanning an unchanged library re-visits every photo; treating those
+    as fresh inserts would wipe (and force regeneration of) the entire
+    thumbnail cache on every scan.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['gull.jpg']})
+    vireo_dir = str(tmp_path / "vireo")
+    thumb_dir = os.path.join(vireo_dir, "thumbnails")
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
+         skip_working_copies=True)
+    pid = db.conn.execute(
+        "SELECT id FROM photos WHERE filename = 'gull.jpg'"
+    ).fetchone()["id"]
+
+    seeded = _seed_derivative_files(vireo_dir, thumb_dir, pid, b"legit-cache")
+
+    scan(root, db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
+         skip_working_copies=True)
+
+    for name, path in seeded.items():
+        assert os.path.exists(path), (
+            f"rescan of an existing photo deleted its {name} cache"
+        )
+
+
+def test_pairing_purges_the_merged_companion_derived_caches(tmp_path):
+    """Folding a JPEG companion into its RAW frees the companion's rowid.
+
+    ``_merge_companion_pair`` deletes the companion photo row with raw
+    SQL. Without unlinking its derivatives, the next photo to inherit that
+    id adopts the companion's thumbnail.
+    """
+    from db import Database
+    from scanner import _pair_raw_jpeg_companions
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+    vireo_dir = str(tmp_path / "vireo")
+    thumb_dir = os.path.join(vireo_dir, "thumbnails")
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(img_dir), name="photos")
+    jpeg_id = db.add_photo(
+        folder_id=fid, filename="IMG_002.jpg", extension=".jpg",
+        file_size=1000, file_mtime=1.0,
+    )
+    raw_id = db.add_photo(
+        folder_id=fid, filename="IMG_002.cr3", extension=".cr3",
+        file_size=2000, file_mtime=1.0,
+    )
+
+    companion_files = _seed_derivative_files(vireo_dir, thumb_dir, jpeg_id)
+    primary_thumb = os.path.join(thumb_dir, f"{raw_id}.jpg")
+    with open(primary_thumb, "wb") as fh:
+        fh.write(b"primary-thumb")
+
+    _pair_raw_jpeg_companions(
+        db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
+    )
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) AS n FROM photos WHERE id = ?", (jpeg_id,)
+    ).fetchone()["n"] == 0
+    for name, path in companion_files.items():
+        assert not os.path.exists(path), (
+            f"merged companion's {name} cache outlived its photo row"
+        )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4251,7 +4251,13 @@ def test_scan_recursive_raises_permission_error_without_callback(
 
 
 def _seed_derivative_files(vireo_dir, thumb_dir, photo_id, marker=b"previous-tenant"):
-    """Write one file per id-keyed derivative family for ``photo_id``."""
+    """Write one file per id-keyed derivative family for ``photo_id``.
+
+    ``external_dng`` is a per-id *directory* (``external-dng/<pid>/``
+    holds Nikon-HE-NEF conversions the external-editor path reuses when
+    ``cached_mtime >= source_mtime``); callers check its presence the
+    same way as the file entries.
+    """
     paths = {
         "thumb": os.path.join(thumb_dir, f"{photo_id}.jpg"),
         "thumb_variant": os.path.join(thumb_dir, f"{photo_id}_raw.jpg"),
@@ -4266,6 +4272,9 @@ def _seed_derivative_files(vireo_dir, thumb_dir, photo_id, marker=b"previous-ten
         ),
         "edit_mask": os.path.join(
             vireo_dir, "edit-masks", f"{photo_id}.abcdef012345.png"
+        ),
+        "external_dng": os.path.join(
+            vireo_dir, "external-dng", str(photo_id), "gull.dng"
         ),
     }
     for path in paths.values():
@@ -4629,3 +4638,29 @@ def test_recycled_id_index_does_not_confuse_id_prefixes(tmp_path):
     assert 7 in index
     assert 4 not in index, "'40.jpg' was parsed as id 4"
     assert 0 not in index
+
+
+def test_recycled_id_index_indexes_external_dng_subdirectories(tmp_path):
+    """The Nikon-HE-NEF DNG cache lives at ``external-dng/<pid>/`` — the
+    entries are bare-digit *directory* names rather than files with a
+    ``.``/``_`` separator, so the standard ``_leading_photo_id`` parser
+    (which requires the separator) skips them. Verify the index's
+    external-dng sweep picks them up so a recycled RAW id doesn't reuse
+    the previous owner's DNG when Darktable is launched.
+    """
+    from preview_cache import RecycledIdIndex
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    external_dng = vireo_dir / "external-dng"
+    (external_dng / "1234").mkdir(parents=True)
+    (external_dng / "1234" / "DSC_9999.dng").write_bytes(b"stale-conversion")
+
+    index = RecycledIdIndex(str(thumb_dir))
+
+    assert 1234 in index, (
+        "batch index missed an external-dng orphan; the recycled RAW id "
+        "would silently reuse the previous owner's DNG through the "
+        "external-editor freshness check"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4251,12 +4251,16 @@ def test_scan_recursive_raises_permission_error_without_callback(
 
 
 def _seed_derivative_files(vireo_dir, thumb_dir, photo_id, marker=b"previous-tenant"):
-    """Write one file per id-keyed derivative family for ``photo_id``.
+    """Write one file per *purgeable* id-keyed derivative family.
 
     ``external_dng`` is a per-id *directory* (``external-dng/<pid>/``
     holds Nikon-HE-NEF conversions the external-editor path reuses when
     ``cached_mtime >= source_mtime``); callers check its presence the
     same way as the file entries.
+
+    ``edit-masks/`` is deliberately absent: those snapshots are
+    content-addressed and owned by ``local_masks.gc_edit_masks``, not by
+    the id-keyed purge. See ``_seed_edit_mask_snapshot``.
     """
     paths = {
         "thumb": os.path.join(thumb_dir, f"{photo_id}.jpg"),
@@ -4270,9 +4274,6 @@ def _seed_derivative_files(vireo_dir, thumb_dir, photo_id, marker=b"previous-ten
         "mask_variant": os.path.join(
             vireo_dir, "masks", f"{photo_id}.sam2-large.png"
         ),
-        "edit_mask": os.path.join(
-            vireo_dir, "edit-masks", f"{photo_id}.abcdef012345.png"
-        ),
         "external_dng": os.path.join(
             vireo_dir, "external-dng", str(photo_id), "gull.dng"
         ),
@@ -4282,6 +4283,15 @@ def _seed_derivative_files(vireo_dir, thumb_dir, photo_id, marker=b"previous-ten
         with open(path, "wb") as fh:
             fh.write(marker)
     return paths
+
+
+def _seed_edit_mask_snapshot(vireo_dir, photo_id, ref="abcdef012345"):
+    """Write a local-adjustment snapshot at ``edit-masks/<pid>.<ref>.png``."""
+    path = os.path.join(vireo_dir, "edit-masks", f"{photo_id}.{ref}.png")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(b"snapshot-bytes")
+    return path
 
 
 def test_scan_purges_derived_caches_when_new_photo_reuses_a_freed_rowid(
@@ -4458,9 +4468,6 @@ def test_scan_purges_variant_only_caches_when_new_photo_reuses_a_freed_rowid(
         ),
         "variant_mask": os.path.join(
             vireo_dir, "masks", f"{doomed_id}.sam2-large.png",
-        ),
-        "edit_mask_snapshot": os.path.join(
-            vireo_dir, "edit-masks", f"{doomed_id}.abcdef012345.png",
         ),
         "offline_original": os.path.join(
             vireo_dir, "offline", "originals", f"{doomed_id}.NEF",
@@ -4663,4 +4670,94 @@ def test_recycled_id_index_indexes_external_dng_subdirectories(tmp_path):
         "batch index missed an external-dng orphan; the recycled RAW id "
         "would silently reuse the previous owner's DNG through the "
         "external-editor freshness check"
+    )
+
+
+def test_pairing_keeps_companion_snapshot_when_transfer_fails(tmp_path, monkeypatch):
+    """A failed snapshot rename must not lose the only copy.
+
+    ``local_masks.transfer_snapshots`` catches ``OSError`` and returns
+    normally (a locked destination on Windows, a permissions blip), so the
+    source ``edit-masks/<companion_id>.<ref>.png`` stays put. The recipe row
+    has *already* been reassigned to the primary by then, so if the
+    companion cleanup deleted edit-mask snapshots by photo id it would
+    destroy the sole remaining copy — ``load_snapshot`` misses, and that
+    local adjustment is silently disabled forever with nothing to recover.
+
+    Snapshots are content-addressed, so the id-keyed purge has no business
+    in that directory at all; ``gc_edit_masks`` reaps by ref instead.
+    """
+    import local_masks
+    from db import Database
+    from scanner import _pair_raw_jpeg_companions
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+    vireo_dir = str(tmp_path / "vireo")
+    thumb_dir = os.path.join(vireo_dir, "thumbnails")
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(img_dir), name="photos")
+    jpeg_id = db.add_photo(
+        folder_id=fid, filename="IMG_004.jpg", extension=".jpg",
+        file_size=1000, file_mtime=1.0,
+    )
+    db.add_photo(
+        folder_id=fid, filename="IMG_004.cr3", extension=".cr3",
+        file_size=2000, file_mtime=1.0,
+    )
+    # A recipe on the JPEG is what makes pairing transfer the row (and the
+    # snapshot files) over to the RAW primary.
+    db.set_photo_edit_recipe(jpeg_id, {"rotation": 90})
+    snapshot = _seed_edit_mask_snapshot(vireo_dir, jpeg_id)
+
+    # Simulate the rename failing the way it does on a locked destination:
+    # transfer_snapshots logs and returns, leaving the source in place.
+    def _failing_replace(src, dst):
+        raise OSError("simulated locked destination")
+
+    monkeypatch.setattr(local_masks.os, "replace", _failing_replace)
+
+    _pair_raw_jpeg_companions(
+        db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
+    )
+
+    assert os.path.exists(snapshot), (
+        "companion's local-mask snapshot was deleted after its rename "
+        "failed; the recipe now points at the primary id, so this was the "
+        "only copy and the local adjustment is unrecoverable"
+    )
+
+
+def test_delete_photos_cleanup_leaves_edit_mask_snapshots_to_gc(tmp_path):
+    """The id-keyed purge must not touch ``edit-masks/``.
+
+    Snapshot filenames carry a photo id, but lookup is by *ref* — a hash of
+    the mask bytes — so a recycled id can't surface a previous owner's
+    snapshot (a new photo has no local section, and a ref match means the
+    masks are byte-identical). ``gc_edit_masks`` owns the directory and
+    reaps by ref with a grace period; purging by id here would only create
+    the data-loss window this test guards.
+    """
+    from preview_cache import cleanup_cached_files_for_deleted_photos
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    (thumb_dir / "77.jpg").write_bytes(b"thumb")
+    subject_mask = vireo_dir / "masks" / "77.png"
+    subject_mask.parent.mkdir(parents=True)
+    subject_mask.write_bytes(b"subject-mask")
+    snapshot = _seed_edit_mask_snapshot(str(vireo_dir), 77)
+
+    cleanup_cached_files_for_deleted_photos(
+        str(thumb_dir), [{"photo_id": 77}],
+    )
+
+    assert not (thumb_dir / "77.jpg").exists(), "thumbnail should be purged"
+    assert not subject_mask.exists(), (
+        "subject mask is read by photo id and must be purged"
+    )
+    assert os.path.exists(snapshot), (
+        "content-addressed edit-mask snapshot must be left to gc_edit_masks"
     )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4277,6 +4277,12 @@ def _seed_derivative_files(vireo_dir, thumb_dir, photo_id, marker=b"previous-ten
         "external_dng": os.path.join(
             vireo_dir, "external-dng", str(photo_id), "gull.dng"
         ),
+        "inat_upload": os.path.join(
+            vireo_dir, "inat-uploads", f"{photo_id}.jpg"
+        ),
+        "inat_upload_meta": os.path.join(
+            vireo_dir, "inat-uploads", f"{photo_id}.json"
+        ),
     }
     for path in paths.values():
         os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -5182,4 +5188,117 @@ def test_prepared_render_survivor_does_not_get_a_preview_marker(tmp_path):
     ).fetchall()
     assert not rows, (
         f"a prepared render earned bogus preview invalidation rows: {rows}"
+    )
+
+
+def test_recycled_id_purge_clears_inat_upload_handoffs(tmp_path):
+    """``inat-uploads/<id>.{jpg,json}`` is id-keyed and must be purged.
+
+    ``_inat_upload_photo_path`` caches the render under the photo id and
+    reuses it when the metadata JSON matches only
+    {recipe, source_path, source_mtime, edit_math_version} — none of which
+    is a photo id or content hash. A recycled id imported at the same path
+    and mtime with the same recipe would therefore ship the previous
+    owner's pixels to iNaturalist.
+    """
+    from preview_cache import (
+        RecycledIdIndex,
+        purge_cached_files_for_recycled_id,
+    )
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    inat_dir = vireo_dir / "inat-uploads"
+    inat_dir.mkdir()
+    render = inat_dir / "77.jpg"
+    meta = inat_dir / "77.json"
+    render.write_bytes(b"previous-tenant-inat-render")
+    meta.write_text('{"recipe": "", "source_mtime": 1.0}')
+
+    index = RecycledIdIndex(str(thumb_dir), vireo_dir=str(vireo_dir))
+    assert 77 in index, "index missed an iNat upload handoff"
+
+    assert purge_cached_files_for_recycled_id(
+        str(thumb_dir), 77, vireo_dir=str(vireo_dir),
+    )
+
+    assert not render.exists(), "iNat upload render outlived its photo"
+    assert not meta.exists(), (
+        "iNat upload cache metadata outlived its photo; it is what makes "
+        "the stale render look valid"
+    )
+
+
+def test_delete_photos_cleanup_removes_inat_upload_handoffs(tmp_path):
+    """``cleanup_cached_files_for_deleted_photos`` must sweep inat-uploads.
+
+    Same reasoning as the external-edit handoff: the metadata compares
+    recipe/source/mtime and never inspects file mtime, so any recycled id
+    with matching envelope would upload the previous owner's pixels.
+    """
+    from preview_cache import cleanup_cached_files_for_deleted_photos
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    inat_dir = vireo_dir / "inat-uploads"
+    inat_dir.mkdir()
+    (inat_dir / "42.jpg").write_bytes(b"render")
+    (inat_dir / "42.json").write_text("{}")
+
+    cleanup_cached_files_for_deleted_photos(
+        str(thumb_dir),
+        [{"photo_id": 42, "filename": "gone.jpg"}],
+        vireo_dir=str(vireo_dir),
+    )
+
+    assert not (inat_dir / "42.jpg").exists()
+    assert not (inat_dir / "42.json").exists()
+
+
+def test_recycled_id_purge_backdates_below_a_negative_source_mtime(tmp_path):
+    """Backdating survivors to ``0`` fails when the source is at/below epoch.
+
+    ``serve_thumbnail`` / ``_prepared_full_resolution_render`` / the
+    external-DNG gate all treat ``cached_mtime >= source_mtime`` as fresh.
+    If a rowid gets recycled onto a photo whose archived filesystem
+    timestamp is ``0`` (or negative), a survivor backdated to ``0`` still
+    satisfies that comparison and the previous owner's pixels are served
+    as fresh. Anchor the backdate to the new photo's own ``file_mtime``.
+    """
+    import preview_cache
+    from preview_cache import purge_cached_files_for_recycled_id
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    stuck = thumb_dir / "88.jpg"
+    stuck.write_bytes(b"previous-tenant")
+    os.utime(stuck, (2_000_000_000, 2_000_000_000))
+
+    real_remove = os.remove
+
+    def _locked_remove(path, *args, **kwargs):
+        if os.path.normpath(str(path)) == os.path.normpath(str(stuck)):
+            raise OSError("simulated Windows lock")
+        return real_remove(path, *args, **kwargs)
+
+    preview_cache.os.remove = _locked_remove
+    try:
+        # New photo's source file_mtime is 0 (an archive preserved an epoch
+        # timestamp). A hard-coded ``0`` sentinel would not invalidate the
+        # survivor for this source.
+        purge_cached_files_for_recycled_id(
+            str(thumb_dir), 88, file_mtime=0.0,
+        )
+    finally:
+        preview_cache.os.remove = real_remove
+
+    assert stuck.exists(), "test setup failed to simulate an undeletable file"
+    survivor_mtime = os.path.getmtime(stuck)
+    assert survivor_mtime < 0.0, (
+        f"survivor mtime {survivor_mtime} is not strictly less than the "
+        "source file_mtime of 0.0, so the freshness guard would still "
+        "serve the previous owner's pixels"
     )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4542,3 +4542,90 @@ def test_pairing_defers_companion_file_cleanup_until_commit_succeeds(
             "succeeded, leaving the restored companion row pointing at a "
             "missing file"
         )
+
+
+def test_scan_probes_recycled_ids_without_walking_dirs_per_photo(
+    tmp_path, monkeypatch,
+):
+    """The recycled-id probe must be batched, not per-photo.
+
+    Answering "does this id already own cached files?" by globbing costs a
+    full directory enumeration per inserted photo — O(new photos × cached
+    files). Measured against a 76k-thumbnail library that was 117 ms per
+    insert, i.e. ~10 minutes of pure ``scandir`` for a 5000-photo import.
+    ``RecycledIdIndex`` snapshots the answer for every id with one
+    ``scandir`` per derivative directory, so the count must not grow with
+    the number of photos ingested.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': [f"bird{i}.jpg" for i in range(12)]})
+    vireo_dir = str(tmp_path / "vireo")
+    thumb_dir = os.path.join(vireo_dir, "thumbnails")
+    # Populate the cache so the directories aren't trivially empty.
+    os.makedirs(thumb_dir, exist_ok=True)
+    for i in range(50):
+        with open(os.path.join(thumb_dir, f"{9000 + i}.jpg"), "wb") as fh:
+            fh.write(b"stale")
+
+    import preview_cache
+    from preview_cache import _derivative_dirs
+
+    derivative_dirs = {
+        os.path.normpath(d) for d in _derivative_dirs(thumb_dir)
+    }
+    enumerations = []
+    real_scandir = os.scandir
+
+    def counting_scandir(path, *args, **kwargs):
+        # ``glob`` reaches os.scandir through the same module attribute we
+        # patch here, so this counts globbing too — which is the point.
+        if isinstance(path, (str, bytes, os.PathLike)):
+            normalized = os.path.normpath(os.fspath(path))
+            if normalized in derivative_dirs:
+                enumerations.append(normalized)
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(preview_cache.os, "scandir", counting_scandir)
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_dir,
+         skip_working_copies=True)
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) AS n FROM photos"
+    ).fetchone()["n"] == 12
+    # Each derivative directory is enumerated at most once for the whole
+    # scan. Per-photo probing would hit each of them 12 times.
+    repeats = {d: enumerations.count(d) for d in set(enumerations)
+               if enumerations.count(d) > 1}
+    assert not repeats, (
+        "recycled-id probe enumerated derivative directories more than "
+        f"once for a 12-photo scan: {repeats}"
+    )
+
+
+def test_recycled_id_index_does_not_confuse_id_prefixes(tmp_path):
+    """``40.jpg`` must not register photo 4 as having a cached derivative.
+
+    Derivative names are the bare id followed by ``.`` or ``_``; parsing
+    the leading digit run without requiring that separator would make
+    every id a false positive for its numeric prefixes, and the purge
+    would delete a *live* photo's cache on every unrelated insert.
+    """
+    from preview_cache import RecycledIdIndex
+
+    thumb_dir = tmp_path / "vireo" / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    (thumb_dir / "40.jpg").write_bytes(b"forty")
+    (thumb_dir / "7_raw.jpg").write_bytes(b"seven-raw")
+    (thumb_dir / "not-a-photo.jpg").write_bytes(b"junk")
+
+    index = RecycledIdIndex(str(thumb_dir))
+
+    assert 40 in index
+    assert 7 in index
+    assert 4 not in index, "'40.jpg' was parsed as id 4"
+    assert 0 not in index

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -4910,3 +4910,62 @@ def test_recycled_id_purge_backdates_files_inside_an_undeletable_dng_dir(
         "the external-editor freshness check would hand Darktable the "
         "previous owner's conversion"
     )
+
+
+def test_recycled_id_purge_marks_surviving_previews_uncacheable(tmp_path):
+    """Backdating a preview does not invalidate it.
+
+    ``_serve_preview``'s lazy-adoption branch tests
+    ``os.path.exists(cache_path)`` with no mtime comparison, so a sized
+    preview that outlived its owner gets adopted and re-registered
+    verbatim — the recycled photo serves the previous owner's pixels *and*
+    the LRU records them as legitimately cached. The durable
+    ``preview_cache_invalidations`` row is the only thing that branch
+    honours, so a preview we could not delete must get one.
+    """
+    import preview_cache
+    from db import Database
+    from preview_cache import purge_cached_files_for_recycled_id
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    preview = vireo_dir / "previews" / "66_1920.jpg"
+    preview.parent.mkdir(parents=True)
+    preview.write_bytes(b"previous-tenant-preview")
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path / "photos"), name="photos")
+    photo_id = db.add_photo(
+        folder_id=fid, filename="gull.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    # Rename the seeded preview onto whatever rowid we actually got, so the
+    # FK on preview_cache_invalidations is satisfiable.
+    survivor = vireo_dir / "previews" / f"{photo_id}_1920.jpg"
+    preview.rename(survivor)
+
+    real_remove = os.remove
+
+    def _locked_remove(path, *args, **kwargs):
+        if os.path.normpath(str(path)) == os.path.normpath(str(survivor)):
+            raise OSError("simulated lock")
+        return real_remove(path, *args, **kwargs)
+
+    preview_cache.os.remove = _locked_remove
+    try:
+        purge_cached_files_for_recycled_id(
+            str(thumb_dir), photo_id, vireo_dir=str(vireo_dir), db=db,
+        )
+    finally:
+        preview_cache.os.remove = real_remove
+
+    assert survivor.exists(), "test setup failed to simulate a locked preview"
+    row = db.conn.execute(
+        "SELECT 1 FROM preview_cache_invalidations WHERE photo_id=? AND size=?",
+        (photo_id, 1920),
+    ).fetchone()
+    assert row is not None, (
+        "surviving preview was only backdated; _serve_preview would still "
+        "adopt it and serve the previous owner's pixels"
+    )

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -1870,3 +1870,51 @@ def test_serve_thumbnail_404s_when_both_thumbnail_and_sidecar_are_locked(
     for path, original in locked.items():
         assert open(path, "rb").read() == original
         assert os.path.getmtime(path) < photo_mtime
+
+
+def test_serve_thumbnail_sidecar_does_not_claim_coverage_for_the_stale_default(
+    tmp_path, monkeypatch,
+):
+    """A sidecar serve must not record ``<id>.jpg`` as a done thumbnail.
+
+    The real ``<id>.jpg`` is still the previous owner's locked, stale file.
+    Writing ``photos.thumb_path = '<id>.jpg'`` would tell the coverage
+    dashboard and ``backfill_thumb_paths`` this photo has a valid
+    thumbnail, so nothing regenerates it once the lock clears — a status
+    that claims work is finished when the next run would not be a no-op is
+    exactly what CORE_PHILOSOPHY forbids.
+    """
+    import app as app_module
+
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+    photo_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    os.utime(thumb_file, (photo_mtime - 86400, photo_mtime - 86400))
+    db.conn.execute("UPDATE photos SET thumb_path=NULL WHERE id=?", (pid,))
+    db.conn.commit()
+
+    real_remove = app_module.os.remove
+
+    def failing_remove(path, *args, **kwargs):
+        if path == thumb_file:
+            raise PermissionError(13, "Permission denied", path)
+        return real_remove(path, *args, **kwargs)
+
+    monkeypatch.setattr(app_module.os, "remove", failing_remove)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+    assert resp.status_code == 200
+
+    stored = db.conn.execute(
+        "SELECT thumb_path FROM photos WHERE id=?", (pid,)
+    ).fetchone()["thumb_path"]
+    assert stored is None, (
+        f"thumb_path was set to {stored!r} while the real thumbnail is "
+        "still the locked stale file; coverage would report this photo "
+        "done and never regenerate it"
+    )

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -1730,3 +1730,91 @@ def test_serve_thumbnail_does_not_serve_stale_pixels_when_unlink_fails(
     # sidecar the purge globs already cover.
     assert open(thumb_file, "rb").read() == sentinel_bytes
     assert os.path.exists(os.path.join(thumb_dir, f"{pid}_regen.jpg"))
+
+
+def test_thumbnail_raw_fallbacks_honor_an_explicit_cache_name():
+    """The RAW-decode fallbacks must write to the caller's cache name.
+
+    ``serve_thumbnail`` redirects to a ``<id>_regen.jpg`` sidecar when the
+    real thumbnail is stale but undeletable. If the companion / working-copy
+    fallbacks re-enter ``generate_thumbnail`` with the default ``<id>.jpg``
+    they target that *locked stale file* — ``generate_thumbnail`` returns it
+    as-is without generating, and the ``os.utime(result, ...)`` that follows
+    pins the previous owner's pixels as permanently fresh, which is exactly
+    what the freshness guard exists to prevent. The response meanwhile points
+    at a sidecar nobody wrote.
+    """
+    import inspect
+
+    import thumbnails as thumbnails_module
+
+    for fn in (
+        thumbnails_module._retry_thumbnail_with_companion,
+        thumbnails_module._retry_thumbnail_with_working_copy,
+    ):
+        params = inspect.signature(fn).parameters
+        assert "cache_name" in params, (
+            f"{fn.__name__} cannot honor a caller-chosen cache name, so the "
+            "sidecar redirect leaks back onto the locked default path"
+        )
+        src = inspect.getsource(fn)
+        assert "cache_name=cache_name" in src, (
+            f"{fn.__name__} accepts cache_name but does not forward it to "
+            "generate_thumbnail"
+        )
+
+
+def test_serve_thumbnail_passes_sidecar_name_to_every_generation_call(
+    tmp_path, monkeypatch,
+):
+    """No generation call may escape the sidecar redirect.
+
+    Guards the wiring end-to-end: once ``serve_thumbnail`` has redirected to
+    the sidecar, every ``generate_thumbnail`` it makes — primary or fallback
+    — must carry that name.
+    """
+    import app as app_module
+
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+    sentinel_bytes = open(thumb_file, "rb").read()
+    photo_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    os.utime(thumb_file, (photo_mtime - 86400, photo_mtime - 86400))
+
+    real_remove = app_module.os.remove
+
+    def failing_remove(path, *args, **kwargs):
+        if path == thumb_file:
+            raise PermissionError(13, "Permission denied", path)
+        return real_remove(path, *args, **kwargs)
+
+    monkeypatch.setattr(app_module.os, "remove", failing_remove)
+
+    import thumbnails as thumbnails_module
+
+    real_generate = thumbnails_module.generate_thumbnail
+    seen_names = []
+
+    def recording_generate(photo_id_, source, cache_dir, **kwargs):
+        seen_names.append(kwargs.get("cache_name"))
+        return real_generate(photo_id_, source, cache_dir, **kwargs)
+
+    monkeypatch.setattr(
+        thumbnails_module, "generate_thumbnail", recording_generate,
+    )
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200
+    assert resp.data != sentinel_bytes
+    assert seen_names, "no thumbnail generation happened"
+    assert all(n == f"{pid}_regen.jpg" for n in seen_names), (
+        f"a generation call escaped the sidecar redirect: {seen_names}"
+    )
+    assert open(thumb_file, "rb").read() == sentinel_bytes
+    assert os.path.getmtime(thumb_file) < photo_mtime

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -1676,3 +1676,57 @@ def test_serve_thumbnail_404s_for_photo_outside_active_workspace(tmp_path, monke
         "thumbnail self-heal must not serve a photo that the active "
         "workspace cannot see"
     )
+
+
+def test_serve_thumbnail_does_not_serve_stale_pixels_when_unlink_fails(
+    tmp_path, monkeypatch,
+):
+    """A stale thumbnail we cannot delete must not be served either.
+
+    This branch fires for recycled rowids, so the cached pixels belong to
+    a *different photo*. The old behaviour served the file "once" and
+    retried the unlink next request — but if the lock persists (which is
+    what locks do), every request serves the previous owner's image. A
+    broken image is better than the wrong bird.
+
+    The route now regenerates to a ``{photo_id}_regen.jpg`` sidecar and
+    serves that. The sidecar's ``{photo_id}_*`` shape means the existing
+    recycled-id purge and delete cleanup already sweep it.
+    """
+    import app as app_module
+
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    thumb_file = os.path.join(thumb_dir, f"{pid}.jpg")
+    # 50x50 flat colour at q70 — nothing like the 800x600 real source, so
+    # a byte comparison is decisive.
+    Image.new("RGB", (50, 50), (1, 2, 3)).save(thumb_file, "JPEG", quality=70)
+    sentinel_bytes = open(thumb_file, "rb").read()
+    photo_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    stale_mtime = photo_mtime - 86400
+    os.utime(thumb_file, (stale_mtime, stale_mtime))
+
+    real_remove = app_module.os.remove
+
+    def failing_remove(path, *args, **kwargs):
+        if path == thumb_file:
+            raise PermissionError(13, "Permission denied", path)
+        return real_remove(path, *args, **kwargs)
+
+    monkeypatch.setattr(app_module.os, "remove", failing_remove)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 200
+    assert resp.data != sentinel_bytes, (
+        "the undeletable stale thumbnail was served; on a recycled rowid "
+        "that is the previous owner's photo, and a persistent lock means "
+        "every request shows it"
+    )
+    # The locked original is left alone, and the fresh bytes came from the
+    # sidecar the purge globs already cover.
+    assert open(thumb_file, "rb").read() == sentinel_bytes
+    assert os.path.exists(os.path.join(thumb_dir, f"{pid}_regen.jpg"))

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -1818,3 +1818,55 @@ def test_serve_thumbnail_passes_sidecar_name_to_every_generation_call(
     )
     assert open(thumb_file, "rb").read() == sentinel_bytes
     assert os.path.getmtime(thumb_file) < photo_mtime
+
+
+def test_serve_thumbnail_404s_when_both_thumbnail_and_sidecar_are_locked(
+    tmp_path, monkeypatch,
+):
+    """Nowhere safe to write means serve nothing, not the wrong photo.
+
+    If a recycled id has an undeletable stale ``<id>.jpg`` *and* an
+    undeletable stale ``<id>_regen.jpg``, suppressing the sidecar's removal
+    failure and falling through would let ``generate_thumbnail`` short-
+    circuit on the stale sidecar and return it — then ``os.utime(result,
+    ...)`` marks the previous owner's pixels fresh and the response serves
+    them. With both cache targets locked there is no safe file to write, so
+    the honest answer is 404.
+    """
+    import app as app_module
+
+    app, db, pid, thumb_dir = _make_app_with_real_photo(tmp_path, monkeypatch)
+
+    photo_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    stale = photo_mtime - 86400
+
+    locked = {}
+    for name in (f"{pid}.jpg", f"{pid}_regen.jpg"):
+        path = os.path.join(thumb_dir, name)
+        Image.new("RGB", (50, 50), (9, 9, 9)).save(path, "JPEG", quality=70)
+        os.utime(path, (stale, stale))
+        locked[path] = open(path, "rb").read()
+
+    real_remove = app_module.os.remove
+
+    def failing_remove(path, *args, **kwargs):
+        if path in locked:
+            raise PermissionError(13, "Permission denied", path)
+        return real_remove(path, *args, **kwargs)
+
+    monkeypatch.setattr(app_module.os, "remove", failing_remove)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404, (
+        "with both the thumbnail and its sidecar stale and locked, the "
+        "route served something — on a recycled rowid that is another "
+        "photo's image"
+    )
+    # Neither locked file may be pinned as fresh; the next request retries.
+    for path, original in locked.items():
+        assert open(path, "rb").read() == original
+        assert os.path.getmtime(path) < photo_mtime

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -82,6 +82,7 @@ def _has_current_raw_failure(photo, source_path):
 
 def _retry_thumbnail_with_companion(
     db, photo, source_path, cache_dir, size, quality, recipe, folder_path,
+    cache_name=None,
 ):
     if not photo or not folder_path:
         return None
@@ -120,12 +121,14 @@ def _retry_thumbnail_with_companion(
         cache_dir,
         size=size,
         quality=quality,
+        cache_name=cache_name,
         **recipe_kwargs,
     )
 
 
 def _retry_thumbnail_with_working_copy(
     db, photo, source_path, cache_dir, size, quality, recipe, vireo_dir,
+    cache_name=None,
 ):
     if not photo or not recipe or not vireo_dir:
         return None
@@ -161,6 +164,7 @@ def _retry_thumbnail_with_working_copy(
         cache_dir,
         size=size,
         quality=quality,
+        cache_name=cache_name,
         **recipe_kwargs,
     )
 


### PR DESCRIPTION
## The bug

The Life List card for **Ring-billed gull** rendered a scaly-breasted munia. Opening the card showed `1 / 17 · _D851953.NEF` — the correct gull. The card and the lightbox agree on the photo id; they disagree on the pixels because the card reads `thumbnails/<id>.jpg` while the lightbox renders the preview.

Traced on the live library:

| | |
|---|---|
| `photos` row 24157 | `_D851953.NEF`, Torrey Pines, tagged Ring-billed gull |
| `working/24157.jpg` | the gull ✅ |
| `thumbnails/24157.jpg` | a munia ❌ |

## Root cause

`photos.id` is `INTEGER PRIMARY KEY` **without** `AUTOINCREMENT`, so SQLite hands the next insert `max(rowid) + 1` — delete the highest-numbered rows and those ids come straight back out. Every derivative under `~/.vireo` is keyed by bare photo id (`thumbnails/<id>.jpg`, `working/<id>.jpg`, `previews/<id>_<size>.jpg`, `masks/<id>.png`, …), so a new photo that inherits a freed id silently adopts the previous photo's cached pixels.

On the live library, ids 24144–24175 are one contiguous block of this: the thumbnails were written Apr 23 13:30–13:55, and the photos that now own those ids had their working copies extracted at 17:12 the same day.

`serve_thumbnail` already tried to catch this (PR #778) by comparing the cached file's mtime against `photos.file_mtime`. That check can't see the common case — the recycled thumbnail was generated recently (Apr 23 2026) while the new photo's source is an old capture (Feb 9 2026), so `cached_mtime > file_mtime` and the stale image is served as "fresh" forever.

## The fix

Purge id-keyed derivatives at the one moment the collision can actually happen: when a brand-new row claims a rowid during ingest. `purge_cached_files_for_recycled_id` probes five exact paths (5 `stat`s per insert — a fresh library pays ~nothing) and only ids that actually collide pay for the globbing purge.

This holds regardless of which delete site leaked, and several still do — `Database._merge_into_existing`, `scanner._merge_companion_pair`, and `audit.remove_orphans` all drop photo rows with raw SQL, and any failed unlink leaves an orphan too.

Also in this PR:
- `_merge_companion_pair` now unlinks the merged companion's derivatives instead of freeing its rowid with the files still on disk.
- `cleanup_cached_files_for_deleted_photos` now covers `masks/` and `edit-masks/`. `photos.mask_path` goes away with the row, so a leftover mask is invisible to the DB but gets picked up by whatever photo later inherits the id — the renderer would apply another photo's mask to the local pass.

## Tests

Three new tests in `vireo/tests/test_scanner.py`. Both new-behavior tests were confirmed RED before the fix and GREEN after; the third is a regression guard that a plain rescan does **not** wipe legitimate caches (it passes either way, by design).

```
vireo/tests/test_scanner.py vireo/tests/test_thumbnails.py \
vireo/tests/test_delete_api.py vireo/tests/test_audit.py    224 passed

tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py
vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py
vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py
vireo/tests/test_config.py                        1939 passed, 14 skipped, 1 failed
```

The single failure is `test_api_exiftool_status_reports_missing`, pre-existing on `main` (verified by re-running with the source changes stashed).

## Verified in the app

Deleted the bad `thumbnails/24157.jpg`, loaded `/life-list` in a real browser against the running app, and card #46 now renders the ring-billed gull — the existing `serve_thumbnail` self-heal regenerates correctly once the poisoned file is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale thumbnails, previews, and derivative caches from being reused when photo row IDs are recycled.
  * Improved deletion/companion cleanup to run filesystem updates only after database changes succeed.
  * Strengthened cache freshness handling for prepared full-resolution renders and reduced clock-skew issues.
  * Enhanced stale/locked thumbnail behavior to regenerate into a safe sidecar variant; improved masking to serve only DB-backed files.
  * Improved edit-mask snapshot transfer resilience when moves fail.
* **Tests**
  * Expanded coverage for recycled-ID purge/probe behavior, companion cleanup timing, cache freshness edge cases, and sidecar/regeneration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->