### PR TITLE
browse: chunk batch location saves above the 1000-photo cap

### DIFF
--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -1735,3 +1735,44 @@ def test_freetext_location_batches_selection_and_refreshes_smart_collection(
         assert row["name"] == "the meadow"
         expect(page.locator(f".grid-card[data-id='{photo_id}']")).to_have_count(0)
     assert db.count_collection_photos(collection_id) == 0
+
+
+def test_location_applies_to_selection_larger_than_batch_cap(live_server, page):
+    """A selection above the server's 1000-photo cap still gets saved.
+
+    Regression: browse.html posted the whole selection in one
+    /api/batch/location/text request, so selecting ~1.3k photos and typing a
+    location came back 400 "too many photo_ids" (vireo/app.py caps photo_ids
+    at 1000) and applied to *nothing*. location_review.html already chunked;
+    the detail-panel path did not.
+    """
+    db = live_server["db"]
+    folder_id = db.add_folder("/photos/laguna", name="laguna")
+    photo_ids = [
+        db.add_photo(
+            folder_id=folder_id, filename=f"laguna{i}.jpg", extension=".jpg",
+            file_size=1000, file_mtime=1.0, timestamp="2024-05-01T09:00:00",
+        )
+        for i in range(1200)
+    ]
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    # Seed the selection directly rather than clicking 1200 cards: the grid
+    # lazy-loads far fewer than that, and multi-select is covered elsewhere.
+    # What's under test is what the save path does with a big selection.
+    page.evaluate(
+        "(ids) => { selectedPhotos.clear(); ids.forEach(function(id) "
+        "{ selectedPhotos.add(id); }); }",
+        photo_ids,
+    )
+    page.evaluate("() => _submitLocationText('Mount Laguna')")
+
+    tagged = db.conn.execute(
+        "SELECT COUNT(DISTINCT pk.photo_id) AS n FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE k.type = 'location' AND k.name = ?",
+        ("Mount Laguna",),
+    ).fetchone()["n"]
+    assert tagged == len(photo_ids)

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -7164,6 +7164,27 @@ function _locationApplyPhotoIds() {
   return getActiveSelection();
 }
 
+// The batch location endpoints reject more than 1000 photo_ids per request
+// (vireo/app.py), and reject the whole request — so posting a bigger selection
+// in one shot applied the location to *nothing*. Split it. location_review.html
+// chunks against the same cap.
+var LOCATION_BATCH_LIMIT = 1000;
+
+async function _postLocationBatched(endpoint, baseBody, ids) {
+  var last = null;
+  for (var offset = 0; offset < ids.length; offset += LOCATION_BATCH_LIMIT) {
+    var body = Object.assign({}, baseBody, {
+      photo_ids: ids.slice(offset, offset + LOCATION_BATCH_LIMIT),
+    });
+    last = await safeFetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+  return last;
+}
+
 async function _afterLocationMutation(photoIds, detailPhotoId) {
   // Bump the location-mutation epoch so any in-flight reverse-geocode from an
   // earlier maybeShowExifSuggestion(A) bails out of its post-await paint. Every
@@ -7299,16 +7320,14 @@ async function _submitLocationPlace(placeId, placeDetails) {
   var detailPhotoId = window._detailPhotoId || null;
   var body = { place_id: placeId };
   if (placeDetails) body.place = placeDetails;
-  if (useBatch) body.photo_ids = ids;
   try {
-    var endpoint = useBatch
-      ? '/api/batch/location'
-      : '/api/photos/' + ids[0] + '/location';
-    var resp = await safeFetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
+    var resp = useBatch
+      ? await _postLocationBatched('/api/batch/location', body, ids)
+      : await safeFetch('/api/photos/' + ids[0] + '/location', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
     }
@@ -7326,16 +7345,14 @@ async function _submitLocationKeyword(keyword) {
   var useBatch = ids.length > 1;
   var detailPhotoId = window._detailPhotoId || null;
   var body = { keyword_id: keyword.id };
-  if (useBatch) body.photo_ids = ids;
   try {
-    var endpoint = useBatch
-      ? '/api/batch/location'
-      : '/api/photos/' + ids[0] + '/location';
-    var resp = await safeFetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
+    var resp = useBatch
+      ? await _postLocationBatched('/api/batch/location', body, ids)
+      : await safeFetch('/api/photos/' + ids[0] + '/location', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
     }
@@ -7352,17 +7369,13 @@ async function _submitLocationText(name) {
   var useBatch = ids.length > 1;
   var detailPhotoId = window._detailPhotoId || null;
   try {
-    var endpoint = useBatch
-      ? '/api/batch/location/text'
-      : '/api/photos/' + ids[0] + '/location/text';
-    var body = useBatch
-      ? { name: name, photo_ids: ids }
-      : { name: name };
-    var resp = await safeFetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
+    var resp = useBatch
+      ? await _postLocationBatched('/api/batch/location/text', { name: name }, ids)
+      : await safeFetch('/api/photos/' + ids[0] + '/location/text', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: name }),
+        });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
       await _afterLocationMutation(ids, detailPhotoId);
@@ -7583,17 +7596,13 @@ async function acceptExifSuggestion(placeId) {
   var ids = _locationApplyPhotoIds();
   var useBatch = ids.length > 1;
   try {
-    var endpoint = useBatch
-      ? '/api/batch/location'
-      : '/api/photos/' + photoId + '/location';
-    var body = useBatch
-      ? { place_id: placeId, photo_ids: ids }
-      : { place_id: placeId };
-    var resp = await safeFetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
+    var resp = useBatch
+      ? await _postLocationBatched('/api/batch/location', { place_id: placeId }, ids)
+      : await safeFetch('/api/photos/' + photoId + '/location', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ place_id: placeId }),
+        });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
     }


### PR DESCRIPTION
## The bug

Selecting ~1.3k photos in browse and typing a location failed with **"too many photo_ids"** and applied the location to **nothing**.

From `~/.vireo/vireo.log`:

```
2026-07-24 20:24:47 INFO __main__: Action: POST /api/batch/location → 400 (0.0s) (1349 photos)
```

`browse.html` posted the entire selection in a single `/api/batch/location{,/text}` request. `vireo/app.py` caps `photo_ids` at 1000 on those two routes and rejects the *whole* request past that — so the 400 came back in 0.000s, before any writes. Zero photos got the location.

`location_review.html:1293` already chunked against the same cap. The detail-panel path never did.

## The fix

Added `_postLocationBatched(endpoint, baseBody, ids)` in `browse.html`, which splits the selection at 1000 and posts sequentially — mirroring what `location_review.html` already does. Routed all four batch save paths through it:

- `_submitLocationPlace` (Google place pick)
- `_submitLocationKeyword` (existing location keyword)
- `_submitLocationText` (free text — the path that failed here)
- `acceptExifSuggestion` (EXIF Accept button)

No backend change; the cap is left as-is.

I checked the other batch endpoints `browse.html` calls (`/api/batch/flag`, `/api/batch/keyword`, `/api/batch/keyword-remove`, `/api/batch/rating`, `/api/batch/best-batch-flags`) — none of them have an id cap, so location was the only affected surface.

## Tests

New regression test `test_location_applies_to_selection_larger_than_batch_cap` in `tests/e2e/test_location_section.py`: seeds 1200 photos, selects them all, applies a free-text location, asserts all 1200 got the keyword.

Confirmed it fails on the pre-fix tree for the right reason (`POST /api/batch/location/text → 400`) and passes after.

```
tests/e2e/test_location_section.py tests/e2e/test_location_review.py   38 passed

tests/test_workspaces.py vireo/tests/{test_db,test_app,test_photos_api,
test_edits_api,test_jobs_api,test_darktable_api,test_config}.py
   1 failed, 1939 passed, 14 skipped
```

The single failure is `test_api_exiftool_status_reports_missing`, which is pre-existing and environment-dependent — it asserts exiftool is *not* available, and exiftool is installed on this machine. Verified it fails identically on a clean tree with my changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)