### PR TITLE
Show real capture dates in the date-folder format dropdown

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1450,3 +1450,94 @@ def test_import_destination_structure_hides_when_folder_browser_picks_destinatio
 
     expect(page.locator("#destInput")).to_have_value("/new-archive")
     expect(page.locator("#destStructure")).to_be_hidden()
+
+
+def test_import_folder_template_examples_retire_with_their_source(
+    live_server, page,
+):
+    """Removing the source must clear the folder-template examples.
+
+    Each preset is labelled with an example folder name taken from the files
+    being imported. Once those files are gone the example describes nothing —
+    and a label that reads "this is what my folder will be called" must never
+    outlive the data behind it. Removing the last source hides the structure
+    table without re-running the destination preview, so the reset has to live
+    on the shared invalidation path, not in the render.
+    """
+    url = live_server["url"]
+
+    def folder_preview(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"files": [{"path": "/tmp/card-a/IMG_0001.jpg"}]}),
+        )
+
+    def check_duplicates(route):
+        route.fulfill(
+            status=200,
+            content_type="text/event-stream",
+            body="data: " + json.dumps({
+                "done": True, "duplicate_count": 0, "checked": 1, "total": 1,
+            }) + "\n\n",
+        )
+
+    def destination_preview(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "folders": [
+                    {"path": "2026/2026-07-01",
+                     "full_path": "/archive/2026/2026-07-01",
+                     "count": 1, "exists": False},
+                ],
+                "total_photos": 1,
+                "total_folders": 1,
+                "new_folders": 1,
+                "existing_folders": 0,
+                "managed_archive": None,
+                "template_samples": {
+                    "samples": {
+                        "%Y/%Y-%m-%d": "2026/2026-07-01",
+                        "%Y/%m/%d": "2026/07/01",
+                        "%Y/%m": "2026/07",
+                        "%Y": "2026",
+                        "%Y-%m-%d": "2026-07-01",
+                    },
+                    "sample_date": "2026-07-01T09:00:00",
+                    "dated_count": 1,
+                },
+            }),
+        )
+
+    page.route("**/api/import/folder-preview", folder_preview)
+    page.route("**/api/import/check-duplicates", check_duplicates)
+    page.route("**/api/import/destination-preview", destination_preview)
+    page.goto(f"{url}/import")
+
+    preset = page.locator("#folderTemplatePreset")
+    # Ships with no example: nothing is known about the files yet.
+    expect(preset.locator("option[value='%Y/%Y-%m-%d']")).to_have_text(
+        "%Y/%Y-%m-%d")
+
+    page.locator("#modeCopy").check()
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
+    page.locator("#destInput").fill("/archive")
+    page.locator("#btnPreview").click()
+
+    expect(page.locator("#destStructure")).to_be_visible()
+    # The example is a folder this import really creates — the first row.
+    expect(preset.locator("option[value='%Y/%Y-%m-%d']")).to_have_text(
+        "%Y/%Y-%m-%d — 2026/2026-07-01")
+    expect(preset.locator("option[value='%Y-%m-%d']")).to_have_text(
+        "%Y-%m-%d — 2026-07-01")
+
+    # Remove the source the way a user does: the × on the source row.
+    page.locator("#sourceList button").last.click()
+
+    expect(page.locator("#destStructure")).to_be_hidden()
+    expect(preset.locator("option[value='%Y/%Y-%m-%d']")).to_have_text(
+        "%Y/%Y-%m-%d")
+    expect(preset.locator("option[value='%Y-%m-%d']")).to_have_text("%Y-%m-%d")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -21959,10 +21959,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("destination must be an absolute path")
 
         if folder_template:
+            from ingest import folder_template_samples
             try:
-                plan = move_mod.plan_folder_date_moves(
-                    _get_db(), folder_id, destination, folder_template,
-                )
+                plan, capture_dts = \
+                    move_mod.plan_folder_date_moves_with_capture_dates(
+                        _get_db(), folder_id, destination, folder_template,
+                    )
             except ValueError as exc:
                 return json_error(str(exc))
             destinations = [
@@ -21984,6 +21986,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "exists": any(item["exists"] for item in destinations),
                 "file_count": 0,
                 "file_count_truncated": False,
+                # Example folder names for the format dropdown, rendered from
+                # the very capture dates that produced ``destinations`` above.
+                # Same scan, same code path — so the label a user reads as
+                # "my folder will be called this" cannot disagree with the
+                # folder list it sits beside.
+                "template_samples": folder_template_samples(capture_dts),
             })
 
         resolved = resolve_folder_dest(

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -123,6 +123,58 @@ def _sanitize_template(template):
     return template
 
 
+# The date-folder formats offered as one-click presets on the import and move
+# pages. Kept here beside ``build_destination_path`` so the UI's example
+# labels are rendered by the same code that builds the real folders.
+FOLDER_TEMPLATE_PRESETS = (
+    "%Y/%Y-%m-%d",
+    "%Y/%m/%d",
+    "%Y/%m",
+    "%Y",
+    "%Y-%m-%d",
+)
+
+
+def folder_template_samples(timestamps, templates=FOLDER_TEMPLATE_PRESETS):
+    """Render each preset folder template against a real capture time.
+
+    The UI labels each preset with an example folder name, and users read that
+    example as "this is what my folder will be called" — so it has to be a
+    folder the operation will really create, not an illustrative constant.
+    (It was a hardcoded ``2026-07-12`` copied from a test fixture, which sat
+    inches from a resulting-folders panel showing a different date. See
+    CORE_PHILOSOPHY.md, "No black boxes".)
+
+    The earliest capture time wins. Rendered paths sort chronologically for
+    every preset here, so the sample is also the first folder the
+    resulting-folders preview lists.
+
+    Args:
+        timestamps: iterable of datetimes, ``None`` for photos with no
+            usable capture time.
+        templates: strftime formats to render. Defaults to the UI presets.
+
+    Returns:
+        dict with ``samples`` (template -> rendered folder name),
+        ``sample_date`` (ISO string or None), and ``dated_count``. Templates
+        that cannot render safely are omitted from ``samples`` rather than
+        raising — a bad custom preset must not take the whole preview down.
+    """
+    dated = sorted(t for t in timestamps if t is not None)
+    sample_dt = dated[0] if dated else None
+    samples = {}
+    for template in templates:
+        try:
+            samples[template] = build_destination_path(sample_dt, template)
+        except ValueError:
+            continue
+    return {
+        "samples": samples,
+        "sample_date": sample_dt.isoformat() if sample_dt else None,
+        "dated_count": len(dated),
+    }
+
+
 def build_destination_path(exif_timestamp, template="%Y/%Y-%m-%d"):
     """Build relative destination folder path from EXIF timestamp.
 
@@ -224,6 +276,10 @@ def preview_destination(sources, destination, folder_template="%Y/%Y-%m-%d",
         "new_folders": new_count,
         "existing_folders": existing_count,
         "files": file_destinations,
+        # Real example folder names for the template dropdown, resolved from
+        # the very timestamps grouped above so the labels and the folder list
+        # can never disagree.
+        "template_samples": folder_template_samples(timestamps.values()),
     }
 
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1559,27 +1559,37 @@ def _tracked_destination_ancestor(db, folder_id, dest_path):
     return None
 
 
-def plan_folder_date_moves(db, folder_id, destination, folder_template):
-    """Plan a folder's tracked photos into capture-date destinations.
-
-    The date comes from the same catalog capture-time helper used elsewhere;
-    file mtime is the fallback, matching import's folder-planning behavior.
-    Returns a list ordered by rendered relative path so previews and jobs are
-    deterministic. Each item contains ``relative_path``, ``destination``,
-    ``photo_ids``, and ``photo_count``.
+def _photo_capture_datetime(photo):
+    """Resolve one photo's date-folder timestamp: EXIF capture time, else file
+    mtime. Shared by the date-move planner and the UI's example-folder samples
+    so a label can never name a folder the move wouldn't create.
     """
-    if not isinstance(destination, str) or not os.path.isabs(destination):
-        raise ValueError("destination must be an absolute path")
-    if not isinstance(folder_template, str) or not folder_template.strip():
-        raise ValueError("folder_template must be a non-empty string")
-
     try:
         from .capture_time import _capture_datetime
-        from .ingest import build_destination_path
     except ImportError:
         from capture_time import _capture_datetime
-        from ingest import build_destination_path
 
+    capture_dt = _capture_datetime(photo)
+    if capture_dt is None and photo["file_mtime"] is not None:
+        try:
+            capture_dt = datetime.fromtimestamp(float(photo["file_mtime"]))
+        except (OSError, OverflowError, TypeError, ValueError):
+            capture_dt = None
+    return capture_dt
+
+
+def _folder_subtree_photos(db, folder_id):
+    """Tracked photos in a folder and its descendants, ordered by id.
+
+    Only the columns date-folder planning actually reads are selected. A
+    ``p.*`` here is expensive at library scale: ``photos`` carries two DINOv2
+    embedding BLOBs and the full ``exif_data`` JSON, which on a 60k-photo
+    subtree is ~800MB pulled into Python to compute one date per row. The
+    keystroke-debounced move preflight runs this on every destination edit.
+
+    Descendant matching is alias-aware (symlinks, case-folding volumes,
+    Windows separators) — see the inline notes below.
+    """
     folder = db.conn.execute(
         "SELECT path FROM folders WHERE id = ?", (folder_id,)
     ).fetchone()
@@ -1652,8 +1662,8 @@ def plan_folder_date_moves(db, folder_id, destination, folder_template):
         )
         descendant_predicate = "VIREO_DATE_MOVE_DESCENDS(f.path) = 1"
         descendant_params = ()
-    photos = db.conn.execute(
-        f"""SELECT p.*, f.path AS folder_path
+    return db.conn.execute(
+        f"""SELECT p.id, p.exif_data, p.timestamp, p.file_mtime
            FROM photos p
            JOIN folders f ON f.id = p.folder_id
            WHERE f.id = ?
@@ -1662,15 +1672,52 @@ def plan_folder_date_moves(db, folder_id, destination, folder_template):
         (folder_id, *descendant_params),
     ).fetchall()
 
+
+def plan_folder_date_moves(db, folder_id, destination, folder_template):
+    """Plan a folder's tracked photos into capture-date destinations.
+
+    The date comes from the same catalog capture-time helper used elsewhere;
+    file mtime is the fallback, matching import's folder-planning behavior.
+    Returns a list ordered by rendered relative path so previews and jobs are
+    deterministic. Each item contains ``relative_path``, ``destination``,
+    ``photo_ids``, and ``photo_count``.
+    """
+    return plan_folder_date_moves_with_capture_dates(
+        db, folder_id, destination, folder_template)[0]
+
+
+def plan_folder_date_moves_with_capture_dates(
+    db, folder_id, destination, folder_template,
+):
+    """``plan_folder_date_moves`` plus the capture datetimes behind the plan.
+
+    The move page labels each date-format preset with an example folder name,
+    and that example has to be a folder this very plan would create. Handing
+    back the resolved datetimes lets the preflight endpoint render those
+    labels from the same scan that produced the plan — one pass over the
+    subtree, and no way for the label to drift from the folder list beside it.
+
+    Returns ``(plans, capture_datetimes)``; ``capture_datetimes`` holds one
+    entry per tracked photo, ``None`` where no date could be resolved.
+    """
+    if not isinstance(destination, str) or not os.path.isabs(destination):
+        raise ValueError("destination must be an absolute path")
+    if not isinstance(folder_template, str) or not folder_template.strip():
+        raise ValueError("folder_template must be a non-empty string")
+
+    try:
+        from .ingest import build_destination_path
+    except ImportError:
+        from ingest import build_destination_path
+
+    photos = _folder_subtree_photos(db, folder_id)
+
     groups = {}
+    capture_dts = []
     template = folder_template.strip()
     for photo in photos:
-        capture_dt = _capture_datetime(photo)
-        if capture_dt is None and photo["file_mtime"] is not None:
-            try:
-                capture_dt = datetime.fromtimestamp(float(photo["file_mtime"]))
-            except (OSError, OverflowError, TypeError, ValueError):
-                capture_dt = None
+        capture_dt = _photo_capture_datetime(photo)
+        capture_dts.append(capture_dt)
         relative = build_destination_path(capture_dt, template)
         if not relative:
             raise ValueError("folder template produced an empty path")
@@ -1768,7 +1815,7 @@ def plan_folder_date_moves(db, folder_id, destination, folder_template):
             "photo_ids": groups[relative],
             "photo_count": len(groups[relative]),
         })
-    return plans
+    return plans, capture_dts
 
 
 def move_folder_by_date(db, folder_id, destination, folder_template,

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -1875,6 +1875,13 @@ function useStagingAsImportSource(result) {
 
 function hideDestStructure() {
   destStructureSeq += 1;
+  // The folder-template examples describe the same file set as the structure
+  // table, so they retire with it. This is the shared invalidation path —
+  // several callers (removing the last source, a preview that finds no
+  // importable files) hide the table and never reach renderDestStructure(),
+  // and resetting only there would leave the dropdown advertising dates from
+  // a source that is no longer selected.
+  applyFolderTemplateSamples(null);
   const el = document.getElementById('destStructure');
   if (!el) return;
   el.style.display = 'none';
@@ -2117,14 +2124,13 @@ function importPreviewSignatureChanged(signature) {
 // source files that will be skipped as duplicates — excluding them keeps the
 // new/existing folder counts matching the files that actually land.
 async function renderDestStructure(excludePaths) {
+  // hideDestStructure() also drops the previous run's example folder names.
+  // Unlike the move page — where the examples depend only on the selected
+  // folder — an import's examples come from the set of source files that will
+  // actually land, which every re-render can change (sources added or
+  // removed, or more files excluded as duplicates). Bare patterns for a
+  // moment beat an example derived from files that are no longer importing.
   hideDestStructure();
-  // Drop the previous run's example folder names up front. Unlike the move
-  // page — where the examples depend only on the selected folder — an
-  // import's examples come from the set of source files that will actually
-  // land, which every re-render can change (sources added or removed, or
-  // more files excluded as duplicates). Bare patterns for a moment beat an
-  // example derived from files that are no longer being imported.
-  applyFolderTemplateSamples(null);
   const destination = resolvedCopyDestination();
   if (!destination) return null;
   const fileTypes = selectedFileTypes();

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -348,12 +348,17 @@ body { display: flex; flex-direction: column; height: 100vh; }
       </div>
       <div class="row">
         <label for="folderTemplatePreset">Folder template</label>
+        <!-- Bare patterns until applyFolderTemplateSamples() fills in real
+             example folder names from the files being imported. Never
+             hardcode a sample date: users read it as the folder they are
+             about to create, and it has to agree with the resulting-folders
+             table below. -->
         <select id="folderTemplatePreset" class="input-fixed" onchange="updateFolderTemplateControls()">
-          <option value="%Y/%Y-%m-%d" selected>%Y/%Y-%m-%d — 2026/2026-07-12</option>
-          <option value="%Y/%m/%d">%Y/%m/%d — 2026/07/12</option>
-          <option value="%Y/%m">%Y/%m — 2026/07</option>
-          <option value="%Y">%Y — 2026</option>
-          <option value="%Y-%m-%d">%Y-%m-%d — 2026-07-12</option>
+          <option value="%Y/%Y-%m-%d" selected>%Y/%Y-%m-%d</option>
+          <option value="%Y/%m/%d">%Y/%m/%d</option>
+          <option value="%Y/%m">%Y/%m</option>
+          <option value="%Y">%Y</option>
+          <option value="%Y-%m-%d">%Y-%m-%d</option>
           <option value="__custom__">Custom…</option>
         </select>
         <input type="text" id="folderTemplate" value="" placeholder="Enter a strftime format"
@@ -660,6 +665,24 @@ function updateFolderTemplateControls() {
   if (!preset || !custom) return;
   custom.style.display = preset.value === '__custom__' ? '' : 'none';
   if (preset.value === '__custom__') custom.focus();
+}
+
+// Label each folder-template preset with a folder this import would really
+// create. The examples come from the destination preview, rendered by the
+// same build_destination_path() the copy uses against the earliest capture
+// time among the source files — so the label agrees with the resulting-folders
+// table instead of contradicting it. Passing null resets to bare patterns,
+// which is what we show whenever the real dates aren't known yet: a stale or
+// invented example is worse than none.
+function applyFolderTemplateSamples(templateSamples) {
+  const preset = document.getElementById('folderTemplatePreset');
+  if (!preset) return;
+  const samples = (templateSamples && templateSamples.samples) || {};
+  Array.from(preset.options).forEach((option) => {
+    if (option.value === '__custom__') return;
+    const sample = samples[option.value];
+    option.textContent = sample ? option.value + ' — ' + sample : option.value;
+  });
 }
 
 function setFolderTemplate(template) {
@@ -2095,6 +2118,13 @@ function importPreviewSignatureChanged(signature) {
 // new/existing folder counts matching the files that actually land.
 async function renderDestStructure(excludePaths) {
   hideDestStructure();
+  // Drop the previous run's example folder names up front. Unlike the move
+  // page — where the examples depend only on the selected folder — an
+  // import's examples come from the set of source files that will actually
+  // land, which every re-render can change (sources added or removed, or
+  // more files excluded as duplicates). Bare patterns for a moment beat an
+  // example derived from files that are no longer being imported.
+  applyFolderTemplateSamples(null);
   const destination = resolvedCopyDestination();
   if (!destination) return null;
   const fileTypes = selectedFileTypes();
@@ -2130,6 +2160,9 @@ async function renderDestStructure(excludePaths) {
   ) {
     return;
   }
+  // Before the early return below: the dropdown's examples are useful even
+  // when there is no folder table to draw.
+  applyFolderTemplateSamples(data.template_samples);
   const folders = data.folders || [];
   if (!folders.length && !data.managed_archive) return data;
 

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -808,15 +808,21 @@ body { padding-bottom: 48px; }
                   <div class="field-hint">Edit this name to rename the folder as part of the move.</div>
                 </div>
                 <div id="quickDateFolderControls" style="display:none;margin-top:8px;">
+                  <!-- Option labels are bare patterns here and gain a real
+                       example folder name from applyQuickDateSamples() once
+                       the selected folder's capture dates are known. Never
+                       hardcode a sample date: users read it as the folder
+                       they are about to create. -->
                   <select class="move-control" id="quickFolderTemplatePreset" aria-label="Date folder format" onchange="updateQuickFolderTemplateControls()">
-                    <option value="%Y/%Y-%m-%d">%Y/%Y-%m-%d — 2026/2026-07-12</option>
-                    <option value="%Y/%m/%d">%Y/%m/%d — 2026/07/12</option>
-                    <option value="%Y/%m">%Y/%m — 2026/07</option>
-                    <option value="%Y">%Y — 2026</option>
-                    <option value="%Y-%m-%d" selected>%Y-%m-%d — 2026-07-12</option>
+                    <option value="%Y/%Y-%m-%d">%Y/%Y-%m-%d</option>
+                    <option value="%Y/%m/%d">%Y/%m/%d</option>
+                    <option value="%Y/%m">%Y/%m</option>
+                    <option value="%Y">%Y</option>
+                    <option value="%Y-%m-%d" selected>%Y-%m-%d</option>
                     <option value="__custom__">Custom…</option>
                   </select>
                   <input class="move-control" type="text" id="quickFolderTemplate" aria-label="Custom date folder format" placeholder="Enter a strftime format" oninput="updateQuickMoveBtn()" style="display:none;margin-top:8px;">
+                  <div class="field-hint" id="quickDateSampleHint"></div>
                   <div class="field-hint">Photos can land in different folders when their capture dates differ. Photos without a capture date go to <code>unsorted</code>.</div>
                 </div>
                 <div class="field-error" id="quickFolderNameError" role="status"></div>
@@ -1083,6 +1089,9 @@ function onQuickFolderChange() {
   var nameInput = document.getElementById('quickFolderName');
   var resetBtn = document.getElementById('quickResetNameBtn');
   var fid = parseInt(sel.value);
+  // Drop the previous folder's example dates immediately — the next preflight
+  // brings this folder's real ones.
+  applyQuickDateSamples(null);
   if (!fid) {
     info.textContent = '';
     nameInput.value = '';
@@ -1131,6 +1140,39 @@ function selectedQuickFolderTemplate() {
   var preset = document.getElementById('quickFolderTemplatePreset');
   if (preset.value !== '__custom__') return preset.value;
   return (document.getElementById('quickFolderTemplate').value || '').trim();
+}
+
+// Label each date-format preset with a folder this move would really create.
+// The examples ride along on the date preflight response, rendered server-side
+// by the same build_destination_path() that produced the resulting-folders
+// list — one scan, one source of truth, so the label a user reads as "my
+// folder will be called this" cannot disagree with the folder list beside it.
+//
+// Passing null resets the labels to bare patterns — the deliberate state
+// before this folder's real dates are known. An example that is stale or
+// invented is worse than no example: this control shipped a frozen sample
+// date for months that contradicted the panel right below it.
+//
+// The examples depend on the selected source folder and nothing else, so the
+// only thing that invalidates them is changing that folder.
+function applyQuickDateSamples(templateSamples) {
+  var preset = document.getElementById('quickFolderTemplatePreset');
+  var hint = document.getElementById('quickDateSampleHint');
+  var samples = (templateSamples && templateSamples.samples) || {};
+  Array.prototype.forEach.call(preset.options, function(option) {
+    if (option.value === '__custom__') return;
+    var sample = samples[option.value];
+    option.textContent = sample ? option.value + ' — ' + sample : option.value;
+  });
+  if (!hint) return;
+  if (!templateSamples) {
+    hint.textContent = '';
+  } else if (!templateSamples.dated_count) {
+    hint.textContent = 'No photo in this folder has a capture date, so every '
+      + 'example reads unsorted.';
+  } else {
+    hint.textContent = 'Examples use the earliest capture date in this folder.';
+  }
 }
 
 function updateQuickFolderTemplateControls() {
@@ -1496,6 +1538,11 @@ var quickPreflightTimer = null;
 function scheduleQuickDatePreflight(fid, destination, folderTemplate) {
   if (quickPreflightTimer) clearTimeout(quickPreflightTimer);
   var seq = ++quickPreflightSeq;
+  // An unusable destination doesn't invalidate the dropdown's examples: they
+  // are rendered from the source folder's capture dates alone, so editing or
+  // clearing the destination cannot change them. Leave the last real values
+  // in place — onQuickFolderChange() clears them when the folder itself
+  // changes, which is the only input they depend on.
   if (!_isAbsolutePath(destination)) return;
   quickPreflightTimer = setTimeout(async function() {
     var data;
@@ -1518,6 +1565,9 @@ function scheduleQuickDatePreflight(fid, destination, folderTemplate) {
     if (seq !== quickPreflightSeq || !quickUsesDateFolders()) return;
     var folder = allFolders.find(function(item) { return item.id === fid; });
     setQuickDateSummary(folder, data);
+    // Same response that drew the folder list above, so the dropdown's
+    // examples and that list are always the same dates.
+    applyQuickDateSamples(data.template_samples);
     var status = document.getElementById('quickDestStatus');
     if (!status) return;
     if (!data.photo_count) {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -13893,12 +13893,15 @@ def test_import_page_offers_common_and_custom_folder_templates(app_and_db):
     html = client.get("/import").data.decode()
 
     assert 'id="folderTemplatePreset"' in html
-    assert '%Y/%m/%d — 2026/07/12' in html
-    assert '%Y/%Y-%m-%d — 2026/2026-07-12' in html
+    assert '<option value="%Y/%m/%d">%Y/%m/%d</option>' in html
     assert '<option value="__custom__">Custom…</option>' in html
     assert 'id="folderTemplate"' in html
     assert "function selectedFolderTemplate()" in html
     assert "preset.value = commonOption ? template : '__custom__'" in html
+    # No baked-in example date: the labels gain a real example from the
+    # source files once the destination preview runs.
+    assert "2026-07-12" not in html
+    assert "applyFolderTemplateSamples" in html
 
 
 def test_process_page_has_no_import_source(app_and_db):

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -1716,6 +1716,84 @@ def test_preview_destination_groups_by_date(tmp_path):
     assert destinations[str(src / "c.jpg")]["full_folder"] == str(dst / "2026" / "2026-03-26")
 
 
+def test_preview_destination_reports_template_samples_from_real_dates(tmp_path):
+    """The import page labels each folder-template preset with an example.
+
+    That example must come from the files actually being imported — it used
+    to be a hardcoded ``2026-07-12`` copied from a test fixture, which
+    contradicted the resulting-folders list rendered right below it.
+    """
+    from ingest import FOLDER_TEMPLATE_PRESETS
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "nas"
+    src.mkdir()
+    dst.mkdir()
+
+    # Later file first: the earliest capture time must win, so the sample
+    # matches the first folder the preview lists.
+    for name, day in (("late.jpg", 26), ("early.jpg", 25)):
+        Image.new("RGB", (100, 100)).save(str(src / name))
+        mtime = datetime(2026, 3, day, 10, 0, 0).timestamp()
+        os.utime(str(src / name), (mtime, mtime))
+
+    result = preview_destination(
+        sources=[str(src)],
+        destination=str(dst),
+        folder_template="%Y/%Y-%m-%d",
+    )
+
+    samples = result["template_samples"]["samples"]
+    assert set(samples) == set(FOLDER_TEMPLATE_PRESETS)
+    assert samples["%Y/%Y-%m-%d"] == "2026/2026-03-25"
+    assert samples["%Y-%m-%d"] == "2026-03-25"
+    assert samples["%Y/%m"] == "2026/03"
+    assert samples["%Y"] == "2026"
+    # The example names a folder the import really creates, and it is the
+    # first one the preview lists.
+    assert samples["%Y/%Y-%m-%d"] == result["folders"][0]["path"]
+
+
+def test_preview_destination_template_samples_say_unsorted_when_undated(
+    tmp_path, monkeypatch
+):
+    """With no usable capture time the files go to ``unsorted`` — the label
+    says so instead of inventing a date."""
+    import ingest as ingest_module
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "nas"
+    src.mkdir()
+    dst.mkdir()
+    Image.new("RGB", (100, 100)).save(str(src / "a.jpg"))
+
+    monkeypatch.setattr(
+        ingest_module, "_source_file_timestamps",
+        lambda files, capture_times=None: {f: None for f in files},
+    )
+
+    result = preview_destination(
+        sources=[str(src)], destination=str(dst), folder_template="%Y-%m-%d",
+    )
+
+    assert set(result["template_samples"]["samples"].values()) == {"unsorted"}
+    assert result["template_samples"]["dated_count"] == 0
+
+
+def test_folder_template_samples_skips_templates_that_cannot_render(tmp_path):
+    """An unsafe preset never yields a label rather than raising and taking
+    the whole preview down with it."""
+    from ingest import folder_template_samples
+
+    result = folder_template_samples(
+        [datetime(2026, 3, 25, 10, 0, 0)],
+        templates=("%Y-%m-%d", "../%Y"),
+    )
+
+    assert result["samples"] == {"%Y-%m-%d": "2026-03-25"}
+    assert result["sample_date"] == "2026-03-25T10:00:00"
+
+
 def test_preview_destination_uses_metadata_dates_when_lightweight_exif_fails(
     tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -965,6 +965,33 @@ def test_plan_folder_date_moves_uses_unsorted_without_a_usable_time(tmp_path):
     assert plan[0]["relative_path"] == "unsorted"
 
 
+def test_folder_subtree_photos_reads_only_date_columns(tmp_path):
+    """Date planning must not pull whole photo rows.
+
+    ``photos`` carries two DINOv2 embedding BLOBs plus the full ``exif_data``
+    JSON. A ``SELECT p.*`` here dragged ~800MB into Python on a real
+    60k-photo subtree just to resolve one date per row — and the move
+    preflight runs this on every keystroke in the destination field.
+    """
+    from move import _folder_subtree_photos
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    src = tmp_path / "src"
+    src.mkdir()
+    fid = db.add_folder(str(src), name="src")
+    db.add_photo(
+        folder_id=fid, filename="photo.jpg", extension=".jpg",
+        file_size=1, file_mtime=1.0, timestamp="2026-07-12T09:30:00",
+    )
+
+    rows = _folder_subtree_photos(db, fid)
+
+    assert len(rows) == 1
+    assert set(rows[0].keys()) == {"id", "exif_data", "timestamp", "file_mtime"}
+
+
 def test_plan_folder_date_moves_normalizes_dot_components(tmp_path):
     """Rendered dot components never leak into catalog destination paths."""
     from move import plan_folder_date_moves

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -29,9 +29,37 @@ def test_move_page_offers_capture_date_folder_formats(app_and_db):
     assert 'id="quickFolderMode"' in html
     assert "Organize photos by capture date" in html
     assert 'id="quickFolderTemplatePreset"' in html
-    assert "%Y-%m-%d — 2026-07-12" in html
     assert 'id="quickFolderTemplate"' in html
     assert "folder_template: templateResult.value" in html
+
+
+def test_move_page_ships_no_hardcoded_example_folder_date(app_and_db):
+    """The date-format dropdown must not bake a sample date into the page.
+
+    A frozen example — it shipped as a fixture date copied into the template —
+    is read by users as "this is what my folder will be called", and it
+    contradicted the resulting-folders panel a few inches below. The options
+    ship as bare strftime patterns; the real capture date arrives with the
+    preflight response that draws that panel.
+    """
+    import re
+
+    app, _ = app_and_db
+    html = app.test_client().get("/move").data.decode()
+
+    select = re.search(
+        r'<select[^>]*id="quickFolderTemplatePreset".*?</select>',
+        html, re.DOTALL,
+    )
+    assert select, "date-format dropdown missing"
+    labels = re.findall(r"<option[^>]*>(.*?)</option>", select.group(0))
+    assert labels, "dropdown has no options"
+    for label in labels:
+        assert not re.search(r"\d", label), (
+            f"option label {label!r} hardcodes an example date"
+        )
+    assert "%Y-%m-%d" in labels
+    assert "applyQuickDateSamples(data.template_samples)" in html
 
 
 def test_move_page_folder_browser_exposes_volumes_shortcut(app_and_db):
@@ -604,6 +632,115 @@ def test_move_folder_preflight_plans_multiple_capture_date_folders(
     assert data["destination_count"] == 2
     assert [item["relative_path"] for item in data["destinations"]] == [
         "2026-07-12", "2026-07-13",
+    ]
+
+
+def test_move_folder_preflight_samples_match_the_folders_it_reports(
+    app_and_db, tmp_path,
+):
+    """Each preset's example folder name comes from the photos being moved.
+
+    The dropdown label and the resulting-folders list are rendered from one
+    scan, so the label always names a folder this move really creates — the
+    ``%Y-%m-%d`` example is exactly the first row of the list.
+    """
+    app, db = app_and_db
+    src = tmp_path / "dated-source"
+    src.mkdir()
+    fid = db.add_folder(str(src), name="dated-source")
+    # Deliberately out of chronological order: the earliest capture time
+    # must win regardless of insertion order.
+    for index, day in enumerate(("13", "11"), start=1):
+        filename = f"bird-{index}.jpg"
+        (src / filename).write_bytes(b"bird")
+        db.add_photo(
+            folder_id=fid, filename=filename, extension=".jpg",
+            file_size=4, file_mtime=float(index),
+            timestamp=f"2026-07-{day}T10:00:00",
+        )
+
+    resp = app.test_client().post("/api/move-folder/preflight", json={
+        "folder_id": fid,
+        "destination": str(tmp_path / "archive"),
+        "folder_template": "%Y-%m-%d",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    samples = data["template_samples"]["samples"]
+    assert samples == {
+        "%Y/%Y-%m-%d": "2026/2026-07-11",
+        "%Y/%m/%d": "2026/07/11",
+        "%Y/%m": "2026/07",
+        "%Y": "2026",
+        "%Y-%m-%d": "2026-07-11",
+    }
+    assert data["template_samples"]["dated_count"] == 2
+
+    relatives = [item["relative_path"] for item in data["destinations"]]
+    assert relatives == ["2026-07-11", "2026-07-13"]
+    assert samples["%Y-%m-%d"] == relatives[0]
+
+
+def test_move_folder_preflight_samples_say_unsorted_without_capture_dates(
+    app_and_db, tmp_path,
+):
+    """Undated photos land in ``unsorted``, so that is what the label shows —
+    not an invented date."""
+    app, db = app_and_db
+    src = tmp_path / "undated-source"
+    src.mkdir()
+    fid = db.add_folder(str(src), name="undated-source")
+    (src / "unknown.jpg").write_bytes(b"x")
+    db.add_photo(
+        folder_id=fid, filename="unknown.jpg", extension=".jpg",
+        file_size=1, file_mtime=None,
+    )
+
+    resp = app.test_client().post("/api/move-folder/preflight", json={
+        "folder_id": fid,
+        "destination": str(tmp_path / "archive"),
+        "folder_template": "%Y-%m-%d",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data["template_samples"]["samples"].values()) == {"unsorted"}
+    assert data["template_samples"]["dated_count"] == 0
+    assert [item["relative_path"] for item in data["destinations"]] == [
+        "unsorted",
+    ]
+
+
+def test_move_folder_preflight_samples_fall_back_to_file_mtime(
+    app_and_db, tmp_path,
+):
+    """Samples use the same EXIF-then-mtime resolution as the plan itself, so
+    a folder whose photos only have mtimes still gets a truthful example."""
+    from datetime import datetime
+
+    app, db = app_and_db
+    src = tmp_path / "mtime-source"
+    src.mkdir()
+    fid = db.add_folder(str(src), name="mtime-source")
+    (src / "bird.jpg").write_bytes(b"bird")
+    db.add_photo(
+        folder_id=fid, filename="bird.jpg", extension=".jpg",
+        file_size=4,
+        file_mtime=datetime(2026, 3, 25, 9, 0, 0).timestamp(),
+    )
+
+    resp = app.test_client().post("/api/move-folder/preflight", json={
+        "folder_id": fid,
+        "destination": str(tmp_path / "archive"),
+        "folder_template": "%Y-%m-%d",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["template_samples"]["samples"]["%Y-%m-%d"] == "2026-03-25"
+    assert [item["relative_path"] for item in data["destinations"]] == [
+        "2026-03-25",
     ]
 
 


### PR DESCRIPTION
## The bug

The date-format dropdown said `2026-07-12` while the "Resulting folders" panel four inches below said `2026-07-11`.

Neither was a rounding or timezone problem — they were unrelated numbers. `vireo/templates/move.html:816` shipped the sample date as **hardcoded text**:

```html
<option value="%Y-%m-%d" selected>%Y-%m-%d — 2026-07-12</option>
```

Nothing computed it. It traces back to a *test fixture* date (`timestamp="2026-07-12T09:30:00"` in `vireo/tests/test_move.py`) copied into the template when the presets were added (`e18a20bf`, `359bc2a9`), and it would have read `2026-07-12` forever regardless of the photos selected or the current date. Same hardcoded strings on the import page (`import.html:352-356`), pinned by a test asserting the literal label.

The `2026-07-11` was the real one: the preflight walks all 1,366 photos and resolves each EXIF `DateTimeOriginal`.

Users read `%Y-%m-%d — 2026-07-12` as "here's what my folder will be called". That is the cheap-proxy failure `CORE_PHILOSOPHY.md` ("No black boxes") forbids — except cheaper than a proxy, it was a constant.

## The fix

Both pages now render every preset's example from the real capture dates of the photos in play, through the same `build_destination_path()` that builds the actual folders:

- **move**: the date preflight response carries `template_samples` alongside the `destinations` it reports. One scan feeds both, so the label and the folder list *cannot* disagree — the `%Y-%m-%d` example is literally the first row of the panel.
- **import**: `preview_destination()` returns `template_samples` from the very timestamps it grouped, after duplicate exclusions.

Options ship as bare strftime patterns and gain their example once the real dates are known. Undated photos render `unsorted` — where they actually go. No invented or stale date is ever shown; a new hint line says where the example comes from.

Deliberately **not** a separate samples endpoint: the first version was, and driving it showed a 60k-photo subtree taking 4.2s on a keystroke-debounced control while duplicating a scan the preflight does a moment later. Riding on the preflight response costs nothing and makes drift structurally impossible.

## Bonus: 800MB → 4 columns

The date planner selected `SELECT p.*`. `photos` carries two DINOv2 embedding BLOBs plus full `exif_data` JSON — on my real 60k-photo subtree that is **213MB of embeddings + 595MB of EXIF JSON** dragged into Python to read one date per row, on an endpoint that fires on every destination keystroke. Narrowed to the four columns it actually reads.

## Testing

`python -m pytest tests/ vireo/tests/ -q` — 1939 passed, 1 pre-existing failure (`test_api_exiftool_status_reports_missing`, which also fails on clean `main` because exiftool is installed locally).

Plus:
- `tests/e2e/test_move_page.py` — 8 passed
- `tests/e2e/test_import_page.py` — 29 passed

New tests:
- preflight samples match the folders it reports, earliest date wins regardless of insertion order
- samples say `unsorted` when nothing has a capture date
- samples fall back to file mtime like the plan does
- import preview samples come from real source dates, and equal the first folder listed
- unrenderable templates are skipped, not raised
- the date planner reads only date columns (no `p.*`)
- neither page ships an option label containing a digit

**Verified in a browser against the reporting catalog** (isolated instance, copy of the real DB): the same 1,366-photo folder from the report now reads `2026-07-11` in both places.


Probes run while verifying: switching presets (label follows panel granularity), switching source folders (labels clear then refill with the new folder's dates), clearing/relative/nonexistent destinations, custom templates, and date→single→date round trips. One inconsistency surfaced and was fixed: a relative destination wiped the examples while an empty one kept them. Since the examples depend only on the source folder, they now persist across destination edits and clear only when the folder changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
