### PR TITLE
Fold typographic apostrophes so one species is one keyword

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1037,6 +1037,56 @@ def test_add_keyword_normalizes_acute_accent_with_leading_whitespace(db):
     assert db.add_keyword("apapane") == kid
 
 
+def test_add_keyword_folds_internal_typographic_apostrophe(db):
+    """A curly apostrophe inside a name must fold to ASCII U+0027.
+
+    macOS smart-quote substitution, pasted iNaturalist common names, and
+    label files all produce ``Say\u2019s phoebe``. Storing that verbatim
+    left it invisibly distinct from ``Say's phoebe`` under SQLite
+    ``COLLATE NOCASE``, so add_keyword inserted a SECOND species row and
+    the Life List showed two cards with two lifer numbers for one bird.
+    Folding in the storage form (not just the match key) keeps
+    keyword_match_key in lockstep with the SQL dedupe.
+    """
+    kid = db.add_keyword("Say's phoebe", is_species=True)
+
+    row = db.conn.execute(
+        "SELECT name FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Say's phoebe"
+    # The curly variant must resolve to the SAME row, not insert a new one.
+    assert db.add_keyword("Say\u2019s phoebe", is_species=True) == kid
+    assert db.conn.execute(
+        "SELECT COUNT(*) c FROM keywords WHERE name LIKE 'Say%phoebe'"
+    ).fetchone()["c"] == 1
+
+
+def test_add_keyword_folds_curly_apostrophe_when_curly_arrives_first(db):
+    """Fold direction must not depend on insertion order."""
+    kid = db.add_keyword("Cassin\u2019s kingbird", is_species=True)
+
+    row = db.conn.execute(
+        "SELECT name FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["name"] == "Cassin's kingbird"
+    assert db.add_keyword("Cassin's kingbird", is_species=True) == kid
+
+
+def test_add_keyword_preserves_okina_against_apostrophe_folding(db):
+    """U+02BB/U+02BC are Lm LETTERS in real species names and must survive
+    the apostrophe fold even when they appear INSIDE a name (where the
+    edge-quote strip does not reach)."""
+    for name in ("Hawai\u02bbi \u02bbamakihi", "\u02bbI\u02bbiwi",
+                 "Lili\u02bbuokalani Gardens", "Hawai\u02bci"):
+        kid = db.add_keyword(name)
+        row = db.conn.execute(
+            "SELECT name FROM keywords WHERE id = ?", (kid,)
+        ).fetchone()
+        assert row["name"] == name, (
+            f"okina folded to apostrophe in {name!r} -> {row['name']!r}"
+        )
+
+
 def test_add_keyword_preserves_internal_acute_accent(db):
     """U+00B4 should be stripped only at the edges, not inside a keyword."""
     keyword_id = db.add_keyword("O\u00b4Brien")

--- a/vireo/analyze.py
+++ b/vireo/analyze.py
@@ -376,8 +376,9 @@ def main():
     parser.add_argument("--no-recursive", action="store_true")
     args = parser.parse_args()
 
-    with open(args.labels_file) as f:
-        labels = [line.strip() for line in f if line.strip()]
+    from labels import read_label_file
+
+    labels = read_label_file(args.labels_file)
     log.info("Loaded %d labels from %s", len(labels), args.labels_file)
 
     analyze(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14909,7 +14909,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_classify_readiness():
         """Check what's ready for classification and what will need work."""
         from classifier import _embedding_cache_path, _resolve_model_dir
-        from labels import get_active_labels, get_saved_labels, load_merged_labels
+        from labels import get_active_labels, get_saved_labels, load_merged_labels, read_label_file
         from models import get_active_model, get_models
 
         model_id = request.args.get("model_id", "")
@@ -14971,14 +14971,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if labels_file:
             # Single file override from query param (classify page picker)
             if os.path.exists(labels_file):
-                with open(labels_file, encoding="utf-8") as f:
-                    label_count = sum(1 for line in f if line.strip())
+                labels = read_label_file(labels_file)
+                label_count = len(labels)
                 for ls in get_saved_labels():
                     if ls.get("labels_file") == labels_file:
                         label_name = ls.get("name", labels_file)
                         break
-                with open(labels_file, encoding="utf-8") as f:
-                    labels = [line.strip() for line in f if line.strip()]
         elif labels_files:
             # Multiple files override from query param
             active_sets = []
@@ -16918,7 +16916,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_embedding_matrix():
         """Return which model+labels combinations have cached embeddings."""
         from classifier import _embedding_cache_path, _resolve_model_dir
-        from labels import get_saved_labels
+        from labels import get_saved_labels, read_label_file
         from models import get_models
 
         # Only BioCLIP-style models use per-label text embeddings. timm models
@@ -16936,8 +16934,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             labels_file = ls.get("labels_file", "")
             if not labels_file or not os.path.exists(labels_file):
                 continue
-            with open(labels_file, encoding="utf-8") as f:
-                labels = [line.strip() for line in f if line.strip()]
+            labels = read_label_file(labels_file)
             row = {
                 "labels_name": ls.get("name", ""),
                 "labels_file": labels_file,
@@ -16973,6 +16970,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         def work(job):
             from classifier import Classifier
+            from labels import read_label_file
             from models import get_models
 
             # Find the model
@@ -17001,8 +16999,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 },
             )
 
-            with open(labels_file, encoding="utf-8") as f:
-                labels = [line.strip() for line in f if line.strip()]
+            labels = read_label_file(labels_file)
 
             log.info(
                 "Pre-computing embeddings: %d labels with %s",
@@ -27644,7 +27641,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if len(q) < 2:
             return jsonify([])
 
-        from labels import get_active_labels
+        from labels import get_active_labels, read_label_file
 
         matches = []
         seen = set()
@@ -27653,20 +27650,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not labels_file or not os.path.exists(labels_file):
                 continue
             try:
-                with open(labels_file, encoding="utf-8") as f:
-                    for line in f:
-                        name = line.strip()
-                        if not name:
-                            continue
-                        name_key = name.casefold()
-                        if (
-                            text_search_match(name, q, match_case, whole_word)
-                            and name_key not in seen
-                        ):
-                            seen.add(name_key)
-                            matches.append(name)
-                            if len(matches) >= 20:
-                                break
+                for name in read_label_file(labels_file):
+                    name_key = name.casefold()
+                    if (
+                        text_search_match(name, q, match_case, whole_word)
+                        and name_key not in seen
+                    ):
+                        seen.add(name_key)
+                        matches.append(name)
+                        if len(matches) >= 20:
+                            break
             except Exception:
                 pass
             if len(matches) >= 20:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14971,13 +14971,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if labels_file:
             # Single file override from query param (classify page picker)
             if os.path.exists(labels_file):
-                with open(labels_file) as f:
+                with open(labels_file, encoding="utf-8") as f:
                     label_count = sum(1 for line in f if line.strip())
                 for ls in get_saved_labels():
                     if ls.get("labels_file") == labels_file:
                         label_name = ls.get("name", labels_file)
                         break
-                with open(labels_file) as f:
+                with open(labels_file, encoding="utf-8") as f:
                     labels = [line.strip() for line in f if line.strip()]
         elif labels_files:
             # Multiple files override from query param
@@ -16936,7 +16936,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             labels_file = ls.get("labels_file", "")
             if not labels_file or not os.path.exists(labels_file):
                 continue
-            with open(labels_file) as f:
+            with open(labels_file, encoding="utf-8") as f:
                 labels = [line.strip() for line in f if line.strip()]
             row = {
                 "labels_name": ls.get("name", ""),
@@ -17001,7 +17001,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 },
             )
 
-            with open(labels_file) as f:
+            with open(labels_file, encoding="utf-8") as f:
                 labels = [line.strip() for line in f if line.strip()]
 
             log.info(
@@ -27653,7 +27653,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not labels_file or not os.path.exists(labels_file):
                 continue
             try:
-                with open(labels_file) as f:
+                with open(labels_file, encoding="utf-8") as f:
                     for line in f:
                         name = line.strip()
                         if not name:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18273,7 +18273,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         active_ws = _get_db()._active_workspace_id
 
         def work(job):
-            from labels import fetch_species_list, save_labels
+            from labels import fetch_species_list, read_label_file, save_labels
 
             def progress_cb(msg, current=None, total=None):
                 job["progress"]["current_file"] = msg
@@ -18323,8 +18323,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 try:
                     from classifier import _embedding_cache_path, _resolve_model_dir
 
-                    with open(labels_path) as f:
-                        labels = [line.strip() for line in f if line.strip()]
+                    labels = read_label_file(labels_path)
                     model_dir = _resolve_model_dir(
                         active_model["model_str"], active_model.get("weights_path")
                     )

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -125,7 +125,7 @@ def _load_labels(
         labels = load_merged_labels(active_sets)
         log.info("Using %d merged labels from %d sets", len(labels), len(active_sets))
     elif labels_file and os.path.exists(labels_file):
-        with open(labels_file) as f:
+        with open(labels_file, encoding="utf-8") as f:
             labels = [line.strip() for line in f if line.strip()]
         log.info("Using %d labels from file: %s", len(labels), labels_file)
     else:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -31,6 +31,7 @@ except ImportError:
     load_working_image = None
 
 from db import AUTO_MATCH_REVIEW_MARKER, Database, commit_with_retry
+from keyword_normalization import normalize_keyword_display
 from models import get_active_model, get_models
 
 try:
@@ -224,6 +225,20 @@ def _run_classifier_on_detection(db, detection_id, classifier_model, labels,
         species = pred.get("species")
         if not species:
             continue
+        # Fold the label's spelling into keyword-storage form before it lands
+        # in predictions.species. Several bundled label files carry curly
+        # apostrophes (`Bosc’s Fringe-toed lizard`, `Geoffroy’s Tamarin`),
+        # and predictions are matched against keywords.name with exact and
+        # COLLATE NOCASE compares -- neither of which folds U+2019. Storing
+        # the raw label left an accepted `Swinhoe's white-eye` keyword unable
+        # to match its own `Swinhoe’s White-eye` prediction. Normalizing here
+        # rather than at label-load keeps labels_fingerprint (derived from the
+        # raw label file) stable, so this does not invalidate cached
+        # classifier runs or trigger a reclassify.
+        normalized_species = normalize_keyword_display(species)
+        if normalized_species:
+            species = normalized_species
+            pred["species"] = normalized_species
         confidence = pred.get("confidence") or pred.get("score")
         tax = pred.get("taxonomy") or {}
         db.conn.execute(

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -11,7 +11,7 @@ import os
 import time
 from dataclasses import dataclass
 
-from labels import get_active_labels, get_saved_labels, load_merged_labels
+from labels import get_active_labels, get_saved_labels, load_merged_labels, read_label_file
 
 try:
     from detector import detect_animals, get_primary_detection
@@ -140,8 +140,7 @@ def _load_labels(
         labels = load_merged_labels(active_sets)
         log.info("Using %d merged labels from %d sets", len(labels), len(active_sets))
     elif labels_file and os.path.exists(labels_file):
-        with open(labels_file, encoding="utf-8") as f:
-            labels = [line.strip() for line in f if line.strip()]
+        labels = read_label_file(labels_file)
         log.info("Using %d labels from file: %s", len(labels), labels_file)
     else:
         # Try workspace-scoped active labels first

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -34,6 +34,20 @@ from db import AUTO_MATCH_REVIEW_MARKER, Database, commit_with_retry
 from keyword_normalization import normalize_keyword_display
 from models import get_active_model, get_models
 
+
+def _folded_species_key(species):
+    """Return the string ``add_prediction`` uses to key ``predictions.species``.
+
+    Mirrors the normalization branch in ``Database.add_prediction``: fold when
+    the result is non-empty, otherwise keep the original. Callers use this to
+    dedupe alternatives against a primary before writing prediction_review
+    rows, so the key must match exactly what ends up in the UNIQUE column.
+    """
+    if species is None:
+        return None
+    folded = normalize_keyword_display(species)
+    return folded if folded else species
+
 try:
     from classifier import ClassificationCancelled, Classifier
 except ImportError:
@@ -1399,7 +1413,23 @@ def _store_match_prediction(
         preserve_manual_review=True,
     )
     if store_alternatives:
+        # Skip alternatives whose normalized species collides with the primary
+        # (or a previously stored alternative). ``add_prediction`` folds
+        # apostrophes centrally, so an active label set with both `Say's
+        # Phoebe` and `Say’s Phoebe` (or a classifier that returns both
+        # spellings in one call) would resolve every ``alt`` to the primary's
+        # unique row. The alternative's re-queried INSERT then upserts
+        # ``prediction_review.status = 'alternative'``, silently overwriting
+        # the auto-accepted match status (or, for a pending primary via
+        # ``_store_pending_detection_prediction``, hiding the top-1 from
+        # review). Dedupe on the same normalized key ``add_prediction`` uses
+        # so alternatives-that-are-actually-the-primary stay unwritten.
+        seen_species = {_folded_species_key(species)}
         for alt in item.get("alternatives", []):
+            alt_key = _folded_species_key(alt["species"])
+            if alt_key in seen_species:
+                continue
+            seen_species.add(alt_key)
             alt_tax = alt.get("taxonomy") or (
                 tax.get_hierarchy(alt["species"]) if tax else {}
             )
@@ -1568,7 +1598,17 @@ def _store_pending_detection_prediction(
         item["prediction"], category,
         auto_accept=False,
     )
+    # See _store_match_prediction for why alternatives are deduped by the
+    # same normalized key that ``add_prediction`` uses: without this, an
+    # alternative that folds to the primary would upsert the primary's
+    # prediction_review row to ``status='alternative'``, hiding the only
+    # top-1 prediction from the pending queue.
+    seen_species = {_folded_species_key(item["prediction"])}
     for alt in item.get("alternatives", []):
+        alt_key = _folded_species_key(alt["species"])
+        if alt_key in seen_species:
+            continue
+        seen_species.add(alt_key)
         alt_tax = alt.get("taxonomy") or (
             tax.get_hierarchy(alt["species"]) if tax else {}
         )

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -31,7 +31,7 @@ except ImportError:
     load_working_image = None
 
 from db import AUTO_MATCH_REVIEW_MARKER, Database, commit_with_retry
-from keyword_normalization import normalize_keyword_display
+from keyword_normalization import _ASCII_LOWER_TABLE, normalize_keyword_display
 from models import get_active_model, get_models
 
 
@@ -47,6 +47,21 @@ def _folded_species_key(species):
         return None
     folded = normalize_keyword_display(species)
     return folded if folded else species
+
+
+def _species_match_key(species):
+    """Return the equivalence key used to dedupe species names.
+
+    Mirrors ``keyword_match_key`` / SQLite ``COLLATE NOCASE``: strip and
+    ASCII-only case fold. Python's ``str.lower()`` folds non-ASCII pairs
+    such as ``É``/``é`` and ``Maße``/``masse`` that SQLite treats as
+    distinct, so using it here would silently drop a legitimate second
+    prediction row or collapse two distinct-per-DB burst species into
+    one consensus vote.
+    """
+    return (_folded_species_key(species) or "").strip().translate(
+        _ASCII_LOWER_TABLE,
+    )
 
 try:
     from classifier import ClassificationCancelled, Classifier
@@ -1425,16 +1440,20 @@ def _store_match_prediction(
         # review). Dedupe on the same normalized key ``add_prediction`` uses
         # so alternatives-that-are-actually-the-primary stay unwritten.
         #
-        # Comparison is case-insensitive (``.strip().lower()``): downstream
-        # keyword joins already use SQLite ``COLLATE NOCASE`` (see
-        # ``_fold_prediction_species_apostrophes``), so a merged label set
-        # yielding primary `Say's Phoebe` and alternative `Say's phoebe`
-        # is semantically one bird — but ``_folded_species_key`` preserves
-        # case, letting them survive as two BINARY-unique rows with the
-        # alternative overwriting the primary's review to ``alternative``.
-        seen_species = {(_folded_species_key(species) or "").strip().lower()}
+        # Comparison uses ``_species_match_key`` (ASCII-only case fold):
+        # downstream keyword joins already use SQLite ``COLLATE NOCASE``
+        # (see ``_fold_prediction_species_apostrophes``), so a merged
+        # label set yielding primary `Say's Phoebe` and alternative
+        # `Say's phoebe` is semantically one bird — but
+        # ``_folded_species_key`` preserves case, letting them survive as
+        # two BINARY-unique rows with the alternative overwriting the
+        # primary's review to ``alternative``. ``str.lower()`` folds
+        # non-ASCII case pairs (``Éclair``/``éclair``, ``Maße``/``masse``)
+        # that the DB treats as distinct, so it would silently drop a
+        # legitimate second alternative.
+        seen_species = {_species_match_key(species)}
         for alt in item.get("alternatives", []):
-            alt_key = (_folded_species_key(alt["species"]) or "").strip().lower()
+            alt_key = _species_match_key(alt["species"])
             if alt_key in seen_species:
                 continue
             seen_species.add(alt_key)
@@ -1608,16 +1627,15 @@ def _store_pending_detection_prediction(
     )
     # See _store_match_prediction for why alternatives are deduped by the
     # same normalized key that ``add_prediction`` uses (and why the
-    # comparison is case-insensitive): without this, an alternative that
-    # folds to the primary — including one that differs only by ASCII
-    # capitalization — would upsert the primary's prediction_review row to
+    # comparison uses the ASCII-only ``_species_match_key`` rather than
+    # ``str.lower``): without this, an alternative that folds to the
+    # primary — including one that differs only by ASCII capitalization —
+    # would upsert the primary's prediction_review row to
     # ``status='alternative'``, hiding the only top-1 prediction from the
     # pending queue.
-    seen_species = {
-        (_folded_species_key(item["prediction"]) or "").strip().lower()
-    }
+    seen_species = {_species_match_key(item["prediction"])}
     for alt in item.get("alternatives", []):
-        alt_key = (_folded_species_key(alt["species"]) or "").strip().lower()
+        alt_key = _species_match_key(alt["species"])
         if alt_key in seen_species:
             continue
         seen_species.add(alt_key)
@@ -1717,24 +1735,35 @@ def _store_grouped_predictions(
             # `_folded_species_key` still returns two distinct case
             # variants. `consensus_prediction` keys on the raw string, so
             # a semantically unanimous burst gets split votes such as
-            # `1/2`, while `group_species` below already lowercases and
+            # `1/2`, while `group_species` below already ASCII-folds and
             # would declare it reviewable — a mismatch that stores split
             # `individual` entries and a wrong vote count. Canonicalize
             # to the first-seen casing for each ASCII-lowercase key so
             # the count sums correctly while `individual_predictions`
             # still shows a real display-cased species name.
+            #
+            # ASCII-only case fold (``_ASCII_LOWER_TABLE``) rather than
+            # ``.lower()``: SQLite ``COLLATE NOCASE`` and
+            # ``keyword_match_key`` treat non-ASCII case pairs such as
+            # ``Éclair``/``éclair`` as distinct, so ``.lower()`` here
+            # would canonicalize them into one species and inflate a
+            # burst into a spuriously unanimous vote.
             _canonical_case = {}
             for item in group:
                 key = _folded_species_key(item.get("prediction"))
                 if key is None:
                     continue
-                _canonical_case.setdefault(key.strip().lower(), key)
+                _canonical_case.setdefault(
+                    key.strip().translate(_ASCII_LOWER_TABLE), key,
+                )
 
             def _cons_key(species, _canon=_canonical_case):
                 folded = _folded_species_key(species)
                 if folded is None:
                     return folded
-                return _canon.get(folded.strip().lower(), folded)
+                return _canon.get(
+                    folded.strip().translate(_ASCII_LOWER_TABLE), folded,
+                )
 
             cons_input = [
                 {
@@ -1748,7 +1777,7 @@ def _store_grouped_predictions(
                 continue
 
             group_species = {
-                (_folded_species_key(item.get("prediction")) or "").strip().lower()
+                _species_match_key(item.get("prediction"))
                 for item in group
                 if item.get("prediction")
             }

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1689,9 +1689,18 @@ def _store_grouped_predictions(
         else:
             group_count += 1
             gid = f"g{job_id[-6:]}-{group_count:04d}"
+            # Fold each frame's species onto the same key ``add_prediction``
+            # uses before computing consensus and the reviewability check.
+            # Without this, a burst whose frames spell the same bird as
+            # both `Say's Phoebe` and `Say’s Phoebe` (because the merged
+            # label set carries both variants) counts as two distinct
+            # species, ``group_reviewable`` becomes False, and the
+            # unanimous burst is stored without its group_id, vote counts,
+            # or individual JSON — so the survivor prediction drops out
+            # of its burst group even though every frame agreed.
             cons_input = [
                 {
-                    "prediction": item["prediction"],
+                    "prediction": _folded_species_key(item["prediction"]),
                     "confidence": item["confidence"],
                 }
                 for item in group
@@ -1701,7 +1710,7 @@ def _store_grouped_predictions(
                 continue
 
             group_species = {
-                (item.get("prediction") or "").strip().lower()
+                (_folded_species_key(item.get("prediction")) or "").strip().lower()
                 for item in group
                 if item.get("prediction")
             }

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1424,9 +1424,17 @@ def _store_match_prediction(
         # ``_store_pending_detection_prediction``, hiding the top-1 from
         # review). Dedupe on the same normalized key ``add_prediction`` uses
         # so alternatives-that-are-actually-the-primary stay unwritten.
-        seen_species = {_folded_species_key(species)}
+        #
+        # Comparison is case-insensitive (``.strip().lower()``): downstream
+        # keyword joins already use SQLite ``COLLATE NOCASE`` (see
+        # ``_fold_prediction_species_apostrophes``), so a merged label set
+        # yielding primary `Say's Phoebe` and alternative `Say's phoebe`
+        # is semantically one bird — but ``_folded_species_key`` preserves
+        # case, letting them survive as two BINARY-unique rows with the
+        # alternative overwriting the primary's review to ``alternative``.
+        seen_species = {(_folded_species_key(species) or "").strip().lower()}
         for alt in item.get("alternatives", []):
-            alt_key = _folded_species_key(alt["species"])
+            alt_key = (_folded_species_key(alt["species"]) or "").strip().lower()
             if alt_key in seen_species:
                 continue
             seen_species.add(alt_key)
@@ -1599,13 +1607,17 @@ def _store_pending_detection_prediction(
         auto_accept=False,
     )
     # See _store_match_prediction for why alternatives are deduped by the
-    # same normalized key that ``add_prediction`` uses: without this, an
-    # alternative that folds to the primary would upsert the primary's
-    # prediction_review row to ``status='alternative'``, hiding the only
-    # top-1 prediction from the pending queue.
-    seen_species = {_folded_species_key(item["prediction"])}
+    # same normalized key that ``add_prediction`` uses (and why the
+    # comparison is case-insensitive): without this, an alternative that
+    # folds to the primary — including one that differs only by ASCII
+    # capitalization — would upsert the primary's prediction_review row to
+    # ``status='alternative'``, hiding the only top-1 prediction from the
+    # pending queue.
+    seen_species = {
+        (_folded_species_key(item["prediction"]) or "").strip().lower()
+    }
     for alt in item.get("alternatives", []):
-        alt_key = _folded_species_key(alt["species"])
+        alt_key = (_folded_species_key(alt["species"]) or "").strip().lower()
         if alt_key in seen_species:
             continue
         seen_species.add(alt_key)

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1698,9 +1698,35 @@ def _store_grouped_predictions(
             # unanimous burst is stored without its group_id, vote counts,
             # or individual JSON — so the survivor prediction drops out
             # of its burst group even though every frame agreed.
+            #
+            # Apostrophe folding alone is not enough: when frames also
+            # differ in ASCII capitalization (`Say's Phoebe` vs
+            # `Say's phoebe` — same word, different label-file entries),
+            # `_folded_species_key` still returns two distinct case
+            # variants. `consensus_prediction` keys on the raw string, so
+            # a semantically unanimous burst gets split votes such as
+            # `1/2`, while `group_species` below already lowercases and
+            # would declare it reviewable — a mismatch that stores split
+            # `individual` entries and a wrong vote count. Canonicalize
+            # to the first-seen casing for each ASCII-lowercase key so
+            # the count sums correctly while `individual_predictions`
+            # still shows a real display-cased species name.
+            _canonical_case = {}
+            for item in group:
+                key = _folded_species_key(item.get("prediction"))
+                if key is None:
+                    continue
+                _canonical_case.setdefault(key.strip().lower(), key)
+
+            def _cons_key(species, _canon=_canonical_case):
+                folded = _folded_species_key(species)
+                if folded is None:
+                    return folded
+                return _canon.get(folded.strip().lower(), folded)
+
             cons_input = [
                 {
-                    "prediction": _folded_species_key(item["prediction"]),
+                    "prediction": _cons_key(item["prediction"]),
                     "confidence": item["confidence"],
                 }
                 for item in group

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11362,6 +11362,87 @@ class Database:
             except Exception:
                 self.conn.rollback()
                 raise
+        # Third-generation sweep: typographic-apostrophe folding.
+        # normalize_keyword_display() previously kept an internal U+2019, so
+        # `Say’s phoebe` was stored as a row distinct from `Say's phoebe`
+        # under SQLite COLLATE NOCASE -- one bird, two keyword rows, two
+        # Life List cards, two lifer numbers. Now that the fold happens on
+        # write, re-run the whole normalization sweep under its own marker
+        # to merge the variants that already exist, and fold the same
+        # characters in predictions.species (joined to keywords.name with
+        # `COLLATE NOCASE`, so a curly prediction silently fails to match
+        # its accepted ASCII keyword).
+        if self.get_meta("keyword_apostrophes_folded_v1") != "1":
+            try:
+                self._normalize_keyword_data_once()
+                folded = self._fold_prediction_species_apostrophes()
+                if folded:
+                    log.info(
+                        "apostrophe fold: rewrote %d prediction species", folded
+                    )
+                self.set_meta(
+                    "keyword_apostrophes_folded_v1", "1", _commit=False
+                )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+
+    def _fold_prediction_species_apostrophes(self):
+        """Rewrite ``predictions.species`` into normalize_keyword_display form.
+
+        Predictions are compared against ``keywords.name`` with exact and
+        ``COLLATE NOCASE`` matches (see the predicted-species subqueries in
+        :meth:`get_photos`), neither of which can fold U+2019. A prediction
+        stored as ``Swinhoe’s White-eye`` therefore never matched the
+        accepted ``Swinhoe's white-eye`` keyword, so the photo's own
+        prediction looked unaccepted in the UI.
+
+        ``predictions`` has UNIQUE(detection_id, classifier_model,
+        labels_fingerprint, species); when folding would collide with a row
+        that already holds the clean spelling, keep the higher-confidence
+        row and drop the variant instead of failing the migration.
+        """
+        folded = 0
+        for row in self.conn.execute(
+            "SELECT id, detection_id, classifier_model, labels_fingerprint, "
+            "species, confidence FROM predictions WHERE species IS NOT NULL"
+        ).fetchall():
+            clean = normalize_keyword_display(row["species"])
+            if clean == row["species"]:
+                continue
+            if not clean:
+                # A prediction whose label is pure stray punctuation has no
+                # canonical spelling to match; leave it rather than inventing
+                # an empty species that would join to nothing.
+                continue
+            dup = self.conn.execute(
+                "SELECT id, confidence FROM predictions "
+                "WHERE detection_id = ? AND classifier_model = ? "
+                "AND labels_fingerprint = ? AND species = ? AND id != ?",
+                (row["detection_id"], row["classifier_model"],
+                 row["labels_fingerprint"], clean, row["id"]),
+            ).fetchone()
+            if dup is not None:
+                if (row["confidence"] or 0) > (dup["confidence"] or 0):
+                    self.conn.execute(
+                        "DELETE FROM predictions WHERE id = ?", (dup["id"],)
+                    )
+                    self.conn.execute(
+                        "UPDATE predictions SET species = ? WHERE id = ?",
+                        (clean, row["id"]),
+                    )
+                else:
+                    self.conn.execute(
+                        "DELETE FROM predictions WHERE id = ?", (row["id"],)
+                    )
+            else:
+                self.conn.execute(
+                    "UPDATE predictions SET species = ? WHERE id = ?",
+                    (clean, row["id"]),
+                )
+            folded += 1
+        return folded
 
     def _align_curation_species_case(self):
         """Re-key curation rows whose species differs from the canonical

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11431,6 +11431,9 @@ class Database:
             ).fetchone()
             if dup is not None:
                 if (row["confidence"] or 0) > (dup["confidence"] or 0):
+                    self._merge_prediction_metadata_before_delete(
+                        loser_id=dup["id"], winner_id=row["id"],
+                    )
                     self._merge_prediction_review_before_delete(
                         loser_id=dup["id"], winner_id=row["id"],
                     )
@@ -11445,6 +11448,9 @@ class Database:
                         (clean, row["id"]),
                     )
                 else:
+                    self._merge_prediction_metadata_before_delete(
+                        loser_id=row["id"], winner_id=dup["id"],
+                    )
                     self._merge_prediction_review_before_delete(
                         loser_id=row["id"], winner_id=dup["id"],
                     )
@@ -11547,6 +11553,75 @@ class Database:
                  chosen["total_votes"] if chosen["total_votes"] is not None
                  else other["total_votes"],
                  winner_id, ws),
+            )
+
+    def _merge_prediction_metadata_before_delete(self, loser_id, winner_id):
+        """Backfill non-null loser columns onto the winner before DELETE.
+
+        Two colliding predictions (same detection / model / fingerprint,
+        spellings that differ only by apostrophe) can hold different amounts
+        of enrichment if they were written by different code paths: the
+        classifier-with-taxonomy path fills ``category`` / ``scientific_name``
+        / ``taxonomy_*``, but a raw-classifier path (or an older insert made
+        before the taxonomy lookup existed) can leave those NULL.  When the
+        row selected as the winner (by ``confidence``) happens to be the
+        one without the enrichment, deleting the loser strips fields that
+        taxonomy filters and review displays rely on.
+
+        Backfills a column only when the winner is currently NULL, so a
+        deliberate override on the winner is preserved.  ``category`` also
+        promotes from the schema default ``'new'`` to a more specific
+        ``'match'`` / ``'change'`` when only the loser carried it, but
+        never overrides an explicit non-default winner category.  Called
+        from ``_fold_prediction_species_apostrophes`` right before the
+        CASCADEd DELETE removes the loser row.
+        """
+        if loser_id == winner_id:
+            return
+        winner = self.conn.execute(
+            """SELECT category, scientific_name,
+                      taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
+                      taxonomy_order, taxonomy_family, taxonomy_genus
+               FROM predictions WHERE id = ?""",
+            (winner_id,),
+        ).fetchone()
+        loser = self.conn.execute(
+            """SELECT category, scientific_name,
+                      taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
+                      taxonomy_order, taxonomy_family, taxonomy_genus
+               FROM predictions WHERE id = ?""",
+            (loser_id,),
+        ).fetchone()
+        if winner is None or loser is None:
+            return
+        updates = []
+        values = []
+        winner_cat = winner["category"]
+        loser_cat = loser["category"]
+        if (
+            loser_cat
+            and loser_cat != "new"
+            and (winner_cat is None or winner_cat == "new")
+        ):
+            updates.append("category = ?")
+            values.append(loser_cat)
+        for field in (
+            "scientific_name",
+            "taxonomy_kingdom",
+            "taxonomy_phylum",
+            "taxonomy_class",
+            "taxonomy_order",
+            "taxonomy_family",
+            "taxonomy_genus",
+        ):
+            if winner[field] is None and loser[field] is not None:
+                updates.append(f"{field} = ?")
+                values.append(loser[field])
+        if updates:
+            values.append(winner_id)
+            self.conn.execute(
+                "UPDATE predictions SET " + ", ".join(updates) + " WHERE id = ?",
+                values,
             )
 
     def _retarget_prediction_edit_history(self, loser_id, winner_id):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11502,12 +11502,10 @@ class Database:
             winner_status = winner["status"] or "pending"
             loser_decided = loser_status in ("accepted", "rejected")
             winner_decided = winner_status in ("accepted", "rejected")
-            prefer_loser = False
-            if loser_decided and not winner_decided:
-                prefer_loser = True
-            elif loser_decided and winner_decided:
-                if (lr["reviewed_at"] or "") > (winner["reviewed_at"] or ""):
-                    prefer_loser = True
+            prefer_loser = loser_decided and (
+                not winner_decided
+                or (lr["reviewed_at"] or "") > (winner["reviewed_at"] or "")
+            )
             if prefer_loser:
                 self.conn.execute(
                     """UPDATE prediction_review

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11574,38 +11574,61 @@ class Database:
             ).fetchone()
             loser_status = lr["status"] or "pending"
             loser_decided = loser_status in ("accepted", "rejected")
+            # ``AUTO_MATCH_REVIEW_MARKER`` in ``individual`` is a
+            # taxonomy-match sentinel, not user-authored metadata worth
+            # preserving. Counting it here would let a bare
+            # ``status='alternative'`` loser row whose only "metadata" is
+            # the sentinel pass the guard below and flip the pending
+            # winner to ``alternative``.
             loser_metadata = {
                 col: lr[col]
                 for col in ("group_id", "vote_count", "total_votes", "individual")
                 if lr[col] is not None
+                and not (
+                    col == "individual" and lr[col] == AUTO_MATCH_REVIEW_MARKER
+                )
             }
             if winner is None:
-                # Winner's absence == implicit pending. Overriding that with
-                # the loser's row only makes sense when the loser carries a
-                # user decision or group metadata worth preserving; a bare
-                # ``status='alternative'`` transfer would silently flip a
-                # higher-confidence pending primary into an alternative and
-                # hide the sole top-1 prediction from the pending queue.
+                # Winner's absence == implicit pending. Overriding that
+                # with the loser's row makes sense only when the loser
+                # carries a real user decision or preserved metadata; a
+                # bare ``status='alternative'`` transfer would flip the
+                # higher-confidence pending primary into an alternative
+                # and hide the sole top-1 prediction from the pending
+                # queue.
                 if not loser_decided and not loser_metadata:
                     continue
-                # Preserve the loser's group metadata / status, but scrub
-                # the auto-match sentinel out of a non-decided row so it
-                # can't later be mistaken for provenance on the winner (see
-                # class-level comment on why the marker must not propagate
-                # onto a manual decision).
-                if (
-                    lr["individual"] == AUTO_MATCH_REVIEW_MARKER
-                    and not loser_decided
-                ):
-                    self.conn.execute(
-                        "UPDATE prediction_review SET prediction_id = ?, "
-                        "individual = NULL "
-                        "WHERE prediction_id = ? AND workspace_id = ?",
-                        (winner_id, loser_id, ws),
-                    )
+                if loser_decided:
+                    # Preserve the loser's accept/reject.  Scrub the
+                    # auto-match sentinel from ``individual`` so a
+                    # manually-decided row can't be mistaken for an
+                    # auto-review row on the winner (see class-level
+                    # comment on why the marker must not propagate onto
+                    # a manual decision).
+                    if lr["individual"] == AUTO_MATCH_REVIEW_MARKER:
+                        self.conn.execute(
+                            "UPDATE prediction_review SET prediction_id = ?, "
+                            "individual = NULL "
+                            "WHERE prediction_id = ? AND workspace_id = ?",
+                            (winner_id, loser_id, ws),
+                        )
+                    else:
+                        self.conn.execute(
+                            "UPDATE prediction_review SET prediction_id = ? "
+                            "WHERE prediction_id = ? AND workspace_id = ?",
+                            (winner_id, loser_id, ws),
+                        )
                 else:
+                    # Undecided loser with real burst metadata: keep the
+                    # metadata but leave the winner implicit-pending by
+                    # downgrading the transferred status. Individual is
+                    # always the sentinel or NULL for undecided rows;
+                    # scrub either way so the winner stays clean of
+                    # spurious auto-match provenance.
                     self.conn.execute(
-                        "UPDATE prediction_review SET prediction_id = ? "
+                        "UPDATE prediction_review "
+                        "SET prediction_id = ?, status = 'pending', "
+                        "    individual = NULL "
                         "WHERE prediction_id = ? AND workspace_id = ?",
                         (winner_id, loser_id, ws),
                     )
@@ -11721,42 +11744,48 @@ class Database:
             )
 
     def _retarget_prediction_edit_history(self, loser_id, winner_id):
-        """Rewrite `prediction_accept` history entries from loser to winner.
+        """Rewrite prediction-id references in edit history from loser to winner.
 
-        `api_accept_prediction` and `api_accept_subject_species` encode the
-        accepted prediction id in `edit_history_items.old_value` on
-        `prediction_accept` rows.  The shape is one of:
+        Three action types anchor prediction ids into
+        ``edit_history_items.old_value``:
 
-        - a bare-int string (single-model, changed-tag accept), or
-        - JSON `{"prediction_id": N, "no_tag": true}` (single, no-op accept),
-          or
-        - JSON `{"prediction_ids": [N, ...], "no_tag"?: true}` (accept-subject
-          collecting agreeing sibling classifier models).
+        - ``prediction_accept`` (``api_accept_prediction`` /
+          ``api_accept_subject_species``): stores either a bare-int string
+          (single-model, changed-tag accept), JSON
+          ``{"prediction_id": N, "no_tag": true}`` (single no-op accept),
+          or JSON ``{"prediction_ids": [N, ...], "no_tag"?: true}``
+          (accept-subject collecting agreeing sibling classifier models).
+        - ``keyword_add`` and ``species_replace``
+          (``api_highlights_relabel``): store a JSON payload whose
+          ``prediction_id`` field points at the top prediction captured
+          when the relabel ran, so undo can restore its ``pending`` status
+          via ``_restore_edit_prediction_status`` (and redo can re-reject
+          it via ``_reject_edit_prediction``). Bare-int ``old_value`` for
+          these two action types encodes the previous keyword id, not a
+          prediction id, so it is left alone.
 
         When the fold migration deletes a colliding prediction row, an
-        undo/redo later would look the id up in `predictions` (see
-        `_apply_undo` in the `prediction_accept` branch) and quietly skip
-        the missing row.  On a mixed workspace this means:
+        undo/redo later would call ``update_prediction_status(loser_id,
+        ...)`` on the vanished id: the ``INSERT`` into ``prediction_review``
+        then fails the FK to ``predictions``, aborting the undo/redo, and
+        for the ``prediction_accept`` accept-subject variant the missing
+        id would silently be skipped by ``_apply_undo`` so the surviving
+        prediction stays anchored in its accepted state.
 
-        - `undo` cannot restore the loser's `prediction_review.status` back
-          to `pending`, so the surviving prediction stays in the accepted
-          state even after the user reverses the edit; and
-        - a subject-accept whose sibling list contained the loser has that
-          sibling's status flip permanently anchored (no way to reset it).
-
-        Retargeting the reference from `loser_id` -> `winner_id` before the
-        DELETE keeps undo/redo sound: the two predictions differed only in
-        spelling, so any status flip captured on either applies to the same
-        (detection, model, labels_fingerprint) scope after the merge.
+        Retargeting the reference from ``loser_id`` -> ``winner_id`` before
+        the DELETE keeps undo/redo sound: the two predictions differ only
+        in spelling, so any status flip captured on either applies to the
+        same (detection, model, labels_fingerprint) scope after the merge.
         """
         if loser_id == winner_id:
             return
         loser_str = str(loser_id)
         winner_str = str(winner_id)
-        # (1) Bare-int old_value: rewrite in place.  Scoped by action_type
-        #     because `keyword_add` / `species_replace` / `keyword_remove`
-        #     store keyword ids in these columns and a blanket UPDATE would
-        #     corrupt any keyword id that happened to equal loser_id.
+        # (1) Bare-int old_value: rewrite in place.  Scoped strictly to
+        #     ``prediction_accept`` because ``keyword_add`` /
+        #     ``species_replace`` / ``keyword_remove`` store keyword ids
+        #     in these columns and a blanket UPDATE would corrupt any
+        #     keyword id that happened to equal loser_id.
         self.conn.execute(
             """UPDATE edit_history_items
                SET old_value = ?
@@ -11767,15 +11796,20 @@ class Database:
                  )""",
             (winner_str, loser_str),
         )
-        # (2) JSON old_value: parse, rewrite `prediction_id` and every
-        #     `prediction_ids` entry that matches the loser, re-serialize.
-        #     The `LIKE '{%'` prefix skips the bare-int rows handled above
-        #     without loading them into Python.
+        # (2) JSON old_value: parse, rewrite ``prediction_id`` and every
+        #     ``prediction_ids`` entry that matches the loser, re-serialize.
+        #     The ``LIKE '{%'`` prefix skips the bare-int rows handled above
+        #     without loading them into Python. Scoped to the three action
+        #     types that carry prediction ids in their JSON payload so a
+        #     ``keyword_remove`` JSON blob (which happens to also start with
+        #     ``{`` if it ever gains structured payloads) is unaffected.
         json_rows = self.conn.execute(
             """SELECT ehi.id, ehi.old_value
                FROM edit_history_items ehi
                JOIN edit_history eh ON eh.id = ehi.edit_id
-               WHERE eh.action_type = 'prediction_accept'
+               WHERE eh.action_type IN (
+                       'prediction_accept', 'keyword_add', 'species_replace'
+                     )
                  AND ehi.old_value IS NOT NULL
                  AND ehi.old_value LIKE ?""",
             ('{%',),
@@ -15779,6 +15813,15 @@ class Database:
         disagreement/refinement enrichment).
         """
         ws = self._ws_id()
+        # Mirror ``add_prediction``'s normalize-on-write: the persisted row
+        # is keyed on the folded spelling, so a caller that hands us the
+        # raw curly form (e.g. a future write path that forgot to fold)
+        # would otherwise miss the row and skip the auto-accept marker
+        # scrub even though the row plainly exists.
+        if species is not None:
+            normalized_species = normalize_keyword_display(species)
+            if normalized_species:
+                species = normalized_species
         row = self.conn.execute(
             """SELECT id, category FROM predictions
                WHERE detection_id = ? AND classifier_model = ?

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11482,6 +11482,14 @@ class Database:
           decision: a non-pending status beats pending, and among two
           non-pending decisions the later ``reviewed_at`` wins.  Ties keep
           the winner's row so the choice stays deterministic.
+        - Independently of the status choice, backfill missing group
+          metadata (``group_id`` / ``vote_count`` / ``total_votes`` /
+          ``individual``) from whichever side carries it: a pending loser
+          that carries the current burst's ``group_id`` while the winner is
+          also pending would otherwise be cascaded away and the surviving
+          prediction would silently drop out of its burst group. This is
+          safe because two rows for the same (detection, species) pair
+          across spelling variants are always about the same burst.
 
         The loser's remaining rows are removed by the caller's DELETE via
         the ON DELETE CASCADE, so no explicit cleanup is needed here.
@@ -11495,7 +11503,8 @@ class Database:
         for lr in loser_rows:
             ws = lr["workspace_id"]
             winner = self.conn.execute(
-                "SELECT status, reviewed_at FROM prediction_review "
+                "SELECT status, reviewed_at, individual, group_id, "
+                "vote_count, total_votes FROM prediction_review "
                 "WHERE prediction_id = ? AND workspace_id = ?",
                 (winner_id, ws),
             ).fetchone()
@@ -11514,16 +11523,31 @@ class Database:
                 not winner_decided
                 or (lr["reviewed_at"] or "") > (winner["reviewed_at"] or "")
             )
-            if prefer_loser:
-                self.conn.execute(
-                    """UPDATE prediction_review
-                       SET status = ?, reviewed_at = ?, individual = ?,
-                           group_id = ?, vote_count = ?, total_votes = ?
-                       WHERE prediction_id = ? AND workspace_id = ?""",
-                    (lr["status"], lr["reviewed_at"], lr["individual"],
-                     lr["group_id"], lr["vote_count"], lr["total_votes"],
-                     winner_id, ws),
-                )
+            chosen = lr if prefer_loser else winner
+            other = winner if prefer_loser else lr
+            # ``prefer_loser`` only reflects the accepted/rejected decision,
+            # so a pending winner whose row lacks ``group_id`` while a
+            # pending loser carries the current burst's grouping would lose
+            # it via CASCADE without this backfill. Symmetric across sides:
+            # whichever side supplied the decision, missing group metadata
+            # is filled from the other so the surviving prediction stays
+            # inside its burst group.
+            self.conn.execute(
+                """UPDATE prediction_review
+                   SET status = ?, reviewed_at = ?, individual = ?,
+                       group_id = ?, vote_count = ?, total_votes = ?
+                   WHERE prediction_id = ? AND workspace_id = ?""",
+                (chosen["status"], chosen["reviewed_at"],
+                 chosen["individual"] if chosen["individual"] is not None
+                 else other["individual"],
+                 chosen["group_id"] if chosen["group_id"] is not None
+                 else other["group_id"],
+                 chosen["vote_count"] if chosen["vote_count"] is not None
+                 else other["vote_count"],
+                 chosen["total_votes"] if chosen["total_votes"] is not None
+                 else other["total_votes"],
+                 winner_id, ws),
+            )
 
     def _retarget_prediction_edit_history(self, loser_id, winner_id):
         """Rewrite `prediction_accept` history entries from loser to winner.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11422,10 +11422,18 @@ class Database:
                 # canonical spelling to match; leave it rather than inventing
                 # an empty species that would join to nothing.
                 continue
+            # ``COLLATE NOCASE`` matches SQLite's ASCII case fold, which is
+            # the same equivalence downstream keyword joins already use. Without
+            # it, a DB carrying `Say's Phoebe` (ASCII, title-case) alongside a
+            # `Say’s phoebe` (curly, lowercase) misses the collision, folds only
+            # the curly row, and leaves two case-variant predictions on the same
+            # (detection, model, fingerprint) — preserving the split review state
+            # and duplicate rendering the fold was meant to erase.
             dup = self.conn.execute(
                 "SELECT id, confidence FROM predictions "
                 "WHERE detection_id = ? AND classifier_model = ? "
-                "AND labels_fingerprint = ? AND species = ? AND id != ?",
+                "AND labels_fingerprint = ? "
+                "AND species = ? COLLATE NOCASE AND id != ?",
                 (row["detection_id"], row["classifier_model"],
                  row["labels_fingerprint"], clean, row["id"]),
             ).fetchone()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11481,8 +11481,15 @@ class Database:
 
         For each ``(loser_id, workspace_id)`` review row:
 
-        - If the winner has no row for that workspace, re-point the loser's
-          row at the winner.
+        - If the winner has no row for that workspace, absence encodes an
+          implicit ``pending`` state, so treat it as a real row rather than
+          a slot to be filled. Move the loser's row onto the winner only
+          when the loser carries a genuine user decision
+          (``accepted``/``rejected``) or non-status metadata (``group_id``
+          etc.) worth preserving. A bare ``status='alternative'`` row on
+          the loser is dropped instead: transferring it would turn a
+          higher-confidence pending primary into an alternative, hiding
+          the sole top-1 prediction from the pending queue.
         - If the winner already has a row for that workspace (both were
           reviewed independently), keep whichever encodes the stronger
           decision: a non-pending status beats pending, and among two
@@ -11496,6 +11503,12 @@ class Database:
           prediction would silently drop out of its burst group. This is
           safe because two rows for the same (detection, species) pair
           across spelling variants are always about the same burst.
+          ``individual`` is filled only when the source value is not the
+          ``AUTO_MATCH_REVIEW_MARKER`` sentinel; that string is provenance
+          for auto-accepted taxonomy matches, and copying it onto a
+          manually chosen accept/reject would let later automation
+          (``preserve_manual_review`` / ``reconcile_match_review_state``)
+          overwrite or delete the user's decision.
 
         The loser's remaining rows are removed by the caller's DELETE via
         the ON DELETE CASCADE, so no explicit cleanup is needed here.
@@ -11514,16 +11527,45 @@ class Database:
                 "WHERE prediction_id = ? AND workspace_id = ?",
                 (winner_id, ws),
             ).fetchone()
-            if winner is None:
-                self.conn.execute(
-                    "UPDATE prediction_review SET prediction_id = ? "
-                    "WHERE prediction_id = ? AND workspace_id = ?",
-                    (winner_id, loser_id, ws),
-                )
-                continue
             loser_status = lr["status"] or "pending"
-            winner_status = winner["status"] or "pending"
             loser_decided = loser_status in ("accepted", "rejected")
+            loser_metadata = {
+                col: lr[col]
+                for col in ("group_id", "vote_count", "total_votes", "individual")
+                if lr[col] is not None
+            }
+            if winner is None:
+                # Winner's absence == implicit pending. Overriding that with
+                # the loser's row only makes sense when the loser carries a
+                # user decision or group metadata worth preserving; a bare
+                # ``status='alternative'`` transfer would silently flip a
+                # higher-confidence pending primary into an alternative and
+                # hide the sole top-1 prediction from the pending queue.
+                if not loser_decided and not loser_metadata:
+                    continue
+                # Preserve the loser's group metadata / status, but scrub
+                # the auto-match sentinel out of a non-decided row so it
+                # can't later be mistaken for provenance on the winner (see
+                # class-level comment on why the marker must not propagate
+                # onto a manual decision).
+                if (
+                    lr["individual"] == AUTO_MATCH_REVIEW_MARKER
+                    and not loser_decided
+                ):
+                    self.conn.execute(
+                        "UPDATE prediction_review SET prediction_id = ?, "
+                        "individual = NULL "
+                        "WHERE prediction_id = ? AND workspace_id = ?",
+                        (winner_id, loser_id, ws),
+                    )
+                else:
+                    self.conn.execute(
+                        "UPDATE prediction_review SET prediction_id = ? "
+                        "WHERE prediction_id = ? AND workspace_id = ?",
+                        (winner_id, loser_id, ws),
+                    )
+                continue
+            winner_status = winner["status"] or "pending"
             winner_decided = winner_status in ("accepted", "rejected")
             prefer_loser = loser_decided and (
                 not winner_decided
@@ -11537,7 +11579,16 @@ class Database:
             # it via CASCADE without this backfill. Symmetric across sides:
             # whichever side supplied the decision, missing group metadata
             # is filled from the other so the surviving prediction stays
-            # inside its burst group.
+            # inside its burst group. ``individual`` intentionally skips
+            # the ``AUTO_MATCH_REVIEW_MARKER`` fill-in: the chosen row is
+            # the surviving decision (a manual accept/reject may store
+            # ``individual=NULL``), and copying the auto-match sentinel
+            # from a stale auto-accepted row would let later runs of
+            # ``reconcile_match_review_state`` delete the user's decision
+            # or let ``preserve_manual_review`` overwrite it.
+            other_individual = other["individual"]
+            if other_individual == AUTO_MATCH_REVIEW_MARKER:
+                other_individual = None
             self.conn.execute(
                 """UPDATE prediction_review
                    SET status = ?, reviewed_at = ?, individual = ?,
@@ -11545,7 +11596,7 @@ class Database:
                    WHERE prediction_id = ? AND workspace_id = ?""",
                 (chosen["status"], chosen["reviewed_at"],
                  chosen["individual"] if chosen["individual"] is not None
-                 else other["individual"],
+                 else other_individual,
                  chosen["group_id"] if chosen["group_id"] is not None
                  else other["group_id"],
                  chosen["vote_count"] if chosen["vote_count"] is not None

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11401,7 +11401,11 @@ class Database:
         ``predictions`` has UNIQUE(detection_id, classifier_model,
         labels_fingerprint, species); when folding would collide with a row
         that already holds the clean spelling, keep the higher-confidence
-        row and drop the variant instead of failing the migration.
+        row and drop the variant instead of failing the migration.  Before
+        deleting the loser, migrate any workspace review rows onto the
+        surviving prediction so an accepted/rejected decision on the variant
+        (`prediction_review.prediction_id` uses `ON DELETE CASCADE`) is not
+        silently lost mid-migration.
         """
         folded = 0
         for row in self.conn.execute(
@@ -11425,6 +11429,9 @@ class Database:
             ).fetchone()
             if dup is not None:
                 if (row["confidence"] or 0) > (dup["confidence"] or 0):
+                    self._merge_prediction_review_before_delete(
+                        loser_id=dup["id"], winner_id=row["id"],
+                    )
                     self.conn.execute(
                         "DELETE FROM predictions WHERE id = ?", (dup["id"],)
                     )
@@ -11433,6 +11440,9 @@ class Database:
                         (clean, row["id"]),
                     )
                 else:
+                    self._merge_prediction_review_before_delete(
+                        loser_id=row["id"], winner_id=dup["id"],
+                    )
                     self.conn.execute(
                         "DELETE FROM predictions WHERE id = ?", (row["id"],)
                     )
@@ -11443,6 +11453,71 @@ class Database:
                 )
             folded += 1
         return folded
+
+    def _merge_prediction_review_before_delete(self, loser_id, winner_id):
+        """Move per-workspace review rows from ``loser_id`` onto ``winner_id``.
+
+        ``prediction_review.prediction_id`` is ``ON DELETE CASCADE``, so a
+        bare ``DELETE FROM predictions`` silently drops any accepted /
+        rejected user decision (and its group metadata) attached to the
+        losing row.  Called from ``_fold_prediction_species_apostrophes``
+        just before it deletes a duplicate: the two predictions differ only
+        in spelling, so a review on either applies to the same (detection,
+        species) pair and must survive the collision-merge.
+
+        For each ``(loser_id, workspace_id)`` review row:
+
+        - If the winner has no row for that workspace, re-point the loser's
+          row at the winner.
+        - If the winner already has a row for that workspace (both were
+          reviewed independently), keep whichever encodes the stronger
+          decision: a non-pending status beats pending, and among two
+          non-pending decisions the later ``reviewed_at`` wins.  Ties keep
+          the winner's row so the choice stays deterministic.
+
+        The loser's remaining rows are removed by the caller's DELETE via
+        the ON DELETE CASCADE, so no explicit cleanup is needed here.
+        """
+        loser_rows = self.conn.execute(
+            "SELECT workspace_id, status, reviewed_at, individual, group_id, "
+            "vote_count, total_votes FROM prediction_review "
+            "WHERE prediction_id = ?",
+            (loser_id,),
+        ).fetchall()
+        for lr in loser_rows:
+            ws = lr["workspace_id"]
+            winner = self.conn.execute(
+                "SELECT status, reviewed_at FROM prediction_review "
+                "WHERE prediction_id = ? AND workspace_id = ?",
+                (winner_id, ws),
+            ).fetchone()
+            if winner is None:
+                self.conn.execute(
+                    "UPDATE prediction_review SET prediction_id = ? "
+                    "WHERE prediction_id = ? AND workspace_id = ?",
+                    (winner_id, loser_id, ws),
+                )
+                continue
+            loser_status = lr["status"] or "pending"
+            winner_status = winner["status"] or "pending"
+            loser_decided = loser_status in ("accepted", "rejected")
+            winner_decided = winner_status in ("accepted", "rejected")
+            prefer_loser = False
+            if loser_decided and not winner_decided:
+                prefer_loser = True
+            elif loser_decided and winner_decided:
+                if (lr["reviewed_at"] or "") > (winner["reviewed_at"] or ""):
+                    prefer_loser = True
+            if prefer_loser:
+                self.conn.execute(
+                    """UPDATE prediction_review
+                       SET status = ?, reviewed_at = ?, individual = ?,
+                           group_id = ?, vote_count = ?, total_votes = ?
+                       WHERE prediction_id = ? AND workspace_id = ?""",
+                    (lr["status"], lr["reviewed_at"], lr["individual"],
+                     lr["group_id"], lr["vote_count"], lr["total_votes"],
+                     winner_id, ws),
+                )
 
     def _align_curation_species_case(self):
         """Re-key curation rows whose species differs from the canonical
@@ -15276,6 +15351,19 @@ class Database:
                 "predictions without a detection row are orphaned and "
                 "invisible to workspace-scoped queries"
             )
+        # Fold the species into keyword-storage form so a curly-apostrophe
+        # label file (`Swinhoe’s White-eye`) cannot re-mint a predictions row
+        # that fails to match its accepted ASCII keyword (`Swinhoe's
+        # white-eye`) under exact and COLLATE NOCASE joins. Doing it here
+        # rather than only in the classify_job helpers covers every caller —
+        # `_store_pending_detection_prediction`, `_store_match_prediction`,
+        # and any future write path — so the invariant that keyword-side and
+        # prediction-side spellings agree can't drift by adding a new caller
+        # that forgot to normalize. Idempotent on already-folded strings.
+        if species is not None:
+            normalized_species = normalize_keyword_display(species)
+            if normalized_species:
+                species = normalized_species
         tax = taxonomy or {}
         cur = self.conn.execute(
             """INSERT OR IGNORE INTO predictions

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11399,21 +11399,37 @@ class Database:
         prediction looked unaccepted in the UI.
 
         ``predictions`` has UNIQUE(detection_id, classifier_model,
-        labels_fingerprint, species); when folding would collide with a row
-        that already holds the clean spelling, keep the higher-confidence
-        row and drop the variant instead of failing the migration.  Before
-        deleting the loser, migrate any workspace review rows onto the
-        surviving prediction so an accepted/rejected decision on the variant
-        (`prediction_review.prediction_id` uses `ON DELETE CASCADE`) is not
-        silently lost mid-migration, and retarget any `prediction_accept`
-        edit-history references from the loser id to the winner id so
-        undo/redo can still find the prediction after the DELETE.
+        labels_fingerprint, species); the constraint is BINARY, so a single
+        (detection, model, fingerprint) scope can legally hold three
+        NOCASE-equivalent variants at once (e.g. ``Say's Phoebe``,
+        ``Say's phoebe``, ``Say’s phoebe``). A per-row ``fetchone`` peer
+        lookup would only merge one of the ASCII neighbours: with the
+        curly row winning by confidence, the subsequent
+        ``UPDATE ... SET species = 'Say's phoebe'`` would then collide with
+        the unmerged ASCII-lowercase row and abort the whole migration
+        under UNIQUE — and on every open thereafter. Fetch every
+        NOCASE-equivalent peer up-front and merge the entire collision set
+        around a single winner so the final UPDATE has no peer left to
+        clash with.
+
+        Before deleting any loser, migrate its workspace review rows onto
+        the surviving prediction so an accepted/rejected decision on a
+        variant (``prediction_review.prediction_id`` uses
+        ``ON DELETE CASCADE``) is not silently lost, and retarget any
+        ``prediction_accept`` edit-history references from the loser id
+        to the winner id so undo/redo can still find the prediction after
+        the DELETE.
         """
         folded = 0
+        processed_ids = set()
         for row in self.conn.execute(
             "SELECT id, detection_id, classifier_model, labels_fingerprint, "
             "species, confidence FROM predictions WHERE species IS NOT NULL"
         ).fetchall():
+            if row["id"] in processed_ids:
+                # Already merged (or deleted) as a peer of an earlier
+                # collision group; skip so we don't reprocess a stale row.
+                continue
             clean = normalize_keyword_display(row["species"])
             if clean == row["species"]:
                 continue
@@ -11429,50 +11445,71 @@ class Database:
             # the curly row, and leaves two case-variant predictions on the same
             # (detection, model, fingerprint) — preserving the split review state
             # and duplicate rendering the fold was meant to erase.
-            dup = self.conn.execute(
-                "SELECT id, confidence FROM predictions "
+            #
+            # ``fetchall`` (not ``fetchone``) so a three-way collision such as
+            # ``Say's Phoebe`` + ``Say's phoebe`` + ``Say’s phoebe`` is merged
+            # in one pass: leaving even one NOCASE-equivalent ASCII peer would
+            # let the winner's final ``UPDATE ... SET species = clean`` collide
+            # with it and abort the migration under UNIQUE.
+            peers = self.conn.execute(
+                "SELECT id, confidence, species FROM predictions "
                 "WHERE detection_id = ? AND classifier_model = ? "
                 "AND labels_fingerprint = ? "
                 "AND species = ? COLLATE NOCASE AND id != ?",
                 (row["detection_id"], row["classifier_model"],
                  row["labels_fingerprint"], clean, row["id"]),
-            ).fetchone()
-            if dup is not None:
-                if (row["confidence"] or 0) > (dup["confidence"] or 0):
+            ).fetchall()
+            if peers:
+                # Whole collision set: this row plus every NOCASE-equivalent
+                # peer. Pick the winner by highest confidence, tie-broken by
+                # (a) already-clean species (avoids a needless UPDATE and
+                # preserves the reviewer's chosen casing) then (b) lowest
+                # id for determinism.
+                candidates = [
+                    (row["id"], row["confidence"] or 0.0, row["species"]),
+                ]
+                for p in peers:
+                    candidates.append(
+                        (p["id"], p["confidence"] or 0.0, p["species"])
+                    )
+                winner_id, _, winner_species = max(
+                    candidates,
+                    key=lambda c: (
+                        c[1],
+                        normalize_keyword_display(c[2]) == c[2],
+                        -c[0],
+                    ),
+                )
+                for cid, _, _ in candidates:
+                    if cid == winner_id:
+                        continue
                     self._merge_prediction_metadata_before_delete(
-                        loser_id=dup["id"], winner_id=row["id"],
+                        loser_id=cid, winner_id=winner_id,
                     )
                     self._merge_prediction_review_before_delete(
-                        loser_id=dup["id"], winner_id=row["id"],
+                        loser_id=cid, winner_id=winner_id,
                     )
                     self._retarget_prediction_edit_history(
-                        loser_id=dup["id"], winner_id=row["id"],
+                        loser_id=cid, winner_id=winner_id,
                     )
                     self.conn.execute(
-                        "DELETE FROM predictions WHERE id = ?", (dup["id"],)
+                        "DELETE FROM predictions WHERE id = ?", (cid,)
                     )
+                    processed_ids.add(cid)
+                # Only rewrite the survivor when it still carries curly
+                # punctuation; an already-clean winner keeps its casing.
+                if normalize_keyword_display(winner_species) != winner_species:
                     self.conn.execute(
                         "UPDATE predictions SET species = ? WHERE id = ?",
-                        (clean, row["id"]),
+                        (clean, winner_id),
                     )
-                else:
-                    self._merge_prediction_metadata_before_delete(
-                        loser_id=row["id"], winner_id=dup["id"],
-                    )
-                    self._merge_prediction_review_before_delete(
-                        loser_id=row["id"], winner_id=dup["id"],
-                    )
-                    self._retarget_prediction_edit_history(
-                        loser_id=row["id"], winner_id=dup["id"],
-                    )
-                    self.conn.execute(
-                        "DELETE FROM predictions WHERE id = ?", (row["id"],)
-                    )
+                processed_ids.add(winner_id)
             else:
                 self.conn.execute(
                     "UPDATE predictions SET species = ? WHERE id = ?",
                     (clean, row["id"]),
                 )
+                processed_ids.add(row["id"])
             folded += 1
         return folded
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11405,7 +11405,9 @@ class Database:
         deleting the loser, migrate any workspace review rows onto the
         surviving prediction so an accepted/rejected decision on the variant
         (`prediction_review.prediction_id` uses `ON DELETE CASCADE`) is not
-        silently lost mid-migration.
+        silently lost mid-migration, and retarget any `prediction_accept`
+        edit-history references from the loser id to the winner id so
+        undo/redo can still find the prediction after the DELETE.
         """
         folded = 0
         for row in self.conn.execute(
@@ -11432,6 +11434,9 @@ class Database:
                     self._merge_prediction_review_before_delete(
                         loser_id=dup["id"], winner_id=row["id"],
                     )
+                    self._retarget_prediction_edit_history(
+                        loser_id=dup["id"], winner_id=row["id"],
+                    )
                     self.conn.execute(
                         "DELETE FROM predictions WHERE id = ?", (dup["id"],)
                     )
@@ -11441,6 +11446,9 @@ class Database:
                     )
                 else:
                     self._merge_prediction_review_before_delete(
+                        loser_id=row["id"], winner_id=dup["id"],
+                    )
+                    self._retarget_prediction_edit_history(
                         loser_id=row["id"], winner_id=dup["id"],
                     )
                     self.conn.execute(
@@ -11515,6 +11523,104 @@ class Database:
                     (lr["status"], lr["reviewed_at"], lr["individual"],
                      lr["group_id"], lr["vote_count"], lr["total_votes"],
                      winner_id, ws),
+                )
+
+    def _retarget_prediction_edit_history(self, loser_id, winner_id):
+        """Rewrite `prediction_accept` history entries from loser to winner.
+
+        `api_accept_prediction` and `api_accept_subject_species` encode the
+        accepted prediction id in `edit_history_items.old_value` on
+        `prediction_accept` rows.  The shape is one of:
+
+        - a bare-int string (single-model, changed-tag accept), or
+        - JSON `{"prediction_id": N, "no_tag": true}` (single, no-op accept),
+          or
+        - JSON `{"prediction_ids": [N, ...], "no_tag"?: true}` (accept-subject
+          collecting agreeing sibling classifier models).
+
+        When the fold migration deletes a colliding prediction row, an
+        undo/redo later would look the id up in `predictions` (see
+        `_apply_undo` in the `prediction_accept` branch) and quietly skip
+        the missing row.  On a mixed workspace this means:
+
+        - `undo` cannot restore the loser's `prediction_review.status` back
+          to `pending`, so the surviving prediction stays in the accepted
+          state even after the user reverses the edit; and
+        - a subject-accept whose sibling list contained the loser has that
+          sibling's status flip permanently anchored (no way to reset it).
+
+        Retargeting the reference from `loser_id` -> `winner_id` before the
+        DELETE keeps undo/redo sound: the two predictions differed only in
+        spelling, so any status flip captured on either applies to the same
+        (detection, model, labels_fingerprint) scope after the merge.
+        """
+        if loser_id == winner_id:
+            return
+        loser_str = str(loser_id)
+        winner_str = str(winner_id)
+        # (1) Bare-int old_value: rewrite in place.  Scoped by action_type
+        #     because `keyword_add` / `species_replace` / `keyword_remove`
+        #     store keyword ids in these columns and a blanket UPDATE would
+        #     corrupt any keyword id that happened to equal loser_id.
+        self.conn.execute(
+            """UPDATE edit_history_items
+               SET old_value = ?
+               WHERE old_value = ?
+                 AND edit_id IN (
+                     SELECT id FROM edit_history
+                     WHERE action_type = 'prediction_accept'
+                 )""",
+            (winner_str, loser_str),
+        )
+        # (2) JSON old_value: parse, rewrite `prediction_id` and every
+        #     `prediction_ids` entry that matches the loser, re-serialize.
+        #     The `LIKE '{%'` prefix skips the bare-int rows handled above
+        #     without loading them into Python.
+        json_rows = self.conn.execute(
+            """SELECT ehi.id, ehi.old_value
+               FROM edit_history_items ehi
+               JOIN edit_history eh ON eh.id = ehi.edit_id
+               WHERE eh.action_type = 'prediction_accept'
+                 AND ehi.old_value IS NOT NULL
+                 AND ehi.old_value LIKE ?""",
+            ('{%',),
+        ).fetchall()
+        for row in json_rows:
+            try:
+                data = json.loads(row["old_value"])
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            changed = False
+            raw_pid = data.get("prediction_id")
+            if raw_pid is not None:
+                try:
+                    if int(raw_pid) == loser_id:
+                        data["prediction_id"] = winner_id
+                        changed = True
+                except (TypeError, ValueError):
+                    pass
+            raw_pids = data.get("prediction_ids")
+            if isinstance(raw_pids, list):
+                new_list = []
+                list_changed = False
+                for raw in raw_pids:
+                    try:
+                        if int(raw) == loser_id:
+                            new_list.append(winner_id)
+                            list_changed = True
+                            continue
+                    except (TypeError, ValueError):
+                        pass
+                    new_list.append(raw)
+                if list_changed:
+                    data["prediction_ids"] = new_list
+                    changed = True
+            if changed:
+                self.conn.execute(
+                    "UPDATE edit_history_items SET old_value = ? WHERE id = ?",
+                    (json.dumps(data), row["id"]),
                 )
 
     def _align_curation_species_case(self):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11534,7 +11534,16 @@ class Database:
           etc.) worth preserving. A bare ``status='alternative'`` row on
           the loser is dropped instead: transferring it would turn a
           higher-confidence pending primary into an alternative, hiding
-          the sole top-1 prediction from the pending queue.
+          the sole top-1 prediction from the pending queue.  When the
+          decided loser IS itself the auto-accepted taxonomy match (its
+          ``individual`` carries ``AUTO_MATCH_REVIEW_MARKER``), the marker
+          is preserved on the transfer: it's the provenance
+          ``reconcile_match_review_state`` uses to delete the row later
+          if the XMP match goes away; scrubbing it would leave a stale
+          auto-accept looking like a manual decision no automation can
+          revisit. A pending-loser transfer still scrubs the marker
+          (a non-decided row carrying it is spurious historical state,
+          not a real auto-accept).
         - If the winner already has a row for that workspace (both were
           reviewed independently), keep whichever encodes the stronger
           decision: a non-pending status beats pending, and among two
@@ -11599,38 +11608,42 @@ class Database:
                 if not loser_decided and not loser_metadata:
                     continue
                 if loser_decided:
-                    # Preserve the loser's accept/reject.  Scrub the
-                    # auto-match sentinel from ``individual`` so a
-                    # manually-decided row can't be mistaken for an
-                    # auto-review row on the winner (see class-level
-                    # comment on why the marker must not propagate onto
-                    # a manual decision).
-                    if lr["individual"] == AUTO_MATCH_REVIEW_MARKER:
-                        self.conn.execute(
-                            "UPDATE prediction_review SET prediction_id = ?, "
-                            "individual = NULL "
-                            "WHERE prediction_id = ? AND workspace_id = ?",
-                            (winner_id, loser_id, ws),
-                        )
-                    else:
-                        self.conn.execute(
-                            "UPDATE prediction_review SET prediction_id = ? "
-                            "WHERE prediction_id = ? AND workspace_id = ?",
-                            (winner_id, loser_id, ws),
-                        )
+                    # Move the row intact, ``individual`` included: the
+                    # loser IS the decision, not a competing manual row
+                    # the sentinel could pollute. Preserving
+                    # ``AUTO_MATCH_REVIEW_MARKER`` when it's set is what
+                    # lets ``reconcile_match_review_state`` recognize an
+                    # auto-accept later and clean it up if the XMP match
+                    # goes away; scrubbing it here would strand the
+                    # accept as an apparent manual decision no automation
+                    # can revisit.
+                    self.conn.execute(
+                        "UPDATE prediction_review SET prediction_id = ? "
+                        "WHERE prediction_id = ? AND workspace_id = ?",
+                        (winner_id, loser_id, ws),
+                    )
                 else:
                     # Undecided loser with real burst metadata: keep the
                     # metadata but leave the winner implicit-pending by
-                    # downgrading the transferred status. Individual is
-                    # always the sentinel or NULL for undecided rows;
-                    # scrub either way so the winner stays clean of
-                    # spurious auto-match provenance.
+                    # downgrading the transferred status. ``individual``
+                    # on a pending row can be the JSON vote breakdown
+                    # ``_store_grouped_predictions`` stores alongside
+                    # ``group_id`` / ``vote_count`` / ``total_votes``,
+                    # so preserve it verbatim; only the auto-match
+                    # sentinel gets scrubbed so future automation
+                    # doesn't misread provenance on a row the user has
+                    # never reviewed.
+                    scrubbed_individual = (
+                        None
+                        if lr["individual"] == AUTO_MATCH_REVIEW_MARKER
+                        else lr["individual"]
+                    )
                     self.conn.execute(
                         "UPDATE prediction_review "
                         "SET prediction_id = ?, status = 'pending', "
-                        "    individual = NULL "
+                        "    individual = ? "
                         "WHERE prediction_id = ? AND workspace_id = ?",
-                        (winner_id, loser_id, ws),
+                        (winner_id, scrubbed_individual, loser_id, ws),
                     )
                 continue
             winner_status = winner["status"] or "pending"

--- a/vireo/keyword_normalization.py
+++ b/vireo/keyword_normalization.py
@@ -55,13 +55,19 @@ _ASCII_LOWER_TABLE = str.maketrans(
 #     ʻamakihi``; folding it would rewrite the taxonomy.
 #   * U+00B4 ACUTE ACCENT — preserved internally by
 #     ``_nfkc_preserving_internal_acute`` for names like ``O´Brien``.
+#   * U+2032 PRIME — the semantic prime symbol used for feet, arcminutes,
+#     and similar measurements. ``normalize_keyword_display`` runs on every
+#     keyword (not only species names), so a folded-in-place `10′ waterfall`
+#     would silently rewrite existing DB and queued XMP values. Species
+#     labels with a stray prime are rare enough that the case-collision
+#     merger below can handle them; folding them here would break the
+#     legitimate measurement case with no way for the user to opt out.
 # Edge occurrences of the folded characters are already removed by
 # ``_EDGE_QUOTES``, so in practice this only rewrites INTERNAL ones.
 _APOSTROPHE_FOLD = {
     ord("‘"): "'",  # LEFT SINGLE QUOTATION MARK
     ord("’"): "'",  # RIGHT SINGLE QUOTATION MARK
     ord("‛"): "'",  # SINGLE HIGH-REVERSED-9 QUOTATION MARK
-    ord("′"): "'",  # PRIME
 }
 
 

--- a/vireo/keyword_normalization.py
+++ b/vireo/keyword_normalization.py
@@ -33,6 +33,37 @@ _ASCII_LOWER_TABLE = str.maketrans(
     "abcdefghijklmnopqrstuvwxyz",
 )
 
+# Typographic single quotes that are unambiguously PUNCTUATION (Unicode
+# categories Pi/Pf/Po) fold to ASCII U+0027 so one species does not split
+# into two keywords. macOS smart-quote substitution, pasted iNaturalist
+# common names, and a handful of label-file lines all yield ``Say’s
+# phoebe``; stored verbatim it is a distinct row from ``Say's phoebe``
+# under SQLite ``COLLATE NOCASE``, which is how one bird ended up with
+# two Life List cards and two lifer numbers.
+#
+# The fold happens in the DISPLAY/STORAGE form rather than only in
+# ``keyword_match_key`` on purpose: ``add_keyword`` dedupes with SQL
+# ``COLLATE NOCASE``, which cannot fold U+2019. Folding only the match key
+# would let the merge pass collapse rows that the SQL layer still treats
+# as distinct, so ``add_keyword`` would immediately re-insert the curly
+# variant and the duplicate would grow back. Normalizing on write keeps
+# the two layers in lockstep — see ``keyword_match_key``'s docstring.
+#
+# Deliberately EXCLUDED:
+#   * U+02BB / U+02BC / U+02B9 — spacing modifier LETTERS (category Lm).
+#     U+02BB is the Hawaiian okina in ``ʻApapane`` and ``Hawaiʻi
+#     ʻamakihi``; folding it would rewrite the taxonomy.
+#   * U+00B4 ACUTE ACCENT — preserved internally by
+#     ``_nfkc_preserving_internal_acute`` for names like ``O´Brien``.
+# Edge occurrences of the folded characters are already removed by
+# ``_EDGE_QUOTES``, so in practice this only rewrites INTERNAL ones.
+_APOSTROPHE_FOLD = {
+    ord("‘"): "'",  # LEFT SINGLE QUOTATION MARK
+    ord("’"): "'",  # RIGHT SINGLE QUOTATION MARK
+    ord("‛"): "'",  # SINGLE HIGH-REVERSED-9 QUOTATION MARK
+    ord("′"): "'",  # PRIME
+}
+
 
 def _nfkc_preserving_internal_acute(value: str) -> str:
     """Apply NFKC while leaving internal U+00B4 ACUTE ACCENT intact.
@@ -80,6 +111,11 @@ def normalize_keyword_display(name: str) -> str:
     value = re.sub(r" +", " ", value).strip()
     value = value.strip(_EDGE_QUOTES)
     value = re.sub(r" +", " ", value).strip()
+    # Fold internal typographic apostrophes LAST, after the edge strips have
+    # had their chance to delete them outright. Doing it earlier would turn a
+    # leading `’` into `'` and still strip it, but running last keeps the
+    # edge-case behavior identical to before this fold existed.
+    value = value.translate(_APOSTROPHE_FOLD)
     return value
 
 

--- a/vireo/label_photos.py
+++ b/vireo/label_photos.py
@@ -175,8 +175,9 @@ def main():
 
     labels = None
     if args.labels_file:
-        with open(args.labels_file) as f:
-            labels = [line.strip() for line in f if line.strip()]
+        from labels import read_label_file
+
+        labels = read_label_file(args.labels_file)
         log.info("Loaded %d labels from %s", len(labels), args.labels_file)
 
     run(

--- a/vireo/labels.py
+++ b/vireo/labels.py
@@ -271,7 +271,11 @@ def _atomic_write_text(path, text):
         prefix=f".{os.path.basename(path)}.", suffix=".tmp", dir=directory
     )
     try:
-        with os.fdopen(fd, "w") as f:
+        # Explicit UTF-8: label files hold species names with non-ASCII
+        # characters (`Köhler’s Vine Snake`, `Hawaiʻi ʻamakihi`), and Python's
+        # default text encoding is the locale codepage on Windows (cp1252),
+        # which cannot represent U+02BB at all.
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(text)
         os.replace(tmp_path, path)
     except Exception:
@@ -419,7 +423,11 @@ def load_merged_labels(label_sets):
         if not path or not os.path.exists(path):
             log.warning("Label file missing, skipping: %s", path)
             continue
-        with open(path) as f:
+        # encoding="utf-8": these files carry non-ASCII species names, and the
+        # platform default is cp1252 on Windows -- reading UTF-8 bytes through
+        # it silently mojibakes `Hawaiʻi ʻamakihi` into `HawaiÊ»i Ê»amakihi`
+        # (and can raise on byte sequences cp1252 leaves undefined).
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 name = line.strip()
                 if name:

--- a/vireo/labels.py
+++ b/vireo/labels.py
@@ -427,11 +427,30 @@ def load_merged_labels(label_sets):
         # platform default is cp1252 on Windows -- reading UTF-8 bytes through
         # it silently mojibakes `Hawaiʻi ʻamakihi` into `HawaiÊ»i Ê»amakihi`
         # (and can raise on byte sequences cp1252 leaves undefined).
-        with open(path, encoding="utf-8") as f:
-            for line in f:
-                name = line.strip()
-                if name:
-                    all_species.add(name)
+        #
+        # cp1252 fallback: _atomic_write_text() only switched to explicit
+        # UTF-8 in the same change that added the reader above, so a Windows
+        # install that saved a label set before then wrote it in cp1252 (the
+        # locale default). Reading such a legacy file strictly as UTF-8
+        # raises UnicodeDecodeError on the first non-ASCII species and
+        # silently drops the whole active set from classification. Fall back
+        # to cp1252 so those files keep working; future saves rewrite as
+        # UTF-8 via _atomic_write_text.
+        try:
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+        except UnicodeDecodeError:
+            log.warning(
+                "Label file %s is not valid UTF-8; falling back to cp1252 "
+                "for legacy Windows-written files",
+                path,
+            )
+            with open(path, encoding="cp1252") as f:
+                lines = f.readlines()
+        for line in lines:
+            name = line.strip()
+            if name:
+                all_species.add(name)
     # Group by the fold key, then collapse only the groups that actually
     # have more than one spelling. Sorting the group makes the survivor
     # deterministic regardless of label-set order.

--- a/vireo/labels.py
+++ b/vireo/labels.py
@@ -258,6 +258,32 @@ def save_labels(name, place_id, place_name, taxon_groups, species,
     return labels_path
 
 
+def read_label_file(path):
+    """Read a label file, returning its stripped, non-empty lines.
+
+    UTF-8 with a cp1252 fallback: label files hold non-ASCII species names
+    and current writes are explicitly UTF-8, but a Windows install that
+    saved a label set before the writer became explicit stored the file in
+    the locale default (cp1252). Reading that legacy file strictly as UTF-8
+    raises ``UnicodeDecodeError`` on the first non-ASCII byte and silently
+    drops the whole active set. Any caller opening a label file directly
+    must route through here so the fallback protects every code path, not
+    just ``load_merged_labels``.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+    except UnicodeDecodeError:
+        log.warning(
+            "Label file %s is not valid UTF-8; falling back to cp1252 "
+            "for legacy Windows-written files",
+            path,
+        )
+        with open(path, encoding="cp1252") as f:
+            lines = f.readlines()
+    return [line.strip() for line in lines if line.strip()]
+
+
 def _atomic_write_text(path, text):
     """Write text to ``path`` via a sibling temp file + os.replace().
 
@@ -423,34 +449,8 @@ def load_merged_labels(label_sets):
         if not path or not os.path.exists(path):
             log.warning("Label file missing, skipping: %s", path)
             continue
-        # encoding="utf-8": these files carry non-ASCII species names, and the
-        # platform default is cp1252 on Windows -- reading UTF-8 bytes through
-        # it silently mojibakes `Hawaiʻi ʻamakihi` into `HawaiÊ»i Ê»amakihi`
-        # (and can raise on byte sequences cp1252 leaves undefined).
-        #
-        # cp1252 fallback: _atomic_write_text() only switched to explicit
-        # UTF-8 in the same change that added the reader above, so a Windows
-        # install that saved a label set before then wrote it in cp1252 (the
-        # locale default). Reading such a legacy file strictly as UTF-8
-        # raises UnicodeDecodeError on the first non-ASCII species and
-        # silently drops the whole active set from classification. Fall back
-        # to cp1252 so those files keep working; future saves rewrite as
-        # UTF-8 via _atomic_write_text.
-        try:
-            with open(path, encoding="utf-8") as f:
-                lines = f.readlines()
-        except UnicodeDecodeError:
-            log.warning(
-                "Label file %s is not valid UTF-8; falling back to cp1252 "
-                "for legacy Windows-written files",
-                path,
-            )
-            with open(path, encoding="cp1252") as f:
-                lines = f.readlines()
-        for line in lines:
-            name = line.strip()
-            if name:
-                all_species.add(name)
+        for name in read_label_file(path):
+            all_species.add(name)
     # Group by the fold key, then collapse only the groups that actually
     # have more than one spelling. Sorting the group makes the survivor
     # deterministic regardless of label-set order.

--- a/vireo/labels.py
+++ b/vireo/labels.py
@@ -396,6 +396,16 @@ def load_merged_labels(label_sets):
     UNIQUE row, and the alternative's INSERT-OR-IGNORE re-queries that row
     and upserts ``prediction_review.status = 'alternative'`` -- hiding the
     only top-1 prediction from the pending review queue.
+
+    The fold decides only which of two COLLIDING spellings to drop; a label
+    whose folded key is unique keeps its original source spelling. That
+    distinction matters because ``compute_fingerprint(labels)`` hashes this
+    exact list and ``classifier_runs`` is keyed on the result: rewriting a
+    non-colliding label (e.g. the lone `Bosc's Fringe-toed lizard` in
+    california-us-reptiles, or `'Anianiau` in the Hawaii set) would change
+    the fingerprint of five of the six shipped label sets and strand ~70k
+    cached runs, re-running inference over the whole catalog for no dedupe
+    benefit.
     """
     # Import here rather than at module load: ``labels.py`` is imported
     # from environments (packaging, first-run bootstrap) that don't yet
@@ -412,8 +422,27 @@ def load_merged_labels(label_sets):
         with open(path) as f:
             for line in f:
                 name = line.strip()
-                if not name:
-                    continue
-                canonical = normalize_keyword_display(name)
-                all_species.add(canonical if canonical else name)
-    return sorted(all_species)
+                if name:
+                    all_species.add(name)
+    # Group by the fold key, then collapse only the groups that actually
+    # have more than one spelling. Sorting the group makes the survivor
+    # deterministic regardless of label-set order.
+    by_key = {}
+    for name in all_species:
+        by_key.setdefault(normalize_keyword_display(name) or name, []).append(
+            name
+        )
+    merged = []
+    for canonical, variants in by_key.items():
+        if len(variants) == 1:
+            # No collision: preserve the source spelling so the fingerprint
+            # is byte-identical to what earlier runs hashed.
+            merged.append(variants[0])
+        else:
+            # Genuine variant collision: keep the folded spelling, which is
+            # what add_prediction will store, so the classifier's label and
+            # the persisted species agree.
+            merged.append(
+                canonical if canonical in variants else sorted(variants)[0]
+            )
+    return sorted(merged)

--- a/vireo/labels.py
+++ b/vireo/labels.py
@@ -386,7 +386,23 @@ def load_merged_labels(label_sets):
 
     Returns:
         sorted, deduplicated list of species name strings.
+
+    Dedupes by the same apostrophe-fold that ``add_prediction`` applies to
+    ``predictions.species``. Some bundled label files carry curly
+    apostrophes (`Bosc's Fringe-toed lizard`, `Geoffroy's Tamarin`) while
+    others use the plain ASCII form. Handing the classifier both spellings
+    lets it return one as primary and the other as an alternative; after
+    the central fold in ``add_prediction`` both writes resolve to the same
+    UNIQUE row, and the alternative's INSERT-OR-IGNORE re-queries that row
+    and upserts ``prediction_review.status = 'alternative'`` -- hiding the
+    only top-1 prediction from the pending review queue.
     """
+    # Import here rather than at module load: ``labels.py`` is imported
+    # from environments (packaging, first-run bootstrap) that don't yet
+    # have ``vireo/`` on ``sys.path``, and this helper is only reachable
+    # once the app is running.
+    from keyword_normalization import normalize_keyword_display
+
     all_species = set()
     for ls in label_sets:
         path = ls.get("labels_file", "")
@@ -396,6 +412,8 @@ def load_merged_labels(label_sets):
         with open(path) as f:
             for line in f:
                 name = line.strip()
-                if name:
-                    all_species.add(name)
+                if not name:
+                    continue
+                canonical = normalize_keyword_display(name)
+                all_species.add(canonical if canonical else name)
     return sorted(all_species)

--- a/vireo/labels.py
+++ b/vireo/labels.py
@@ -417,31 +417,40 @@ def load_merged_labels(label_sets):
     Returns:
         sorted, deduplicated list of species name strings.
 
-    Dedupes by the same apostrophe-fold that ``add_prediction`` applies to
-    ``predictions.species``. Some bundled label files carry curly
-    apostrophes (`Bosc's Fringe-toed lizard`, `Geoffroy's Tamarin`) while
-    others use the plain ASCII form. Handing the classifier both spellings
-    lets it return one as primary and the other as an alternative; after
-    the central fold in ``add_prediction`` both writes resolve to the same
-    UNIQUE row, and the alternative's INSERT-OR-IGNORE re-queries that row
-    and upserts ``prediction_review.status = 'alternative'`` -- hiding the
-    only top-1 prediction from the pending review queue.
+    Dedupes by the same ASCII-NOCASE key that ``add_prediction``,
+    alternative dedupe, and burst consensus use downstream — matching
+    SQLite's ``COLLATE NOCASE`` semantics via ``keyword_match_key``.
+    Some bundled label files carry curly apostrophes (`Bosc's
+    Fringe-toed lizard`, `Geoffroy's Tamarin`) while others use the
+    plain ASCII form, and hand-edited sets can differ only in case
+    (`Say's Phoebe` vs `Say's phoebe`). Handing the classifier two
+    spellings of the same species feeds its softmax two near-duplicate
+    classes that split probability between them — because each result
+    is thresholded independently in ``_build_custom_results``, a valid
+    prediction can fall below the configured threshold or lose an
+    alternative slot. Grouping by ``normalize_keyword_display`` alone
+    would miss the case-only collision because that helper preserves
+    case; ``keyword_match_key`` composes it with the same ASCII-only
+    lowercase table SQLite uses.
 
-    The fold decides only which of two COLLIDING spellings to drop; a label
-    whose folded key is unique keeps its original source spelling. That
-    distinction matters because ``compute_fingerprint(labels)`` hashes this
-    exact list and ``classifier_runs`` is keyed on the result: rewriting a
-    non-colliding label (e.g. the lone `Bosc's Fringe-toed lizard` in
-    california-us-reptiles, or `'Anianiau` in the Hawaii set) would change
-    the fingerprint of five of the six shipped label sets and strand ~70k
-    cached runs, re-running inference over the whole catalog for no dedupe
-    benefit.
+    The fold decides only which of two COLLIDING spellings to drop; a
+    label whose folded key is unique keeps its original source spelling.
+    That distinction matters because ``compute_fingerprint(labels)``
+    hashes this exact list and ``classifier_runs`` is keyed on the
+    result: rewriting a non-colliding label (e.g. the lone `Bosc's
+    Fringe-toed lizard` in california-us-reptiles, or `'Anianiau` in the
+    Hawaii set) would change the fingerprint of five of the six shipped
+    label sets and strand ~70k cached runs, re-running inference over
+    the whole catalog for no dedupe benefit.
     """
     # Import here rather than at module load: ``labels.py`` is imported
     # from environments (packaging, first-run bootstrap) that don't yet
     # have ``vireo/`` on ``sys.path``, and this helper is only reachable
     # once the app is running.
-    from keyword_normalization import normalize_keyword_display
+    from keyword_normalization import (
+        keyword_match_key,
+        normalize_keyword_display,
+    )
 
     all_species = set()
     for ls in label_sets:
@@ -451,28 +460,28 @@ def load_merged_labels(label_sets):
             continue
         for name in read_label_file(path):
             all_species.add(name)
-    # Group by the fold key, then collapse only the groups that actually
-    # have more than one spelling. Sorting the group makes the survivor
-    # deterministic regardless of label-set order.
+    # Group by the ASCII-NOCASE key so case-only variants collapse the
+    # same way SQLite's ``COLLATE NOCASE`` does, then collapse only the
+    # groups that actually have more than one raw spelling.
     by_key = {}
     for name in all_species:
-        by_key.setdefault(normalize_keyword_display(name) or name, []).append(
-            name
-        )
+        by_key.setdefault(keyword_match_key(name) or name, []).append(name)
     merged = []
-    for canonical, variants in by_key.items():
+    for variants in by_key.values():
         if len(variants) == 1:
             # No collision: preserve the source spelling so the fingerprint
             # is byte-identical to what earlier runs hashed.
             merged.append(variants[0])
         else:
-            # Genuine variant collision: always use the folded canonical
-            # spelling. That's what ``add_prediction`` will store, so the
-            # classifier's label and the persisted species agree. If neither
-            # raw variant already equals it (both are non-ASCII apostrophe
-            # spellings, e.g. ``Say’s phoebe`` + ``Say‛s phoebe``), a
-            # ``sorted(variants)[0]`` fallback would leave a curly form in
-            # the label list even though ``add_prediction`` will fold it —
-            # so labels and persisted species would still disagree.
-            merged.append(canonical)
+            # Genuine variant collision: prefer a spelling that
+            # ``normalize_keyword_display`` leaves unchanged (i.e. one
+            # already in the storage form, so the classifier's label and
+            # what ``add_prediction`` writes agree byte-for-byte). Sort
+            # first so both the primary preference and the fallback are
+            # deterministic regardless of label-set order.
+            ordered = sorted(variants)
+            merged.append(next(
+                (v for v in ordered if normalize_keyword_display(v) == v),
+                ordered[0],
+            ))
     return sorted(merged)

--- a/vireo/labels.py
+++ b/vireo/labels.py
@@ -466,10 +466,13 @@ def load_merged_labels(label_sets):
             # is byte-identical to what earlier runs hashed.
             merged.append(variants[0])
         else:
-            # Genuine variant collision: keep the folded spelling, which is
-            # what add_prediction will store, so the classifier's label and
-            # the persisted species agree.
-            merged.append(
-                canonical if canonical in variants else sorted(variants)[0]
-            )
+            # Genuine variant collision: always use the folded canonical
+            # spelling. That's what ``add_prediction`` will store, so the
+            # classifier's label and the persisted species agree. If neither
+            # raw variant already equals it (both are non-ASCII apostrophe
+            # spellings, e.g. ``Say’s phoebe`` + ``Say‛s phoebe``), a
+            # ``sorted(variants)[0]`` fallback would leave a curly form in
+            # the label list even though ``add_prediction`` will fold it —
+            # so labels and persisted species would still disagree.
+            merged.append(canonical)
     return sorted(merged)

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5209,3 +5209,129 @@ def test_precancelled_job_finalizes_all_step_rows(tmp_path):
             f"Step {step_id!r} must be marked cancelled on the "
             f"pre-resolution cancel gate, got {finals.get(step_id)!r}"
         )
+
+
+def test_store_pending_alt_that_folds_to_primary_does_not_hide_top1(tmp_path):
+    """A pending primary + a curly-spelled alternative that folds to the
+    same species must NOT overwrite the primary's review row with
+    ``status='alternative'``.
+
+    ``Database.add_prediction`` folds species centrally, so both the
+    primary and the collision-alternative resolve to the same predictions
+    row. The alternative's INSERT-OR-IGNORE is a no-op on that row, but
+    the second call still re-queries and unconditionally upserts
+    ``prediction_review`` — with ``status='alternative'``. Without the
+    dedupe added in ``_store_pending_detection_prediction``, the only
+    top-1 prediction for that detection would appear as an alternative
+    and drop out of the pending queue.
+    """
+    from unittest.mock import patch
+
+    from classify_job import _store_grouped_predictions
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos", name="photos")
+    pid = db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
+                       file_size=1000, file_mtime=1.0,
+                       timestamp="2024-01-15T10:00:00")
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
+    ], detector_model="megadetector-v6")
+
+    raw_results = [{
+        "photo": {"id": pid, "filename": "bird.jpg",
+                  "timestamp": "2024-01-15T10:00:00"},
+        "detection_id": det_ids[0],
+        "folder_path": "/photos",
+        "image_path": "/photos/bird.jpg",
+        "prediction": "Say's phoebe",
+        "confidence": 0.85,
+        "timestamp": None,
+        "filename": "bird.jpg",
+        "embedding": None,
+        "taxonomy": None,
+        # Curly-spelled variant folds to the same species as the primary.
+        # Also include a genuinely different alternative to confirm the
+        # dedupe skips only the collision.
+        "alternatives": [
+            {"species": "Say’s phoebe", "confidence": 0.10, "taxonomy": None},
+            {"species": "Cassin's kingbird", "confidence": 0.05,
+             "taxonomy": None},
+        ],
+    }]
+
+    with patch("xmp.read_keywords", return_value=[]), \
+         patch("compare.categorize", return_value="new"):
+        _store_grouped_predictions(
+            raw_results=raw_results,
+            job_id="test-alt-collision-1",
+            model_name="test-model",
+            grouping_window=10,
+            similarity_threshold=0.85,
+            tax=None,
+            db=db,
+        )
+
+    all_preds = db.get_predictions()
+    species = sorted(p["species"] for p in all_preds)
+    assert species == ["Cassin's kingbird", "Say's phoebe"], species
+
+    pending = db.get_predictions(status="pending")
+    assert [p["species"] for p in pending] == ["Say's phoebe"], (
+        "the primary must remain in the pending queue — an alternative that "
+        "folds to the same species must not upsert status='alternative' onto it"
+    )
+    alts = db.get_predictions(status="alternative")
+    assert [p["species"] for p in alts] == ["Cassin's kingbird"]
+
+
+def test_store_match_alt_that_folds_to_primary_preserves_auto_accept(tmp_path):
+    """Same collision on the match path: an auto-accepted primary with the
+    ``AUTO_MATCH_REVIEW_MARKER`` must keep its accepted status when an
+    alternative folds to it. Without the dedupe, the alternative's
+    ``status='alternative'`` upsert would overwrite the auto-accept and
+    the previously-labeled match would silently reappear in review."""
+    from classify_job import _store_match_prediction
+    from db import AUTO_MATCH_REVIEW_MARKER, Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos", name="photos")
+    pid = db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
+                       file_size=1000, file_mtime=1.0)
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
+    ], detector_model="megadetector-v6")
+
+    item = {
+        "detection_id": det_ids[0],
+        "prediction": "Say's phoebe",
+        "confidence": 0.85,
+        "taxonomy": None,
+        "alternatives": [
+            {"species": "Say’s phoebe", "confidence": 0.10, "taxonomy": None},
+        ],
+    }
+    _store_match_prediction(
+        db, item, model_name="test-model", labels_fingerprint="fp1",
+    )
+
+    rows = db.conn.execute(
+        "SELECT p.species, pr.status, pr.individual "
+        "FROM predictions p "
+        "LEFT JOIN prediction_review pr "
+        "  ON pr.prediction_id = p.id AND pr.workspace_id = ? "
+        "WHERE p.detection_id = ?",
+        (ws_id, det_ids[0]),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["species"] == "Say's phoebe"
+    assert rows[0]["status"] == "accepted", (
+        "the alternative that folds to the primary must not overwrite the "
+        "auto-accept back to status='alternative'"
+    )
+    assert rows[0]["individual"] == AUTO_MATCH_REVIEW_MARKER

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5540,3 +5540,114 @@ def test_store_match_alt_that_only_differs_in_case_preserves_auto_accept(
     )
     assert rows[0]["status"] == "accepted"
     assert rows[0]["individual"] == AUTO_MATCH_REVIEW_MARKER
+
+
+def test_store_match_alt_non_ascii_case_preserves_both_predictions(tmp_path):
+    """SQLite ``COLLATE NOCASE`` and ``keyword_match_key`` fold only A-Z, so
+    ``Éclair`` and ``éclair`` are distinct keywords on the DB side.
+    ``str.lower()`` would collapse them into one dedupe key and drop the
+    alternative; the ASCII-only fold used by ``_species_match_key`` must
+    preserve both predictions so the alternative reaches the UI.
+    """
+    from classify_job import _store_match_prediction
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos", name="photos")
+    pid = db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
+                       file_size=1000, file_mtime=1.0)
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
+    ], detector_model="megadetector-v6")
+
+    item = {
+        "detection_id": det_ids[0],
+        "prediction": "Éclair",
+        "confidence": 0.85,
+        "taxonomy": None,
+        "alternatives": [
+            # Non-ASCII case difference only. SQLite treats these as
+            # distinct rows; a Python ``str.lower()`` dedupe would drop
+            # this alternative and hide it from the user.
+            {"species": "éclair", "confidence": 0.10, "taxonomy": None},
+        ],
+    }
+    _store_match_prediction(
+        db, item, model_name="test-model", labels_fingerprint="fp1",
+    )
+
+    species = sorted(
+        r["species"]
+        for r in db.conn.execute(
+            "SELECT species FROM predictions WHERE detection_id = ?",
+            (det_ids[0],),
+        ).fetchall()
+    )
+    assert species == ["Éclair", "éclair"], (
+        "non-ASCII case variants are distinct rows under COLLATE NOCASE; "
+        "the alternative must not be deduped away by a Unicode ``.lower()``"
+    )
+
+
+def test_burst_consensus_non_ascii_case_variants_stay_split(tmp_path):
+    """Two burst frames predicting ``Éclair`` and ``éclair`` are distinct
+    species under SQLite ``COLLATE NOCASE``. A Python ``.lower()`` fold
+    would report them as one unanimous species; the ASCII-only fold used
+    by ``_species_match_key`` must keep them separate so ``group_species``
+    has two entries and ``group_reviewable`` stays False (no group_id or
+    inflated vote count on the stored predictions).
+    """
+    from datetime import datetime
+    from unittest.mock import MagicMock
+
+    from classify_job import _store_grouped_predictions
+
+    mock_db = MagicMock()
+
+    raw_results = [
+        {
+            "photo": {"id": 1, "filename": "a.jpg"},
+            "detection_id": 201,
+            "folder_path": "/photos",
+            "prediction": "Éclair",
+            "confidence": 0.95,
+            "timestamp": datetime(2024, 1, 15, 10, 0, 0),
+            "filename": "a.jpg",
+            "embedding": None,
+            "taxonomy": None,
+        },
+        {
+            "photo": {"id": 2, "filename": "b.jpg"},
+            "detection_id": 202,
+            "folder_path": "/photos",
+            "prediction": "éclair",
+            "confidence": 0.90,
+            "timestamp": datetime(2024, 1, 15, 10, 0, 3),
+            "filename": "b.jpg",
+            "embedding": None,
+            "taxonomy": None,
+        },
+    ]
+
+    _store_grouped_predictions(
+        raw_results=raw_results,
+        job_id="classify-test",
+        model_name="BioCLIP",
+        grouping_window=10,
+        similarity_threshold=0.85,
+        tax=None,
+        db=mock_db,
+    )
+
+    calls = mock_db.add_prediction.call_args_list
+    assert len(calls) == 2
+    for c in calls:
+        kwargs = c.kwargs or c[1]
+        assert kwargs["group_id"] is None, (
+            "non-ASCII case variants are distinct species; the burst must "
+            "not collapse to a single group_id via ``.lower()``"
+        )
+        assert kwargs["vote_count"] is None
+        assert kwargs["individual"] is None

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -3190,6 +3190,82 @@ def test_store_grouped_predictions_burst_group():
     assert mock_db.add_prediction.call_count == 2
 
 
+def test_store_grouped_predictions_folds_species_before_group_consensus():
+    """When the active labels carry both `Say's Phoebe` (ASCII) and
+    `Say’s Phoebe` (U+2019) — a common situation with merged bundled
+    label files — the classifier can return either spelling per frame.
+    Before central folding was applied inside ``_store_grouped_predictions``,
+    ``group_species`` was computed off the raw ``item["prediction"]``
+    strings, so a two-frame burst with one of each spelling produced
+    ``{'say\\'s phoebe', 'say’s phoebe'}`` and ``group_reviewable``
+    became False. The consensus itself also split the votes.
+
+    Because ``add_prediction`` folds the stored species centrally, both
+    frames land on the same prediction row afterwards; the burst was
+    unanimous. So the burst_group *must* survive with a group_id and
+    the full vote count, or the survivor prediction silently loses its
+    grouping metadata."""
+    from datetime import datetime
+    from unittest.mock import MagicMock
+
+    from classify_job import _store_grouped_predictions
+
+    mock_db = MagicMock()
+
+    raw_results = [
+        {
+            "photo": {"id": 1, "filename": "bird1.jpg"},
+            "detection_id": 101,
+            "folder_path": "/photos",
+            "prediction": "Say's Phoebe",
+            "confidence": 0.95,
+            "timestamp": datetime(2024, 1, 15, 10, 0, 0),
+            "filename": "bird1.jpg",
+            "embedding": None,
+            "taxonomy": None,
+        },
+        {
+            "photo": {"id": 2, "filename": "bird2.jpg"},
+            "detection_id": 102,
+            "folder_path": "/photos",
+            # Curly-apostrophe variant of the same species name.
+            "prediction": "Say’s Phoebe",
+            "confidence": 0.90,
+            "timestamp": datetime(2024, 1, 15, 10, 0, 3),
+            "filename": "bird2.jpg",
+            "embedding": None,
+            "taxonomy": None,
+        },
+    ]
+
+    result = _store_grouped_predictions(
+        raw_results=raw_results,
+        job_id="classify-test",
+        model_name="BioCLIP",
+        grouping_window=10,
+        similarity_threshold=0.85,
+        tax=None,
+        db=mock_db,
+    )
+
+    assert result["burst_groups"] == 1, (
+        "unanimous burst was split into non-group predictions because "
+        "raw species strings differ only by apostrophe glyph"
+    )
+    # Both frames should be stored with a group_id and full vote counts.
+    calls = mock_db.add_prediction.call_args_list
+    assert len(calls) == 2
+    for c in calls:
+        kwargs = c.kwargs or c[1]
+        assert kwargs["group_id"] is not None, (
+            "group_id dropped: group_reviewable was False, so the "
+            "survivor prediction lost its burst grouping"
+        )
+        assert kwargs["vote_count"] == 2
+        assert kwargs["total_votes"] == 2
+        assert kwargs["individual"] is not None
+
+
 # ── Task 6: run_classify_job full pipeline test ───────────────────────────────
 
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -3266,6 +3266,82 @@ def test_store_grouped_predictions_folds_species_before_group_consensus():
         assert kwargs["individual"] is not None
 
 
+def test_store_grouped_predictions_folds_case_for_burst_consensus():
+    """When burst frames' predictions differ in both apostrophe glyph AND
+    ASCII capitalization (e.g., `Say's Phoebe` and `Say’s phoebe`), the
+    apostrophe fold alone still yields two distinct consensus keys.
+    ``consensus_prediction`` keys on the raw string, so a semantically
+    unanimous burst would report a `1/2` vote count. Meanwhile
+    ``group_species`` already lowercases and would set
+    ``group_reviewable=True``: the mismatch stored split ``individual``
+    entries against an inconsistent count.
+
+    Canonicalizing to the first-seen casing for each ASCII-lowercase
+    fold key sums the vote correctly while ``individual_predictions``
+    still shows a real display-cased name."""
+    import json
+    from datetime import datetime
+    from unittest.mock import MagicMock
+
+    from classify_job import _store_grouped_predictions
+
+    mock_db = MagicMock()
+
+    raw_results = [
+        {
+            "photo": {"id": 1, "filename": "bird1.jpg"},
+            "detection_id": 101,
+            "folder_path": "/photos",
+            "prediction": "Say's Phoebe",
+            "confidence": 0.95,
+            "timestamp": datetime(2024, 1, 15, 10, 0, 0),
+            "filename": "bird1.jpg",
+            "embedding": None,
+            "taxonomy": None,
+        },
+        {
+            "photo": {"id": 2, "filename": "bird2.jpg"},
+            "detection_id": 102,
+            "folder_path": "/photos",
+            # Curly apostrophe AND lowercase — differs from frame 1 in
+            # two axes at once.
+            "prediction": "Say’s phoebe",
+            "confidence": 0.90,
+            "timestamp": datetime(2024, 1, 15, 10, 0, 3),
+            "filename": "bird2.jpg",
+            "embedding": None,
+            "taxonomy": None,
+        },
+    ]
+
+    result = _store_grouped_predictions(
+        raw_results=raw_results,
+        job_id="classify-test",
+        model_name="BioCLIP",
+        grouping_window=10,
+        similarity_threshold=0.85,
+        tax=None,
+        db=mock_db,
+    )
+
+    assert result["burst_groups"] == 1
+    calls = mock_db.add_prediction.call_args_list
+    assert len(calls) == 2
+    for c in calls:
+        kwargs = c.kwargs or c[1]
+        assert kwargs["group_id"] is not None
+        assert kwargs["vote_count"] == 2, (
+            "vote_count was split because case-variant apostrophe folds "
+            "keyed consensus separately"
+        )
+        assert kwargs["total_votes"] == 2
+        # After case folding the individual dict has one entry summing
+        # to 2, not two entries of 1 each.
+        votes = json.loads(kwargs["individual"])
+        assert sum(votes.values()) == 2
+        assert len(votes) == 1
+
+
 # ── Task 6: run_classify_job full pipeline test ───────────────────────────────
 
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -2343,6 +2343,94 @@ def test_ungrouped_burst_clears_stale_group_id_on_reuse(
         assert not after[det_id]["individual"]
 
 
+def test_stored_prediction_species_folds_curly_apostrophe(tmp_path):
+    """Bundled label files contain curly apostrophes (`Geoffroy’s Tamarin`,
+    `Bosc’s Fringe-toed lizard`). predictions.species is matched against
+    keywords.name with exact / COLLATE NOCASE compares that cannot fold
+    U+2019, so storing the raw label left an accepted ASCII keyword unable
+    to match its own prediction. Fold on write so the variant cannot come
+    back after the one-shot migration."""
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    try:
+        folder_id = db.add_folder("/tmp/p")
+        ws = db.create_workspace("A")
+        db._active_workspace_id = ws
+        db.add_workspace_folder(ws, folder_id)
+        photo_id = db.add_photo(
+            folder_id, "a.jpg", extension=".jpg", file_size=100,
+            file_mtime=1.0,
+        )
+        det_id = db.save_detections(
+            photo_id,
+            [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+              "category": "animal"}],
+            detector_model="megadetector-v6",
+        )[0]
+
+        stored = classify_job._run_classifier_on_detection(
+            db=db, detection_id=det_id, classifier_model="bioclip-2",
+            labels=["Geoffroy’s Tamarin"], labels_fingerprint="fp1",
+            classify_fn=lambda: [
+                {"species": "Geoffroy’s Tamarin", "confidence": 0.77}
+            ],
+        )
+
+        row = db.conn.execute(
+            "SELECT species FROM predictions WHERE detection_id = ?",
+            (det_id,),
+        ).fetchone()
+        assert row["species"] == "Geoffroy's Tamarin"
+        # The returned dicts feed downstream accept/count logic, so they must
+        # agree with what was persisted.
+        assert stored[0]["species"] == "Geoffroy's Tamarin"
+    finally:
+        db.close()
+
+
+def test_stored_prediction_species_preserves_okina(tmp_path):
+    """U+02BB is a letter in `ʻApapane`, not a stray quote — the fold on the
+    prediction write path must not touch it, or the Hawaii label set would
+    store species that no longer match their keywords."""
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    try:
+        folder_id = db.add_folder("/tmp/p")
+        ws = db.create_workspace("A")
+        db._active_workspace_id = ws
+        db.add_workspace_folder(ws, folder_id)
+        photo_id = db.add_photo(
+            folder_id, "a.jpg", extension=".jpg", file_size=100,
+            file_mtime=1.0,
+        )
+        det_id = db.save_detections(
+            photo_id,
+            [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+              "category": "animal"}],
+            detector_model="megadetector-v6",
+        )[0]
+
+        classify_job._run_classifier_on_detection(
+            db=db, detection_id=det_id, classifier_model="bioclip-2",
+            labels=["Hawaiʻi ʻamakihi"], labels_fingerprint="fp1",
+            classify_fn=lambda: [
+                {"species": "Hawaiʻi ʻamakihi", "confidence": 0.77}
+            ],
+        )
+
+        row = db.conn.execute(
+            "SELECT species FROM predictions WHERE detection_id = ?",
+            (det_id,),
+        ).fetchone()
+        assert row["species"] == "Hawaiʻi ʻamakihi"
+    finally:
+        db.close()
+
+
 def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
     """If (detection, classifier_model, fingerprint) already ran, don't invoke again."""
     from db import Database

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5487,3 +5487,56 @@ def test_store_match_alt_that_folds_to_primary_preserves_auto_accept(tmp_path):
         "auto-accept back to status='alternative'"
     )
     assert rows[0]["individual"] == AUTO_MATCH_REVIEW_MARKER
+
+
+def test_store_match_alt_that_only_differs_in_case_preserves_auto_accept(
+    tmp_path,
+):
+    """Downstream keyword joins already use ``COLLATE NOCASE``, so a merged
+    label set yielding primary ``Say's Phoebe`` and alternative ``Say's
+    phoebe`` is semantically one bird. The BINARY UNIQUE on
+    ``predictions.species`` would still let both survive as distinct rows,
+    with the alternative overwriting the primary's ``prediction_review``.
+    The alternatives-dedupe must therefore match case-insensitively too,
+    otherwise the auto-accepted match silently reappears in review.
+    """
+    from classify_job import _store_match_prediction
+    from db import AUTO_MATCH_REVIEW_MARKER, Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos", name="photos")
+    pid = db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
+                       file_size=1000, file_mtime=1.0)
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}
+    ], detector_model="megadetector-v6")
+
+    item = {
+        "detection_id": det_ids[0],
+        "prediction": "Say's Phoebe",
+        "confidence": 0.85,
+        "taxonomy": None,
+        "alternatives": [
+            {"species": "Say's phoebe", "confidence": 0.10, "taxonomy": None},
+        ],
+    }
+    _store_match_prediction(
+        db, item, model_name="test-model", labels_fingerprint="fp1",
+    )
+
+    rows = db.conn.execute(
+        "SELECT p.species, pr.status, pr.individual "
+        "FROM predictions p "
+        "LEFT JOIN prediction_review pr "
+        "  ON pr.prediction_id = p.id AND pr.workspace_id = ? "
+        "WHERE p.detection_id = ?",
+        (ws_id, det_ids[0]),
+    ).fetchall()
+    assert len(rows) == 1, (
+        "case-differing alternative must be deduped: it and the primary are "
+        "one species under COLLATE NOCASE"
+    )
+    assert rows[0]["status"] == "accepted"
+    assert rows[0]["individual"] == AUTO_MATCH_REVIEW_MARKER

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -3022,3 +3022,177 @@ def test_prediction_fold_scrubs_auto_marker_when_transferring_pending_loser(tmp_
         )
     finally:
         db.close()
+
+
+def test_prediction_fold_preserves_auto_marker_on_decided_transfer(tmp_path):
+    """When the winner has no ``prediction_review`` row (implicit pending)
+    and the loser IS a genuine auto-accepted taxonomy match — ``status=
+    'accepted'`` with ``individual=AUTO_MATCH_REVIEW_MARKER`` — moving the
+    row must preserve the marker. ``reconcile_match_review_state`` deletes
+    stale auto-accepts by matching the marker; scrubbing it here would
+    convert a real auto-accept into an apparent manual decision, stranding
+    the acceptance even after the XMP match evidence goes away."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence, category) "
+            "VALUES (?, 'm1', 'fp1', ?, ?, 'match')",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, individual) "
+            "VALUES (?, ?, 'accepted', ?)",
+            (loser_pid, ws_id, AUTO_MATCH_REVIEW_MARKER),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, individual FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        assert review["status"] == "accepted"
+        assert review["individual"] == AUTO_MATCH_REVIEW_MARKER, (
+            "auto-match sentinel was scrubbed while transferring a genuine "
+            "auto-accept; reconcile_match_review_state can no longer "
+            "identify (and clean up) this row when the match evidence "
+            "goes away"
+        )
+    finally:
+        db.close()
+
+
+def test_prediction_fold_preserves_individual_json_on_pending_transfer(tmp_path):
+    """Complement to the sentinel-scrub test: ``individual`` on a pending
+    review row can be the real JSON vote-breakdown that
+    ``_store_grouped_predictions`` stores alongside ``group_id`` /
+    ``vote_count`` / ``total_votes``, not only the auto-match sentinel.
+    Blanket-scrubbing ``individual`` to NULL when transferring a pending
+    loser would silently drop the burst's per-frame vote payload so a
+    later group-accept could no longer derive the consensus species from
+    the individual votes. Only the sentinel gets scrubbed; ordinary
+    JSON payloads are preserved verbatim."""
+    import json
+
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        individual_json = json.dumps(
+            [{"species": "Say's phoebe", "confidence": 0.91},
+             {"species": "Say's phoebe", "confidence": 0.83}]
+        )
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, group_id, vote_count, "
+            " total_votes, individual) "
+            "VALUES (?, ?, 'pending', 'burst-13', 2, 3, ?)",
+            (loser_pid, ws_id, individual_json),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, group_id, vote_count, total_votes, individual "
+            "FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        assert review["group_id"] == "burst-13"
+        assert review["vote_count"] == 2
+        assert review["total_votes"] == 3
+        assert review["individual"] == individual_json, (
+            "burst per-frame vote JSON was scrubbed to NULL on transfer; "
+            "later group acceptance can no longer derive the consensus "
+            "species from the individual votes"
+        )
+    finally:
+        db.close()
+
+
+def test_prediction_fold_preserves_individual_json_on_alternative_transfer(
+    tmp_path,
+):
+    """Same shape as the pending-transfer test but with the loser row
+    carrying ``status='alternative'`` plus burst metadata *and* the JSON
+    vote payload. The existing ``moves_loser_alternative_metadata_when_
+    present`` test only pins the ``group_id`` / ``vote_count`` /
+    ``total_votes`` copy-through and leaves the ``individual`` slot
+    untested; without this the JSON silently disappears on transfer,
+    breaking the same burst-consensus flow. Only the sentinel gets
+    scrubbed."""
+    import json
+
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        individual_json = json.dumps(
+            [{"species": "Say's phoebe", "confidence": 0.72}]
+        )
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, group_id, vote_count, "
+            " total_votes, individual) "
+            "VALUES (?, ?, 'alternative', 'burst-14', 3, 4, ?)",
+            (loser_pid, ws_id, individual_json),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, group_id, vote_count, total_votes, individual "
+            "FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        # Alternative status is downgraded to pending on the survivor so
+        # the higher-confidence primary stays visible in the queue.
+        assert review["status"] == "pending"
+        assert review["group_id"] == "burst-14"
+        assert review["vote_count"] == 3
+        assert review["total_votes"] == 4
+        assert review["individual"] == individual_json
+    finally:
+        db.close()

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -16,7 +16,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from db import Database  # noqa: E402
+from db import AUTO_MATCH_REVIEW_MARKER, Database  # noqa: E402
 
 
 def _make_db(tmp_path):
@@ -2593,5 +2593,212 @@ def test_prediction_fold_metadata_merge_does_not_clobber_winner(tmp_path):
         assert row["scientific_name"] == "Sayornis saya"
         assert row["taxonomy_family"] == "Tyrannidae"
         assert row["category"] == "match"
+    finally:
+        db.close()
+
+
+def test_prediction_fold_keeps_pending_winner_when_loser_is_alternative(tmp_path):
+    """A pre-migration setup can leave the clean spelling as the pending
+    top-1 (no ``prediction_review`` row at all, since absence == pending)
+    and the curly spelling as a per-frame runner-up stored with an explicit
+    ``status='alternative'`` row. After the fold collides them onto one
+    ``predictions`` row, blindly re-pointing the loser's row at the winner
+    would flip the surviving top-1 to ``alternative`` and hide it from the
+    pending queue. The merge must treat an absent winner review as implicit
+    pending and drop a bare ``alternative`` loser instead of transferring
+    it."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status) VALUES (?, ?, 'alternative')",
+            (loser_pid, ws_id),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is None, (
+            "loser's status='alternative' row was moved onto the surviving "
+            "pending primary, hiding it from the review queue"
+        )
+    finally:
+        db.close()
+
+
+def test_prediction_fold_moves_loser_alternative_metadata_when_present(tmp_path):
+    """Complement to the previous test: when the loser's alternative row
+    still carries burst grouping metadata (an atypical but legal state),
+    the merge should preserve that metadata on the winner rather than
+    discarding it — the ``continue`` shortcut only applies when the loser
+    row has nothing worth keeping beyond ``status='alternative'``."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, group_id, vote_count, "
+            " total_votes) "
+            "VALUES (?, ?, 'alternative', 'burst-9', 4, 5)",
+            (loser_pid, ws_id),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, group_id, vote_count, total_votes "
+            "FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        assert review["group_id"] == "burst-9"
+        assert review["vote_count"] == 4
+        assert review["total_votes"] == 5
+    finally:
+        db.close()
+
+
+def test_prediction_fold_does_not_stamp_auto_marker_on_manual_review(tmp_path):
+    """When two spellings each carry a review row and the chosen (later)
+    row is a manual accept with ``individual=NULL``, the merge previously
+    copied the losing spelling's ``AUTO_MATCH_REVIEW_MARKER`` into the
+    ``individual`` slot as a backfill. That misrepresents provenance:
+    ``preserve_manual_review`` and ``reconcile_match_review_state`` both
+    treat the marker as "auto-generated", so a subsequent classify run
+    could overwrite or delete the user's manual decision. The merge must
+    never propagate the auto-match sentinel onto a chosen manual review.
+    """
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        winner_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        # Winner carries the manual accept (later reviewed_at, individual NULL).
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, reviewed_at, individual) "
+            "VALUES (?, ?, 'accepted', '2026-01-02 03:04:05', NULL)",
+            (winner_pid, ws_id),
+        )
+        # Loser is an older auto-accept — the sentinel must not migrate onto
+        # the manual decision when it wins the tie-break.
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, reviewed_at, individual) "
+            "VALUES (?, ?, 'accepted', '2025-06-01 00:00:00', ?)",
+            (loser_pid, ws_id, AUTO_MATCH_REVIEW_MARKER),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, individual FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        assert review["status"] == "accepted"
+        assert review["individual"] is None, (
+            "auto-match sentinel leaked from loser onto the manual accept — "
+            "later reconcile / preserve_manual_review would treat this as "
+            "auto-generated"
+        )
+    finally:
+        db.close()
+
+
+def test_prediction_fold_scrubs_auto_marker_when_transferring_pending_loser(tmp_path):
+    """Same anti-provenance concern applies on the "winner has no row"
+    path: if the loser is a pending row (some odd historical state) that
+    still carries the auto-match sentinel in ``individual``, moving it
+    onto the winner would stamp the sentinel onto a row the user has never
+    reviewed. Scrub the sentinel to NULL when transferring a non-decided
+    row so future automation cannot misinterpret provenance."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, group_id, individual) "
+            "VALUES (?, ?, 'pending', 'burst-11', ?)",
+            (loser_pid, ws_id, AUTO_MATCH_REVIEW_MARKER),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, group_id, individual FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        assert review["group_id"] == "burst-11"
+        assert review["individual"] is None, (
+            "auto-match sentinel from a non-decided loser leaked onto the "
+            "surviving prediction"
+        )
     finally:
         db.close()

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -2393,3 +2393,103 @@ def test_curation_case_alignment_leaves_ambiguous_homonyms_alone(tmp_path):
         assert db.get_meta("curation_species_case_aligned_v2") == "1"
     finally:
         db.close()
+
+
+def test_prime_symbol_not_folded_in_keywords(tmp_path):
+    """U+2032 PRIME is the semantic prime symbol used for feet and
+    arcminutes. Keywords like `10′ waterfall` must not be silently
+    rewritten to `10' waterfall` by the apostrophe fold — the fold table
+    intentionally excludes U+2032 so measurement notation survives the
+    display/storage normalization applied on every keyword write."""
+    from keyword_normalization import normalize_keyword_display
+
+    assert normalize_keyword_display("10′ waterfall") == "10′ waterfall"
+    # Middle-of-string preservation matters most, but a lone prime as an
+    # edge char is stripped by _EDGE_QUOTES (measurement notation almost
+    # never appears at the boundary of a keyword name — the edge behavior
+    # is unchanged from before the fold table existed).
+
+    db, _ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = db.conn.execute(
+            "INSERT INTO detections (photo_id, category, detector_confidence) "
+            "VALUES (?, 'animal', 0.99)",
+            (p1,),
+        ).lastrowid
+        db.conn.commit()
+
+        # A prediction whose species carries a legitimate prime stays intact
+        # after add_prediction normalizes on write.
+        db.add_prediction(
+            detection_id=det,
+            species="10′ waterfall bird",
+            confidence=0.5,
+            model="m1",
+            labels_fingerprint="fp1",
+        )
+        stored = db.conn.execute(
+            "SELECT species FROM predictions WHERE detection_id = ?", (det,)
+        ).fetchone()["species"]
+        assert stored == "10′ waterfall bird"
+    finally:
+        db.close()
+
+
+def test_prediction_fold_merge_backfills_pending_group_metadata(tmp_path):
+    """Two spellings can both have PENDING review rows in the same
+    workspace — the loser carrying the current burst's ``group_id`` and
+    vote counts, the winner just a bare pending stub. The prior merge
+    logic only preserved group metadata when the loser's status was
+    accepted/rejected, so a pending loser's grouping was cascaded away
+    and the surviving prediction silently fell out of its burst group.
+    The merge helper now backfills group metadata from whichever side
+    supplies it, independently of the accepted/rejected decision."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        winner_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status) VALUES (?, ?, 'pending')",
+            (winner_pid, ws_id),
+        )
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, group_id, vote_count, "
+            " total_votes, individual) "
+            "VALUES (?, ?, 'pending', 'burst-1', 2, 3, 'ind-1')",
+            (loser_pid, ws_id),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, group_id, vote_count, total_votes, individual "
+            "FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        assert review["status"] == "pending"
+        assert review["group_id"] == "burst-1"
+        assert review["vote_count"] == 2
+        assert review["total_votes"] == 3
+        assert review["individual"] == "ind-1"
+    finally:
+        db.close()

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -1023,6 +1023,297 @@ def test_prediction_fold_resolves_unique_collision_by_confidence(tmp_path):
         db.close()
 
 
+def test_prediction_fold_preserves_review_when_loser_carries_decision(tmp_path):
+    """When the collision-merge deletes the losing prediction, its per-
+    workspace prediction_review row must migrate onto the surviving row.
+    `prediction_review.prediction_id` uses `ON DELETE CASCADE`, so a bare
+    delete would silently drop the user's accepted/rejected decision (and
+    its group metadata) during the one-shot migration.
+
+    Reproduces the P1 finding on the direction where the curly variant is
+    the *losing* row: its review sits on the id that gets deleted.
+    """
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        # Curly variant has lower confidence and is therefore the loser.
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, reviewed_at, "
+            " individual, group_id, vote_count, total_votes) "
+            "VALUES (?, ?, 'accepted', '2025-01-02 03:04:05', "
+            "        'reviewer-note', 'g-1', 3, 5)",
+            (loser_pid, ws_id),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        rows = db.conn.execute(
+            "SELECT species FROM predictions"
+        ).fetchall()
+        assert [r["species"] for r in rows] == ["Say's phoebe"]
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, individual, group_id, vote_count, total_votes "
+            "FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None, "loser's accepted review was dropped"
+        assert review["status"] == "accepted"
+        assert review["individual"] == "reviewer-note"
+        assert review["group_id"] == "g-1"
+        assert review["vote_count"] == 3
+        assert review["total_votes"] == 5
+    finally:
+        db.close()
+
+
+def test_prediction_fold_preserves_review_when_variant_wins_collision(tmp_path):
+    """Symmetric to the loser-side case: when the variant has *higher*
+    confidence, the migration deletes the clean row and renames the variant
+    onto the clean spelling. A review row attached to the deleted clean row
+    would be lost without an explicit merge step."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.4)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.8),
+        )
+        clean_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, reviewed_at) "
+            "VALUES (?, ?, 'rejected', '2025-01-02 03:04:05')",
+            (clean_pid, ws_id),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        rows = db.conn.execute(
+            "SELECT species FROM predictions"
+        ).fetchall()
+        assert [r["species"] for r in rows] == ["Say's phoebe"]
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        assert review["status"] == "rejected"
+    finally:
+        db.close()
+
+
+def test_prediction_fold_prefers_stronger_decision_on_review_collision(
+    tmp_path,
+):
+    """Both spellings can independently have review rows in the same
+    workspace (e.g. one was reviewed under the curly spelling, then the
+    clean one appeared and was left pending). The merge must keep the
+    non-pending user decision instead of the pending stub."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        winner_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        # Winner has a pending stub row; loser carries the real decision.
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status) VALUES (?, ?, 'pending')",
+            (winner_pid, ws_id),
+        )
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, reviewed_at, individual) "
+            "VALUES (?, ?, 'accepted', '2025-01-02 03:04:05', 'kept-me')",
+            (loser_pid, ws_id),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status, individual FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is not None
+        assert review["status"] == "accepted"
+        assert review["individual"] == "kept-me"
+
+
+        reviews = db.conn.execute(
+            "SELECT COUNT(*) AS c FROM prediction_review"
+        ).fetchone()["c"]
+        assert reviews == 1
+    finally:
+        db.close()
+
+
+def test_prediction_fold_preserves_review_per_workspace_independently(tmp_path):
+    """A collision can touch multiple workspaces at once: each workspace's
+    review row on the loser must migrate to the survivor independently and
+    unaffected by other workspaces' state.
+    """
+    db, ws_a, p1, _p2 = _make_db(tmp_path)
+    try:
+        ws_b = db.create_workspace("Beta")
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, reviewed_at) "
+            "VALUES (?, ?, 'accepted', '2025-01-02 03:04:05')",
+            (loser_pid, ws_a),
+        )
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, reviewed_at) "
+            "VALUES (?, ?, 'rejected', '2025-01-03 03:04:05')",
+            (loser_pid, ws_b),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        rows = {
+            r["workspace_id"]: r["status"]
+            for r in db.conn.execute(
+                "SELECT workspace_id, status FROM prediction_review "
+                "WHERE prediction_id = ?",
+                (survivor_pid,),
+            ).fetchall()
+        }
+        assert rows == {ws_a: "accepted", ws_b: "rejected"}
+    finally:
+        db.close()
+
+
+def test_add_prediction_folds_curly_apostrophe_species(tmp_path):
+    """`Database.add_prediction` is the shared choke point for the classify
+    job's storage helpers (`_store_pending_detection_prediction`,
+    `_store_match_prediction`). Neither production path runs
+    `normalize_keyword_display` before calling here, so a bundled label
+    that spells `Swinhoe’s White-eye` with U+2019 would still land in
+    predictions.species as-is and fail to match its accepted
+    `Swinhoe's white-eye` keyword row (both exact and COLLATE NOCASE joins
+    are quote-preserving). Folding inside `add_prediction` closes that
+    hole once for every caller."""
+    db, _ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = db.conn.execute(
+            "INSERT INTO detections (photo_id, category, detector_confidence) "
+            "VALUES (?, 'animal', 0.99)",
+            (p1,),
+        ).lastrowid
+        db.conn.commit()
+
+        db.add_prediction(
+            detection_id=det,
+            species="Swinhoe’s White-eye",
+            confidence=0.8,
+            model="m1",
+            labels_fingerprint="fp1",
+        )
+
+        stored = [
+            r["species"] for r in db.conn.execute(
+                "SELECT species FROM predictions"
+            ).fetchall()
+        ]
+        assert stored == ["Swinhoe's White-eye"]
+    finally:
+        db.close()
+
+
+def test_add_prediction_folds_review_row_to_normalized_species(tmp_path):
+    """When add_prediction folds species, the workspace-scoped
+    prediction_review row must land on the *folded* prediction row's id,
+    not on a stray original-spelling row (which would never exist because
+    the fold applies before insert). Verifies the id lookup after fold."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = db.conn.execute(
+            "INSERT INTO detections (photo_id, category, detector_confidence) "
+            "VALUES (?, 'animal', 0.99)",
+            (p1,),
+        ).lastrowid
+        db.conn.commit()
+
+        db.add_prediction(
+            detection_id=det,
+            species="Swinhoe’s White-eye",
+            confidence=0.8,
+            model="m1",
+            status="accepted",
+            labels_fingerprint="fp1",
+        )
+
+        row = db.conn.execute(
+            "SELECT p.id AS pid, p.species, pr.status "
+            "FROM predictions p "
+            "LEFT JOIN prediction_review pr "
+            "  ON pr.prediction_id = p.id AND pr.workspace_id = ? "
+            "WHERE p.detection_id = ?",
+            (ws_id, det),
+        ).fetchone()
+        assert row is not None
+        assert row["species"] == "Swinhoe's White-eye"
+        assert row["status"] == "accepted"
+    finally:
+        db.close()
+
+
 def test_apostrophe_fold_migration_gated_by_its_own_marker(tmp_path):
     """The v1 sweep already ran on live DBs (marker
     `keyword_names_normalized` is set), so the apostrophe fold needs its

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -2493,3 +2493,105 @@ def test_prediction_fold_merge_backfills_pending_group_metadata(tmp_path):
         assert review["individual"] == "ind-1"
     finally:
         db.close()
+
+
+def test_prediction_fold_merges_taxonomy_metadata_from_loser(tmp_path):
+    """When the higher-confidence row happens to be the one written by a
+    raw-classifier path that never filled in `scientific_name` or the
+    taxonomy hierarchy, the migration must backfill those fields from the
+    loser before the CASCADEd DELETE strips them. Otherwise taxonomy
+    filters and review displays that rely on `taxonomy_family` etc. show
+    the surviving prediction as unclassified. `category` also promotes
+    from the schema default `'new'` to the loser's more specific
+    `'match'`, since the two rows describe the same (detection, species)
+    pair and any classifier enrichment belongs to whichever survives."""
+    db, _ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = db.conn.execute(
+            "INSERT INTO detections (photo_id, category, detector_confidence) "
+            "VALUES (?, 'animal', 0.99)",
+            (p1,),
+        ).lastrowid
+        # Winner (higher confidence, clean spelling): no taxonomy fields.
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence, category) "
+            "VALUES (?, 'm1', 'fp1', ?, ?, 'new')",
+            (det, "Say's phoebe", 0.8),
+        )
+        # Loser (curly, lower confidence): full taxonomy.
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence, category, "
+            "scientific_name, taxonomy_kingdom, taxonomy_phylum, "
+            "taxonomy_class, taxonomy_order, taxonomy_family, "
+            "taxonomy_genus) "
+            "VALUES (?, 'm1', 'fp1', ?, ?, 'match', ?, 'Animalia', "
+            "'Chordata', 'Aves', 'Passeriformes', 'Tyrannidae', 'Sayornis')",
+            (det, "Say’s phoebe", 0.4, "Sayornis saya"),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        row = db.conn.execute(
+            "SELECT species, category, scientific_name, taxonomy_kingdom, "
+            "taxonomy_phylum, taxonomy_class, taxonomy_order, "
+            "taxonomy_family, taxonomy_genus, confidence "
+            "FROM predictions"
+        ).fetchone()
+        assert row["species"] == "Say's phoebe"
+        assert row["confidence"] == 0.8
+        assert row["scientific_name"] == "Sayornis saya"
+        assert row["taxonomy_kingdom"] == "Animalia"
+        assert row["taxonomy_phylum"] == "Chordata"
+        assert row["taxonomy_class"] == "Aves"
+        assert row["taxonomy_order"] == "Passeriformes"
+        assert row["taxonomy_family"] == "Tyrannidae"
+        assert row["taxonomy_genus"] == "Sayornis"
+        assert row["category"] == "match"
+    finally:
+        db.close()
+
+
+def test_prediction_fold_metadata_merge_does_not_clobber_winner(tmp_path):
+    """When the winning row already carries taxonomy fields, the merge
+    must not overwrite them with the loser's values. Backfill-only
+    keeps a deliberate override in place on the survivor."""
+    db, _ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = db.conn.execute(
+            "INSERT INTO detections (photo_id, category, detector_confidence) "
+            "VALUES (?, 'animal', 0.99)",
+            (p1,),
+        ).lastrowid
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence, category, "
+            "scientific_name, taxonomy_family) "
+            "VALUES (?, 'm1', 'fp1', ?, ?, 'match', 'Sayornis saya', "
+            "'Tyrannidae')",
+            (det, "Say's phoebe", 0.8),
+        )
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence, category, "
+            "scientific_name, taxonomy_family) "
+            "VALUES (?, 'm1', 'fp1', ?, ?, 'new', 'wrong sci name', "
+            "'WrongFamily')",
+            (det, "Say’s phoebe", 0.4),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        row = db.conn.execute(
+            "SELECT scientific_name, taxonomy_family, category FROM predictions"
+        ).fetchone()
+        assert row["scientific_name"] == "Sayornis saya"
+        assert row["taxonomy_family"] == "Tyrannidae"
+        assert row["category"] == "match"
+    finally:
+        db.close()

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -887,6 +887,174 @@ def test_migration_preserves_okina_names(tmp_path):
         db.close()
 
 
+def test_migration_merges_typographic_apostrophe_keyword_rows(tmp_path):
+    """`Say’s phoebe` (U+2019) and `Say's phoebe` (U+0027) are one bird.
+
+    Both spellings could be stored as separate rows because SQLite's
+    COLLATE NOCASE cannot fold U+2019, which produced two Life List cards
+    with two lifer numbers for the same species. Tags from the variant must
+    migrate onto the ASCII survivor.
+    """
+    db, ws_id, p1, p2 = _make_db(tmp_path)
+    try:
+        ascii_id = _insert_keyword(
+            db, "Say's phoebe", "taxonomy", is_species=1
+        )
+        curly_id = _insert_keyword(
+            db, "Say’s phoebe", "taxonomy", is_species=1
+        )
+        db.conn.execute(
+            "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (p1, ascii_id),
+        )
+        db.conn.execute(
+            "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (p2, curly_id),
+        )
+        db.conn.commit()
+
+        db._normalize_keyword_data_once()
+        db.conn.commit()
+
+        names = [
+            r["name"] for r in db.conn.execute(
+                "SELECT name FROM keywords WHERE name LIKE 'Say%phoebe'"
+            ).fetchall()
+        ]
+        assert names == ["Say's phoebe"], names
+        survivor = db.conn.execute(
+            "SELECT id FROM keywords WHERE name = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        tagged = {
+            r["photo_id"] for r in db.conn.execute(
+                "SELECT photo_id FROM photo_keywords WHERE keyword_id = ?",
+                (survivor,),
+            ).fetchall()
+        }
+        assert tagged == {p1, p2}
+    finally:
+        db.close()
+
+
+def test_migration_preserves_internal_okina_against_apostrophe_fold(tmp_path):
+    """U+02BB inside a name (``Hawaiʻi ʻamakihi``) is a letter, not a
+    quote, and the apostrophe fold must not reach it. The edge-quote strip
+    never touched internal characters, so this is only at risk now that the
+    fold applies mid-string."""
+    db, _ws_id, _p1, _p2 = _make_db(tmp_path)
+    try:
+        kid = _insert_keyword(db, "Hawaiʻi ʻamakihi", "taxonomy", is_species=1)
+        db.conn.commit()
+
+        db._normalize_keyword_data_once()
+        db.conn.commit()
+
+        row = db.conn.execute(
+            "SELECT name FROM keywords WHERE id = ?", (kid,)
+        ).fetchone()
+        assert row["name"] == "Hawaiʻi ʻamakihi"
+    finally:
+        db.close()
+
+
+def _insert_prediction(db, photo_id, species, confidence=0.9, model="m1"):
+    det = db.conn.execute(
+        "INSERT INTO detections (photo_id, category, detector_confidence) "
+        "VALUES (?, 'animal', 0.99)",
+        (photo_id,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence) VALUES (?, ?, 'fp1', ?, ?)",
+        (det, model, species, confidence),
+    )
+    return det
+
+
+def test_migration_folds_prediction_species_apostrophes(tmp_path):
+    """predictions.species is joined to keywords.name with COLLATE NOCASE,
+    which cannot fold U+2019 — so a `Swinhoe’s White-eye` prediction never
+    matched the accepted `Swinhoe's white-eye` keyword and the photo's own
+    prediction rendered as unaccepted."""
+    db, _ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        _insert_prediction(db, p1, "Swinhoe’s White-eye")
+        db.conn.commit()
+
+        assert db._fold_prediction_species_apostrophes() == 1
+        db.conn.commit()
+
+        species = [
+            r["species"] for r in db.conn.execute(
+                "SELECT species FROM predictions"
+            ).fetchall()
+        ]
+        assert species == ["Swinhoe's White-eye"]
+    finally:
+        db.close()
+
+
+def test_prediction_fold_resolves_unique_collision_by_confidence(tmp_path):
+    """predictions has UNIQUE(detection_id, classifier_model,
+    labels_fingerprint, species). When both spellings exist on one
+    detection, folding would violate it — keep the higher-confidence row
+    rather than aborting the whole migration."""
+    db, _ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.4)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.8),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        rows = db.conn.execute(
+            "SELECT species, confidence FROM predictions"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["species"] == "Say's phoebe"
+        assert rows[0]["confidence"] == 0.8
+    finally:
+        db.close()
+
+
+def test_apostrophe_fold_migration_gated_by_its_own_marker(tmp_path):
+    """The v1 sweep already ran on live DBs (marker
+    `keyword_names_normalized` is set), so the apostrophe fold needs its
+    own marker or it would silently never run on the databases that
+    actually have the duplicate rows."""
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    # Simulate a DB that completed the earlier sweeps, then acquired an
+    # apostrophe-variant duplicate before the fold existed.
+    db.set_meta("keyword_names_normalized", "1")
+    db.set_meta("curation_species_case_aligned_v2", "1")
+    db.conn.execute(
+        "DELETE FROM db_meta WHERE key = 'keyword_apostrophes_folded_v1'"
+    )
+    _insert_keyword(db, "Say's phoebe", "taxonomy", is_species=1)
+    _insert_keyword(db, "Say’s phoebe", "taxonomy", is_species=1)
+    db.conn.commit()
+    db.close()
+
+    reopened = Database(db_path)
+    try:
+        names = [
+            r["name"] for r in reopened.conn.execute(
+                "SELECT name FROM keywords WHERE name LIKE 'Say%phoebe'"
+            ).fetchall()
+        ]
+        assert names == ["Say's phoebe"], names
+        assert reopened.get_meta("keyword_apostrophes_folded_v1") == "1"
+    finally:
+        reopened.close()
+
+
 def test_migration_gated_by_db_meta_marker(tmp_path):
     """The backfill runs once per database, gated by the db_meta marker
     (NOT PRAGMA user_version — live DBs have been advanced past the next

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -1503,6 +1503,88 @@ def test_prediction_fold_retargets_edit_history_when_variant_wins_collision(
         db.close()
 
 
+def test_prediction_fold_retargets_relabel_edit_history(tmp_path):
+    """``/api/highlights/relabel`` records edits as ``keyword_add`` or
+    ``species_replace`` (not ``prediction_accept``), stashing the top
+    prediction's id in ``edit_history_items.old_value`` as JSON
+    ``{"prediction_id": N, "prediction_status": ...}`` so undo can restore
+    the pending status via ``_restore_edit_prediction_status``.
+
+    Before the fold retargets these action types too, an undo/redo would
+    call ``update_prediction_status(loser_id, ...)`` on a vanished
+    prediction id, failing the ``prediction_review`` FK to
+    ``predictions`` and aborting the undo/redo."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+
+        payload = json.dumps({
+            "keyword_id": "17",
+            "keyword_ids": [17],
+            "prediction_id": loser_pid,
+            "prediction_status": "pending",
+        }, sort_keys=True)
+
+        # keyword_add relabel
+        ka_edit = db.conn.execute(
+            "INSERT INTO edit_history (workspace_id, action_type, description, "
+            "new_value) VALUES (?, 'keyword_add', 'relabel', '17')",
+            (ws_id,),
+        ).lastrowid
+        ka_item = db.conn.execute(
+            "INSERT INTO edit_history_items (edit_id, photo_id, old_value, "
+            "new_value) VALUES (?, ?, ?, '17')",
+            (ka_edit, p1, payload),
+        ).lastrowid
+
+        # species_replace relabel (photo already had a species tag)
+        sr_edit = db.conn.execute(
+            "INSERT INTO edit_history (workspace_id, action_type, description, "
+            "new_value) VALUES (?, 'species_replace', 'relabel', '17')",
+            (ws_id,),
+        ).lastrowid
+        sr_item = db.conn.execute(
+            "INSERT INTO edit_history_items (edit_id, photo_id, old_value, "
+            "new_value) VALUES (?, ?, ?, '17')",
+            (sr_edit, p1, payload),
+        ).lastrowid
+
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        for item_id, label in ((ka_item, "keyword_add"),
+                               (sr_item, "species_replace")):
+            row = db.conn.execute(
+                "SELECT old_value FROM edit_history_items WHERE id = ?",
+                (item_id,),
+            ).fetchone()
+            data = json.loads(row["old_value"])
+            assert data["prediction_id"] == survivor_pid, (
+                f"{label}.old_value prediction_id was not retargeted to the "
+                f"surviving prediction"
+            )
+            assert data["keyword_id"] == "17", (
+                f"{label}.old_value keyword_id must survive the retarget "
+                "unchanged"
+            )
+    finally:
+        db.close()
+
+
 def test_prediction_fold_only_retargets_prediction_accept_history(tmp_path):
     """Guard against a blanket UPDATE: `keyword_add.new_value` and
     `species_replace.new_value`/`.old_value` store keyword ids in the
@@ -2729,7 +2811,13 @@ def test_prediction_fold_moves_loser_alternative_metadata_when_present(tmp_path)
     still carries burst grouping metadata (an atypical but legal state),
     the merge should preserve that metadata on the winner rather than
     discarding it — the ``continue`` shortcut only applies when the loser
-    row has nothing worth keeping beyond ``status='alternative'``."""
+    row has nothing worth keeping beyond ``status='alternative'``.
+
+    Status is downgraded to ``pending`` on the survivor, though: the
+    winner had no review row of its own (implicit pending), and
+    propagating ``alternative`` would hide the higher-confidence primary
+    from the pending queue even though we're keeping its burst
+    metadata."""
     db, ws_id, p1, _p2 = _make_db(tmp_path)
     try:
         det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
@@ -2764,9 +2852,62 @@ def test_prediction_fold_moves_loser_alternative_metadata_when_present(tmp_path)
             (survivor_pid, ws_id),
         ).fetchone()
         assert review is not None
+        assert review["status"] == "pending", (
+            "surviving pending primary must not inherit the loser's "
+            "'alternative' status even when transferring its burst metadata"
+        )
         assert review["group_id"] == "burst-9"
         assert review["vote_count"] == 4
         assert review["total_votes"] == 5
+    finally:
+        db.close()
+
+
+def test_prediction_fold_drops_sentinel_only_alternative_loser(tmp_path):
+    """A losing ``status='alternative'`` row whose only non-null metadata
+    is ``individual=AUTO_MATCH_REVIEW_MARKER`` carries no user decision
+    and no burst grouping — the sentinel is provenance for auto-accepted
+    taxonomy matches, not metadata worth preserving. Transferring it
+    would flip the higher-confidence pending winner to ``alternative``
+    (and NULL-out the marker on the way) even though nothing survives
+    the scrub except the misleading status."""
+    from db import AUTO_MATCH_REVIEW_MARKER
+
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        db.conn.execute(
+            "INSERT INTO prediction_review "
+            "(prediction_id, workspace_id, status, individual) "
+            "VALUES (?, ?, 'alternative', ?)",
+            (loser_pid, ws_id, AUTO_MATCH_REVIEW_MARKER),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        review = db.conn.execute(
+            "SELECT status FROM prediction_review "
+            "WHERE prediction_id = ? AND workspace_id = ?",
+            (survivor_pid, ws_id),
+        ).fetchone()
+        assert review is None, (
+            "sentinel-only 'alternative' loser was moved onto the "
+            "surviving pending primary, hiding it from the review queue"
+        )
     finally:
         db.close()
 

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -1239,6 +1239,242 @@ def test_prediction_fold_preserves_review_per_workspace_independently(tmp_path):
         db.close()
 
 
+def _insert_prediction_accept_history(db, ws_id, photo_id, old_value,
+                                      new_value="42"):
+    """Insert a `prediction_accept` edit_history + edit_history_items pair
+    directly, mirroring what `record_edit` would write for an accept edit
+    without going through the full API. Returns (edit_id, item_id)."""
+    cur = db.conn.execute(
+        "INSERT INTO edit_history (workspace_id, action_type, description, "
+        "new_value) VALUES (?, 'prediction_accept', 'accept', ?)",
+        (ws_id, new_value),
+    )
+    edit_id = cur.lastrowid
+    cur = db.conn.execute(
+        "INSERT INTO edit_history_items (edit_id, photo_id, old_value, "
+        "new_value) VALUES (?, ?, ?, ?)",
+        (edit_id, photo_id, old_value, new_value),
+    )
+    return edit_id, cur.lastrowid
+
+
+def test_prediction_fold_retargets_bare_edit_history_on_loser_delete(tmp_path):
+    """The compact single-model accept encodes the prediction id as a
+    bare-int string in `edit_history_items.old_value`. When the collision-
+    merge deletes the loser, that id must be rewritten to the surviving
+    prediction id so `_apply_undo` can still restore the status flip."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        _, item_id = _insert_prediction_accept_history(
+            db, ws_id, p1, old_value=str(loser_pid),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        row = db.conn.execute(
+            "SELECT old_value FROM edit_history_items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        assert row["old_value"] == str(survivor_pid), (
+            "loser prediction id in bare-int edit history was not retargeted"
+        )
+    finally:
+        db.close()
+
+
+def test_prediction_fold_retargets_json_prediction_id_on_loser_delete(tmp_path):
+    """`no_tag` accepts serialize `{"prediction_id": N, "no_tag": true}` as
+    the item's old_value. That id must be rewritten too — otherwise the
+    reverse-a-no-op-accept undo path silently loses the reference and the
+    prediction stays flipped."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        payload = json.dumps({"prediction_id": loser_pid, "no_tag": True})
+        _, item_id = _insert_prediction_accept_history(
+            db, ws_id, p1, old_value=payload,
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        row = db.conn.execute(
+            "SELECT old_value FROM edit_history_items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        data = json.loads(row["old_value"])
+        assert data["prediction_id"] == survivor_pid, (
+            "JSON prediction_id was not retargeted to the surviving row"
+        )
+        assert data.get("no_tag") is True, (
+            "unrelated JSON keys must survive the retarget"
+        )
+    finally:
+        db.close()
+
+
+def test_prediction_fold_retargets_prediction_ids_list_entry(tmp_path):
+    """Accept-subject records `{"prediction_ids": [pid_a, pid_b, ...]}`
+    covering agreeing sibling classifier models on one detection. If one
+    sibling is the collision loser, only that entry must be rewritten:
+    the untouched siblings must remain byte-identical so undo/redo still
+    reaches every model's scope."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        sibling_a = 9001
+        sibling_b = 9002
+        payload = json.dumps({
+            "prediction_ids": [sibling_a, loser_pid, sibling_b],
+        })
+        _, item_id = _insert_prediction_accept_history(
+            db, ws_id, p1, old_value=payload,
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        row = db.conn.execute(
+            "SELECT old_value FROM edit_history_items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        data = json.loads(row["old_value"])
+        assert data["prediction_ids"] == [sibling_a, survivor_pid, sibling_b]
+    finally:
+        db.close()
+
+
+def test_prediction_fold_retargets_edit_history_when_variant_wins_collision(
+    tmp_path,
+):
+    """Symmetric case: when the curly variant has higher confidence, the
+    migration deletes the *clean* row. A prediction_accept history item
+    that references the clean row must be retargeted to the variant id
+    (which then gets renamed onto the clean spelling in place)."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.4)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.8),
+        )
+        clean_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        _, item_id = _insert_prediction_accept_history(
+            db, ws_id, p1, old_value=str(clean_pid),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        survivor_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say's phoebe",)
+        ).fetchone()["id"]
+        row = db.conn.execute(
+            "SELECT old_value FROM edit_history_items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        assert row["old_value"] == str(survivor_pid)
+    finally:
+        db.close()
+
+
+def test_prediction_fold_only_retargets_prediction_accept_history(tmp_path):
+    """Guard against a blanket UPDATE: `keyword_add.new_value` and
+    `species_replace.new_value`/`.old_value` store keyword ids in the
+    same columns. A keyword id that numerically happens to equal a
+    deleted-prediction id must not be silently rewritten to the
+    surviving prediction id."""
+    db, ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's phoebe", confidence=0.8)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.4),
+        )
+        loser_pid = db.conn.execute(
+            "SELECT id FROM predictions WHERE species = ?", ("Say’s phoebe",)
+        ).fetchone()["id"]
+        # A `keyword_add` row whose new_value is the numeric string that
+        # matches the loser prediction id. Must survive the fold unchanged.
+        kw_edit = db.conn.execute(
+            "INSERT INTO edit_history (workspace_id, action_type, description, "
+            "new_value) VALUES (?, 'keyword_add', 'add', ?)",
+            (ws_id, str(loser_pid)),
+        ).lastrowid
+        kw_item = db.conn.execute(
+            "INSERT INTO edit_history_items (edit_id, photo_id, old_value, "
+            "new_value) VALUES (?, ?, ?, ?)",
+            (kw_edit, p1, "", str(loser_pid)),
+        ).lastrowid
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        row = db.conn.execute(
+            "SELECT old_value, new_value FROM edit_history_items WHERE id = ?",
+            (kw_item,),
+        ).fetchone()
+        assert row["old_value"] == "", (
+            "keyword_add.old_value was unexpectedly rewritten by the "
+            "prediction-id retarget"
+        )
+        assert row["new_value"] == str(loser_pid), (
+            "keyword_add.new_value carries a keyword id and must not be "
+            "retargeted by the prediction-id path"
+        )
+    finally:
+        db.close()
+
+
 def test_add_prediction_folds_curly_apostrophe_species(tmp_path):
     """`Database.add_prediction` is the shared choke point for the classify
     job's storage helpers (`_store_pending_detection_prediction`,

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -1057,6 +1057,51 @@ def test_prediction_fold_collision_matches_case_insensitively(tmp_path):
         db.close()
 
 
+def test_prediction_fold_merges_three_way_case_and_apostrophe_collision(tmp_path):
+    """A single (detection, model, fingerprint) scope can legally hold three
+    NOCASE-equivalent variants at once (``predictions.species`` is BINARY
+    UNIQUE): ``Say's Phoebe`` (ASCII title-case), ``Say's phoebe`` (ASCII
+    lowercase), ``Say's phoebe`` (curly, lowercase). A per-row ``fetchone``
+    peer lookup would only merge one of the two ASCII neighbours, and if
+    the curly row wins by confidence the subsequent
+    ``UPDATE ... SET species = 'Say's phoebe'`` collides with the unmerged
+    ASCII-lowercase row and aborts the migration under UNIQUE — reopening
+    the DB just fails again. All three must merge in one pass.
+    """
+    db, _ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's Phoebe", confidence=0.5)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say's phoebe", 0.3),
+        )
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.9),
+        )
+        db.conn.commit()
+
+        # No exception: the whole collision set is merged in one pass.
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        rows = db.conn.execute(
+            "SELECT species, confidence FROM predictions"
+        ).fetchall()
+        assert len(rows) == 1
+        # Curly row (0.9) is the highest-confidence winner; it gets folded
+        # to the clean spelling, and neither ASCII peer remains to collide
+        # with the UPDATE.
+        assert rows[0]["species"] == "Say's phoebe"
+        assert rows[0]["confidence"] == 0.9
+    finally:
+        db.close()
+
+
 def test_prediction_fold_preserves_review_when_loser_carries_decision(tmp_path):
     """When the collision-merge deletes the losing prediction, its per-
     workspace prediction_review row must migrate onto the surviving row.

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -1023,6 +1023,40 @@ def test_prediction_fold_resolves_unique_collision_by_confidence(tmp_path):
         db.close()
 
 
+def test_prediction_fold_collision_matches_case_insensitively(tmp_path):
+    """Downstream keyword joins use ``COLLATE NOCASE``, so a DB carrying
+    both `Say's Phoebe` (ASCII, title-case) and `Say’s phoebe` (curly,
+    lowercase) already renders as one bird. The fold must merge them
+    the same way; a case-sensitive collision lookup would rename only
+    the curly row and leave two ASCII case-variants that survive as
+    duplicate predictions on the same (detection, model, fingerprint).
+    """
+    db, _ws_id, p1, _p2 = _make_db(tmp_path)
+    try:
+        det = _insert_prediction(db, p1, "Say's Phoebe", confidence=0.9)
+        db.conn.execute(
+            "INSERT INTO predictions (detection_id, classifier_model, "
+            "labels_fingerprint, species, confidence) "
+            "VALUES (?, 'm1', 'fp1', ?, ?)",
+            (det, "Say’s phoebe", 0.3),
+        )
+        db.conn.commit()
+
+        db._fold_prediction_species_apostrophes()
+        db.conn.commit()
+
+        rows = db.conn.execute(
+            "SELECT species, confidence FROM predictions"
+        ).fetchall()
+        assert len(rows) == 1
+        # Higher-confidence winner keeps its casing; loser's curly variant
+        # is deleted rather than left as a folded duplicate.
+        assert rows[0]["species"] == "Say's Phoebe"
+        assert rows[0]["confidence"] == 0.9
+    finally:
+        db.close()
+
+
 def test_prediction_fold_preserves_review_when_loser_carries_decision(tmp_path):
     """When the collision-merge deletes the losing prediction, its per-
     workspace prediction_review row must migrate onto the surviving row.

--- a/vireo/tests/test_labels.py
+++ b/vireo/tests/test_labels.py
@@ -5,7 +5,12 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from labels import get_active_labels, load_merged_labels, set_active_labels
+from labels import (
+    get_active_labels,
+    load_merged_labels,
+    read_label_file,
+    set_active_labels,
+)
 
 
 def test_get_active_labels_empty(tmp_path, monkeypatch):
@@ -264,6 +269,32 @@ def test_load_merged_labels_falls_back_to_cp1252_for_legacy_windows_files(
 
     result = load_merged_labels([{"labels_file": txt}])
 
+    assert result == ["Köhler’s Vine Snake", "Say's phoebe"], (
+        "legacy cp1252 label file did not round-trip through the fallback: "
+        f"got {result}"
+    )
+
+
+def test_read_label_file_falls_back_to_cp1252_for_legacy_windows_files(
+    tmp_path,
+):
+    """``read_label_file`` is the shared primitive used by every direct
+    label-file reader (``load_merged_labels`` and every ``labels_file``
+    branch in ``app.py``/``classify_job.py``). A legacy Windows install
+    saved label sets in cp1252 before the writer became explicit UTF-8, so
+    reading such a file strictly as UTF-8 raises ``UnicodeDecodeError`` on
+    the first non-ASCII byte -- 0xF6 for ``ö``, 0x92 for the curly right
+    single quote -- and hides the entire label set from classification.
+    The helper's fallback must keep those legacy files loadable through
+    every code path that touches label bytes, not just the merge path.
+    """
+    dir_ = str(tmp_path / "labels")
+    os.makedirs(dir_)
+    txt = os.path.join(dir_, "legacy.txt")
+    with open(txt, "wb") as f:
+        f.write("Köhler’s Vine Snake\nSay's phoebe\n".encode("cp1252"))
+
+    result = read_label_file(txt)
     assert result == ["Köhler’s Vine Snake", "Say's phoebe"], (
         "legacy cp1252 label file did not round-trip through the fallback: "
         f"got {result}"

--- a/vireo/tests/test_labels.py
+++ b/vireo/tests/test_labels.py
@@ -143,3 +143,50 @@ def test_load_merged_labels_skips_missing(tmp_path):
     ]
     result = load_merged_labels(label_sets)
     assert result == ["Jay", "Robin"]
+
+
+def test_load_merged_labels_dedupes_apostrophe_variants(tmp_path):
+    """Two label files that spell the same species with a curly vs plain
+    apostrophe must merge into a single canonical entry — otherwise the
+    classifier can return one as primary and the other as an alternative,
+    and after ``add_prediction`` folds both onto the same UNIQUE row the
+    alternative's INSERT-OR-IGNORE upserts ``prediction_review.status =
+    'alternative'``, hiding the only top-1 prediction from the pending
+    review queue.
+    """
+    dir_ = str(tmp_path / "labels")
+    os.makedirs(dir_)
+
+    txt1 = os.path.join(dir_, "birds_ascii.txt")
+    with open(txt1, "w") as f:
+        f.write("Say's phoebe\nJay\n")
+
+    txt2 = os.path.join(dir_, "birds_curly.txt")
+    with open(txt2, "w", encoding="utf-8") as f:
+        f.write("Say’s phoebe\nRobin\n")
+
+    label_sets = [
+        {"labels_file": txt1, "name": "Birds ASCII"},
+        {"labels_file": txt2, "name": "Birds curly"},
+    ]
+    result = load_merged_labels(label_sets)
+    assert result == ["Jay", "Robin", "Say's phoebe"], (
+        "curly and ASCII apostrophe spellings of the same species must "
+        f"merge to a single canonical entry — got {result}"
+    )
+
+
+def test_load_merged_labels_preserves_okina_letters(tmp_path):
+    """The apostrophe fold in ``normalize_keyword_display`` deliberately
+    excludes the Hawaiian okina (U+02BB, category Lm — a letter, not
+    punctuation). Species names like ``ʻApapane`` and ``Hawaiʻi ʻamakihi``
+    must round-trip through the label loader unchanged."""
+    dir_ = str(tmp_path / "labels")
+    os.makedirs(dir_)
+
+    txt = os.path.join(dir_, "hawaii.txt")
+    with open(txt, "w", encoding="utf-8") as f:
+        f.write("ʻApapane\nHawaiʻi ʻamakihi\n")
+
+    result = load_merged_labels([{"labels_file": txt}])
+    assert result == ["Hawaiʻi ʻamakihi", "ʻApapane"]

--- a/vireo/tests/test_labels.py
+++ b/vireo/tests/test_labels.py
@@ -182,6 +182,73 @@ def test_load_merged_labels_dedupes_apostrophe_variants(tmp_path):
     )
 
 
+def test_load_merged_labels_dedupes_case_only_variants(tmp_path):
+    """Two label files that spell the same species with different case must
+    merge into a single entry — otherwise the classifier's softmax gets fed
+    both prompts as separate classes, splitting probability between
+    near-duplicates. Each result is thresholded independently in
+    ``_build_custom_results``, so a valid prediction can fall below the
+    configured threshold or lose an alternative slot. SQLite's ``COLLATE
+    NOCASE`` and ``add_prediction`` already treat these as one species at
+    the storage layer; label merging must match that semantics.
+    """
+    dir_ = str(tmp_path / "labels")
+    os.makedirs(dir_)
+
+    txt1 = os.path.join(dir_, "birds_titlecase.txt")
+    with open(txt1, "w") as f:
+        f.write("Say's Phoebe\nJay\n")
+
+    txt2 = os.path.join(dir_, "birds_lowercase.txt")
+    with open(txt2, "w") as f:
+        f.write("say's phoebe\nRobin\n")
+
+    label_sets = [
+        {"labels_file": txt1, "name": "Birds Title Case"},
+        {"labels_file": txt2, "name": "Birds lowercase"},
+    ]
+    result = load_merged_labels(label_sets)
+    # Exactly one Say's phoebe survives — either capitalization is
+    # DB-equivalent under COLLATE NOCASE, so the test asserts the count
+    # rather than the specific case.
+    say_variants = [n for n in result if n.lower() == "say's phoebe"]
+    assert len(say_variants) == 1, (
+        "case-only apostrophe variants must merge to a single entry — "
+        f"got {result}"
+    )
+    assert "Jay" in result and "Robin" in result
+
+
+def test_load_merged_labels_dedupes_case_plus_apostrophe_variants(tmp_path):
+    """Case + apostrophe collision (``Say's Phoebe`` ASCII vs ``Say's
+    phoebe`` curly) collapses to a single spelling. The prior fold used
+    ``normalize_keyword_display`` for the group key, which preserved case
+    and left these in separate buckets; the ASCII-NOCASE key matches the
+    downstream storage/consensus/alternative dedupe.
+    """
+    dir_ = str(tmp_path / "labels")
+    os.makedirs(dir_)
+
+    txt = os.path.join(dir_, "birds.txt")
+    with open(txt, "w", encoding="utf-8") as f:
+        f.write("Say's Phoebe\nSay’s phoebe\nJay\n")
+
+    result = load_merged_labels([{"labels_file": txt}])
+    say_variants = [n for n in result if n.lower().replace("’", "'")
+                    == "say's phoebe"]
+    assert len(say_variants) == 1, (
+        "case + apostrophe collision must merge to a single entry — "
+        f"got {result}"
+    )
+    # The survivor should be in add_prediction's storage form (ASCII
+    # apostrophe), so the classifier's label and the persisted species
+    # agree byte-for-byte.
+    assert "’" not in say_variants[0], (
+        "collision survivor should be in the ASCII apostrophe form so it "
+        f"matches what add_prediction stores — got {say_variants[0]!r}"
+    )
+
+
 def test_load_merged_labels_preserves_spelling_without_collision(tmp_path):
     """A curly-apostrophe label with no ASCII twin keeps its source spelling.
 

--- a/vireo/tests/test_labels.py
+++ b/vireo/tests/test_labels.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 import os
 import sys
@@ -206,6 +207,40 @@ def test_load_merged_labels_preserves_spelling_without_collision(tmp_path):
         f"spelling so the fingerprint stays stable — got {result}"
     )
     assert compute_fingerprint(result) == compute_fingerprint(sorted(raw))
+
+
+def test_load_merged_labels_reads_utf8_regardless_of_locale(tmp_path,
+                                                            monkeypatch):
+    """Label files must be read as UTF-8, not the platform default.
+
+    Python picks the locale codepage for text files opened without an
+    explicit ``encoding``, which is cp1252 on Windows. Label files hold
+    non-ASCII species names, so the platform default silently mojibakes
+    ``Hawaiʻi ʻamakihi`` into ``HawaiÊ»i Ê»amakihi`` (U+02BB cannot be
+    represented in cp1252 at all) and can raise on byte sequences cp1252
+    leaves undefined. This reproduced as three Windows-only CI failures.
+    """
+    dir_ = str(tmp_path / "labels")
+    os.makedirs(dir_)
+    txt = os.path.join(dir_, "mixed.txt")
+    with open(txt, "w", encoding="utf-8") as f:
+        f.write("Hawaiʻi ʻamakihi\nKöhler’s Vine Snake\nSkink\n")
+
+    # Simulate a Windows interpreter: default text encoding = cp1252.
+    real_open = builtins.open
+
+    def locale_default_open(*args, **kwargs):
+        mode = args[1] if len(args) > 1 else kwargs.get("mode", "r")
+        if "b" not in str(mode) and "encoding" not in kwargs:
+            kwargs["encoding"] = "cp1252"
+        return real_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", locale_default_open)
+    result = load_merged_labels([{"labels_file": txt}])
+
+    assert result == ["Hawaiʻi ʻamakihi", "Köhler’s Vine Snake", "Skink"], (
+        f"label names were decoded with the locale codepage — got {result}"
+    )
 
 
 def test_load_merged_labels_preserves_okina_letters(tmp_path):

--- a/vireo/tests/test_labels.py
+++ b/vireo/tests/test_labels.py
@@ -176,6 +176,38 @@ def test_load_merged_labels_dedupes_apostrophe_variants(tmp_path):
     )
 
 
+def test_load_merged_labels_preserves_spelling_without_collision(tmp_path):
+    """A curly-apostrophe label with no ASCII twin keeps its source spelling.
+
+    ``compute_fingerprint(labels)`` hashes this exact list and
+    ``classifier_runs`` is keyed on the result, so rewriting a label that
+    has nothing to dedupe against changes the fingerprint of the label set
+    and strands every cached run — re-running inference over the whole
+    catalog for no benefit. Five of the six shipped label sets contain such
+    lone variants (`Bosc’s Fringe-toed lizard`, `Geoffroy’s Tamarin`,
+    `'Anianiau`), which together account for ~70k cached runs.
+    """
+    from labels_fingerprint import compute_fingerprint
+
+    dir_ = str(tmp_path / "labels")
+    os.makedirs(dir_)
+
+    txt = os.path.join(dir_, "reptiles.txt")
+    with open(txt, "w", encoding="utf-8") as f:
+        f.write("Bosc’s Fringe-toed lizard\nGeyr’s Spiny-tailed Lizard\n"
+                "'Anianiau\nSkink\n")
+
+    raw = ["'Anianiau", "Bosc’s Fringe-toed lizard",
+           "Geyr’s Spiny-tailed Lizard", "Skink"]
+    result = load_merged_labels([{"labels_file": txt}])
+
+    assert result == sorted(raw), (
+        "labels with no folded-key collision must keep their source "
+        f"spelling so the fingerprint stays stable — got {result}"
+    )
+    assert compute_fingerprint(result) == compute_fingerprint(sorted(raw))
+
+
 def test_load_merged_labels_preserves_okina_letters(tmp_path):
     """The apostrophe fold in ``normalize_keyword_display`` deliberately
     excludes the Hawaiian okina (U+02BB, category Lm — a letter, not

--- a/vireo/tests/test_labels.py
+++ b/vireo/tests/test_labels.py
@@ -243,6 +243,33 @@ def test_load_merged_labels_reads_utf8_regardless_of_locale(tmp_path,
     )
 
 
+def test_load_merged_labels_falls_back_to_cp1252_for_legacy_windows_files(
+    tmp_path,
+):
+    """Files saved by _atomic_write_text before it took an explicit UTF-8
+    encoding used the locale default -- cp1252 on Windows. Reading those
+    legacy files strictly as UTF-8 raises UnicodeDecodeError on the first
+    non-ASCII species (0x92 for a curly apostrophe, 0xF6 for `ö`), which
+    would silently drop the active set from classification. The reader
+    falls back to cp1252 so those files keep working.
+    """
+    dir_ = str(tmp_path / "labels")
+    os.makedirs(dir_)
+    txt = os.path.join(dir_, "legacy.txt")
+    # Write cp1252 bytes for `Köhler's Vine Snake` (with a curly apostrophe)
+    # and `Say's phoebe` (ASCII apostrophe) -- 0xF6 is `ö` and 0x92 is the
+    # curly right single quote in cp1252, both invalid as standalone UTF-8.
+    with open(txt, "wb") as f:
+        f.write("Köhler’s Vine Snake\nSay's phoebe\n".encode("cp1252"))
+
+    result = load_merged_labels([{"labels_file": txt}])
+
+    assert result == ["Köhler’s Vine Snake", "Say's phoebe"], (
+        "legacy cp1252 label file did not round-trip through the fallback: "
+        f"got {result}"
+    )
+
+
 def test_load_merged_labels_preserves_okina_letters(tmp_path):
     """The apostrophe fold in ``normalize_keyword_display`` deliberately
     excludes the Hawaiian okina (U+02BB, category Lm — a letter, not

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -1441,6 +1441,44 @@ def test_life_list_bucket_survives_root_repair_spelling_drift(tmp_path, monkeypa
     db.close()
 
 
+def test_life_list_merges_apostrophe_variant_species_into_one_entry(life_app):
+    """One bird must get ONE card and ONE lifer number.
+
+    Regression: photos tagged ``Say's phoebe`` (ASCII U+0027) and
+    ``Say’s phoebe`` (curly U+2019) produced two separate Life List
+    cards — ``#47`` with 345 photos and ``#203`` with 27 — even though
+    both keyword rows carried the same ``taxon_id``. The Life List
+    buckets on the canonicalized name, and nothing folded the curly
+    apostrophe, so the two spellings never met.
+    """
+    app, db, ids = life_app
+
+    ascii_kw = db.add_keyword("Say's phoebe", is_species=True)
+    curly_kw = db.add_keyword("Say’s phoebe", is_species=True)
+    # The fold happens at the storage choke point, so both spellings must
+    # land on a single keyword row.
+    assert curly_kw == ascii_kw
+
+    for i, filename in enumerate(("say-ascii.jpg", "say-curly.jpg")):
+        pid = db.add_photo(
+            folder_id=ids["folder"],
+            filename=filename,
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=300.0 + i,
+            timestamp=f"2026-02-0{i + 1}T09:00:00",
+        )
+        db.tag_photo(pid, ascii_kw)
+
+    data = _get_life_list(app)
+    matches = [e for e in data["species"] if "phoebe" in e["species"].lower()]
+    assert len(matches) == 1, (
+        f"expected one phoebe entry, got {[m['species'] for m in matches]}"
+    )
+    assert matches[0]["species"] == "Say's phoebe"
+    assert matches[0]["photo_count"] == 2
+
+
 def test_life_list_alphabetical_key_ignores_apostrophe_variants():
     """Server-side sort key strips the same leading apostrophe variants
     the client's ``lifeListAlphabeticalName`` does, so lifer numbering


### PR DESCRIPTION
## The bug

The Life List showed **two cards for Say's phoebe** — `#47` with 345 photos and `#203` with 27:

`normalize_keyword_display()` strips edge quotes but left an **internal** U+2019 alone, and SQLite's `COLLATE NOCASE` (what `add_keyword` dedupes with) only folds A–Z. So `Say’s phoebe` was a genuinely distinct keyword row from `Say's phoebe` — even though both carried the same `taxon_id`. Nothing in the "standardization process" ever folded them: `merge_duplicate_keywords` groups by `keyword_match_key`, which derives from `normalize_keyword_display` and so preserved the curly form too.

The live catalog had three such pairs (Say's phoebe, Cassin's kingbird, Costa's hummingbird) and **a second, quieter instance of the same bug**: 60 predictions spelled `Swinhoe’s White-eye` while the accepted keyword was `Swinhoe's white-eye`, so the `k.name = pr.species COLLATE NOCASE` joins behind the predicted-species surfaces silently never matched.

## The fix

**1. Fold at the storage choke point** — punctuation-category single quotes (U+2018/2019/201B/2032) → ASCII U+0027 in `normalize_keyword_display`.

Doing this in the *storage* form rather than only in `keyword_match_key` is deliberate. `keyword_match_key`'s docstring documents that it must stay in lockstep with SQLite's `COLLATE NOCASE`; folding only the match key would let the merge pass collapse rows the SQL layer still treats as distinct, so `add_keyword` would immediately re-insert the curly variant and the duplicate would grow back. Normalizing on write keeps both layers agreeing.

Deliberately **excluded**: U+02BB / U+02BC (the Hawaiian okina — Unicode `Lm` *letters*, not punctuation) and U+00B4, so `ʻApapane`, `Hawaiʻi ʻamakihi`, `Liliʻuokalani Gardens`, and `O´Brien` are untouched. This is the first time the normalizer rewrites anything mid-string, so the okina is newly at risk and explicitly tested.

**2. Heal existing data** — re-run the normalization sweep under a new `keyword_apostrophes_folded_v1` marker. The v1 marker is already set on live DBs, so without its own marker the fold would never run on the databases that actually have the duplicates. Also folds `predictions.species`, resolving `UNIQUE(detection_id, classifier_model, labels_fingerprint, species)` collisions by keeping the higher-confidence row instead of aborting the migration.

**3. Stop it recurring** — fold on the prediction write path, since several bundled label files contain curly apostrophes (`Geoffroy’s Tamarin`, `Bosc’s Fringe-toed lizard`) and would re-mint the variant after the migration. Done at the write rather than at label load so `labels_fingerprint` (derived from the raw label file) stays stable and no reclassify is triggered.

## Verification

Ran the migration against a copy of the live DB, then drove the real page in a browser:

- 3 keyword rows merged (849 → 846); `Say's phoebe` 302 → 329 photos
- 231 prediction species rewritten, 0 curly remaining
- All four okina names intact
- Life List renders **a single `#47` card with 372 photos** (345 + 27), with `Harry Griffen Park` from the old `#203` folded into its locations

Of the 231 prediction rewrites, 169 are `'Anianiau` → `Anianiau` (a pre-existing `_EDGE_QUOTES` rule already applied to every keyword row) — the stored keyword is `anianiau`, so this fixes a join that was already failing rather than changing policy.

## Tests

2174 passed, 1 pre-existing failure (`test_api_exiftool_status_reports_missing` — confirmed failing on the unmodified tree).

New coverage: keyword-row merge in both insertion orders, internal-okina preservation at both `add_keyword` and migration level, prediction fold + UNIQUE-collision tie-break, own-marker gating, and a Life-List-level regression asserting one card / one lifer number.

## Note, not fixed here

`_TAXON_LOOKUP_TRANSLATION` (`db.py`) and `Taxonomy._normalize` omit U+02BB from their punctuation-folding tables, so a keyword spelled with an okina can't match a taxa row spelled with an ASCII apostrophe. It happens not to bite today (the taxa rows use U+02BB too), so I left it out to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized keyword/species names with typographic apostrophes (e.g., `’`) to ASCII to prevent duplicates across keywords, predictions, burst consensus, and Life List.
  * Preserved okina (ʻ/ʽ-like) and excluded prime-like symbols so they aren’t incorrectly folded.
  * Improved prediction alternative deduplication and review-state transfer so alternatives don’t overwrite accepted/pending outcomes.
  * Improved label-file handling: UTF-8 first with legacy fallback, and merged labels now dedupe via folded-key logic.
* **Tests**
  * Added/expanded regression coverage for folding, migration gating, collision resolution, review-transfer correctness, consensus grouping, and Life List merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->