### PR TITLE
Fix flaky mask-toggle e2e test racing the overlay load event

### DIFF
--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -397,13 +397,17 @@ def test_mask_toggle_off_detaches_loaded_overlay_image(live_server, page):
         _lbApplyMaskVisibility();
         """
     )
+    # `show` is added from the overlay's onload handler, and Chromium exposes
+    # naturalWidth/complete as soon as the bitmap is decoded — one task tick
+    # before it dispatches the load event. Waiting on naturalWidth alone races
+    # that dispatch, so wait for the class the hide assertions depend on.
     page.wait_for_function(
-        "document.getElementById('lightboxMaskOverlay').naturalWidth > 0",
+        """() => {
+            const el = document.getElementById('lightboxMaskOverlay');
+            return el.naturalWidth > 0 && el.classList.contains('show');
+        }""",
         timeout=3000,
     )
-    assert page.locator("#lightboxMaskOverlay").evaluate(
-        "el => el.classList.contains('show')"
-    ), "loaded mask overlay should be visible before hiding"
 
     page.locator("#lightboxToggleMasks").click()
     assert page.evaluate("localStorage.getItem('vireo.lb.masksVisible')") == "0"


### PR DESCRIPTION
## The failure

`tests/e2e/test_lightbox_context_menu.py::test_mask_toggle_off_detaches_loaded_overlay_image` was flaky, not broken — it passes in isolation. Running it in a loop reproduced **4 failures in ~430 runs (~1%)**, always the same assertion:

```
assert page.locator("#lightboxMaskOverlay").evaluate("el => el.classList.contains('show')")
E  AssertionError: loaded mask overlay should be visible before hiding
```

## Root cause

I instrumented the page during a failing run (MutationObserver on the overlay's `class`/`src`, wrappers around `_lbResetMaskOverlay`/`_lbApplyMaskVisibility`/`_lbApplyMaskUrl`, plus a `load` listener). State at the moment of the assert:

```json
{"show": false, "complete": true, "nw": 1, "hasSrc": true, "seq": 2,
 "vis": true, "cur": true, "avail": true, "pending": false,
 "trace": [ _lbApplyMaskVisibility, class-mutation, src-mutation ]}   // no "load" entry
```

The image was fully decoded but **the `load` event had not been dispatched yet**. `_lbMaskLoadSeq` was untouched and `_lbVisualTransitionPending` was false, so none of the async actors (`/api/photos/<id>`, `/api/photos/<id>/masks`, or the `/photos/<id>/full` 500 → `handleInitialImageError`) were involved.

`_navbar.html:6446` adds `show` only from `img.onload`. Chromium exposes `naturalWidth`/`complete` as soon as the bitmap is decoded, one task tick before it queues the load event; Playwright's `wait_for_function` polls on rAF and can land in that window. So the test's wait condition never implied the class it asserted on the next line.

**This is a test-synchronization bug, not a product bug** — no user-visible defect, `show` just lands a tick later. No production code is changed.

## The fix

Wait on the condition the test actually depends on, and drop the now-redundant assert:

```python
page.wait_for_function(
    """() => {
        const el = document.getElementById('lightboxMaskOverlay');
        return el.naturalWidth > 0 && el.classList.contains('show');
    }""",
    timeout=3000,
)
```

If `show` genuinely stopped appearing, this times out — still a real failure signal.

## Test results

- **450 consecutive passes** of the target test with the fix (250 + 200 runs). At the ~1% baseline failure rate, P(0 failures by chance) ≈ 1.5%.
- **Mutation check**: temporarily removing `img.removeAttribute('src')` from `_lbApplyMaskVisibility` (`_navbar.html:6419`) makes the test fail with `AssertionError: hide must detach the loaded mask src` — it still catches the regression it exists for.
- `tests/e2e/test_lightbox_context_menu.py` + `tests/e2e/test_browse_lightbox.py`: **50 passed**.
- Required suite from CLAUDE.md: **1945 passed, 14 skipped, 1 failed**.

### Note on the 1 unrelated failure

`vireo/tests/test_app.py::test_api_exiftool_status_reports_missing` fails with `assert True is False`. I confirmed it fails on stock `main` as well (stashed this change and re-ran) — it patches `metadata.shutil.which` but the endpoint resolves exiftool by another path, so it only passes on machines without exiftool installed. Pre-existing, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by waiting for the lightbox overlay image to finish loading and become visible before verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->