### PR TITLE
website: update download links for v0.30.4

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.30.2';
-const windowsVersion = '0.30.2';
-const linuxVersion = '0.30.2';
+const macosArm64Version = '0.30.4';
+const windowsVersion = '0.30.4';
+const linuxVersion = '0.30.4';
 
 // The Windows 11 public beta ships as the first SignPath-signed build.
 // Until the download link points at that signed build, the older Windows


### PR DESCRIPTION
Automated update of download links following the v0.30.4 release. Auto-merges once required checks pass; deploy-website.yml runs on the resulting push to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated download links and displayed release versions for macOS (Apple Silicon), Windows, and Linux to version 0.30.4.
  * Ensured users are directed to the latest platform-specific releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->