### PR TITLE
NAS setup wizard: guided remote-target creation from a mounted volume

### DIFF
--- a/docs/superpowers/plans/2026-07-26-nas-setup-wizard.md
+++ b/docs/superpowers/plans/2026-07-26-nas-setup-wizard.md
@@ -1,0 +1,549 @@
+# NAS Setup Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A guided Settings-page wizard that takes a user from a Finder-mounted NAS share to a tested, saved remote target — auto-detecting mounts, installing an SSH key, and proving the NAS-side path with a nonce probe — without Terminal or hand-typed absolute paths.
+
+**Architecture:** One new pure-logic module `vireo/remote_setup.py` with an injectable command-runner seam (mirroring `move.py`), four new synchronous `/api/remote-setup/*` endpoints in `app.py`, a wizard modal inline in `settings.html` (project convention: one file per page, inline JS), and a deep-link from the Import page's "Move to NAS unavailable" hint. Spec: `docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md`.
+
+**Tech Stack:** Python 3 / Flask, `pty` + `select` for the password-driven key install, vanilla JS + existing `safeFetch`, pytest with the `app_and_db` fixture (`vireo/tests/conftest.py`).
+
+**One deliberate refinement vs. the spec:** the key install drives plain `ssh` through a pty (running an idempotent `authorized_keys` append snippet) instead of `ssh-copy-id`. Same mechanism, same UX, but it reuses the already-configurable `ssh` binary (`move.resolve_ssh_bin`) — one fewer external tool to locate, and the e2e/stub seam is the binary path itself. The spec is amended alongside this plan.
+
+**Working rules for every task:** TDD (test first, watch it fail, minimal code, watch it pass, commit). Run tests with `python -m pytest <file> -q` from the repo root. All new backend code goes through the injectable runner — no test may spawn a real `ssh`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `vireo/remote_setup.py` | Create | Mount parsing, friendly-name resolution, Vireo key management, pty key install, nonce share-locate, remote dir listing. Pure logic, injectable runner, no Flask imports. |
+| `vireo/tests/test_remote_setup.py` | Create | Unit tests for the module (fake runners, stub pty script). |
+| `vireo/tests/test_remote_setup_api.py` | Create | Endpoint tests via `app_and_db` fixture + monkeypatched `remote_setup`. |
+| `vireo/app.py` | Modify | Five `/api/remote-setup/*` routes + loopback guard (near `api_remote_target_test`, ~line 22134). |
+| `vireo/templates/settings.html` | Modify | "Set up from mounted volume…" button + wizard modal + inline JS (near the remote-targets section, ~line 867, and the editor JS, ~line 1566). |
+| `vireo/templates/import.html` | Modify | Turn the "Move to NAS unavailable…" hint (`updateAfterMoveUI`, ~line 1467) into a link to the wizard. |
+| `tests/e2e/test_nas_setup_wizard.py` | Create | Wizard walk-through with `remote_setup` monkeypatched in the in-process server. |
+
+### Runner seam (used everywhere)
+
+`remote_setup.py` functions take `run=subprocess.run` keyword args (the `move.py` pattern: real subprocess in production, a fake callable in tests returning `subprocess.CompletedProcess`-shaped objects). The pty driver takes `spawn_argv` (list) so tests point it at a stub script instead of real ssh.
+
+---
+
+### Task 1: Mount enumeration — parsing
+
+**Files:**
+- Create: `vireo/remote_setup.py`
+- Create: `vireo/tests/test_remote_setup.py`
+
+- [ ] **Step 1: Write failing tests** for `parse_mount_output(text)` → list of dicts `{fs_type, host, share, mount_point, user}`. Fixtures (real `mount` output shapes):
+
+```python
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import remote_setup
+
+
+SMB = "//julius_admin@100.80.236.59/Photography on /Volumes/Photography (smbfs, nodev, nosuid, mounted by julius)"
+SMB_SPACES = "//guest@My%20NAS._smb._tcp.local/Photo%20Library on /Volumes/Photo Library (smbfs, nodev, nosuid, mounted by julius)"
+NFS = "truenas:/mnt/tank/photos on /Volumes/photos (nfs, nodev, nosuid, mounted by julius)"
+LOCAL = "/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)"
+AUTOFS = "map auto_home on /System/Volumes/Data/home (autofs, automounted, nobrowse)"
+
+
+def test_parse_smbfs_mount():
+    rows = remote_setup.parse_mount_output(SMB + "\n" + LOCAL + "\n" + AUTOFS)
+    assert rows == [{
+        "fs_type": "smbfs", "host": "100.80.236.59",
+        "share": "Photography", "mount_point": "/Volumes/Photography",
+        "user": "julius_admin",
+    }]
+
+
+def test_parse_smbfs_url_encoding_and_spaces():
+    (row,) = remote_setup.parse_mount_output(SMB_SPACES)
+    assert row["share"] == "Photo Library"
+    assert row["host"] == "My NAS._smb._tcp.local"
+    assert row["mount_point"] == "/Volumes/Photo Library"
+    assert row["user"] == "guest"
+
+
+def test_parse_nfs_mount():
+    (row,) = remote_setup.parse_mount_output(NFS)
+    assert row == {"fs_type": "nfs", "host": "truenas",
+                   "share": "photos", "mount_point": "/Volumes/photos",
+                   "user": ""}
+
+
+def test_parse_ignores_non_network_and_garbage():
+    assert remote_setup.parse_mount_output(LOCAL + "\nnot a mount line\n") == []
+```
+
+- [ ] **Step 2: Run** `python -m pytest vireo/tests/test_remote_setup.py -q` — expect FAIL (`ModuleNotFoundError` / `AttributeError`).
+
+- [ ] **Step 3: Implement** in `vireo/remote_setup.py`:
+
+```python
+"""Discovery + one-time setup helpers behind the NAS setup wizard.
+
+Pure logic with an injectable command-runner seam (the ``move.py``
+pattern): production passes nothing and gets ``subprocess``; tests pass
+fakes. Nothing here imports Flask or touches the database.
+"""
+
+import os
+import re
+import subprocess
+import urllib.parse
+
+# `mount` line: "<source> on <mount point> (<fstype>, opt, ...)".
+# The mount point may contain spaces, so anchor on the LAST " on " before
+# a trailing "(...)" group instead of splitting naively.
+_MOUNT_RE = re.compile(r"^(?P<src>.+) on (?P<mp>.+) \((?P<opts>[^()]*)\)$")
+# smbfs/afp source: //[user@]host/share  (URL-encoded)
+_SMB_SRC_RE = re.compile(r"^//(?:(?P<user>[^@/]+)@)?(?P<host>[^/]+)/(?P<share>.+)$")
+# nfs source: host:/export/path
+_NFS_SRC_RE = re.compile(r"^(?P<host>[^:/]+):(?P<path>/.*)$")
+
+_NETWORK_FS = ("smbfs", "nfs", "afpfs", "webdav")
+
+
+def parse_mount_output(text):
+    """Parse ``mount`` output into network-share rows the wizard can offer."""
+    rows = []
+    for line in text.splitlines():
+        m = _MOUNT_RE.match(line.strip())
+        if not m:
+            continue
+        fs_type = (m.group("opts").split(",")[0] or "").strip()
+        if fs_type not in _NETWORK_FS:
+            continue
+        src, mount_point = m.group("src"), m.group("mp")
+        if fs_type == "nfs":
+            n = _NFS_SRC_RE.match(src)
+            if not n:
+                continue
+            rows.append({
+                "fs_type": fs_type, "host": n.group("host"),
+                "share": os.path.basename(n.group("path").rstrip("/")),
+                "mount_point": mount_point, "user": "",
+            })
+            continue
+        s = _SMB_SRC_RE.match(src)
+        if not s:
+            continue
+        unq = urllib.parse.unquote
+        rows.append({
+            "fs_type": fs_type, "host": unq(s.group("host")),
+            "share": unq(s.group("share").rstrip("/")),
+            "mount_point": mount_point, "user": unq(s.group("user") or ""),
+        })
+    return rows
+```
+
+- [ ] **Step 4: Run tests** — expect PASS.
+- [ ] **Step 5: Commit** `feat: mount-output parsing for NAS setup wizard`.
+
+---
+
+### Task 2: Mount enumeration — listing + friendly names
+
+**Files:** same two.
+
+- [ ] **Step 1: Failing tests** for `list_network_mounts(run=...)` (invokes `["mount"]`, parses, attaches `friendly_host`) and `friendly_host_name(host, resolver=...)`:
+
+```python
+class FakeRun:
+    def __init__(self, stdout="", returncode=0):
+        self.calls = []
+        self.stdout, self.returncode = stdout, returncode
+
+    def __call__(self, argv, **kw):
+        self.calls.append(argv)
+        return subprocess.CompletedProcess(argv, self.returncode,
+                                           stdout=self.stdout, stderr="")
+
+
+def test_list_network_mounts_runs_mount_and_resolves():
+    run = FakeRun(stdout=SMB)
+    rows = remote_setup.list_network_mounts(
+        run=run, resolver=lambda ip: "synology-nas.tail1234.ts.net")
+    assert run.calls == [["mount"]]
+    assert rows[0]["friendly_host"] == "synology-nas.tail1234.ts.net"
+    assert rows[0]["display_name"] == "synology-nas"
+
+
+def test_friendly_host_passthrough_for_hostnames_and_failed_reverse():
+    # Non-IP hosts pass through; resolver failures fall back to the raw host.
+    assert remote_setup.friendly_host_name("mynas.local", resolver=None) == "mynas.local"
+    def boom(ip):
+        raise OSError("no PTR")
+    assert remote_setup.friendly_host_name("100.80.236.59", resolver=boom) == "100.80.236.59"
+```
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement.** `friendly_host_name(host, resolver=None)`: if `host` doesn't parse as an IP (`ipaddress.ip_address`), return it. Otherwise call `resolver` (default: `socket.gethostbyaddr` wrapped in a 2-second `concurrent.futures` timeout — reverse DNS can hang) and return the resolved name stripped of a trailing dot, falling back to the IP on any exception. `list_network_mounts(run=subprocess.run, resolver=None)`: `run(["mount"], capture_output=True, text=True, timeout=10)`, parse, and for each row set `friendly_host` and `display_name` (first dot-component of `friendly_host`).
+- [ ] **Step 4: Run — PASS.**  **Step 5: Commit** `feat: network mount listing with reverse-DNS friendly names`.
+
+---
+
+### Task 3: Vireo key management + key-auth probe
+
+**Files:** same two.
+
+- [ ] **Step 1: Failing tests:**
+
+```python
+def test_key_paths_under_vireo_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    priv, pub = remote_setup.vireo_key_paths()
+    assert priv == str(tmp_path / ".vireo" / "ssh" / "vireo_ed25519")
+    assert pub == priv + ".pub"
+
+
+def test_ensure_vireo_key_generates_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    calls = []
+    def fake_run(argv, **kw):
+        calls.append(argv)
+        priv, pub = remote_setup.vireo_key_paths()
+        open(priv, "w").write("KEY")
+        open(pub, "w").write("ssh-ed25519 AAAA vireo")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+    priv, pub = remote_setup.ensure_vireo_key(run=fake_run)
+    assert calls and calls[0][0] == "ssh-keygen"
+    assert "-N" in calls[0] and "-t" in calls[0]
+    assert oct(os.stat(os.path.dirname(priv)).st_mode & 0o777) == "0o700"
+    # Second call: key exists, no regeneration.
+    remote_setup.ensure_vireo_key(run=fake_run)
+    assert len(calls) == 1
+
+
+def test_key_auth_works_builds_batchmode_ssh(tmp_path):
+    run = FakeRun(stdout="vireo_ok\n")
+    ok = remote_setup.key_auth_works(
+        host="nas", user="admin", port=2222, key="/k", ssh_bin="/usr/bin/ssh",
+        run=run)
+    assert ok is True
+    argv = run.calls[0]
+    assert argv[0] == "/usr/bin/ssh"
+    assert ["-o", "BatchMode=yes"] == argv[1:3] or "BatchMode=yes" in argv
+    assert "-p" in argv and "2222" in argv and "-i" in argv and "/k" in argv
+    assert argv[-2:] == ["admin@nas", "echo vireo_ok"]
+```
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement.** `vireo_key_paths()` → `~/.vireo/ssh/vireo_ed25519(.pub)` via `os.path.expanduser`. `ensure_vireo_key(run=subprocess.run, ssh_keygen_bin="ssh-keygen")`: mkdir `~/.vireo/ssh` mode 0700 (and `os.chmod` it — pre-existing dirs), return early if both files exist; else `run([ssh_keygen_bin, "-t", "ed25519", "-N", "", "-f", priv, "-C", "vireo"], ...)`, raise `RuntimeError` on nonzero rc, `os.chmod(priv, 0o600)`. `key_auth_works(...)`: build argv exactly like `move.ssh_base_args` does (BatchMode, accept-new, ConnectTimeout, `-p` when ≠22, `-i` when key given) and return `rc == 0 and "vireo_ok" in stdout`. Import nothing from Flask; reuse `move.py` helpers only if importable without cycles — otherwise keep the 6-line argv builder local with a comment pointing at `move.ssh_base_args`.
+- [ ] **Step 4: Run — PASS.**  **Step 5: Commit** `feat: vireo-managed SSH key generation and key-auth probe`.
+
+---
+
+### Task 4: Password-driven key install (pty)
+
+**Files:** same two, plus a stub script written by the test into `tmp_path`.
+
+The production call runs, through a pty: `ssh <base args, NO BatchMode> user@host "<append snippet>"` where the snippet is
+
+```
+umask 077; mkdir -p ~/.ssh; touch ~/.ssh/authorized_keys; grep -qxF <quoted pubkey line> ~/.ssh/authorized_keys || echo <quoted pubkey line> >> ~/.ssh/authorized_keys
+```
+
+(idempotent; `shlex.quote` the pubkey line once and reuse).
+
+- [ ] **Step 1: Failing tests** using a Python stub as the "ssh" binary:
+
+```python
+STUB = r'''#!/usr/bin/env python3
+import sys
+mode = sys.argv[1]  # test passes: ok | wrongpw | nopw
+if mode == "nopw":
+    sys.stderr.write("admin@nas: Permission denied (publickey).\n")
+    sys.exit(255)
+sys.stderr.write("admin@nas's password: ")
+sys.stderr.flush()
+pw = input()
+if mode == "ok" and pw == "sekret":
+    sys.exit(0)
+sys.stderr.write("Permission denied, please try again.\nadmin@nas's password: ")
+sys.stderr.flush()
+sys.exit(255)
+'''
+
+def _stub(tmp_path, mode):
+    p = tmp_path / "fake_ssh.py"
+    p.write_text(STUB)
+    p.chmod(0o755)
+    return [sys.executable, str(p), mode]
+
+
+def test_install_key_success(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "ok"), password="sekret", timeout=15)
+    assert res == {"ok": True, "error": None}
+
+
+def test_install_key_wrong_password(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "wrongpw"), password="nope", timeout=15)
+    assert res["ok"] is False and res["error"] == "wrong_password"
+
+
+def test_install_key_password_auth_disabled(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "nopw"), password="x", timeout=15)
+    assert res["ok"] is False and res["error"] == "password_auth_disabled"
+
+
+def test_password_never_in_result_or_exception_text(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "wrongpw"), password="hunter2", timeout=15)
+    assert "hunter2" not in repr(res)
+```
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement** `install_key_with_password(spawn_argv, password, timeout=30)`:
+  - `pty.openpty()`; `subprocess.Popen(spawn_argv, stdin=slave, stdout=slave, stderr=slave, start_new_session=True)`; close slave in parent.
+  - Loop: `select.select([master], [], [], deadline-remaining)`; accumulate decoded output (replace errors). On buffer matching `re.search(r"[Pp]assword.*: ?$", tail)`: first prompt → write `password + "\n"`; **second** prompt → wrong password: kill process, return `{"ok": False, "error": "wrong_password"}`.
+  - On EOF/exit: rc 0 → ok. Output containing `Permission denied (publickey` (no password prompt ever shown) → `password_auth_disabled`. Host-key verification text → `host_key`. Anything else → `{"ok": False, "error": "ssh_failed", "detail": <output tail, max ~400 chars>}`.
+  - Timeout → kill, `{"ok": False, "error": "timeout"}`.
+  - Never put the password into logs, exceptions, or the returned dict. `del password` before returning is cosmetic — the real rule is simply never to log it; note this in a comment.
+  - A small pure helper `build_install_argv(host, user, port, key_pub_line, ssh_bin)` assembles the argv (unit-testable without pty): base ssh args **without** BatchMode (password prompts must reach the pty) but **with** `accept-new`, plus the quoted append snippet. Add a direct test asserting BatchMode is absent and the snippet greps before appending.
+- [ ] **Step 4: Run — PASS** (also on a second consecutive run; pty tests can flake if reads race — use the deadline loop, not fixed sleeps).
+- [ ] **Step 5: Commit** `feat: pty-driven authorized_keys install for NAS wizard`.
+
+---
+
+### Task 5: Nonce share-locate + remote dir listing
+
+**Files:** same two.
+
+- [ ] **Step 1: Failing tests:**
+
+```python
+def test_locate_share_writes_nonce_probes_and_cleans_up(tmp_path):
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+    seen = {}
+    def fake_run(argv, **kw):
+        seen["cmd"] = argv[-1]
+        # Server-side: pretend /volume1/Photography contains the nonce.
+        return subprocess.CompletedProcess(argv, 0,
+            stdout="FOUND:/volume1/Photography\n", stderr="")
+    path = remote_setup.locate_share(
+        mount_point=str(mount), share="Photography",
+        host="nas", user="admin", port=22, key="/k", ssh_bin="ssh",
+        run=fake_run)
+    assert path == "/volume1/Photography"
+    assert ".vireo-probe-" in seen["cmd"] and "/volume*/" in seen["cmd"]
+    assert list(mount.iterdir()) == []          # nonce cleaned up
+
+
+def test_locate_share_no_match_returns_none_and_cleans_up(tmp_path):
+    mount = tmp_path / "mnt"; mount.mkdir()
+    fake_run = FakeRun(stdout="")               # no candidate matched
+    assert remote_setup.locate_share(
+        mount_point=str(mount), share="Photography", host="nas",
+        user="admin", port=22, key="/k", ssh_bin="ssh", run=fake_run) is None
+    assert list(mount.iterdir()) == []
+
+
+def test_locate_share_readonly_mount_raises(tmp_path, monkeypatch):
+    mount = tmp_path / "mnt"; mount.mkdir()
+    def deny(*a, **k):
+        raise PermissionError("read-only")
+    monkeypatch.setattr("builtins.open", deny)
+    with pytest.raises(remote_setup.MountNotWritable):
+        remote_setup.locate_share(
+            mount_point=str(mount), share="S", host="h", user="u",
+            port=22, key="", ssh_bin="ssh", run=FakeRun())
+
+
+def test_list_remote_dirs_parses_and_quotes(tmp_path):
+    run = FakeRun(stdout="Raw Files\nExports\n")
+    dirs = remote_setup.list_remote_dirs(
+        path="/volume1/My Photos", host="nas", user="admin", port=22,
+        key="", ssh_bin="ssh", run=run)
+    assert dirs == ["Exports", "Raw Files"]
+    assert "'/volume1/My Photos'" in run.calls[0][-1]
+```
+
+- [ ] **Step 2: Run — FAIL.**
+- [ ] **Step 3: Implement.**
+  - `class MountNotWritable(RuntimeError)`.
+  - `locate_share(...)`: nonce = `".vireo-probe-" + secrets.token_hex(8)`; write it inside `mount_point` (wrap `OSError`/`PermissionError` → `MountNotWritable`); `try/finally` unlink (missing-ok). One ssh command with `S=<shlex.quote(share)>` and candidates `/volume*/"$S" /share/"$S" /shares/"$S" /mnt/*/"$S" /srv/*/"$S"`, `[ -e "$p/<nonce>" ] && { echo "FOUND:$p"; break; }` — parse the `FOUND:` line. `timeout=20` on the run.
+  - `list_remote_dirs(...)`: `find <quoted path> -mindepth 1 -maxdepth 1 -type d -exec basename {} \;` (avoids `ls -p` symlink ambiguity), sorted casefolded; return `[]` on nonzero rc.
+- [ ] **Step 4: Run — PASS.**  **Step 5: Commit** `feat: nonce-verified share location and remote dir listing`.
+
+---
+
+### Task 6: Flask endpoints
+
+**Files:**
+- Modify: `vireo/app.py` (immediately after `api_remote_target_test`, ~line 22168)
+- Create: `vireo/tests/test_remote_setup_api.py`
+
+- [ ] **Step 1: Failing tests** (pattern: `app_and_db` fixture; monkeypatch `remote_setup` functions — endpoints stay thin):
+
+```python
+import os, sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_mounts_endpoint_returns_parsed_mounts(app_and_db, monkeypatch):
+    app, _db = app_and_db
+    import remote_setup
+    monkeypatch.setattr(remote_setup, "list_network_mounts", lambda **kw: [
+        {"fs_type": "smbfs", "host": "1.2.3.4", "friendly_host": "nas.ts.net",
+         "display_name": "nas", "share": "Photos",
+         "mount_point": "/Volumes/Photos", "user": "admin"}])
+    res = app.test_client().get("/api/remote-setup/mounts")
+    assert res.status_code == 200
+    assert res.get_json()["mounts"][0]["share"] == "Photos"
+
+
+def test_ssh_check_reports_port_key_and_auth(app_and_db, monkeypatch):
+    app, _db = app_and_db
+    import remote_setup
+    monkeypatch.setattr(remote_setup, "port_reachable", lambda host, port, timeout=5: True)
+    monkeypatch.setattr(remote_setup, "vireo_key_paths", lambda: ("/k", "/k.pub"))
+    monkeypatch.setattr(os.path, "exists", os.path.exists)  # key_exists computed in endpoint via os.path.exists("/k")
+    monkeypatch.setattr(remote_setup, "key_auth_works", lambda **kw: False)
+    res = app.test_client().post("/api/remote-setup/ssh-check",
+        json={"host": "nas", "port": 22, "user": "admin"})
+    body = res.get_json()
+    assert body["port_open"] is True and body["key_auth_ok"] is False
+
+
+def test_ssh_check_validates_input(app_and_db):
+    app, _db = app_and_db
+    res = app.test_client().post("/api/remote-setup/ssh-check", json={"host": ""})
+    assert res.status_code == 400
+
+
+def test_install_key_rejects_non_loopback(app_and_db):
+    app, _db = app_and_db
+    res = app.test_client().post(
+        "/api/remote-setup/install-key",
+        json={"host": "nas", "user": "a", "port": 22, "password": "x"},
+        environ_overrides={"REMOTE_ADDR": "192.168.1.50"})
+    assert res.status_code == 403
+
+
+def test_install_key_happy_path_never_echoes_password(app_and_db, monkeypatch):
+    app, _db = app_and_db
+    import remote_setup
+    monkeypatch.setattr(remote_setup, "ensure_vireo_key", lambda **kw: ("/k", "/k.pub"))
+    monkeypatch.setattr(remote_setup, "build_install_argv", lambda **kw: ["ssh"])
+    monkeypatch.setattr(remote_setup, "install_key_with_password",
+                        lambda **kw: {"ok": True, "error": None})
+    monkeypatch.setattr(remote_setup, "key_auth_works", lambda **kw: True)
+    monkeypatch.setattr("builtins.open", open)
+    res = app.test_client().post("/api/remote-setup/install-key",
+        json={"host": "nas", "user": "a", "port": 22, "password": "hunter2"})
+    body = res.get_json()
+    assert body["ok"] is True
+    assert "hunter2" not in res.get_data(as_text=True)
+
+
+def test_locate_share_endpoint(app_and_db, monkeypatch, tmp_path):
+    app, _db = app_and_db
+    import remote_setup
+    monkeypatch.setattr(remote_setup, "locate_share",
+                        lambda **kw: "/volume1/Photos")
+    res = app.test_client().post("/api/remote-setup/locate-share",
+        json={"mount_path": str(tmp_path), "share": "Photos",
+              "host": "nas", "user": "a", "port": 22})
+    assert res.get_json()["remote_path"] == "/volume1/Photos"
+
+
+def test_locate_share_readonly_mount_is_clean_error(app_and_db, monkeypatch, tmp_path):
+    app, _db = app_and_db
+    import remote_setup
+    def boom(**kw):
+        raise remote_setup.MountNotWritable("read-only")
+    monkeypatch.setattr(remote_setup, "locate_share", boom)
+    res = app.test_client().post("/api/remote-setup/locate-share",
+        json={"mount_path": str(tmp_path), "share": "P", "host": "n",
+              "user": "a", "port": 22})
+    body = res.get_json()
+    assert res.status_code == 400 and "writable" in body["error"].lower()
+```
+
+- [ ] **Step 2: Run — FAIL** (404s).
+- [ ] **Step 3: Implement the five routes** in `app.py`. Shared shape:
+  - `_remote_setup_loopback_guard()` helper: `request.remote_addr not in ("127.0.0.1", "::1")` → `json_error("remote setup is only available from this machine", 403)`. Applied to **all** `/api/remote-setup/*` routes (cheapest consistent rule; the app binds loopback via waitress anyway — this is defense in depth).
+  - `GET /api/remote-setup/mounts` → `{"mounts": remote_setup.list_network_mounts()}` (platform gate: non-darwin returns `{"mounts": [], "unsupported_platform": True}`).
+  - `POST /api/remote-setup/ssh-check` `{host, port, user}` (validate host/user non-empty, port int 1–65535) → `{"port_open", "key_exists", "key_auth_ok"}`. `port_open` via new `remote_setup.port_reachable(host, port, timeout=5)` (plain `socket.create_connection`; add a unit test in Task 6 too — fake socket via monkeypatch). `key_auth_ok` only probed when the key exists; `ssh_bin` resolved via `move_mod.resolve_ssh_bin(effective_cfg.get("ssh_bin", ""))` exactly like `api_remote_target_test`; `key_auth_ok` is `False` with `"ssh_missing": True` when no ssh binary resolves.
+  - `POST /api/remote-setup/install-key` `{host, port, user, password}` → ensure key, `build_install_argv`, `install_key_with_password`, then verify with `key_auth_works`; response `{"ok", "error", "fingerprint"}` (fingerprint via `ssh-keygen -lf pub`, best-effort). The password variable is request-scoped; never logged (request-timing logs only record the URL — confirm no body logging on this path).
+  - `POST /api/remote-setup/locate-share` `{mount_path, share, host, port, user}` → validate `mount_path` is an absolute existing dir; map `MountNotWritable` → 400 with a "mount is not writable" message; result `{"remote_path": ... or None}`.
+  - `POST /api/remote-setup/list-remote-dirs` `{path, host, port, user}` → `{"dirs": [...]}` for the fallback browser.
+- [ ] **Step 4: Run — PASS.** Also run the neighbors: `python -m pytest vireo/tests/test_app.py -q` (no route collisions).
+- [ ] **Step 5: Commit** `feat: /api/remote-setup endpoints for the NAS wizard`.
+
+---
+
+### Task 7: Settings wizard UI
+
+**Files:**
+- Modify: `vireo/templates/settings.html`
+
+No unit tests (vanilla JS in template, covered by Task 9 e2e). Structure — follow the page's existing inline-style idiom:
+
+- [ ] **Step 1: Button.** Next to `+ Add remote target` (~line 874): `Set up from mounted volume…` (primary accent styling), `onclick="openNasWizard()"`.
+- [ ] **Step 2: Modal skeleton** appended near the page's other overlays: `#nasWizard` fixed overlay, one step container per spec step (`data-step="volume|ssh|share|archive|review"`), Back/Next footer, close ×. Step state machine in JS: `_nwState = {step, mounts, mount, host, port, user, keyExists, keyAuthOk, remotePath, archiveRoot, name}`.
+- [ ] **Step 3: Step logic**, one function per step:
+  - `nwLoadMounts()` → `GET /api/remote-setup/mounts`; zero mounts → guidance ("connect in Finder ⌘K") + Refresh; one → preselect and advance enabled.
+  - `nwSshStep()` → editable user/host/port prefilled from mount (`friendly_host` preferred, IP shown as hint); on entry call `ssh-check`; port closed → Synology-aware help text (detect via `display_name`/`share` heuristic `/synology|diskstation/i`, generic otherwise) + Retry. `key_auth_ok` already true → skip password UI, auto-advance ("This Mac is already authorized ✓"). Password form posts `install-key`; map `error` codes to messages (`wrong_password` → retry with field cleared; `password_auth_disabled` → point at the Terminal expander; `timeout`/`ssh_failed` → show detail). Terminal expander shows the equivalent one-liner (built client-side from state: `ssh user@host` + append snippet with the actual pubkey — fetch the pubkey line from the install-key response's new `pub_key_line` field, added in Task 6's endpoint; include it there) and a **Verify** button that re-runs `ssh-check` until `key_auth_ok`.
+  - `nwShareStep()` → auto-runs `locate-share`; found → green "Verified: /volume1/Photography" + Next; not found → fallback mini-browser (`list-remote-dirs`, drill-down list starting at `/`, plus a manual text input); read-only-mount 400 → its own error text.
+  - `nwArchiveStep()` → folder picker on `/api/browse` + `/api/browse/mkdir` (compact list: current path, subdirs, "New folder" inline input), default suggestion `<home>/Pictures/Vireo Archive` (home = the `path` returned by parameterless `/api/browse`); "create it" action; free-space line (add `free_bytes` of the containing volume to the archive step via a tiny `GET /api/remote-setup/disk-free?path=` — **no**: YAGNI, reuse client-side `navigator` is impossible; instead extend `locate-share`? Simplest honest option: add `free_gb` to the `/api/browse` response? Don't touch a shared endpoint for this — **drop the free-space readout to a follow-up if it needs new surface area**; the spec lists it, so implement it as `GET /api/remote-setup/disk-free` returning `shutil.disk_usage(path).free` — 5 lines + 1 test in Task 6's file). Validation mirror: absolute, not inside mount (client-side check copying `collectRemoteTargets`' spirit; server re-validates on save anyway).
+  - `nwReviewStep()` → assembled card (name defaulted from `display_name` or share; `bwlimit_kbps: 0`; `ssh_key`: the wizard key path); auto-POST `/api/remote-targets/test` with the assembled target; per-check lines from its response (`ssh`, `remote_path_writable`, `rsync_ok`, `remote_rsync_ok`, mount presence); failures link back ("Fix connection" → step 2, "Fix path" → step 3). Save = push into `_remoteTargetsState` + `renderRemoteTargets()` + `saveConfig()` (the existing config-save path), close, scroll to the new card.
+- [ ] **Step 4: Deep link.** On settings page load: `location.hash === "#nas-setup"` → `openNasWizard()`.
+- [ ] **Step 5: Manual smoke** (see Task 10) then **commit** `feat: NAS setup wizard modal on the settings page`.
+
+---
+
+### Task 8: Import-page entry point
+
+**Files:**
+- Modify: `vireo/templates/import.html` (`updateAfterMoveUI`, ~line 1461–1471)
+
+- [ ] **Step 1:** Where `afterMoveUnavailable` text is set, append a link: `Set up remote target…` → `href="/settings#nas-setup"` (build via DOM nodes, matching how `remotePreviewWarn` builds elements — the hint currently uses `textContent`; switch this one message to element children, keeping the text copy identical plus the trailing link).
+- [ ] **Step 2:** Run the import-page e2e neighbors that assert on this hint if any exist: `grep -rn "not inside any remote target" tests/e2e/` first; update matching assertions.
+- [ ] **Step 3: Commit** `feat: link the unavailable-NAS-move hint to the setup wizard`.
+
+---
+
+### Task 9: Wizard e2e
+
+**Files:**
+- Create: `tests/e2e/test_nas_setup_wizard.py`
+
+The e2e server runs in-process (`tests/e2e/conftest.py` uses `make_server`), so monkeypatch `remote_setup` module functions in the fixture — no real ssh anywhere.
+
+- [ ] **Step 1:** Fixture: patch `list_network_mounts` (one smbfs row), `port_reachable` (True), `ensure_vireo_key`/`build_install_argv`/`install_key_with_password` (success)/`key_auth_works` (False until install called, True after — a tiny stateful fake), `locate_share` ("/volume1/Photography"), and `move.test_remote_connection` (all-green dict). Follow the existing e2e patching idiom in that conftest.
+- [ ] **Step 2:** Test A — happy path: open `/settings`, click "Set up from mounted volume…", walk all five steps (select mount → password `sekret` → verified share → pick archive root via the picker into a tmp dir → review shows green → Save), assert the new target card renders in the remote-targets list and `GET /api/config` now contains the target with `ssh_key` = wizard key path and `bwlimit_kbps` 0.
+- [ ] **Step 3:** Test B — Terminal fallback branch: stateful fake starts with `install_key_with_password` unused; expand the fallback, flip the fake's auth state, click Verify, assert the wizard advances without ever calling `install_key_with_password`.
+- [ ] **Step 4:** Run `python -m pytest tests/e2e/test_nas_setup_wizard.py -v` — PASS. **Commit** `test: e2e coverage for the NAS setup wizard`.
+
+---
+
+### Task 10: Full suite, manual verify, PR
+
+- [ ] **Step 1:** Required suite (CLAUDE.md): `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_remote_setup.py vireo/tests/test_remote_setup_api.py -q` — all green.
+- [ ] **Step 2:** Manual verify against the real app (`python vireo/app.py --db ~/.vireo/vireo.db --port 8080`): walk the wizard against the real mounted share `/Volumes/Photography` (this machine has the real thing — the ultimate fixture). Confirm: mount detected with friendly name `synology-nas`, ssh-check reports port open, key install path exercised (key already authorized → skip branch), nonce probe returns the real `/volume1/...` path, target saves and Test connection is green.
+- [ ] **Step 3:** `gh pr create --base main` with summary, spec/plan links, and test results per CLAUDE.md.
+
+---
+
+## Out of scope (per spec)
+
+Windows/Linux mount enumeration and key install; multi-key/passphrase/ssh-agent; wizard-based editing of saved targets; NAS-brand APIs.

--- a/docs/superpowers/plans/2026-07-26-nas-setup-wizard.md
+++ b/docs/superpowers/plans/2026-07-26-nas-setup-wizard.md
@@ -4,7 +4,7 @@
 
 **Goal:** A guided Settings-page wizard that takes a user from a Finder-mounted NAS share to a tested, saved remote target — auto-detecting mounts, installing an SSH key, and proving the NAS-side path with a nonce probe — without Terminal or hand-typed absolute paths.
 
-**Architecture:** One new pure-logic module `vireo/remote_setup.py` with an injectable command-runner seam (mirroring `move.py`), four new synchronous `/api/remote-setup/*` endpoints in `app.py`, a wizard modal inline in `settings.html` (project convention: one file per page, inline JS), and a deep-link from the Import page's "Move to NAS unavailable" hint. Spec: `docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md`.
+**Architecture:** One new pure-logic module `vireo/remote_setup.py` with an injectable command-runner seam (mirroring `move.py`), six new synchronous `/api/remote-setup/*` endpoints in `app.py`, a wizard modal inline in `settings.html` (project convention: one file per page, inline JS), and a deep-link from the Import page's "Move to NAS unavailable" hint. Spec: `docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md`.
 
 **Tech Stack:** Python 3 / Flask, `pty` + `select` for the password-driven key install, vanilla JS + existing `safeFetch`, pytest with the `app_and_db` fixture (`vireo/tests/conftest.py`).
 
@@ -371,11 +371,9 @@ def test_locate_share_no_match_returns_none_and_cleans_up(tmp_path):
     assert list(mount.iterdir()) == []
 
 
-def test_locate_share_readonly_mount_raises(tmp_path, monkeypatch):
+def test_locate_share_readonly_mount_raises(tmp_path):
     mount = tmp_path / "mnt"; mount.mkdir()
-    def deny(*a, **k):
-        raise PermissionError("read-only")
-    monkeypatch.setattr("builtins.open", deny)
+    mount.chmod(0o500)          # no write bit — nonce write must fail cleanly
     with pytest.raises(remote_setup.MountNotWritable):
         remote_setup.locate_share(
             mount_point=str(mount), share="S", host="h", user="u",
@@ -552,7 +550,7 @@ No unit tests (vanilla JS in template, covered by Task 9 e2e). Structure — fol
 
 The e2e server runs in-process (`tests/e2e/conftest.py` uses `make_server`), so monkeypatch `remote_setup` module functions in the fixture — no real ssh anywhere.
 
-- [ ] **Step 1:** Fixture: patch `list_network_mounts` (one smbfs row), `port_reachable` (True), `ensure_vireo_key`/`build_install_argv`/`install_key_with_password` (success)/`key_auth_works` (False until install called, True after — a tiny stateful fake), `locate_share` ("/volume1/Photography"), and `move.test_remote_connection` (all-green dict). Follow the existing e2e patching idiom in that conftest.
+- [ ] **Step 1:** Fixture: patch `list_network_mounts` (one smbfs row), `port_reachable` (True), `ensure_vireo_key` (must return a path to a **real** pub file on disk in the test home — the ssh-check route reads it for `pub_key_line`), `build_install_argv`/`install_key_with_password` (success)/`key_auth_works` (False until install called, True after — a tiny stateful fake), `locate_share` ("/volume1/Photography"), and `move.test_remote_connection` (all-green dict). Follow the existing e2e patching idiom in that conftest.
 - [ ] **Step 2:** Test A — happy path: open `/settings`, click "Set up from mounted volume…", walk all five steps (select mount → password `sekret` → verified share → pick archive root via the picker into a tmp dir → review shows green → Save), assert the new target card renders in the remote-targets list and `GET /api/config` now contains the target with `ssh_key` = wizard key path and `bwlimit_kbps` 0.
 - [ ] **Step 3:** Test B — Terminal fallback branch: stateful fake starts with `install_key_with_password` unused; expand the fallback, flip the fake's auth state, click Verify, assert the wizard advances without ever calling `install_key_with_password`.
 - [ ] **Step 4:** Run `python -m pytest tests/e2e/test_nas_setup_wizard.py -v` — PASS. **Commit** `test: e2e coverage for the NAS setup wizard`.

--- a/docs/superpowers/plans/2026-07-26-nas-setup-wizard.md
+++ b/docs/superpowers/plans/2026-07-26-nas-setup-wizard.md
@@ -21,7 +21,7 @@
 | `vireo/remote_setup.py` | Create | Mount parsing, friendly-name resolution, Vireo key management, pty key install, nonce share-locate, remote dir listing. Pure logic, injectable runner, no Flask imports. |
 | `vireo/tests/test_remote_setup.py` | Create | Unit tests for the module (fake runners, stub pty script). |
 | `vireo/tests/test_remote_setup_api.py` | Create | Endpoint tests via `app_and_db` fixture + monkeypatched `remote_setup`. |
-| `vireo/app.py` | Modify | Five `/api/remote-setup/*` routes + loopback guard (near `api_remote_target_test`, ~line 22134). |
+| `vireo/app.py` | Modify | Six `/api/remote-setup/*` routes + loopback guard (near `api_remote_target_test`, ~line 22134). |
 | `vireo/templates/settings.html` | Modify | "Set up from mounted volume…" button + wizard modal + inline JS (near the remote-targets section, ~line 867, and the editor JS, ~line 1566). |
 | `vireo/templates/import.html` | Modify | Turn the "Move to NAS unavailable…" hint (`updateAfterMoveUI`, ~line 1467) into a link to the wizard. |
 | `tests/e2e/test_nas_setup_wizard.py` | Create | Wizard walk-through with `remote_setup` monkeypatched in the in-process server. |
@@ -84,6 +84,14 @@ def test_parse_nfs_mount():
 
 def test_parse_ignores_non_network_and_garbage():
     assert remote_setup.parse_mount_output(LOCAL + "\nnot a mount line\n") == []
+
+
+def test_parse_afpfs_and_ipv6_hosts():
+    afp = "//julius@mynas._afpovertcp._tcp.local/Media on /Volumes/Media (afpfs, nodev, nosuid, mounted by julius)"
+    v6 = "//admin@[fe80::1%25en0]/Backup on /Volumes/Backup (smbfs, nodev, nosuid, mounted by julius)"
+    rows = remote_setup.parse_mount_output(afp + "\n" + v6)
+    assert rows[0]["fs_type"] == "afpfs" and rows[0]["share"] == "Media"
+    assert rows[1]["host"] == "[fe80::1%en0]" and rows[1]["share"] == "Backup"
 ```
 
 - [ ] **Step 2: Run** `python -m pytest vireo/tests/test_remote_setup.py -q` — expect FAIL (`ModuleNotFoundError` / `AttributeError`).
@@ -262,9 +270,12 @@ umask 077; mkdir -p ~/.ssh; touch ~/.ssh/authorized_keys; grep -qxF <quoted pubk
 ```python
 STUB = r'''#!/usr/bin/env python3
 import sys
-mode = sys.argv[1]  # test passes: ok | wrongpw | nopw
+mode = sys.argv[1]  # test passes: ok | wrongpw | nopw | hostkey
 if mode == "nopw":
     sys.stderr.write("admin@nas: Permission denied (publickey).\n")
+    sys.exit(255)
+if mode == "hostkey":
+    sys.stderr.write("Host key verification failed.\n")
     sys.exit(255)
 sys.stderr.write("admin@nas's password: ")
 sys.stderr.flush()
@@ -295,6 +306,12 @@ def test_install_key_wrong_password(tmp_path):
     assert res["ok"] is False and res["error"] == "wrong_password"
 
 
+def test_install_key_host_key_rejected(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "hostkey"), password="x", timeout=15)
+    assert res["ok"] is False and res["error"] == "host_key"
+
+
 def test_install_key_password_auth_disabled(tmp_path):
     res = remote_setup.install_key_with_password(
         spawn_argv=_stub(tmp_path, "nopw"), password="x", timeout=15)
@@ -310,8 +327,8 @@ def test_password_never_in_result_or_exception_text(tmp_path):
 - [ ] **Step 2: Run — FAIL.**
 - [ ] **Step 3: Implement** `install_key_with_password(spawn_argv, password, timeout=30)`:
   - `pty.openpty()`; `subprocess.Popen(spawn_argv, stdin=slave, stdout=slave, stderr=slave, start_new_session=True)`; close slave in parent.
-  - Loop: `select.select([master], [], [], deadline-remaining)`; accumulate decoded output (replace errors). On buffer matching `re.search(r"[Pp]assword.*: ?$", tail)`: first prompt → write `password + "\n"`; **second** prompt → wrong password: kill process, return `{"ok": False, "error": "wrong_password"}`.
-  - On EOF/exit: rc 0 → ok. Output containing `Permission denied (publickey` (no password prompt ever shown) → `password_auth_disabled`. Host-key verification text → `host_key`. Anything else → `{"ok": False, "error": "ssh_failed", "detail": <output tail, max ~400 chars>}`.
+  - Loop: `select.select([master], [], [], deadline-remaining)`; accumulate decoded output (replace errors). Count password prompts (`re.findall(r"[Pp]assword[^\n]*:", output)`): on the first prompt → write `password + "\n"`; a second prompt at any point (live read OR post-EOF accumulated output) → wrong password: kill process if alive, return `{"ok": False, "error": "wrong_password"}`.
+  - On EOF/exit: rc 0 → ok. Classify from the **accumulated output**, not just the live reads (the stub prints its second prompt and exits immediately, so prompt+EOF can arrive in one read): ≥2 password prompts observed → `wrong_password`; `Permission denied (publickey` with no password prompt ever shown → `password_auth_disabled`; `Host key verification failed` → `host_key`; anything else → `{"ok": False, "error": "ssh_failed", "detail": <output tail, max ~400 chars>}`.
   - Timeout → kill, `{"ok": False, "error": "timeout"}`.
   - Never put the password into logs, exceptions, or the returned dict. `del password` before returning is cosmetic — the real rule is simply never to log it; note this in a comment.
   - A small pure helper `build_install_argv(host, user, port, key_pub_line, ssh_bin)` assembles the argv (unit-testable without pty): base ssh args **without** BatchMode (password prompts must reach the pty) but **with** `accept-new`, plus the quoted append snippet. Add a direct test asserting BatchMode is absent and the snippet greps before appending.
@@ -377,7 +394,7 @@ def test_list_remote_dirs_parses_and_quotes(tmp_path):
 - [ ] **Step 2: Run — FAIL.**
 - [ ] **Step 3: Implement.**
   - `class MountNotWritable(RuntimeError)`.
-  - `locate_share(...)`: nonce = `".vireo-probe-" + secrets.token_hex(8)`; write it inside `mount_point` (wrap `OSError`/`PermissionError` → `MountNotWritable`); `try/finally` unlink (missing-ok). One ssh command with `S=<shlex.quote(share)>` and candidates `/volume*/"$S" /share/"$S" /shares/"$S" /mnt/*/"$S" /srv/*/"$S"`, `[ -e "$p/<nonce>" ] && { echo "FOUND:$p"; break; }` — parse the `FOUND:` line. `timeout=20` on the run.
+  - `locate_share(...)`: nonce = `".vireo-probe-" + secrets.token_hex(8)`; write it inside `mount_point` (wrap `OSError`/`PermissionError` → `MountNotWritable`); `try/finally` unlink (missing-ok). Cleanup is mount-side only — a deliberate narrowing of the spec's "best-effort over SSH too": it's the same file either way, and the mount is by definition writable once the nonce was written. One ssh command with `S=<shlex.quote(share)>` and candidates `/volume*/"$S" /share/"$S" /shares/"$S" /mnt/*/"$S" /srv/*/"$S"`, `[ -e "$p/<nonce>" ] && { echo "FOUND:$p"; break; }` — parse the `FOUND:` line. `timeout=20` on the run.
   - `list_remote_dirs(...)`: `find <quoted path> -mindepth 1 -maxdepth 1 -type d -exec basename {} \;` (avoids `ls -p` symlink ambiguity), sorted casefolded; return `[]` on nonzero rc.
 - [ ] **Step 4: Run — PASS.**  **Step 5: Commit** `feat: nonce-verified share location and remote dir listing`.
 
@@ -410,17 +427,23 @@ def test_mounts_endpoint_returns_parsed_mounts(app_and_db, monkeypatch):
     assert res.get_json()["mounts"][0]["share"] == "Photos"
 
 
-def test_ssh_check_reports_port_key_and_auth(app_and_db, monkeypatch):
+def test_ssh_check_reports_port_auth_and_pubkey(app_and_db, monkeypatch, tmp_path):
+    # ssh-check ensures the Vireo key exists (idempotent, local-only) and
+    # returns its public line — the Terminal-fallback expander needs it
+    # WITHOUT ever calling install-key (no password submitted).
     app, _db = app_and_db
     import remote_setup
+    pub = tmp_path / "vireo_ed25519.pub"
+    pub.write_text("ssh-ed25519 AAAA vireo\n")
     monkeypatch.setattr(remote_setup, "port_reachable", lambda host, port, timeout=5: True)
-    monkeypatch.setattr(remote_setup, "vireo_key_paths", lambda: ("/k", "/k.pub"))
-    monkeypatch.setattr(os.path, "exists", os.path.exists)  # key_exists computed in endpoint via os.path.exists("/k")
+    monkeypatch.setattr(remote_setup, "ensure_vireo_key",
+                        lambda **kw: (str(tmp_path / "vireo_ed25519"), str(pub)))
     monkeypatch.setattr(remote_setup, "key_auth_works", lambda **kw: False)
     res = app.test_client().post("/api/remote-setup/ssh-check",
         json={"host": "nas", "port": 22, "user": "admin"})
     body = res.get_json()
     assert body["port_open"] is True and body["key_auth_ok"] is False
+    assert body["pub_key_line"] == "ssh-ed25519 AAAA vireo"
 
 
 def test_ssh_check_validates_input(app_and_db):
@@ -446,7 +469,6 @@ def test_install_key_happy_path_never_echoes_password(app_and_db, monkeypatch):
     monkeypatch.setattr(remote_setup, "install_key_with_password",
                         lambda **kw: {"ok": True, "error": None})
     monkeypatch.setattr(remote_setup, "key_auth_works", lambda **kw: True)
-    monkeypatch.setattr("builtins.open", open)
     res = app.test_client().post("/api/remote-setup/install-key",
         json={"host": "nas", "user": "a", "port": 22, "password": "hunter2"})
     body = res.get_json()
@@ -479,11 +501,12 @@ def test_locate_share_readonly_mount_is_clean_error(app_and_db, monkeypatch, tmp
 ```
 
 - [ ] **Step 2: Run — FAIL** (404s).
-- [ ] **Step 3: Implement the five routes** in `app.py`. Shared shape:
+- [ ] **Step 3: Implement the six routes** in `app.py`. Shared shape:
   - `_remote_setup_loopback_guard()` helper: `request.remote_addr not in ("127.0.0.1", "::1")` → `json_error("remote setup is only available from this machine", 403)`. Applied to **all** `/api/remote-setup/*` routes (cheapest consistent rule; the app binds loopback via waitress anyway — this is defense in depth).
   - `GET /api/remote-setup/mounts` → `{"mounts": remote_setup.list_network_mounts()}` (platform gate: non-darwin returns `{"mounts": [], "unsupported_platform": True}`).
-  - `POST /api/remote-setup/ssh-check` `{host, port, user}` (validate host/user non-empty, port int 1–65535) → `{"port_open", "key_exists", "key_auth_ok"}`. `port_open` via new `remote_setup.port_reachable(host, port, timeout=5)` (plain `socket.create_connection`; add a unit test in Task 6 too — fake socket via monkeypatch). `key_auth_ok` only probed when the key exists; `ssh_bin` resolved via `move_mod.resolve_ssh_bin(effective_cfg.get("ssh_bin", ""))` exactly like `api_remote_target_test`; `key_auth_ok` is `False` with `"ssh_missing": True` when no ssh binary resolves.
+  - `POST /api/remote-setup/ssh-check` `{host, port, user}` (validate host/user non-empty, port int 1–65535) → `{"port_open", "key_auth_ok", "pub_key_line"}`. This endpoint calls `remote_setup.ensure_vireo_key()` (idempotent, local-only, no network) and reads the public line — the Terminal-fallback expander builds its one-liner from `pub_key_line` and must work without install-key ever being called. `port_open` via new `remote_setup.port_reachable(host, port, timeout=5)` (plain `socket.create_connection`; unit test with a monkeypatched socket). `ssh_bin` resolved via `move_mod.resolve_ssh_bin(effective_cfg.get("ssh_bin", ""))` exactly like `api_remote_target_test`; `key_auth_ok` is `False` with `"ssh_missing": True` when no ssh binary resolves.
   - `POST /api/remote-setup/install-key` `{host, port, user, password}` → ensure key, `build_install_argv`, `install_key_with_password`, then verify with `key_auth_works`; response `{"ok", "error", "fingerprint"}` (fingerprint via `ssh-keygen -lf pub`, best-effort). The password variable is request-scoped; never logged (request-timing logs only record the URL — confirm no body logging on this path).
+  - `GET /api/remote-setup/disk-free?path=` → `{"free_bytes": shutil.disk_usage(path).free}` for the archive-root step's free-space readout; 400 on non-absolute or missing path. One test: create a tmp dir, assert `free_bytes > 0`.
   - `POST /api/remote-setup/locate-share` `{mount_path, share, host, port, user}` → validate `mount_path` is an absolute existing dir; map `MountNotWritable` → 400 with a "mount is not writable" message; result `{"remote_path": ... or None}`.
   - `POST /api/remote-setup/list-remote-dirs` `{path, host, port, user}` → `{"dirs": [...]}` for the fallback browser.
 - [ ] **Step 4: Run — PASS.** Also run the neighbors: `python -m pytest vireo/tests/test_app.py -q` (no route collisions).
@@ -502,9 +525,9 @@ No unit tests (vanilla JS in template, covered by Task 9 e2e). Structure — fol
 - [ ] **Step 2: Modal skeleton** appended near the page's other overlays: `#nasWizard` fixed overlay, one step container per spec step (`data-step="volume|ssh|share|archive|review"`), Back/Next footer, close ×. Step state machine in JS: `_nwState = {step, mounts, mount, host, port, user, keyExists, keyAuthOk, remotePath, archiveRoot, name}`.
 - [ ] **Step 3: Step logic**, one function per step:
   - `nwLoadMounts()` → `GET /api/remote-setup/mounts`; zero mounts → guidance ("connect in Finder ⌘K") + Refresh; one → preselect and advance enabled.
-  - `nwSshStep()` → editable user/host/port prefilled from mount (`friendly_host` preferred, IP shown as hint); on entry call `ssh-check`; port closed → Synology-aware help text (detect via `display_name`/`share` heuristic `/synology|diskstation/i`, generic otherwise) + Retry. `key_auth_ok` already true → skip password UI, auto-advance ("This Mac is already authorized ✓"). Password form posts `install-key`; map `error` codes to messages (`wrong_password` → retry with field cleared; `password_auth_disabled` → point at the Terminal expander; `timeout`/`ssh_failed` → show detail). Terminal expander shows the equivalent one-liner (built client-side from state: `ssh user@host` + append snippet with the actual pubkey — fetch the pubkey line from the install-key response's new `pub_key_line` field, added in Task 6's endpoint; include it there) and a **Verify** button that re-runs `ssh-check` until `key_auth_ok`.
+  - `nwSshStep()` → editable user/host/port prefilled from mount (`friendly_host` preferred, IP shown as hint); on entry call `ssh-check`; port closed → Synology-aware help text (detect via `display_name`/`share` heuristic `/synology|diskstation/i`, generic otherwise) + Retry. `key_auth_ok` already true → skip password UI, auto-advance ("This Mac is already authorized ✓"). Password form posts `install-key`; map `error` codes to messages (`wrong_password` → retry with field cleared; `password_auth_disabled` → point at the Terminal expander; `timeout`/`ssh_failed` → show detail). Terminal expander shows the equivalent one-liner (built client-side from state: `ssh user@host` + append snippet with the actual pubkey, taken from `ssh-check`'s `pub_key_line` — available before and without any password submission) and a **Verify** button that re-runs `ssh-check` until `key_auth_ok`.
   - `nwShareStep()` → auto-runs `locate-share`; found → green "Verified: /volume1/Photography" + Next; not found → fallback mini-browser (`list-remote-dirs`, drill-down list starting at `/`, plus a manual text input); read-only-mount 400 → its own error text.
-  - `nwArchiveStep()` → folder picker on `/api/browse` + `/api/browse/mkdir` (compact list: current path, subdirs, "New folder" inline input), default suggestion `<home>/Pictures/Vireo Archive` (home = the `path` returned by parameterless `/api/browse`); "create it" action; free-space line (add `free_bytes` of the containing volume to the archive step via a tiny `GET /api/remote-setup/disk-free?path=` — **no**: YAGNI, reuse client-side `navigator` is impossible; instead extend `locate-share`? Simplest honest option: add `free_gb` to the `/api/browse` response? Don't touch a shared endpoint for this — **drop the free-space readout to a follow-up if it needs new surface area**; the spec lists it, so implement it as `GET /api/remote-setup/disk-free` returning `shutil.disk_usage(path).free` — 5 lines + 1 test in Task 6's file). Validation mirror: absolute, not inside mount (client-side check copying `collectRemoteTargets`' spirit; server re-validates on save anyway).
+  - `nwArchiveStep()` → folder picker on `/api/browse` + `/api/browse/mkdir` (compact list: current path, subdirs, "New folder" inline input), default suggestion `<home>/Pictures/Vireo Archive` (home = the `path` returned by parameterless `/api/browse`); "create it" action; free-space line from `GET /api/remote-setup/disk-free?path=` (built in Task 6). Validation mirror: absolute, not inside mount (client-side check copying `collectRemoteTargets`' spirit; server re-validates on save anyway).
   - `nwReviewStep()` → assembled card (name defaulted from `display_name` or share; `bwlimit_kbps: 0`; `ssh_key`: the wizard key path); auto-POST `/api/remote-targets/test` with the assembled target; per-check lines from its response (`ssh`, `remote_path_writable`, `rsync_ok`, `remote_rsync_ok`, mount presence); failures link back ("Fix connection" → step 2, "Fix path" → step 3). Save = push into `_remoteTargetsState` + `renderRemoteTargets()` + `saveConfig()` (the existing config-save path), close, scroll to the new card.
 - [ ] **Step 4: Deep link.** On settings page load: `location.hash === "#nas-setup"` → `openNasWizard()`.
 - [ ] **Step 5: Manual smoke** (see Task 10) then **commit** `feat: NAS setup wizard modal on the settings page`.

--- a/docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md
+++ b/docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md
@@ -1,0 +1,199 @@
+# "Set up NAS" wizard for remote targets
+
+**Date:** 2026-07-26
+**Status:** Approved by Julius (design conversation, this workspace)
+**Branch:** `missing-local-processing-option`
+
+## Problem
+
+The chained import → process → move-to-NAS workflow (spec:
+`2026-07-19-import-process-move-chain-design.md`) requires a configured
+remote target, and today the only way to create one is a nine-field form in
+Settings → Remote targets: SSH user, host, port, NAS-side absolute path,
+local mount path, local archive root, key path, bandwidth limit. Every path
+is hand-typed. The two real cliffs for a non-technical user:
+
+1. **SSH key setup happens entirely outside the app.** Vireo's rsync move
+   needs passwordless key auth; a user without `~/.ssh` keys gets
+   `Permission denied (publickey,password)` and no guidance.
+2. **The NAS-side path is unknowable from the Mac.** The SMB mount shows
+   `/Volumes/Photography`; nothing on the client says the share lives at
+   `/volume1/Photography` on the NAS.
+
+Yet nearly everything is discoverable: a walkthrough on Julius's machine
+pre-filled 8 of 9 fields automatically (mount table → user/host/share/mount
+path; reverse DNS → friendly Tailscale hostname; Synology convention → NAS
+path candidate). The only step that fundamentally needs the user is entering
+the NAS password once to install a key.
+
+## Goal
+
+A guided wizard that takes a user from "my NAS shows up in Finder" to a
+tested, saved remote target without opening Terminal or typing an absolute
+path. The existing manual form remains as the advanced/edit path.
+
+## Decisions (agreed with Julius)
+
+1. **Scope: full guided wizard** (not just form pre-fill) — it owns key
+   generation, key installation, share location, and verification, ending in
+   a green Test connection.
+2. **Password in the wizard, Terminal as visible fallback.** The wizard asks
+   for the NAS password in the browser and uses it once, server-side, to
+   install the public key; it is never persisted or logged. An expander
+   ("prefer to do this yourself in Terminal?") shows the equivalent
+   `ssh-copy-id` command with a Verify button for users who won't type a
+   password into an app.
+3. **Verified share mapping, not heuristics.** The NAS-side path is proven
+   with a nonce probe (below), because the chained move deletes local
+   originals after transfer — a wrong same-named share would be
+   catastrophic; a nonce match cannot be wrong.
+4. **Dedicated Vireo key**, `~/.vireo/ssh/vireo_ed25519` (ed25519, mode 600,
+   no passphrase), saved as the target's key path. The wizard never touches
+   `~/.ssh` keys. No passphrase is a deliberate trade-off: background rsync
+   jobs must run unattended; the key grants only what the NAS account
+   grants, and it never leaves the machine.
+5. **macOS first.** Mount enumeration is the only platform-specific piece;
+   Windows (`net use` parsing) slots in later without redesign.
+
+## User flow
+
+Five steps in a modal on the Settings page. Every step can be overridden
+manually; automation pre-fills, the user confirms.
+
+### Step 1 — Pick your NAS volume
+
+`GET /api/remote-setup/mounts` enumerates network mounts by parsing `mount`
+output for `smbfs` / `nfs` / `afpfs` entries. The smbfs source string
+(`//julius_admin@100.80.236.59/Photography` on `/Volumes/Photography`)
+yields SSH-user candidate, host, share name, and local mount path. IP hosts
+are reverse-resolved to a friendly name when possible (Tailscale MagicDNS,
+mDNS, DNS) and the name is preferred, with the IP shown as detail.
+
+- One mount → preselected. Multiple → list. Zero → guidance to connect the
+  share in Finder (⌘K) first, with a Refresh button.
+
+### Step 2 — Connect over SSH
+
+Pre-filled user/host/port. On entry the wizard probes TCP reachability of
+the port (`POST /api/remote-setup/ssh-check`); a closed port shows
+brand-aware help (Synology: "Control Panel → Terminal & SNMP → Enable
+SSH"), detected best-effort from the mount metadata/hostname, with a
+generic fallback. The same endpoint reports whether the Vireo key already
+exists and whether key auth already succeeds (idempotent re-runs skip
+ahead).
+
+The password form explains exactly what will happen ("used once to
+authorize this Mac's key, never stored"). Submitting calls
+`POST /api/remote-setup/install-key`, which:
+
+1. Generates `~/.vireo/ssh/vireo_ed25519` if missing.
+2. Installs the public key by driving `ssh-copy-id` through a pty (macOS
+   ships no `sshpass`; Python's `pty` module answers the password prompt).
+   The password lives only in request scope; it is never written to config,
+   DB, or logs.
+3. Accepts the host key on first contact (`accept-new`) and returns the
+   fingerprint for display.
+4. Verifies `BatchMode=yes` login now succeeds.
+
+The Terminal fallback expander shows the `ssh-copy-id -i … user@host`
+command and a Verify button that re-runs the ssh-check until key auth
+passes.
+
+### Step 3 — Locate the share on the NAS (automatic, verified)
+
+`POST /api/remote-setup/locate-share`:
+
+1. Write a nonce file `.vireo-probe-<random hex>` into the *local mount*.
+2. Over SSH, test candidate directories for that exact filename:
+   `/volume*/<share>`, `/share/<share>`, `/mnt/*/<share>`, plus the share
+   name under common export roots.
+3. The candidate containing the nonce is the verified `remote_path`.
+4. Delete the nonce (via the mount; best-effort cleanup over SSH too).
+
+No match → fall back to a minimal SSH-backed remote directory browser
+(list directories via the established connection), then manual entry.
+Failure to *write* the nonce (read-only mount) surfaces as its own error —
+the move workflow needs a writable share anyway.
+
+### Step 4 — Local archive root
+
+Reuse the import page's folder-browser component. Suggest
+`~/Pictures/Vireo Archive` with an inline "create it" action. Plain-English
+explanation: "Photos you import here are processed on this Mac, then moved
+to the NAS." Show free space for the containing volume. Validation mirrors
+`_coerce_remote_target`: absolute, not inside the mount path.
+
+### Step 5 — Review and test
+
+Show the assembled target (name defaulted from the friendly hostname or
+share). Auto-run the existing Test connection check (ssh login, GNU rsync
+presence, mount writability). Green → Save appends to
+`config.remote_targets` through the existing coercion/validation. Any
+failure links back to the relevant step.
+
+## Entry points
+
+- Settings → Remote targets: primary button **"Set up from mounted
+  volume…"**; the existing manual form stays, presented as the
+  advanced path (also used for editing saved targets).
+- Import page: the "Move to NAS unavailable: the destination is not inside
+  any remote target's local archive root…" hint gains a link that opens
+  Settings at the wizard.
+
+## Backend
+
+Four new endpoints in `app.py` under `/api/remote-setup/`:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `mounts` | GET | Enumerate network mounts, parsed + reverse-resolved |
+| `ssh-check` | POST | Port reachability, key existence, key-auth status |
+| `install-key` | POST | Generate key if needed, install via pty, verify |
+| `locate-share` | POST | Nonce probe, return verified remote path |
+
+Constraints:
+
+- **Loopback guard:** `install-key` refuses (403) when the request does not
+  arrive on a loopback address, so the password can never transit a LAN
+  even if the app is bound wide.
+- **Injectable runner:** all `ssh`/`ssh-keygen`/`ssh-copy-id` invocations go
+  through one injectable command-runner seam (module `remote_setup.py`,
+  pattern matching `move.py`'s rsync wrapper) so unit tests never need a
+  real NAS.
+- Timeouts on every network call; endpoints are synchronous (each step is
+  seconds, not minutes — no job/SSE machinery).
+
+## Error handling (first-class cases)
+
+| Failure | Treatment |
+|---|---|
+| SSH port closed | Brand-aware enable-SSH instructions, Retry button |
+| Wrong password | Clean retry, distinguished from key-install failure |
+| Password auth disabled on NAS | Detected from ssh output; point at the Terminal fallback / NAS console |
+| Nonce not found in any candidate | Remote directory browser fallback, then manual entry |
+| Read-only mount | Explicit error naming the mount; move workflow requires write access |
+| No GNU rsync / OpenSSH locally | Reuse the existing Test-connection warnings and Settings > Paths pointer |
+
+## Testing
+
+- **Mount parsing:** fixture strings for smbfs (user@host/share, IP and
+  hostname, spaces and URL-encoding in share names, IPv6 brackets), nfs
+  (`host:/export`), afpfs; non-network mounts filtered out.
+- **locate-share:** fake runner returning candidate hits/misses; nonce
+  cleanup on success, failure, and exception paths.
+- **install-key:** pty driver against a stub script that imitates
+  ssh-copy-id prompts (password prompt, wrong password, host-key prompt);
+  assert the password never appears in logs or config.
+- **Endpoints:** validation errors, loopback guard, idempotent re-entry
+  (key already installed → ssh-check short-circuits).
+- **Wizard e2e:** existing e2e harness with the runner mocked at the Flask
+  layer; walks all five steps including the Terminal-fallback branch.
+
+## Out of scope (YAGNI)
+
+- Windows/Linux mount enumeration (design slot exists; not built now).
+- Multiple keys per target, passphrase-protected keys, ssh-agent
+  integration.
+- Editing existing targets through the wizard (manual form covers it).
+- NAS-brand API integrations (Synology API etc.) — SSH + nonce is
+  brand-agnostic.

--- a/docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md
+++ b/docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md
@@ -52,8 +52,10 @@ path. The existing manual form remains as the advanced/edit path.
    `~/.ssh` keys. No passphrase is a deliberate trade-off: background rsync
    jobs must run unattended; the key grants only what the NAS account
    grants, and it never leaves the machine.
-5. **macOS first.** Mount enumeration is the only platform-specific piece;
-   Windows (`net use` parsing) slots in later without redesign.
+5. **macOS first.** Two pieces are platform-specific: mount enumeration
+   (Windows `net use` parsing slots in later without redesign) and the
+   pty-driven key install (Python's `pty` is POSIX-only; a Windows port
+   needs its own mechanism). Neither is built now.
 
 ## User flow
 
@@ -126,10 +128,12 @@ to the NAS." Show free space for the containing volume. Validation mirrors
 ### Step 5 — Review and test
 
 Show the assembled target (name defaulted from the friendly hostname or
-share). Auto-run the existing Test connection check (ssh login, GNU rsync
-presence, mount writability). Green → Save appends to
-`config.remote_targets` through the existing coercion/validation. Any
-failure links back to the relevant step.
+share; `bwlimit_kbps` stays 0 — the wizard adds no field for it, the
+manual form covers changing it later). Auto-run the existing Test
+connection check (ssh login, GNU rsync presence, mount writability).
+Green → Save appends to `config.remote_targets` through the existing
+settings config-save path and `_coerce_remote_target` validation — no new
+save endpoint. Any failure links back to the relevant step.
 
 ## Entry points
 

--- a/docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md
+++ b/docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md
@@ -89,10 +89,14 @@ authorize this Mac's key, never stored"). Submitting calls
 `POST /api/remote-setup/install-key`, which:
 
 1. Generates `~/.vireo/ssh/vireo_ed25519` if missing.
-2. Installs the public key by driving `ssh-copy-id` through a pty (macOS
-   ships no `sshpass`; Python's `pty` module answers the password prompt).
-   The password lives only in request scope; it is never written to config,
-   DB, or logs.
+2. Installs the public key by driving plain `ssh` through a pty (macOS
+   ships no `sshpass`; Python's `pty` module answers the password prompt),
+   running an idempotent append snippet (`umask 077; mkdir -p ~/.ssh;
+   grep -qxF <key> ~/.ssh/authorized_keys || echo <key> >> …`) — the same
+   thing `ssh-copy-id` does, but reusing the already-configurable ssh
+   binary so tests and Settings → Paths overrides cover it. The password
+   lives only in request scope; it is never written to config, DB, or
+   logs.
 3. Accepts the host key on first contact (`accept-new`) and returns the
    fingerprint for display.
 4. Verifies `BatchMode=yes` login now succeeds.
@@ -146,7 +150,7 @@ save endpoint. Any failure links back to the relevant step.
 
 ## Backend
 
-Four new endpoints in `app.py` under `/api/remote-setup/`:
+Endpoints in `app.py` under `/api/remote-setup/`:
 
 | Endpoint | Method | Purpose |
 |---|---|---|
@@ -154,6 +158,8 @@ Four new endpoints in `app.py` under `/api/remote-setup/`:
 | `ssh-check` | POST | Port reachability, key existence, key-auth status |
 | `install-key` | POST | Generate key if needed, install via pty, verify |
 | `locate-share` | POST | Nonce probe, return verified remote path |
+| `list-remote-dirs` | POST | SSH-backed directory listing for the fallback browser |
+| `disk-free` | GET | Free bytes for the archive-root step's free-space readout |
 
 Constraints:
 

--- a/tests/e2e/test_nas_setup_wizard.py
+++ b/tests/e2e/test_nas_setup_wizard.py
@@ -107,7 +107,7 @@ def _finish_from_share_step(page, live_server, nas_env):
             break
         time.sleep(0.2)
     assert target, "remote target was not saved to config"
-    assert target["host"] == "synology-nas.ts.net"
+    assert target["host"] == "100.80.236.59"  # pinned to the verified mount IP
     assert target["user"] == "julius_admin"
     assert target["remote_path"] == "/volume1/Photography"
     assert target["mount_path"] == nas_env["mount_dir"]

--- a/tests/e2e/test_nas_setup_wizard.py
+++ b/tests/e2e/test_nas_setup_wizard.py
@@ -31,6 +31,11 @@ def nas_env(live_server, tmp_path, monkeypatch):
 
     state = {"auth": False, "installs": 0}
 
+    # The full E2E suite runs on Ubuntu, but the wizard is macOS-only in
+    # production — force platform_supported() true so /api/remote-setup/mounts
+    # doesn't short-circuit to `unsupported_platform` before returning the
+    # seeded mount below.
+    monkeypatch.setattr(remote_setup, "platform_supported", lambda: True)
     monkeypatch.setattr(remote_setup, "list_network_mounts", lambda **kw: [{
         "fs_type": "smbfs", "host": "100.80.236.59",
         "friendly_host": "synology-nas.ts.net", "display_name": "synology-nas",

--- a/tests/e2e/test_nas_setup_wizard.py
+++ b/tests/e2e/test_nas_setup_wizard.py
@@ -1,0 +1,139 @@
+"""E2E coverage for the Settings-page NAS setup wizard.
+
+The live server runs in-process, so remote_setup's discovery/SSH functions
+are monkeypatched at the module level — no test spawns a real ssh. The
+wizard JS, the /api/remote-setup endpoints, the config save path, and the
+remote-target list rendering are all real.
+"""
+
+import json
+import os
+import time
+
+import pytest
+
+
+@pytest.fixture()
+def nas_env(live_server, tmp_path, monkeypatch):
+    """Patch remote_setup for a one-NAS world with controllable key auth."""
+    import move
+    import remote_setup
+
+    mount_dir = tmp_path / "mnt-photography"
+    mount_dir.mkdir()
+
+    key_dir = tmp_path / ".vireo" / "ssh"
+    os.makedirs(key_dir, exist_ok=True)
+    priv = key_dir / "vireo_ed25519"
+    pub = key_dir / "vireo_ed25519.pub"
+    priv.write_text("FAKE KEY\n")
+    pub.write_text("ssh-ed25519 AAAATESTKEY vireo\n")
+
+    state = {"auth": False, "installs": 0}
+
+    monkeypatch.setattr(remote_setup, "list_network_mounts", lambda **kw: [{
+        "fs_type": "smbfs", "host": "100.80.236.59",
+        "friendly_host": "synology-nas.ts.net", "display_name": "synology-nas",
+        "share": "Photography", "mount_point": str(mount_dir),
+        "user": "julius_admin",
+    }])
+    monkeypatch.setattr(remote_setup, "port_reachable",
+                        lambda host, port, timeout=5: True)
+    monkeypatch.setattr(remote_setup, "ensure_vireo_key",
+                        lambda **kw: (str(priv), str(pub)))
+
+    def fake_key_auth(**kw):
+        return state["auth"]
+
+    def fake_install(**kw):
+        state["installs"] += 1
+        state["auth"] = True
+        return {"ok": True, "error": None}
+
+    monkeypatch.setattr(remote_setup, "key_auth_works", fake_key_auth)
+    monkeypatch.setattr(remote_setup, "install_key_with_password", fake_install)
+    monkeypatch.setattr(remote_setup, "build_install_argv", lambda **kw: ["ssh"])
+    monkeypatch.setattr(remote_setup, "locate_share",
+                        lambda **kw: "/volume1/Photography")
+    monkeypatch.setattr(move, "test_remote_connection", lambda remote, rsync_bin: {
+        "ok": True, "ssh": True, "remote_path_writable": True,
+        "rsync_ok": True, "remote_rsync_ok": True,
+        "message": "Connection OK",
+    })
+    return {"state": state, "mount_dir": str(mount_dir), "priv": str(priv)}
+
+
+def _walk_to_ssh_step(page, live_server):
+    page.goto(f"{live_server['url']}/settings")
+    page.get_by_role("button", name="Set up from mounted volume…").click()
+    page.locator("#nwTitle").wait_for(state="visible")
+    # Step 1: the seeded mount is preselected.
+    assert "Pick your NAS volume" in page.locator("#nwTitle").text_content()
+    page.locator("#nwBody").get_by_text("Photography on synology-nas").wait_for()
+    page.locator("#nwNext").click()
+    assert "Connect over SSH" in page.locator("#nwTitle").text_content()
+
+
+def _finish_from_share_step(page, live_server, nas_env):
+    # Step 3: nonce-verified share path.
+    page.locator("#nwBody").get_by_text("/volume1/Photography").wait_for()
+    page.locator("#nwNext").click()
+    # Step 4: create & use the suggested archive folder.
+    assert "local archive folder" in page.locator("#nwTitle").text_content()
+    page.get_by_role("button", name="Create & use").click()
+    page.locator("#nwBody").get_by_text("Archive folder:").wait_for()
+    page.locator("#nwNext").click()
+    # Step 5: review auto-runs the connection test.
+    page.locator("#nwBody").get_by_text("Connection OK").wait_for()
+    page.locator("#nwNext").click()  # Save
+    page.locator("#nasWizard").wait_for(state="hidden")
+    # The new target card appears in the manual editor list.
+    page.locator("#cfgRemoteTargetsList").get_by_text("Test connection").first.wait_for()
+
+    # Saved config (500ms debounce) contains the assembled target.
+    deadline = time.time() + 5
+    target = None
+    while time.time() < deadline:
+        cfg = json.loads(page.evaluate(
+            "async () => JSON.stringify(await (await fetch('/api/config')).json())"))
+        targets = cfg.get("remote_targets") or []
+        if targets:
+            target = targets[0]
+            break
+        time.sleep(0.2)
+    assert target, "remote target was not saved to config"
+    assert target["host"] == "synology-nas.ts.net"
+    assert target["user"] == "julius_admin"
+    assert target["remote_path"] == "/volume1/Photography"
+    assert target["mount_path"] == nas_env["mount_dir"]
+    assert target["local_archive_root"].endswith("Vireo Archive")
+    assert target["ssh_key"] == nas_env["priv"]
+    assert target["bwlimit_kbps"] == 0
+
+
+def test_wizard_happy_path_with_password(nas_env, live_server, page):
+    _walk_to_ssh_step(page, live_server)
+    # Step 2: not yet authorized -> password form.
+    pw = page.locator("#nwBody input[type=password]")
+    pw.wait_for(state="visible")
+    pw.fill("sekret")
+    page.get_by_role("button", name="Authorize").click()
+    page.locator("#nwBody").get_by_text("Authorized").wait_for()
+    assert nas_env["state"]["installs"] == 1
+    page.locator("#nwNext").click()
+    _finish_from_share_step(page, live_server, nas_env)
+
+
+def test_wizard_terminal_fallback_never_sends_password(nas_env, live_server, page):
+    _walk_to_ssh_step(page, live_server)
+    page.locator("#nwBody input[type=password]").wait_for(state="visible")
+    # Expand the Terminal fallback: the one-liner embeds the real public key.
+    page.get_by_text("Prefer to do this yourself in Terminal?").click()
+    assert "AAAATESTKEY" in page.locator("#nwBody pre").text_content()
+    # User runs the command out-of-band; simulate its effect, then Verify.
+    nas_env["state"]["auth"] = True
+    page.get_by_role("button", name="Verify", exact=True).click()
+    page.locator("#nwBody").get_by_text("already authorized").wait_for()
+    assert nas_env["state"]["installs"] == 0   # password path never used
+    page.locator("#nwNext").click()
+    _finish_from_share_step(page, live_server, nas_env)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -22211,7 +22211,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         forbidden = _remote_setup_forbidden()
         if forbidden:
             return forbidden
-        if sys.platform != "darwin":
+        if not remote_setup.platform_supported():
             return jsonify({"mounts": [], "unsupported_platform": True})
         return jsonify({"mounts": remote_setup.list_network_mounts()})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -22167,6 +22167,213 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         return jsonify(res)
 
+    # --- NAS setup wizard (/api/remote-setup/*) --------------------------
+    # Synchronous discovery/setup endpoints behind the Settings-page wizard
+    # (docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md). All of
+    # them are loopback-only: the app already binds 127.0.0.1 via waitress,
+    # but the install-key route carries a NAS password, so defense in depth
+    # is cheap and the consistent rule is simplest.
+
+    def _remote_setup_forbidden():
+        if request.remote_addr not in ("127.0.0.1", "::1"):
+            return json_error(
+                "remote setup is only available from this machine", 403)
+        return None
+
+    def _remote_setup_conn_args(body):
+        """Validate and extract {host, user, port} shared by the wizard's
+        SSH-touching endpoints. Returns (args, None) or (None, response)."""
+        host = (body.get("host") or "").strip()
+        user = (body.get("user") or "").strip()
+        port = body.get("port", 22)
+        if not host or not user:
+            return None, json_error("host and user are required")
+        try:
+            port = int(port)
+        except (TypeError, ValueError):
+            return None, json_error("port must be an integer")
+        if not 1 <= port <= 65535:
+            return None, json_error("port must be between 1 and 65535")
+        return {"host": host, "user": user, "port": port}, None
+
+    def _remote_setup_ssh_bin():
+        import config as cfg
+        import move as move_mod
+
+        effective_cfg = _get_db().get_effective_config(cfg.load())
+        return move_mod.resolve_ssh_bin(effective_cfg.get("ssh_bin", "") or "")
+
+    @app.route("/api/remote-setup/mounts")
+    def api_remote_setup_mounts():
+        """Mounted network shares the wizard can offer as NAS candidates."""
+        import remote_setup
+
+        forbidden = _remote_setup_forbidden()
+        if forbidden:
+            return forbidden
+        if sys.platform != "darwin":
+            return jsonify({"mounts": [], "unsupported_platform": True})
+        return jsonify({"mounts": remote_setup.list_network_mounts()})
+
+    @app.route("/api/remote-setup/ssh-check", methods=["POST"])
+    def api_remote_setup_ssh_check():
+        """Port reachability + current key-auth status for a candidate NAS.
+
+        Also ensures the Vireo keypair exists (idempotent, local-only) and
+        returns its public line: the wizard's Terminal-fallback expander
+        builds its authorized_keys one-liner from ``pub_key_line`` and must
+        work without install-key (no password) ever being called.
+        """
+        import remote_setup
+
+        forbidden = _remote_setup_forbidden()
+        if forbidden:
+            return forbidden
+        conn, err = _remote_setup_conn_args(request.get_json(silent=True) or {})
+        if err:
+            return err
+        try:
+            _priv, pub = remote_setup.ensure_vireo_key()
+            with open(pub) as f:
+                pub_key_line = f.read().strip()
+        except (RuntimeError, OSError) as exc:
+            return json_error(f"could not prepare the Vireo SSH key: {exc}")
+        result = {
+            "port_open": remote_setup.port_reachable(conn["host"], conn["port"]),
+            "pub_key_line": pub_key_line,
+            "key_auth_ok": False,
+        }
+        ssh_bin = _remote_setup_ssh_bin()
+        if not ssh_bin:
+            result["ssh_missing"] = True
+        elif result["port_open"]:
+            result["key_auth_ok"] = remote_setup.key_auth_works(
+                host=conn["host"], user=conn["user"], port=conn["port"],
+                key=_priv, ssh_bin=ssh_bin)
+        return jsonify(result)
+
+    @app.route("/api/remote-setup/install-key", methods=["POST"])
+    def api_remote_setup_install_key():
+        """Authorize this Mac's Vireo key on the NAS using a password, once.
+
+        The password is request-scoped only: written to the ssh pty and
+        nowhere else — never config, DB, logs, or this response.
+        """
+        import remote_setup
+
+        forbidden = _remote_setup_forbidden()
+        if forbidden:
+            return forbidden
+        body = request.get_json(silent=True) or {}
+        conn, err = _remote_setup_conn_args(body)
+        if err:
+            return err
+        password = body.get("password") or ""
+        if not password:
+            return json_error("password is required")
+        ssh_bin = _remote_setup_ssh_bin()
+        if not ssh_bin:
+            return json_error("no OpenSSH client found — set its path under "
+                              "Settings > Paths")
+        try:
+            priv, pub = remote_setup.ensure_vireo_key()
+            with open(pub) as f:
+                pub_key_line = f.read().strip()
+        except (RuntimeError, OSError) as exc:
+            return json_error(f"could not prepare the Vireo SSH key: {exc}")
+        argv = remote_setup.build_install_argv(
+            host=conn["host"], user=conn["user"], port=conn["port"],
+            key_pub_line=pub_key_line, ssh_bin=ssh_bin)
+        res = remote_setup.install_key_with_password(
+            spawn_argv=argv, password=password)
+        out = {"ok": bool(res.get("ok")), "error": res.get("error")}
+        if res.get("detail"):
+            out["detail"] = res["detail"]
+        if out["ok"]:
+            out["key_auth_ok"] = remote_setup.key_auth_works(
+                host=conn["host"], user=conn["user"], port=conn["port"],
+                key=priv, ssh_bin=ssh_bin)
+            try:
+                fp = subprocess.run(
+                    ["ssh-keygen", "-lf", pub], capture_output=True,
+                    text=True, timeout=10)
+                if fp.returncode == 0:
+                    out["fingerprint"] = fp.stdout.strip()
+            except (OSError, subprocess.SubprocessError):
+                pass
+        return jsonify(out)
+
+    @app.route("/api/remote-setup/locate-share", methods=["POST"])
+    def api_remote_setup_locate_share():
+        """Nonce-verified NAS-side path for a mounted share. Proof, not a
+        guess — the chained move deletes local originals, so a same-named
+        share on the wrong volume must be impossible to configure here."""
+        import remote_setup
+
+        forbidden = _remote_setup_forbidden()
+        if forbidden:
+            return forbidden
+        body = request.get_json(silent=True) or {}
+        conn, err = _remote_setup_conn_args(body)
+        if err:
+            return err
+        mount_path = (body.get("mount_path") or "").strip()
+        share = (body.get("share") or "").strip()
+        if not share:
+            return json_error("share is required")
+        if not os.path.isabs(mount_path) or not os.path.isdir(mount_path):
+            return json_error("mount_path must be an existing absolute path")
+        ssh_bin = _remote_setup_ssh_bin()
+        if not ssh_bin:
+            return json_error("no OpenSSH client found — set its path under "
+                              "Settings > Paths")
+        priv, _pub = remote_setup.vireo_key_paths()
+        try:
+            remote_path = remote_setup.locate_share(
+                mount_point=mount_path, share=share, host=conn["host"],
+                user=conn["user"], port=conn["port"], key=priv,
+                ssh_bin=ssh_bin)
+        except remote_setup.MountNotWritable:
+            return json_error(
+                "the mounted volume is not writable — the wizard (and the "
+                "move workflow it sets up) needs write access to the share")
+        return jsonify({"remote_path": remote_path})
+
+    @app.route("/api/remote-setup/list-remote-dirs", methods=["POST"])
+    def api_remote_setup_list_remote_dirs():
+        """SSH-backed directory listing for the wizard's fallback browser."""
+        import remote_setup
+
+        forbidden = _remote_setup_forbidden()
+        if forbidden:
+            return forbidden
+        body = request.get_json(silent=True) or {}
+        conn, err = _remote_setup_conn_args(body)
+        if err:
+            return err
+        path = (body.get("path") or "").strip()
+        if not path.startswith("/"):
+            return json_error("path must be absolute")
+        ssh_bin = _remote_setup_ssh_bin()
+        if not ssh_bin:
+            return json_error("no OpenSSH client found — set its path under "
+                              "Settings > Paths")
+        priv, _pub = remote_setup.vireo_key_paths()
+        return jsonify({"dirs": remote_setup.list_remote_dirs(
+            path=path, host=conn["host"], user=conn["user"],
+            port=conn["port"], key=priv, ssh_bin=ssh_bin)})
+
+    @app.route("/api/remote-setup/disk-free")
+    def api_remote_setup_disk_free():
+        """Free bytes on the volume containing ``path`` (archive-root step)."""
+        forbidden = _remote_setup_forbidden()
+        if forbidden:
+            return forbidden
+        path = (request.args.get("path") or "").strip()
+        if not os.path.isabs(path) or not os.path.isdir(path):
+            return json_error("path must be an existing absolute path")
+        return jsonify({"free_bytes": shutil.disk_usage(path).free})
+
     @app.route("/api/jobs/import-full", methods=["POST"])
     def api_job_import_full():
         """Full-chain import: copy files -> scan -> create collection."""

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -22241,6 +22241,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result = {
             "port_open": remote_setup.port_reachable(conn["host"], conn["port"]),
             "pub_key_line": pub_key_line,
+            "key_path": _priv,
             "key_auth_ok": False,
         }
         ssh_bin = _remote_setup_ssh_bin()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -31297,4 +31297,20 @@ if __name__ == "__main__":
     # when we actually call it.
     import multiprocessing
     multiprocessing.freeze_support()
+    # --pty-spawn-helper: pty setup shim dispatched by remote_setup's
+    # install-key path. In the packaged (PyInstaller --onefile) build
+    # sys.executable is this same binary, so remote_setup can't shell
+    # out via `[python, "-c", helper]` and instead re-executes us with
+    # this flag. Must run BEFORE argparse — the wrapped ssh argv follows
+    # and would otherwise get rejected as unknown options.
+    if len(sys.argv) >= 3 and sys.argv[1] == "--pty-spawn-helper":
+        import fcntl
+        import termios
+        os.setsid()
+        fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+        a = termios.tcgetattr(0)
+        a[3] &= ~(termios.ECHO | termios.ECHOE | termios.ECHOK
+                  | termios.ECHONL)
+        termios.tcsetattr(0, termios.TCSANOW, a)
+        os.execvp(sys.argv[2], sys.argv[2:])
     main()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -22375,6 +22375,37 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("path must be an existing absolute path")
         return jsonify({"free_bytes": shutil.disk_usage(path).free})
 
+    @app.route("/api/remote-setup/check-archive-root", methods=["POST"])
+    def api_remote_setup_check_archive_root():
+        """True if ``path`` resolves (through symlinks or case-only aliases)
+        into ``mount_path``. Exposes the same filesystem-aware containment
+        check ``_coerce_remote_target`` runs at save time so the wizard's
+        archive-root step can reject aliased folders up front instead of
+        letting the save silently blank ``local_archive_root``, which would
+        leave the target unable to offer the chained move the wizard was
+        meant to configure. A purely-lexical check on the client can't see
+        symlinks, so this has to be server-side."""
+        import move as move_mod
+
+        forbidden = _remote_setup_forbidden()
+        if forbidden:
+            return forbidden
+        body = request.get_json(silent=True) or {}
+        path = (body.get("path") or "").strip()
+        mount_path = (body.get("mount_path") or "").strip()
+        if not path or not mount_path:
+            return json_error("path and mount_path are required")
+        if not os.path.isabs(path) or not os.path.isabs(mount_path):
+            return json_error("both paths must be absolute")
+        try:
+            inside = bool(move_mod._path_equal_or_descends(path, mount_path))
+        except (OSError, ValueError):
+            # realpath failed (unreadable / cross-device on Windows) — the
+            # save-time validator is the authoritative check, so let the
+            # user proceed rather than block on a transient FS hiccup.
+            inside = False
+        return jsonify({"inside_mount": inside})
+
     @app.route("/api/jobs/import-full", methods=["POST"])
     def api_job_import_full():
         """Full-chain import: copy files -> scan -> create collection."""

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -14,6 +14,8 @@ import select
 import shlex
 import socket
 import subprocess
+import sys
+import termios
 import time
 import urllib.parse
 
@@ -28,6 +30,19 @@ _SMB_SRC_RE = re.compile(r"^//(?:(?P<user>[^@/]+)@)?(?P<host>[^/]+)/(?P<share>.+
 _NFS_SRC_RE = re.compile(r"^(?P<host>[^:/]+):(?P<path>/.*)$")
 
 _NETWORK_FS = ("smbfs", "nfs", "afpfs", "webdav")
+
+
+def platform_supported():
+    """True where the wizard can meaningfully enumerate mounted NAS shares.
+
+    Only macOS today: mount-line parsing (``_MOUNT_RE`` + URL-decoded smbfs
+    sources) is written against ``/sbin/mount`` output. Linux and Windows
+    format ``mount`` differently, so the wizard's mounts endpoint returns
+    ``unsupported_platform`` there. Named as its own function so tests that
+    exercise the wizard end-to-end can flip it without stomping on
+    ``sys.platform`` globally.
+    """
+    return sys.platform == "darwin"
 
 
 def parse_mount_output(text):
@@ -66,10 +81,23 @@ def parse_mount_output(text):
 def _reverse_dns(ip):
     """Default resolver: PTR lookup with a hard 2s cap — gethostbyaddr has
     no timeout parameter and can hang for many seconds on networks that
-    drop PTR queries, which would stall the wizard's mounts endpoint."""
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+    drop PTR queries, which would stall the wizard's mounts endpoint.
+
+    The executor is torn down without waiting: the ``with`` form calls
+    ``shutdown(wait=True)`` on exit even when ``fut.result`` already raised
+    a TimeoutError, which would silently re-block the endpoint for the full
+    DNS delay. Leftover worker threads are daemons — they die on process
+    exit, or when ``gethostbyaddr`` finally returns.
+    """
+    ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
         fut = ex.submit(socket.gethostbyaddr, ip)
         return fut.result(timeout=2)[0]
+    finally:
+        try:
+            ex.shutdown(wait=False, cancel_futures=True)
+        except TypeError:  # cancel_futures added in 3.9
+            ex.shutdown(wait=False)
 
 
 def friendly_host_name(host, resolver=None):
@@ -177,6 +205,19 @@ def install_key_with_password(spawn_argv, password, timeout=30):
     import pty  # POSIX-only; imported here so module import stays portable
 
     master, slave = pty.openpty()
+    # Disable pty ECHO up front — a new pty defaults to ECHO=ON, and any
+    # bytes we write for the password prompt would then be echoed back into
+    # our read buffer, leaving the password sitting in ``output`` where an
+    # unclassified failure (below) could return it as ``detail``. ssh sets
+    # ECHO off itself when it prompts, but the default state before that is
+    # too fragile to rely on.
+    try:
+        attrs = termios.tcgetattr(slave)
+        attrs[3] &= ~(termios.ECHO | termios.ECHOE | termios.ECHOK
+                      | termios.ECHONL)
+        termios.tcsetattr(slave, termios.TCSANOW, attrs)
+    except termios.error:
+        pass  # if we can't disable echo, redaction below is the backstop
     try:
         proc = subprocess.Popen(
             spawn_argv, stdin=slave, stdout=slave, stderr=slave,
@@ -232,8 +273,12 @@ def install_key_with_password(spawn_argv, password, timeout=30):
         return {"ok": False, "error": "host_key"}
     if "Permission denied" in output and not answered:
         return {"ok": False, "error": "password_auth_disabled"}
+    # Belt-and-braces on top of the pty ECHO=off above: never let the
+    # password reach the returned detail even if something along the way
+    # (an unusual terminal driver, a stubborn ssh build) echoed it back.
+    safe = output.replace(password, "<redacted>") if password else output
     return {"ok": False, "error": "ssh_failed",
-            "detail": output[-400:].strip()}
+            "detail": safe[-400:].strip()}
 
 
 def port_reachable(host, port, timeout=5):

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -6,6 +6,7 @@ fakes. Nothing here imports Flask or touches the database.
 """
 
 import concurrent.futures
+import contextlib
 import ipaddress
 import os
 import re
@@ -341,10 +342,8 @@ def locate_share(mount_point, share, host, user, port, key, ssh_bin,
     finally:
         # Mount-side cleanup only: the nonce lives on the share, so this
         # removes it regardless of which NAS path it appeared at.
-        try:
+        with contextlib.suppress(OSError):
             os.unlink(nonce_path)
-        except OSError:
-            pass
 
 
 def list_remote_dirs(path, host, user, port, key, ssh_bin,

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -5,10 +5,10 @@ pattern): production passes nothing and gets ``subprocess``; tests pass
 fakes. Nothing here imports Flask or touches the database.
 """
 
-import concurrent.futures
 import contextlib
 import ipaddress
 import os
+import queue as _queue
 import re
 import secrets
 import select
@@ -16,6 +16,7 @@ import shlex
 import socket
 import subprocess
 import sys
+import threading
 import time
 import urllib.parse
 
@@ -90,21 +91,32 @@ def _reverse_dns(ip):
     no timeout parameter and can hang for many seconds on networks that
     drop PTR queries, which would stall the wizard's mounts endpoint.
 
-    The executor is torn down without waiting: the ``with`` form calls
-    ``shutdown(wait=True)`` on exit even when ``fut.result`` already raised
-    a TimeoutError, which would silently re-block the endpoint for the full
-    DNS delay. Leftover worker threads are daemons — they die on process
-    exit, or when ``gethostbyaddr`` finally returns.
+    Runs the lookup in a daemon thread and reads the answer through a
+    bounded queue. The daemon flag is what makes the leak-free story true:
+    a hung ``gethostbyaddr`` cannot block interpreter shutdown, and each
+    stuck lookup costs exactly one OS thread that dies the moment the
+    kernel returns from the syscall. ``ThreadPoolExecutor`` doesn't work
+    here — its worker threads are NON-daemon and are joined via an
+    ``atexit`` hook, so a stuck PTR query would silently block process
+    exit, and dropping the executor with ``shutdown(wait=False)`` leaks
+    a non-daemon worker per timed-out lookup.
     """
-    ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    try:
-        fut = ex.submit(socket.gethostbyaddr, ip)
-        return fut.result(timeout=2)[0]
-    finally:
+    result_q = _queue.Queue(maxsize=1)
+
+    def _worker():
         try:
-            ex.shutdown(wait=False, cancel_futures=True)
-        except TypeError:  # cancel_futures added in 3.9
-            ex.shutdown(wait=False)
+            result_q.put(("ok", socket.gethostbyaddr(ip)))
+        except BaseException as exc:  # pylint: disable=broad-except
+            result_q.put(("err", exc))
+
+    threading.Thread(target=_worker, daemon=True).start()
+    try:
+        kind, value = result_q.get(timeout=2)
+    except _queue.Empty:
+        raise TimeoutError(f"reverse DNS for {ip} timed out")
+    if kind == "err":
+        raise value
+    return value[0]
 
 
 def friendly_host_name(host, resolver=None):
@@ -134,12 +146,46 @@ def ensure_vireo_key(run=subprocess.run, ssh_keygen_bin="ssh-keygen"):
 
     No passphrase: background rsync jobs must run unattended. The key never
     leaves this machine and grants only what the NAS account grants.
+
+    Repairs partial state: if only ``priv`` exists (interrupted generation,
+    or the ``.pub`` was deleted), regenerate the public key with
+    ``ssh-keygen -y -f priv`` rather than falling through to a fresh
+    ``-f priv`` that would sit forever on the non-interactive overwrite
+    prompt. Always normalizes ``priv`` to ``0600`` so an existing key with
+    loose permissions doesn't cause ssh to reject it later.
     """
     priv, pub = vireo_key_paths()
     key_dir = os.path.dirname(priv)
     os.makedirs(key_dir, mode=0o700, exist_ok=True)
     os.chmod(key_dir, 0o700)  # makedirs mode is ignored for existing dirs
-    if os.path.exists(priv) and os.path.exists(pub):
+    if os.path.exists(priv):
+        try:
+            os.chmod(priv, 0o600)
+        except OSError:
+            pass
+        if os.path.exists(pub):
+            return priv, pub
+        # Rebuild the .pub from the existing private key. ``-y`` reads the
+        # private key and prints the corresponding public key to stdout —
+        # no interactive prompts, no risk of clobbering ``priv``.
+        r = run([ssh_keygen_bin, "-y", "-f", priv],
+                capture_output=True, text=True, timeout=15)
+        pub_line = (getattr(r, "stdout", "") or "").strip()
+        if r.returncode != 0 or not pub_line:
+            detail = (getattr(r, "stderr", "") or "").strip()
+            raise RuntimeError(
+                f"ssh-keygen -y failed: {detail or 'unknown error'}")
+        # -y output omits the trailing comment; add "vireo" to match what
+        # fresh generation produces so the rest of the app doesn't see two
+        # shapes of the same key.
+        if len(pub_line.split()) == 2:
+            pub_line = pub_line + " vireo"
+        with open(pub, "w") as f:
+            f.write(pub_line + "\n")
+        try:
+            os.chmod(pub, 0o644)
+        except OSError:
+            pass
         return priv, pub
     r = run([ssh_keygen_bin, "-t", "ed25519", "-N", "", "-f", priv,
              "-C", "vireo"], capture_output=True, text=True, timeout=30)

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -9,6 +9,7 @@ import concurrent.futures
 import ipaddress
 import os
 import re
+import secrets
 import select
 import shlex
 import socket
@@ -233,6 +234,78 @@ def install_key_with_password(spawn_argv, password, timeout=30):
         return {"ok": False, "error": "password_auth_disabled"}
     return {"ok": False, "error": "ssh_failed",
             "detail": output[-400:].strip()}
+
+
+class MountNotWritable(RuntimeError):
+    """The local mount refused the nonce write — the wizard needs a
+    writable share (so does the move workflow it is setting up)."""
+
+
+def _ssh_exec(host, user, port, key, ssh_bin, command, run, timeout=20):
+    argv = ([ssh_bin] + _ssh_option_args(port, key)
+            + [f"{user}@{host}", command])
+    return run(argv, capture_output=True, text=True, timeout=timeout)
+
+
+# Candidate export roots checked for the share, in likelihood order:
+# Synology (/volume*), QNAP (/share, /shares), TrueNAS/generic (/mnt/*),
+# plain Linux servers (/srv/*).
+_SHARE_CANDIDATE_ROOTS = '/volume*/"$S" /share/"$S" /shares/"$S" /mnt/*/"$S" /srv/*/"$S"'
+
+
+def locate_share(mount_point, share, host, user, port, key, ssh_bin,
+                 run=subprocess.run):
+    """Prove which NAS-side directory backs ``mount_point``.
+
+    Writes a nonce file through the mount, then asks the NAS (over SSH)
+    which candidate share directory contains that exact file. A match is
+    the verified remote path — heuristics could pick a same-named share on
+    the wrong volume, and the chained move DELETES local originals, so
+    only proof is acceptable here. Returns None when no candidate matched.
+    """
+    nonce = ".vireo-probe-" + secrets.token_hex(8)
+    nonce_path = os.path.join(mount_point, nonce)
+    try:
+        with open(nonce_path, "w") as f:
+            f.write("vireo share-locate probe; safe to delete\n")
+    except OSError as exc:
+        raise MountNotWritable(str(exc)) from exc
+    try:
+        cmd = (f"S={shlex.quote(share)}; "
+               f"for p in {_SHARE_CANDIDATE_ROOTS}; do "
+               f'[ -e "$p/{nonce}" ] && {{ echo "FOUND:$p"; break; }}; '
+               f"done; true")
+        try:
+            r = _ssh_exec(host, user, port, key, ssh_bin, cmd, run)
+        except (OSError, subprocess.SubprocessError):
+            return None
+        for line in (r.stdout or "").splitlines():
+            if line.startswith("FOUND:"):
+                return line[len("FOUND:"):].strip() or None
+        return None
+    finally:
+        # Mount-side cleanup only: the nonce lives on the share, so this
+        # removes it regardless of which NAS path it appeared at.
+        try:
+            os.unlink(nonce_path)
+        except OSError:
+            pass
+
+
+def list_remote_dirs(path, host, user, port, key, ssh_bin,
+                     run=subprocess.run):
+    """Immediate subdirectory names of ``path`` on the NAS, for the
+    fallback browser when the nonce probe finds nothing."""
+    cmd = (f"find {shlex.quote(path)} -mindepth 1 -maxdepth 1 -type d "
+           f"-exec basename {{}} \\;")
+    try:
+        r = _ssh_exec(host, user, port, key, ssh_bin, cmd, run)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if r.returncode != 0:
+        return []
+    names = [n for n in (r.stdout or "").splitlines() if n.strip()]
+    return sorted(names, key=str.casefold)
 
 
 def list_network_mounts(run=subprocess.run, resolver=None):

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -459,13 +459,23 @@ def list_remote_dirs(path, host, user, port, key, ssh_bin,
 
 
 def list_network_mounts(run=subprocess.run, resolver=None):
-    """Enumerate mounted network shares, each with a display-friendly host."""
+    """Enumerate mounted network shares, each with a display-friendly host.
+
+    Reverse-DNS results are memoized per unique host across the rows, so N
+    shares from the same IP-based NAS cost one PTR lookup instead of N.
+    Without this, a single unresponsive PTR server would stall the mounts
+    endpoint by ``2s × number_of_shares`` (the ``_reverse_dns`` cap).
+    """
     try:
         r = run(["mount"], capture_output=True, text=True, timeout=10)
     except (OSError, subprocess.SubprocessError):
         return []
     rows = parse_mount_output(r.stdout or "")
+    friendly_by_host = {}
     for row in rows:
-        row["friendly_host"] = friendly_host_name(row["host"], resolver=resolver)
+        host = row["host"]
+        if host not in friendly_by_host:
+            friendly_by_host[host] = friendly_host_name(host, resolver=resolver)
+        row["friendly_host"] = friendly_by_host[host]
         row["display_name"] = row["friendly_host"].split(".", 1)[0]
     return rows

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -70,8 +70,15 @@ def parse_mount_output(text):
         if not s:
             continue
         unq = urllib.parse.unquote
+        # SMB URL-authority form wraps IPv6 in brackets (`[fe80::1%25en0]`).
+        # Keep the URL form out of downstream consumers: socket.create_connection
+        # and friendly_host_name want the plain address (`fe80::1%en0`), and
+        # the brackets confuse both. Strip them once here.
+        host = unq(s.group("host"))
+        if host.startswith("[") and host.endswith("]"):
+            host = host[1:-1]
         rows.append({
-            "fs_type": fs_type, "host": unq(s.group("host")),
+            "fs_type": fs_type, "host": host,
             "share": unq(s.group("share").rstrip("/")),
             "mount_point": mount_point, "user": unq(s.group("user") or ""),
         })
@@ -158,7 +165,13 @@ def _ssh_option_args(port, key, batch=True):
     except (TypeError, ValueError):
         pass
     if key:
-        args += ["-i", key]
+        # IdentitiesOnly=yes is what makes ``key_auth_works`` a truthful check.
+        # Without it, ssh still consults ssh-agent and any default identities,
+        # so an ambient agent identity already authorized on the NAS lets `-i
+        # <vireo-key>` succeed on the agent's key rather than ours — the wizard
+        # would then skip install-key and save a target that stops working the
+        # moment the agent identity is unavailable.
+        args += ["-o", "IdentitiesOnly=yes", "-i", key]
     return args
 
 

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -249,6 +249,33 @@ def build_install_argv(host, user, port, key_pub_line, ssh_bin):
 
 _PASSWORD_PROMPT_RE = re.compile(r"[Pp]assword[^\n]*:")
 
+# Runs in a fresh Python interpreter (spawned via subprocess), NOT as a
+# preexec_fn callback in the forked child. That distinction matters: this
+# install-key path runs inside the 16-thread Waitress worker pool, and the
+# subprocess docs warn that preexec_fn is unsafe under threads because the
+# forked child inherits every lock the parent's other threads were holding
+# and can deadlock before exec. A subprocess helper avoids that entirely —
+# the child process is a brand-new Python with no inherited threads or
+# locks, and Popen without preexec_fn uses posix_spawn/vfork under the
+# hood (thread-safe). The helper does the pty setup real ssh needs
+# (setsid + TIOCSCTTY so /dev/tty resolves) plus a defensive ECHO=off,
+# then execvp's the real ssh argv. Written as a one-line -c snippet so
+# there's no separate file to ship or find at runtime.
+_PTY_SPAWN_HELPER = (
+    "import os,sys,fcntl,termios;"
+    "os.setsid();"
+    "fcntl.ioctl(0,termios.TIOCSCTTY,0);"
+    # ECHO=off before ssh takes over: a fresh pty defaults to ECHO=ON, and
+    # the password we write later would then echo into the parent's read
+    # buffer where an unclassified failure could return it as `detail`.
+    # ssh sets ECHO off itself when it prompts, but pre-disabling closes
+    # the race; the redaction below is the belt-and-braces backstop.
+    "a=termios.tcgetattr(0);"
+    "a[3]&=~(termios.ECHO|termios.ECHOE|termios.ECHOK|termios.ECHONL);"
+    "termios.tcsetattr(0,termios.TCSANOW,a);"
+    "os.execvp(sys.argv[1],sys.argv[1:])"
+)
+
 
 def install_key_with_password(spawn_argv, password, timeout=30):
     """Drive ``spawn_argv`` through a pty, answering one password prompt.
@@ -261,42 +288,20 @@ def install_key_with_password(spawn_argv, password, timeout=30):
     The password must never reach logs, exceptions, or the returned dict —
     it is written to the pty and nowhere else.
     """
-    # pty + termios + fcntl are POSIX-only; import here so `remote_setup`
-    # still loads on Windows (the wizard itself is macOS-only in production).
-    import fcntl
+    # pty is POSIX-only; import here so `remote_setup` still loads on
+    # Windows (the wizard itself is macOS-only in production).
     import pty
-    import termios
 
     master, slave = pty.openpty()
-    # Disable pty ECHO up front — a new pty defaults to ECHO=ON, and any
-    # bytes we write for the password prompt would then be echoed back into
-    # our read buffer, leaving the password sitting in ``output`` where an
-    # unclassified failure (below) could return it as ``detail``. ssh sets
-    # ECHO off itself when it prompts, but the default state before that is
-    # too fragile to rely on.
-    try:
-        attrs = termios.tcgetattr(slave)
-        attrs[3] &= ~(termios.ECHO | termios.ECHOE | termios.ECHOK
-                      | termios.ECHONL)
-        termios.tcsetattr(slave, termios.TCSANOW, attrs)
-    except termios.error:
-        pass  # if we can't disable echo, redaction below is the backstop
-    def _preexec():
-        # Real OpenSSH reads the password prompt from /dev/tty, not stdin,
-        # so start_new_session on its own is not enough: setsid detaches the
-        # child from the parent's tty but leaves the child with NO controlling
-        # terminal, and `/dev/tty` then fails with ENXIO. TIOCSCTTY on the
-        # slave (which is stdin/stdout/stderr in the child) is what promotes
-        # the pty to being the controlling terminal so the prompt reaches us.
-        # The test stub in test_remote_setup.py reads from stdin via input()
-        # and doesn't need this, but real ssh does.
-        os.setsid()
-        fcntl.ioctl(0, termios.TIOCSCTTY, 0)
-
+    # Spawn the real ssh through a Python helper (see _PTY_SPAWN_HELPER):
+    # the helper does the setsid+TIOCSCTTY+ECHO=off dance and then execs
+    # ssh. No preexec_fn — Popen without one is thread-safe under
+    # Waitress, and the helper Python is a fresh process with no
+    # inherited locks so its setup code cannot deadlock.
     try:
         proc = subprocess.Popen(
-            spawn_argv, stdin=slave, stdout=slave, stderr=slave,
-            preexec_fn=_preexec)
+            [sys.executable, "-c", _PTY_SPAWN_HELPER, *spawn_argv],
+            stdin=slave, stdout=slave, stderr=slave)
     except OSError as exc:
         os.close(master)
         os.close(slave)

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -236,6 +236,16 @@ def install_key_with_password(spawn_argv, password, timeout=30):
             "detail": output[-400:].strip()}
 
 
+def port_reachable(host, port, timeout=5):
+    """True when a TCP connection to host:port succeeds within timeout."""
+    try:
+        sock = socket.create_connection((host, int(port)), timeout=timeout)
+    except (OSError, ValueError):
+        return False
+    sock.close()
+    return True
+
+
 class MountNotWritable(RuntimeError):
     """The local mount refused the nonce write — the wizard needs a
     writable share (so does the move workflow it is setting up)."""

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -215,8 +215,9 @@ def install_key_with_password(spawn_argv, password, timeout=30):
     The password must never reach logs, exceptions, or the returned dict —
     it is written to the pty and nowhere else.
     """
-    # pty + termios are POSIX-only; import here so `remote_setup` still
-    # loads on Windows (the wizard itself is macOS-only in production).
+    # pty + termios + fcntl are POSIX-only; import here so `remote_setup`
+    # still loads on Windows (the wizard itself is macOS-only in production).
+    import fcntl
     import pty
     import termios
 
@@ -234,10 +235,22 @@ def install_key_with_password(spawn_argv, password, timeout=30):
         termios.tcsetattr(slave, termios.TCSANOW, attrs)
     except termios.error:
         pass  # if we can't disable echo, redaction below is the backstop
+    def _preexec():
+        # Real OpenSSH reads the password prompt from /dev/tty, not stdin,
+        # so start_new_session on its own is not enough: setsid detaches the
+        # child from the parent's tty but leaves the child with NO controlling
+        # terminal, and `/dev/tty` then fails with ENXIO. TIOCSCTTY on the
+        # slave (which is stdin/stdout/stderr in the child) is what promotes
+        # the pty to being the controlling terminal so the prompt reaches us.
+        # The test stub in test_remote_setup.py reads from stdin via input()
+        # and doesn't need this, but real ssh does.
+        os.setsid()
+        fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+
     try:
         proc = subprocess.Popen(
             spawn_argv, stdin=slave, stdout=slave, stderr=slave,
-            start_new_session=True)
+            preexec_fn=_preexec)
     except OSError as exc:
         os.close(master)
         os.close(slave)

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -27,8 +27,13 @@ import urllib.parse
 _MOUNT_RE = re.compile(r"^(?P<src>\S+?) on (?P<mp>.+) \((?P<opts>[^()]*)\)$")
 # smbfs/afp source: //[user@]host/share  (URL-encoded)
 _SMB_SRC_RE = re.compile(r"^//(?:(?P<user>[^@/]+)@)?(?P<host>[^/]+)/(?P<share>.+)$")
-# nfs source: host:/export/path
-_NFS_SRC_RE = re.compile(r"^(?P<host>[^:/]+):(?P<path>/.*)$")
+# nfs source: host:/export/path — host may be a hostname, IPv4, or a
+# bracketed IPv6 address (`[fe80::1%en0]:/exports/photos`). The colon count
+# in an IPv6 literal forces the brackets so the host/path split stays
+# unambiguous, so accept either form and normalize the host below.
+_NFS_SRC_RE = re.compile(
+    r"^(?:\[(?P<hostv6>[^\]]+)\]|(?P<host>[^:/]+)):(?P<path>/.*)$"
+)
 
 _NETWORK_FS = ("smbfs", "nfs", "afpfs", "webdav")
 
@@ -61,8 +66,12 @@ def parse_mount_output(text):
             n = _NFS_SRC_RE.match(src)
             if not n:
                 continue
+            # Return the plain address for IPv6 hosts (matches the smbfs
+            # path above): socket.create_connection and friendly_host_name
+            # both want `fe80::1%en0`, not `[fe80::1%en0]`.
+            host = n.group("hostv6") or n.group("host")
             rows.append({
-                "fs_type": fs_type, "host": n.group("host"),
+                "fs_type": fs_type, "host": host,
                 "share": os.path.basename(n.group("path").rstrip("/")),
                 "mount_point": mount_point, "user": "",
             })

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -16,7 +16,6 @@ import shlex
 import socket
 import subprocess
 import sys
-import termios
 import time
 import urllib.parse
 
@@ -203,7 +202,10 @@ def install_key_with_password(spawn_argv, password, timeout=30):
     The password must never reach logs, exceptions, or the returned dict —
     it is written to the pty and nowhere else.
     """
-    import pty  # POSIX-only; imported here so module import stays portable
+    # pty + termios are POSIX-only; import here so `remote_setup` still
+    # loads on Windows (the wizard itself is macOS-only in production).
+    import pty
+    import termios
 
     master, slave = pty.openpty()
     # Disable pty ECHO up front — a new pty defaults to ECHO=ON, and any

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -201,10 +201,13 @@ def ensure_vireo_key(run=subprocess.run, ssh_keygen_bin="ssh-keygen"):
     return priv, pub
 
 
-def _ssh_option_args(port, key, batch=True):
+def _ssh_option_args(port, key, batch=True, password_only=False):
     """Mirror of move.ssh_base_args for wizard probes (kept local so this
     module stays import-light; see that docstring for the option rationale).
-    ``batch=False`` drops BatchMode so a password prompt can reach a pty."""
+    ``batch=False`` drops BatchMode so a password prompt can reach a pty.
+    ``password_only=True`` disables public-key auth entirely so the pty
+    driver reaches the password prompt without first getting stuck on a
+    passphrase prompt for an encrypted default identity."""
     args = []
     if batch:
         args += ["-o", "BatchMode=yes"]
@@ -215,6 +218,14 @@ def _ssh_option_args(port, key, batch=True):
             args += ["-p", str(int(port))]
     except (TypeError, ValueError):
         pass
+    if password_only:
+        # Without these, ssh first offers any ssh-agent identities and any
+        # ~/.ssh/id_* defaults; an encrypted one prompts for its PASSPHRASE
+        # ("Enter passphrase for key ..."), which _PASSWORD_PROMPT_RE does
+        # not match, and the pty driver waits out the 30s timeout instead
+        # of ever seeing the NAS password prompt it is designed to answer.
+        args += ["-o", "PubkeyAuthentication=no",
+                 "-o", "PreferredAuthentications=password"]
     if key:
         # IdentitiesOnly=yes is what makes ``key_auth_works`` a truthful check.
         # Without it, ssh still consults ssh-agent and any default identities,
@@ -248,7 +259,8 @@ def build_install_argv(host, user, port, key_pub_line, ssh_bin):
         f"grep -qxF {quoted} ~/.ssh/authorized_keys || "
         f"echo {quoted} >> ~/.ssh/authorized_keys"
     )
-    return ([ssh_bin] + _ssh_option_args(port, key="", batch=False)
+    return ([ssh_bin] + _ssh_option_args(port, key="", batch=False,
+                                         password_only=True)
             + [f"{user}@{host}", snippet])
 
 

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -122,7 +122,7 @@ def _reverse_dns(ip):
     try:
         kind, value = result_q.get(timeout=2)
     except _queue.Empty:
-        raise TimeoutError(f"reverse DNS for {ip} timed out")
+        raise TimeoutError(f"reverse DNS for {ip} timed out") from None
     if kind == "err":
         raise value
     return value[0]
@@ -168,10 +168,8 @@ def ensure_vireo_key(run=subprocess.run, ssh_keygen_bin="ssh-keygen"):
     os.makedirs(key_dir, mode=0o700, exist_ok=True)
     os.chmod(key_dir, 0o700)  # makedirs mode is ignored for existing dirs
     if os.path.exists(priv):
-        try:
+        with contextlib.suppress(OSError):
             os.chmod(priv, 0o600)
-        except OSError:
-            pass
         if os.path.exists(pub):
             return priv, pub
         # Rebuild the .pub from the existing private key. ``-y`` reads the
@@ -191,10 +189,8 @@ def ensure_vireo_key(run=subprocess.run, ssh_keygen_bin="ssh-keygen"):
             pub_line = pub_line + " vireo"
         with open(pub, "w") as f:
             f.write(pub_line + "\n")
-        try:
+        with contextlib.suppress(OSError):
             os.chmod(pub, 0o644)
-        except OSError:
-            pass
         return priv, pub
     r = run([ssh_keygen_bin, "-t", "ed25519", "-N", "", "-f", priv,
              "-C", "vireo"], capture_output=True, text=True, timeout=30)

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -294,6 +294,24 @@ _PTY_SPAWN_HELPER = (
 )
 
 
+def _pty_helper_prefix():
+    """argv prefix that wraps ssh in the pty setup helper.
+
+    In a PyInstaller ``--onefile`` build (the production packaging on
+    macOS via ``scripts/build_sidecar.py``) ``sys.executable`` is the
+    frozen ``vireo-server`` binary, not a Python interpreter, so the
+    ``[sys.executable, "-c", helper]`` shape used in dev would relaunch
+    the whole app with an unrecognized ``-c`` and never exec ssh. The
+    frozen build instead routes through the app's ``--pty-spawn-helper``
+    subcommand (dispatched in ``app.py`` before ``main()``'s argparse
+    runs), which performs the identical setsid + TIOCSCTTY + ECHO=off +
+    execvp dance.
+    """
+    if getattr(sys, "frozen", False):
+        return [sys.executable, "--pty-spawn-helper"]
+    return [sys.executable, "-c", _PTY_SPAWN_HELPER]
+
+
 def install_key_with_password(spawn_argv, password, timeout=30):
     """Drive ``spawn_argv`` through a pty, answering one password prompt.
 
@@ -317,7 +335,7 @@ def install_key_with_password(spawn_argv, password, timeout=30):
     # inherited locks so its setup code cannot deadlock.
     try:
         proc = subprocess.Popen(
-            [sys.executable, "-c", _PTY_SPAWN_HELPER, *spawn_argv],
+            [*_pty_helper_prefix(), *spawn_argv],
             stdin=slave, stdout=slave, stderr=slave)
     except OSError as exc:
         os.close(master)

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -9,8 +9,11 @@ import concurrent.futures
 import ipaddress
 import os
 import re
+import select
+import shlex
 import socket
 import subprocess
+import time
 import urllib.parse
 
 # `mount` line: "<source> on <mount point> (<fstype>, opt, ...)".
@@ -139,6 +142,97 @@ def key_auth_works(host, user, port, key, ssh_bin, run=subprocess.run):
     except (OSError, subprocess.SubprocessError):
         return False
     return r.returncode == 0 and "vireo_ok" in (r.stdout or "")
+
+
+def build_install_argv(host, user, port, key_pub_line, ssh_bin):
+    """ssh argv that appends our public key to the NAS user's
+    authorized_keys — what ssh-copy-id does, minus the extra binary.
+    No BatchMode: the password prompt must reach the pty driver. The
+    append is idempotent (grep before echo) so re-runs are safe."""
+    quoted = shlex.quote(key_pub_line.strip())
+    snippet = (
+        f"umask 077; mkdir -p ~/.ssh; touch ~/.ssh/authorized_keys; "
+        f"grep -qxF {quoted} ~/.ssh/authorized_keys || "
+        f"echo {quoted} >> ~/.ssh/authorized_keys"
+    )
+    return ([ssh_bin] + _ssh_option_args(port, key="", batch=False)
+            + [f"{user}@{host}", snippet])
+
+
+_PASSWORD_PROMPT_RE = re.compile(r"[Pp]assword[^\n]*:")
+
+
+def install_key_with_password(spawn_argv, password, timeout=30):
+    """Drive ``spawn_argv`` through a pty, answering one password prompt.
+
+    Returns ``{"ok": bool, "error": code-or-None}`` (plus ``"detail"`` for
+    unclassified failures). Error codes: ``wrong_password`` (a second
+    prompt appeared — never answered twice), ``password_auth_disabled``,
+    ``host_key``, ``timeout``, ``ssh_failed``.
+
+    The password must never reach logs, exceptions, or the returned dict —
+    it is written to the pty and nowhere else.
+    """
+    import pty  # POSIX-only; imported here so module import stays portable
+
+    master, slave = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            spawn_argv, stdin=slave, stdout=slave, stderr=slave,
+            start_new_session=True)
+    except OSError as exc:
+        os.close(master)
+        os.close(slave)
+        return {"ok": False, "error": "ssh_failed", "detail": str(exc)}
+    os.close(slave)
+
+    output = ""
+    answered = False
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                proc.kill()
+                return {"ok": False, "error": "timeout"}
+            ready, _, _ = select.select([master], [], [], min(remaining, 0.5))
+            if ready:
+                try:
+                    chunk = os.read(master, 4096)
+                except OSError:  # EIO on macOS/Linux when the child exits
+                    chunk = b""
+                if chunk:
+                    output += chunk.decode("utf-8", "replace")
+                    prompts = len(_PASSWORD_PROMPT_RE.findall(output))
+                    if prompts >= 2:
+                        # A re-prompt means the first answer was rejected.
+                        # Never answer twice — fail fast as wrong password.
+                        proc.kill()
+                        return {"ok": False, "error": "wrong_password"}
+                    if prompts == 1 and not answered:
+                        answered = True
+                        os.write(master, (password + "\n").encode())
+                    continue
+            if proc.poll() is not None:
+                break
+    finally:
+        os.close(master)
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()
+
+    if proc.returncode == 0:
+        return {"ok": True, "error": None}
+    # Classify from the ACCUMULATED output — the failure text and EOF can
+    # arrive in a single read, after the loop has already answered once.
+    if len(_PASSWORD_PROMPT_RE.findall(output)) >= 2:
+        return {"ok": False, "error": "wrong_password"}
+    if "Host key verification failed" in output:
+        return {"ok": False, "error": "host_key"}
+    if "Permission denied" in output and not answered:
+        return {"ok": False, "error": "password_auth_disabled"}
+    return {"ok": False, "error": "ssh_failed",
+            "detail": output[-400:].strip()}
 
 
 def list_network_mounts(run=subprocess.run, resolver=None):

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -82,6 +82,65 @@ def friendly_host_name(host, resolver=None):
     return (name or host).rstrip(".") or host
 
 
+def vireo_key_paths():
+    """Paths of the dedicated wizard-managed keypair. Lives under ~/.vireo
+    (not ~/.ssh) so setup never touches or clobbers user-managed keys."""
+    priv = os.path.join(os.path.expanduser("~"), ".vireo", "ssh",
+                        "vireo_ed25519")
+    return priv, priv + ".pub"
+
+
+def ensure_vireo_key(run=subprocess.run, ssh_keygen_bin="ssh-keygen"):
+    """Generate the Vireo keypair if missing; return (private, public) paths.
+
+    No passphrase: background rsync jobs must run unattended. The key never
+    leaves this machine and grants only what the NAS account grants.
+    """
+    priv, pub = vireo_key_paths()
+    key_dir = os.path.dirname(priv)
+    os.makedirs(key_dir, mode=0o700, exist_ok=True)
+    os.chmod(key_dir, 0o700)  # makedirs mode is ignored for existing dirs
+    if os.path.exists(priv) and os.path.exists(pub):
+        return priv, pub
+    r = run([ssh_keygen_bin, "-t", "ed25519", "-N", "", "-f", priv,
+             "-C", "vireo"], capture_output=True, text=True, timeout=30)
+    if r.returncode != 0 or not os.path.exists(priv):
+        detail = (getattr(r, "stderr", "") or "").strip()
+        raise RuntimeError(f"ssh-keygen failed: {detail or 'unknown error'}")
+    os.chmod(priv, 0o600)
+    return priv, pub
+
+
+def _ssh_option_args(port, key, batch=True):
+    """Mirror of move.ssh_base_args for wizard probes (kept local so this
+    module stays import-light; see that docstring for the option rationale).
+    ``batch=False`` drops BatchMode so a password prompt can reach a pty."""
+    args = []
+    if batch:
+        args += ["-o", "BatchMode=yes"]
+    args += ["-o", "StrictHostKeyChecking=accept-new",
+             "-o", "ConnectTimeout=10"]
+    try:
+        if int(port or 22) != 22:
+            args += ["-p", str(int(port))]
+    except (TypeError, ValueError):
+        pass
+    if key:
+        args += ["-i", key]
+    return args
+
+
+def key_auth_works(host, user, port, key, ssh_bin, run=subprocess.run):
+    """True when passwordless (key) SSH login works right now."""
+    argv = ([ssh_bin] + _ssh_option_args(port, key)
+            + [f"{user}@{host}", "echo vireo_ok"])
+    try:
+        r = run(argv, capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return r.returncode == 0 and "vireo_ok" in (r.stdout or "")
+
+
 def list_network_mounts(run=subprocess.run, resolver=None):
     """Enumerate mounted network shares, each with a display-friendly host."""
     try:

--- a/vireo/remote_setup.py
+++ b/vireo/remote_setup.py
@@ -1,0 +1,95 @@
+"""Discovery + one-time setup helpers behind the NAS setup wizard.
+
+Pure logic with an injectable command-runner seam (the ``move.py``
+pattern): production passes nothing and gets ``subprocess``; tests pass
+fakes. Nothing here imports Flask or touches the database.
+"""
+
+import concurrent.futures
+import ipaddress
+import os
+import re
+import socket
+import subprocess
+import urllib.parse
+
+# `mount` line: "<source> on <mount point> (<fstype>, opt, ...)".
+# The source is space-free for the network filesystems we accept (smbfs/afp
+# URL-encode spaces; nfs is host:/path), while the mount point may contain
+# spaces — so split at the FIRST " on " (non-greedy source).
+_MOUNT_RE = re.compile(r"^(?P<src>\S+?) on (?P<mp>.+) \((?P<opts>[^()]*)\)$")
+# smbfs/afp source: //[user@]host/share  (URL-encoded)
+_SMB_SRC_RE = re.compile(r"^//(?:(?P<user>[^@/]+)@)?(?P<host>[^/]+)/(?P<share>.+)$")
+# nfs source: host:/export/path
+_NFS_SRC_RE = re.compile(r"^(?P<host>[^:/]+):(?P<path>/.*)$")
+
+_NETWORK_FS = ("smbfs", "nfs", "afpfs", "webdav")
+
+
+def parse_mount_output(text):
+    """Parse ``mount`` output into network-share rows the wizard can offer."""
+    rows = []
+    for line in text.splitlines():
+        m = _MOUNT_RE.match(line.strip())
+        if not m:
+            continue
+        fs_type = (m.group("opts").split(",")[0] or "").strip()
+        if fs_type not in _NETWORK_FS:
+            continue
+        src, mount_point = m.group("src"), m.group("mp")
+        if fs_type == "nfs":
+            n = _NFS_SRC_RE.match(src)
+            if not n:
+                continue
+            rows.append({
+                "fs_type": fs_type, "host": n.group("host"),
+                "share": os.path.basename(n.group("path").rstrip("/")),
+                "mount_point": mount_point, "user": "",
+            })
+            continue
+        s = _SMB_SRC_RE.match(src)
+        if not s:
+            continue
+        unq = urllib.parse.unquote
+        rows.append({
+            "fs_type": fs_type, "host": unq(s.group("host")),
+            "share": unq(s.group("share").rstrip("/")),
+            "mount_point": mount_point, "user": unq(s.group("user") or ""),
+        })
+    return rows
+
+
+def _reverse_dns(ip):
+    """Default resolver: PTR lookup with a hard 2s cap — gethostbyaddr has
+    no timeout parameter and can hang for many seconds on networks that
+    drop PTR queries, which would stall the wizard's mounts endpoint."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        fut = ex.submit(socket.gethostbyaddr, ip)
+        return fut.result(timeout=2)[0]
+
+
+def friendly_host_name(host, resolver=None):
+    """Reverse-resolve an IP host to a name (Tailscale MagicDNS, mDNS, DNS);
+    non-IP hosts and failed lookups pass through unchanged."""
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        return host
+    try:
+        name = (resolver or _reverse_dns)(host)
+    except Exception:
+        return host
+    return (name or host).rstrip(".") or host
+
+
+def list_network_mounts(run=subprocess.run, resolver=None):
+    """Enumerate mounted network shares, each with a display-friendly host."""
+    try:
+        r = run(["mount"], capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    rows = parse_mount_output(r.stdout or "")
+    for row in rows:
+        row["friendly_host"] = friendly_host_name(row["host"], resolver=resolver)
+        row["display_name"] = row["friendly_host"].split(".", 1)[0]
+    return rows

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -1466,7 +1466,11 @@ function updateAfterMoveUI() {
     if (importIsAbsolutePath(destination)) {
       unavailable.textContent =
         "Move to NAS unavailable: the destination is not inside any remote "
-        + "target's local archive root. Set one under Settings > Remote targets.";
+        + "target's local archive root. ";
+      const setup = document.createElement('a');
+      setup.href = '/settings#nas-setup';
+      setup.textContent = 'Set up remote target…';
+      unavailable.appendChild(setup);
       unavailable.style.display = '';
     }
     return;

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2112,14 +2112,34 @@ async function nwArchiveStep(body) {
   var freeLine = _nwEl('div', _nwHintCss, '');
   var err = _nwEl('div', _nwErrCss, '');
   var setChosen = async function(p) {
-    // Mirror _coerce_remote_target: absolute and not inside the mount.
-    var norm = function(x) { return String(x || '').replace(/\/+$/, '').toLowerCase(); };
-    var inMount = norm(p) === norm(_nw.mount.mount_point) ||
-      norm(p).indexOf(norm(_nw.mount.mount_point) + '/') === 0;
-    if (inMount) {
-      err.textContent = 'The archive folder must be on this Mac, not on the NAS volume itself.';
-      _nwSetNext(false);
-      return;
+    // Filesystem-aware containment: the same check _coerce_remote_target
+    // performs at save time. A purely-lexical prefix compare on the client
+    // (which we used to do here) misses symlink aliases — e.g. ~/Archive
+    // that points at /Volumes/Photography — and the save-time validator
+    // would then silently blank local_archive_root, leaving the wizard's
+    // target unable to offer the chained move. Fail here instead so the
+    // user gets an actionable error while still in step 4.
+    err.textContent = '';
+    _nwSetNext(false);
+    try {
+      var chk = await safeFetch('/api/remote-setup/check-archive-root', {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({path: p, mount_path: _nw.mount.mount_point}),
+      }, { toast: false });
+      if (chk && chk.inside_mount) {
+        err.textContent = 'That folder resolves inside the NAS mount (symlink or alias). Pick a folder on this Mac instead.';
+        return;
+      }
+    } catch (e) {
+      // Endpoint unavailable (e.g. offline test harness) — fall back to a
+      // lexical check so this step still gates the obvious case.
+      var norm = function(x) { return String(x || '').replace(/\/+$/, '').toLowerCase(); };
+      var inMount = norm(p) === norm(_nw.mount.mount_point) ||
+        norm(p).indexOf(norm(_nw.mount.mount_point) + '/') === 0;
+      if (inMount) {
+        err.textContent = 'The archive folder must be on this Mac, not on the NAS volume itself.';
+        return;
+      }
     }
     err.textContent = '';
     _nw.archiveRoot = p;

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -871,7 +871,25 @@
       Destinations for moving folders to a NAS over SSH — far more reliable than an SMB mount over a slow/remote link, with resume and integrity verification. The <b>Remote path</b> is the NAS-side filesystem path rsync writes to (e.g. <code>/volume1/Photography</code>); the <b>Local mount path</b> is where you can read those same files afterward (e.g. <code>/Volumes/Photography</code>) — moved photos are repointed there so they stay in your library. Remote moves need GNU rsync (set its path under “GNU rsync path” in the Paths settings if auto-detect fails). <b>Local archive root</b> is the local folder that mirrors the remote path. Imports under this folder can chain an automatic move to this target after processing. It must be an absolute path outside the local mount path — other values are cleared on save.
     </p>
     <div id="cfgRemoteTargetsList" style="display:flex;flex-direction:column;gap:10px;margin-bottom:8px;"></div>
-    <button type="button" onclick="addRemoteTarget()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">+ Add remote target</button>
+    <div style="display:flex;gap:8px;align-items:center;">
+      <button type="button" onclick="openNasWizard()" style="background:var(--accent);color:var(--bg-primary);border:1px solid var(--accent);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;font-weight:600;">Set up from mounted volume…</button>
+      <button type="button" onclick="addRemoteTarget()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">+ Add manually</button>
+    </div>
+  </div>
+
+  <!-- NAS setup wizard -->
+  <div id="nasWizard" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:1000;align-items:center;justify-content:center;">
+    <div style="background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:8px;width:560px;max-width:92vw;max-height:86vh;display:flex;flex-direction:column;">
+      <div style="display:flex;align-items:center;justify-content:space-between;padding:14px 18px;border-bottom:1px solid var(--border-secondary);">
+        <h3 id="nwTitle" style="margin:0;font-size:15px;">Set up NAS</h3>
+        <button type="button" onclick="closeNasWizard()" style="background:none;border:0;color:var(--text-dim);font-size:18px;cursor:pointer;line-height:1;">&times;</button>
+      </div>
+      <div id="nwBody" style="padding:16px 18px;overflow-y:auto;font-size:13px;color:var(--text-primary);"></div>
+      <div style="display:flex;gap:8px;justify-content:space-between;padding:12px 18px;border-top:1px solid var(--border-secondary);">
+        <button type="button" id="nwBack" onclick="nwBack()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 14px;font-size:12px;cursor:pointer;">Back</button>
+        <button type="button" id="nwNext" onclick="nwNext()" style="background:var(--accent);color:var(--bg-primary);border:1px solid var(--accent);border-radius:4px;padding:6px 14px;font-size:12px;cursor:pointer;font-weight:600;">Next</button>
+      </div>
+    </div>
   </div>
 
   <!-- darktable Development -->
@@ -1716,6 +1734,534 @@ async function testRemoteTarget(i, btn, statusEl) {
     btn.disabled = false;
     btn.textContent = orig;
   }
+}
+
+// ---------------------------------------------------------------------
+// NAS setup wizard. Five steps: volume -> ssh -> share -> archive ->
+// review. Every step pre-fills from discovery and lets the user override;
+// the manual card editor above stays the advanced/edit path.
+// ---------------------------------------------------------------------
+
+var _nw = null;   // wizard state; null when closed
+
+function _nwEl(tag, css, text) {
+  var el = document.createElement(tag);
+  if (css) el.style.cssText = css;
+  if (text != null) el.textContent = text;
+  return el;
+}
+
+var _nwBtnCss = 'background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:5px 11px;font-size:12px;cursor:pointer;';
+var _nwInputCss = _rtInputCss + 'font-family:monospace;';
+var _nwHintCss = 'font-size:12px;color:var(--text-dim);margin:6px 0;';
+var _nwErrCss = 'font-size:12px;color:var(--warning);margin:6px 0;white-space:pre-wrap;';
+var _nwOkCss = 'font-size:12px;color:var(--success, #4caf50);margin:6px 0;';
+
+function openNasWizard() {
+  _nw = { step: 'volume', mounts: [], mount: null, host: '', user: '',
+          port: 22, keyAuthOk: false, pubKeyLine: '', remotePath: '',
+          archiveRoot: '', browsePath: '', remoteBrowsePath: '/' };
+  document.getElementById('nasWizard').style.display = 'flex';
+  nwRender();
+}
+
+function closeNasWizard() {
+  _nw = null;
+  document.getElementById('nasWizard').style.display = 'none';
+}
+
+var _nwSteps = ['volume', 'ssh', 'share', 'archive', 'review'];
+var _nwTitles = {
+  volume: 'Step 1 of 5 — Pick your NAS volume',
+  ssh: 'Step 2 of 5 — Connect over SSH',
+  share: 'Step 3 of 5 — Locate the share on the NAS',
+  archive: 'Step 4 of 5 — Choose a local archive folder',
+  review: 'Step 5 of 5 — Review and test',
+};
+
+function nwBack() {
+  if (!_nw) return;
+  var i = _nwSteps.indexOf(_nw.step);
+  if (i <= 0) { closeNasWizard(); return; }
+  _nw.step = _nwSteps[i - 1];
+  nwRender();
+}
+
+function nwNext() {
+  if (!_nw) return;
+  var i = _nwSteps.indexOf(_nw.step);
+  if (_nw.step === 'review') { nwSave(); return; }
+  if (i < _nwSteps.length - 1) {
+    _nw.step = _nwSteps[i + 1];
+    nwRender();
+  }
+}
+
+function _nwSetNext(enabled, label) {
+  var btn = document.getElementById('nwNext');
+  btn.disabled = !enabled;
+  btn.style.opacity = enabled ? '1' : '0.5';
+  btn.textContent = label || (_nw && _nw.step === 'review' ? 'Save' : 'Next');
+}
+
+function nwRender() {
+  if (!_nw) return;
+  document.getElementById('nwTitle').textContent = _nwTitles[_nw.step];
+  document.getElementById('nwBack').textContent =
+    _nw.step === 'volume' ? 'Cancel' : 'Back';
+  var body = document.getElementById('nwBody');
+  body.replaceChildren();
+  ({ volume: nwVolumeStep, ssh: nwSshStep, share: nwShareStep,
+     archive: nwArchiveStep, review: nwReviewStep })[_nw.step](body);
+}
+
+// --- Step 1: volume ----------------------------------------------------
+
+async function nwVolumeStep(body) {
+  _nwSetNext(false);
+  body.appendChild(_nwEl('div', _nwHintCss, 'Looking for mounted network volumes…'));
+  var res;
+  try {
+    res = await safeFetch('/api/remote-setup/mounts', {}, { toast: false });
+  } catch (e) {
+    body.replaceChildren(_nwEl('div', _nwErrCss, 'Could not list volumes: ' + (e && e.message || e)));
+    return;
+  }
+  if (!_nw || _nw.step !== 'volume') return;
+  _nw.mounts = res.mounts || [];
+  body.replaceChildren();
+  if (res.unsupported_platform) {
+    body.appendChild(_nwEl('div', _nwErrCss,
+      'Automatic volume detection is only available on macOS for now. Use "+ Add manually" instead.'));
+    return;
+  }
+  if (!_nw.mounts.length) {
+    body.appendChild(_nwEl('div', _nwHintCss,
+      'No network volumes are mounted. Connect to your NAS in Finder first (Go → Connect to Server, or ⌘K), then refresh.'));
+    var refresh = _nwEl('button', _nwBtnCss, 'Refresh');
+    refresh.type = 'button';
+    refresh.onclick = function() { nwRender(); };
+    body.appendChild(refresh);
+    return;
+  }
+  body.appendChild(_nwEl('div', _nwHintCss, 'Pick the volume that lives on your NAS:'));
+  _nw.mounts.forEach(function(m, i) {
+    var row = _nwEl('label', 'display:flex;gap:8px;align-items:center;padding:8px;border:1px solid var(--border-secondary);border-radius:6px;margin-bottom:6px;cursor:pointer;');
+    var radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.name = 'nwMount';
+    radio.checked = _nw.mount ? _nw.mount.mount_point === m.mount_point : i === 0;
+    radio.onchange = function() { _nwPickMount(m); };
+    var info = _nwEl('div', 'display:flex;flex-direction:column;gap:2px;');
+    info.appendChild(_nwEl('div', 'font-weight:600;', m.share + ' on ' + (m.display_name || m.host)));
+    info.appendChild(_nwEl('div', 'font-size:11px;color:var(--text-dim);font-family:monospace;',
+      m.mount_point + '  ·  ' + (m.user ? m.user + '@' : '') + m.host));
+    row.appendChild(radio);
+    row.appendChild(info);
+    body.appendChild(row);
+  });
+  _nwPickMount(_nw.mount && _nw.mounts.some(function(m) { return m.mount_point === _nw.mount.mount_point; })
+    ? _nw.mount : _nw.mounts[0]);
+}
+
+function _nwPickMount(m) {
+  _nw.mount = m;
+  _nw.host = m.friendly_host || m.host;
+  _nw.user = m.user || _nw.user;
+  _nwSetNext(true);
+}
+
+// --- Step 2: ssh ---------------------------------------------------------
+
+function _nwLooksSynology() {
+  var probe = ((_nw.mount && _nw.mount.display_name) || '') + ' ' + _nw.host;
+  return /synology|diskstation|dsm/i.test(probe);
+}
+
+function nwSshStep(body) {
+  _nwSetNext(false);
+  var fields = _nwEl('div', 'display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px;');
+  var mk = function(label, value, width, oninput) {
+    var wrap = _nwEl('div', 'display:flex;flex-direction:column;gap:3px;' + (width ? 'width:' + width + ';' : 'flex:1;'));
+    wrap.appendChild(_nwEl('label', 'font-size:11px;color:var(--text-dim);', label));
+    var inp = document.createElement('input');
+    inp.value = value;
+    inp.style.cssText = _nwInputCss;
+    inp.addEventListener('input', function() { oninput(inp.value); });
+    wrap.appendChild(inp);
+    return wrap;
+  };
+  fields.appendChild(mk('User', _nw.user, null, function(v) { _nw.user = v.trim(); }));
+  fields.appendChild(mk('Host', _nw.host, null, function(v) { _nw.host = v.trim(); }));
+  fields.appendChild(mk('Port', String(_nw.port), '70px', function(v) { _nw.port = parseInt(v, 10) || 22; }));
+  body.appendChild(fields);
+  var status = _nwEl('div', '');
+  body.appendChild(status);
+  var recheck = _nwEl('button', _nwBtnCss, 'Check again');
+  recheck.type = 'button';
+  recheck.onclick = function() { _nwRunSshCheck(status, recheck); };
+  body.appendChild(recheck);
+  _nwRunSshCheck(status, recheck);
+}
+
+async function _nwRunSshCheck(status, recheck) {
+  status.replaceChildren(_nwEl('div', _nwHintCss, 'Checking SSH on ' + _nw.host + '…'));
+  var res;
+  try {
+    res = await safeFetch('/api/remote-setup/ssh-check', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ host: _nw.host, user: _nw.user, port: _nw.port }),
+    }, { toast: false });
+  } catch (e) {
+    status.replaceChildren(_nwEl('div', _nwErrCss, (e && e.message) || 'Check failed.'));
+    return;
+  }
+  if (!_nw || _nw.step !== 'ssh') return;
+  _nw.pubKeyLine = res.pub_key_line || '';
+  status.replaceChildren();
+  if (res.ssh_missing) {
+    status.appendChild(_nwEl('div', _nwErrCss,
+      'No OpenSSH client was found on this computer. Set its path under Settings → Paths, then check again.'));
+    return;
+  }
+  if (!res.port_open) {
+    status.appendChild(_nwEl('div', _nwErrCss,
+      'SSH is not reachable on ' + _nw.host + ':' + _nw.port + '.\n' +
+      (_nwLooksSynology()
+        ? 'On a Synology NAS: Control Panel → Terminal & SNMP → Enable SSH service, then check again.'
+        : 'Enable the SSH service on your NAS (check its admin console), then check again.')));
+    return;
+  }
+  if (res.key_auth_ok) {
+    _nw.keyAuthOk = true;
+    status.appendChild(_nwEl('div', _nwOkCss, '✓ This Mac is already authorized on ' + _nw.host + '.'));
+    _nwSetNext(true);
+    return;
+  }
+  // Password form. Used once server-side to authorize this Mac's key —
+  // never stored, never logged.
+  status.appendChild(_nwEl('div', _nwHintCss,
+    'Enter the NAS password for "' + _nw.user + '" once. Vireo uses it to authorize this Mac’s key on the NAS, then never needs it again — it is not stored or logged.'));
+  var row = _nwEl('div', 'display:flex;gap:8px;align-items:center;margin:6px 0;');
+  var pw = document.createElement('input');
+  pw.type = 'password';
+  pw.placeholder = 'NAS password';
+  pw.style.cssText = _nwInputCss + 'flex:1;';
+  var submit = _nwEl('button', _nwBtnCss, 'Authorize');
+  submit.type = 'button';
+  var msg = _nwEl('div', _nwErrCss, '');
+  submit.onclick = async function() {
+    if (!pw.value) return;
+    submit.disabled = true;
+    msg.textContent = 'Authorizing…';
+    msg.style.cssText = _nwHintCss;
+    try {
+      var r = await safeFetch('/api/remote-setup/install-key', {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ host: _nw.host, user: _nw.user,
+                               port: _nw.port, password: pw.value }),
+      }, { toast: false });
+      if (r.ok && r.key_auth_ok) {
+        _nw.keyAuthOk = true;
+        status.replaceChildren(_nwEl('div', _nwOkCss,
+          '✓ Authorized. ' + (r.fingerprint ? 'Key: ' + r.fingerprint : '')));
+        _nwSetNext(true);
+        return;
+      }
+      msg.style.cssText = _nwErrCss;
+      msg.textContent = {
+        wrong_password: 'That password was not accepted — try again.',
+        password_auth_disabled: 'The NAS refuses password logins over SSH. Use the Terminal option below, or enable password authentication on the NAS.',
+        host_key: 'The NAS’s host key changed since a previous connection — fix ~/.ssh/known_hosts and retry.',
+        timeout: 'The NAS did not respond in time — try again.',
+      }[r.error] || ('Setup failed: ' + (r.detail || r.error || 'unknown error'));
+      if (r.error === 'wrong_password') pw.value = '';
+    } catch (e) {
+      msg.style.cssText = _nwErrCss;
+      msg.textContent = (e && e.message) || 'Setup failed.';
+    } finally {
+      submit.disabled = false;
+    }
+  };
+  pw.addEventListener('keydown', function(ev) { if (ev.key === 'Enter') submit.onclick(); });
+  row.appendChild(pw);
+  row.appendChild(submit);
+  status.appendChild(row);
+  status.appendChild(msg);
+
+  var details = document.createElement('details');
+  details.style.cssText = 'margin-top:10px;font-size:12px;color:var(--text-dim);';
+  var summary = document.createElement('summary');
+  summary.textContent = 'Prefer to do this yourself in Terminal?';
+  summary.style.cursor = 'pointer';
+  details.appendChild(summary);
+  var cmd = 'ssh' + (_nw.port !== 22 ? ' -p ' + _nw.port : '') + ' ' +
+    _nw.user + '@' + _nw.host +
+    ' "umask 077; mkdir -p ~/.ssh; touch ~/.ssh/authorized_keys; ' +
+    "grep -qxF '" + _nw.pubKeyLine + "' ~/.ssh/authorized_keys || " +
+    "echo '" + _nw.pubKeyLine + "' >> ~/.ssh/authorized_keys\"";
+  var pre = _nwEl('pre', 'background:var(--bg-input);border:1px solid var(--border-secondary);border-radius:4px;padding:8px;font-size:11px;white-space:pre-wrap;word-break:break-all;user-select:all;', cmd);
+  details.appendChild(_nwEl('div', _nwHintCss, 'Run this in Terminal (it asks for the NAS password), then click Verify:'));
+  details.appendChild(pre);
+  var verify = _nwEl('button', _nwBtnCss, 'Verify');
+  verify.type = 'button';
+  verify.onclick = function() { _nwRunSshCheck(status, recheck); };
+  details.appendChild(verify);
+  status.appendChild(details);
+}
+
+// --- Step 3: share -------------------------------------------------------
+
+async function nwShareStep(body) {
+  _nwSetNext(false);
+  body.appendChild(_nwEl('div', _nwHintCss,
+    'Verifying where "' + _nw.mount.share + '" lives on the NAS… (Vireo drops a marker file on the mounted volume and finds it over SSH — proof, not a guess.)'));
+  var res;
+  try {
+    res = await safeFetch('/api/remote-setup/locate-share', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ mount_path: _nw.mount.mount_point,
+                             share: _nw.mount.share, host: _nw.host,
+                             user: _nw.user, port: _nw.port }),
+    }, { toast: false });
+  } catch (e) {
+    if (!_nw || _nw.step !== 'share') return;
+    body.replaceChildren(_nwEl('div', _nwErrCss, (e && e.message) || 'Verification failed.'));
+    _nwShareFallback(body);
+    return;
+  }
+  if (!_nw || _nw.step !== 'share') return;
+  body.replaceChildren();
+  if (res.remote_path) {
+    _nw.remotePath = res.remote_path;
+    body.appendChild(_nwEl('div', _nwOkCss,
+      '✓ Verified: ' + _nw.mount.mount_point + ' is ' + res.remote_path + ' on the NAS.'));
+    _nwSetNext(true);
+    return;
+  }
+  body.appendChild(_nwEl('div', _nwErrCss,
+    'Could not find the share automatically. Browse the NAS filesystem or type the path:'));
+  _nwShareFallback(body);
+}
+
+function _nwShareFallback(body) {
+  var list = _nwEl('div', 'border:1px solid var(--border-secondary);border-radius:6px;max-height:180px;overflow-y:auto;margin:6px 0;');
+  var pathLabel = _nwEl('div', 'font-family:monospace;font-size:12px;margin:6px 0;', '');
+  var manual = document.createElement('input');
+  manual.placeholder = '/volume1/' + _nw.mount.share;
+  manual.style.cssText = _nwInputCss + 'width:100%;margin-top:6px;';
+  manual.addEventListener('input', function() {
+    _nw.remotePath = manual.value.trim();
+    _nwSetNext(!!_nw.remotePath && _nw.remotePath.startsWith('/'));
+  });
+  var load = async function(path) {
+    _nw.remoteBrowsePath = path;
+    pathLabel.textContent = path;
+    list.replaceChildren(_nwEl('div', _nwHintCss + 'padding:8px;', 'Loading…'));
+    var res;
+    try {
+      res = await safeFetch('/api/remote-setup/list-remote-dirs', {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ path: path, host: _nw.host, user: _nw.user, port: _nw.port }),
+      }, { toast: false });
+    } catch (e) {
+      list.replaceChildren(_nwEl('div', _nwErrCss + 'padding:8px;', 'Listing failed.'));
+      return;
+    }
+    list.replaceChildren();
+    if (path !== '/') {
+      var up = _nwEl('div', 'padding:6px 10px;cursor:pointer;font-family:monospace;', '← up');
+      up.onclick = function() { load(path.replace(/\/[^/]+$/, '') || '/'); };
+      list.appendChild(up);
+    }
+    (res.dirs || []).forEach(function(name) {
+      var row = _nwEl('div', 'padding:6px 10px;cursor:pointer;font-family:monospace;border-top:1px solid var(--border-secondary);', name + '/');
+      row.onclick = function() {
+        var next = (path === '/' ? '' : path) + '/' + name;
+        manual.value = next;
+        _nw.remotePath = next;
+        _nwSetNext(true);
+        load(next);
+      };
+      list.appendChild(row);
+    });
+    if (!(res.dirs || []).length) {
+      list.appendChild(_nwEl('div', _nwHintCss + 'padding:8px;', '(no subfolders)'));
+    }
+  };
+  body.appendChild(pathLabel);
+  body.appendChild(list);
+  body.appendChild(_nwEl('div', _nwHintCss, 'Selected NAS path (click a folder above or type it):'));
+  body.appendChild(manual);
+  load(_nw.remoteBrowsePath || '/');
+}
+
+// --- Step 4: archive root ------------------------------------------------
+
+async function nwArchiveStep(body) {
+  _nwSetNext(false);
+  body.appendChild(_nwEl('div', _nwHintCss,
+    'Pick a folder on this Mac. Photos you import here are processed locally (fast), then moved to the NAS automatically.'));
+  var home;
+  try {
+    home = (await safeFetch('/api/browse', {}, { toast: false })).path;
+  } catch (e) { home = ''; }
+  if (!_nw || _nw.step !== 'archive') return;
+  var suggestion = home ? home + '/Pictures/Vireo Archive' : '';
+  var chosen = _nwEl('div', 'font-family:monospace;font-size:12px;margin:6px 0;', '');
+  var freeLine = _nwEl('div', _nwHintCss, '');
+  var err = _nwEl('div', _nwErrCss, '');
+  var setChosen = async function(p) {
+    // Mirror _coerce_remote_target: absolute and not inside the mount.
+    var norm = function(x) { return String(x || '').replace(/\/+$/, '').toLowerCase(); };
+    var inMount = norm(p) === norm(_nw.mount.mount_point) ||
+      norm(p).indexOf(norm(_nw.mount.mount_point) + '/') === 0;
+    if (inMount) {
+      err.textContent = 'The archive folder must be on this Mac, not on the NAS volume itself.';
+      _nwSetNext(false);
+      return;
+    }
+    err.textContent = '';
+    _nw.archiveRoot = p;
+    chosen.textContent = 'Archive folder: ' + p;
+    _nwSetNext(true);
+    try {
+      var df = await safeFetch('/api/remote-setup/disk-free?path=' +
+        encodeURIComponent(p), {}, { toast: false });
+      freeLine.textContent = (df.free_bytes / (1024 * 1024 * 1024)).toFixed(0) +
+        ' GB free on this volume. Staged photos live here until each move to the NAS completes.';
+    } catch (e) { freeLine.textContent = ''; }
+  };
+  if (suggestion) {
+    var sugRow = _nwEl('div', 'display:flex;gap:8px;align-items:center;margin:6px 0;');
+    sugRow.appendChild(_nwEl('span', 'font-family:monospace;font-size:12px;', suggestion));
+    var mk = _nwEl('button', _nwBtnCss, 'Create & use');
+    mk.type = 'button';
+    mk.onclick = async function() {
+      try {
+        await safeFetch('/api/browse/mkdir', {
+          method: 'POST', headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({ path: suggestion }),
+        }, { toast: false });
+        setChosen(suggestion);
+      } catch (e) {
+        err.textContent = (e && e.message) || 'Could not create the folder.';
+      }
+    };
+    sugRow.appendChild(mk);
+    body.appendChild(sugRow);
+  }
+  body.appendChild(_nwEl('div', _nwHintCss, 'Or pick an existing folder:'));
+  var list = _nwEl('div', 'border:1px solid var(--border-secondary);border-radius:6px;max-height:160px;overflow-y:auto;margin:6px 0;');
+  var pathLabel = _nwEl('div', 'font-family:monospace;font-size:12px;margin:4px 0;', '');
+  var browse = async function(path) {
+    _nw.browsePath = path;
+    pathLabel.textContent = path;
+    list.replaceChildren(_nwEl('div', _nwHintCss + 'padding:8px;', 'Loading…'));
+    var res;
+    try {
+      res = await safeFetch('/api/browse?path=' + encodeURIComponent(path), {}, { toast: false });
+    } catch (e) {
+      list.replaceChildren(_nwEl('div', _nwErrCss + 'padding:8px;', 'Listing failed.'));
+      return;
+    }
+    list.replaceChildren();
+    var parent = path.replace(/\/[^/]+$/, '') || '/';
+    if (parent !== path) {
+      var up = _nwEl('div', 'padding:6px 10px;cursor:pointer;font-family:monospace;', '← up');
+      up.onclick = function() { browse(parent); };
+      list.appendChild(up);
+    }
+    (res.dirs || []).forEach(function(d) {
+      var row = _nwEl('div', 'padding:6px 10px;cursor:pointer;font-family:monospace;border-top:1px solid var(--border-secondary);', d.name + '/');
+      row.onclick = function() { browse(d.path); };
+      list.appendChild(row);
+    });
+    var useBtn = _nwEl('button', _nwBtnCss + 'margin:8px;', 'Use this folder');
+    useBtn.type = 'button';
+    useBtn.onclick = function() { setChosen(path); };
+    list.appendChild(useBtn);
+  };
+  body.appendChild(pathLabel);
+  body.appendChild(list);
+  body.appendChild(chosen);
+  body.appendChild(freeLine);
+  body.appendChild(err);
+  browse(_nw.browsePath || home || '/');
+  if (_nw.archiveRoot) setChosen(_nw.archiveRoot);
+}
+
+// --- Step 5: review + test ------------------------------------------------
+
+function _nwAssembledTarget() {
+  return {
+    id: _genTargetId(),
+    name: (_nw.mount && (_nw.mount.display_name || _nw.mount.share)) || _nw.host,
+    host: _nw.host, user: _nw.user, port: _nw.port,
+    ssh_key: _nw.keyPath || '',   // the wizard-managed key, from ssh-check
+    remote_path: _nw.remotePath,
+    mount_path: _nw.mount ? _nw.mount.mount_point : '',
+    local_archive_root: _nw.archiveRoot,
+    bwlimit_kbps: 0,
+  };
+}
+
+async function nwReviewStep(body) {
+  _nwSetNext(false, 'Save');
+  // The server knows the real key path; ask it rather than guessing "~".
+  var keyPath = '';
+  try {
+    var chk = await safeFetch('/api/remote-setup/ssh-check', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ host: _nw.host, user: _nw.user, port: _nw.port }),
+    }, { toast: false });
+    keyPath = chk.key_path || '';
+  } catch (e) { /* key path shown blank; save still works via default */ }
+  if (!_nw || _nw.step !== 'review') return;
+  _nw.keyPath = keyPath;
+  var t = _nwAssembledTarget();
+  var rows = [
+    ['Name', t.name], ['SSH', t.user + '@' + t.host + (t.port !== 22 ? ':' + t.port : '')],
+    ['NAS path', t.remote_path], ['Mounted at', t.mount_path],
+    ['Local archive', t.local_archive_root], ['SSH key', t.ssh_key || '(default)'],
+  ];
+  var table = _nwEl('div', 'display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:12px;margin-bottom:10px;');
+  rows.forEach(function(r) {
+    table.appendChild(_nwEl('div', 'color:var(--text-dim);', r[0]));
+    table.appendChild(_nwEl('div', 'font-family:monospace;word-break:break-all;', r[1]));
+  });
+  body.appendChild(table);
+  var status = _nwEl('div', _nwHintCss, 'Testing the connection…');
+  body.appendChild(status);
+  try {
+    var res = await safeFetch('/api/remote-targets/test', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(t),
+    }, { toast: false });
+    if (!_nw || _nw.step !== 'review') return;
+    status.style.cssText = res.ok ? _nwOkCss : _nwErrCss;
+    status.textContent = (res.ok ? '✓ ' : '⚠ ') + (res.message || '');
+    if (res.ok) _nwSetNext(true, 'Save');
+  } catch (e) {
+    if (!_nw || _nw.step !== 'review') return;
+    status.style.cssText = _nwErrCss;
+    status.textContent = '⚠ ' + ((e && e.message) || 'Test failed.');
+  }
+}
+
+function nwSave() {
+  var t = _nwAssembledTarget();
+  _remoteTargetsState.push(t);
+  renderRemoteTargets();
+  saveConfig();
+  closeNasWizard();
+  var listEl = document.getElementById('cfgRemoteTargetsList');
+  if (listEl) listEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+if (location.hash === '#nas-setup') {
+  // Deep link from the Import page's "Move to NAS unavailable" hint.
+  setTimeout(openNasWizard, 0);
 }
 
 async function loadConfig() {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1866,7 +1866,11 @@ async function nwVolumeStep(body) {
 
 function _nwPickMount(m) {
   _nw.mount = m;
-  _nw.host = m.friendly_host || m.host;
+  // Pin SSH ops to the mount's verified network address — a stale or spoofed
+  // PTR record could otherwise steer the password prompt at install-key time
+  // to a different machine. `display_name` in the picker still surfaces the
+  // friendly name; users can override the host in step 2 if they need to.
+  _nw.host = m.host;
   _nw.user = m.user || _nw.user;
   _nwSetNext(true);
 }

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2249,11 +2249,32 @@ async function nwReviewStep(body) {
   }
 }
 
-function nwSave() {
+async function nwSave() {
   var t = _nwAssembledTarget();
   _remoteTargetsState.push(t);
   renderRemoteTargets();
-  saveConfig();
+  // The debounced saveConfig used by inline handlers only SCHEDULES a POST
+  // 500 ms out; if the user reloads or closes the tab in that window the
+  // target is lost. This is an explicit Save action, so flush immediately
+  // and keep the modal up until the write lands.
+  clearTimeout(_saveTimer);
+  _nwSetNext(false, 'Saving…');
+  document.getElementById('nwBack').disabled = true;
+  try {
+    await _saveConfigNow();
+  } catch (e) {
+    // Roll back the optimistic push so the row disappears when we show the
+    // error — the target didn't actually make it to disk.
+    var idx = _remoteTargetsState.indexOf(t);
+    if (idx >= 0) _remoteTargetsState.splice(idx, 1);
+    renderRemoteTargets();
+    var body = document.getElementById('nwBody');
+    if (body) body.appendChild(_nwEl('div', _nwErrCss,
+      '⚠ Could not save: ' + ((e && e.message) || e)));
+    _nwSetNext(true, 'Save');
+    document.getElementById('nwBack').disabled = false;
+    return;
+  }
   closeNasWizard();
   var listEl = document.getElementById('cfgRemoteTargetsList');
   if (listEl) listEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -2486,9 +2507,7 @@ function getSelectedCardFields() {
   return fields;
 }
 
-function saveConfig() {
-  clearTimeout(_saveTimer);
-  _saveTimer = setTimeout(async function() {
+async function _saveConfigNow() {
     var threshold = parseInt(document.getElementById('cfgThreshold').value, 10) / 100;
     var grouping = parseInt(document.getElementById('cfgGroupingWindow').value, 10);
     if (isNaN(grouping)) grouping = 10;
@@ -2497,8 +2516,7 @@ function saveConfig() {
     var keywordCase = document.getElementById('cfgKeywordCase').value;
     var maxEditHistory = parseInt(document.getElementById('cfgMaxEditHistory').value, 10);
     if (isNaN(maxEditHistory)) maxEditHistory = 1000;
-    try {
-      await safeFetch('/api/config', {
+    await safeFetch('/api/config', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
@@ -2599,13 +2617,23 @@ function saveConfig() {
           },
         }),
       });
-      if (typeof loadPreviewCacheStatus === 'function') loadPreviewCacheStatus();
-      // Drop the cached editor list so the next "Open in Editor" action
-      // sees changes to the editors list without a page reload.
-      if (typeof window.invalidateEditorsCache === 'function') {
-        window.invalidateEditorsCache();
-      }
-    } catch(e) {}
+    if (typeof loadPreviewCacheStatus === 'function') loadPreviewCacheStatus();
+    // Drop the cached editor list so the next "Open in Editor" action
+    // sees changes to the editors list without a page reload.
+    if (typeof window.invalidateEditorsCache === 'function') {
+      window.invalidateEditorsCache();
+    }
+}
+
+function saveConfig() {
+  // Debounced fire-and-forget for the settings-page inline handlers. Errors
+  // are silent — the network layer already toasts on failure and the next
+  // change re-tries. Callers that need to KNOW the write landed (e.g. the
+  // NAS wizard, before it tears down its modal) must call _saveConfigNow()
+  // directly and await it.
+  clearTimeout(_saveTimer);
+  _saveTimer = setTimeout(function() {
+    _saveConfigNow().catch(function() {});
   }, 500);
 }
 

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -342,6 +342,7 @@ POST         /api/preview-cache/clear
 POST         /api/processes
 POST         /api/recent-destinations
 POST         /api/redo
+POST         /api/remote-setup/check-archive-root
 POST         /api/remote-setup/install-key
 POST         /api/remote-setup/list-remote-dirs
 POST         /api/remote-setup/locate-share

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -111,6 +111,8 @@ GET          /api/predictions/group/<group_id>
 GET          /api/preview-cache
 GET          /api/processes
 GET          /api/redo/status
+GET          /api/remote-setup/disk-free
+GET          /api/remote-setup/mounts
 GET          /api/remote-targets
 GET          /api/scan/status
 GET          /api/settings/export
@@ -340,6 +342,10 @@ POST         /api/preview-cache/clear
 POST         /api/processes
 POST         /api/recent-destinations
 POST         /api/redo
+POST         /api/remote-setup/install-key
+POST         /api/remote-setup/list-remote-dirs
+POST         /api/remote-setup/locate-share
+POST         /api/remote-setup/ssh-check
 POST         /api/remote-targets/test
 POST         /api/report-issue
 POST         /api/selection/keyword-suggestions

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -7647,24 +7647,51 @@ def test_api_photos_missing_stale_in_flight_result_is_discarded(
 
 def test_api_photos_missing_automatic_skips_during_heavy_job(app_and_db):
     """Automatic idle checks must not start while heavy jobs are running."""
+    import threading
     import time
 
     app, db = app_and_db
     client = app.test_client()
 
+    # Hold the scan job in the running queue until the assertion runs. A
+    # ``time.sleep`` in the work function is not reliable under load: on a
+    # slow CI runner the main thread can be preempted long enough for the
+    # sleep to elapse and the job to transition to ``completed`` before the
+    # heavy-job check runs, at which point the automatic scan is no longer
+    # suppressed.
+    release = threading.Event()
+
+    def _hold_running(job):
+        release.wait(timeout=5.0)
+        return {"ok": True}
+
     scan_job = app._job_runner.start(
         "scan",
-        lambda job: (time.sleep(0.2), {"ok": True})[1],
+        _hold_running,
         workspace_id=db._active_workspace_id,
         ephemeral=True,
     )
-    resp = client.post("/api/photos/missing/check", json={"automatic": True})
-    assert resp.status_code == 200
-    data = resp.get_json()
-    assert data["suppressed"] is True
-    assert data["reason"] == "heavy_job_active"
-    assert data["status"] == "skipped"
-    wait_for_job_via_client(client, scan_job)
+    try:
+        # Give the runner a moment to move the job to "running" so
+        # _missing_originals_heavy_job_active sees it.
+        for _ in range(50):
+            jobs = app._job_runner.list_jobs()
+            if any(
+                j.get("id") == scan_job and j.get("status") in ("running", "queued")
+                for j in jobs
+            ):
+                break
+            time.sleep(0.02)
+
+        resp = client.post("/api/photos/missing/check", json={"automatic": True})
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        data = resp.get_json()
+        assert data["suppressed"] is True, data
+        assert data["reason"] == "heavy_job_active", data
+        assert data["status"] == "skipped", data
+    finally:
+        release.set()
+        wait_for_job_via_client(client, scan_job)
 
 
 def test_api_photos_missing_automatic_skips_during_missing_originals_scan(app_and_db):

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -160,7 +160,7 @@ def test_port_reachable(monkeypatch):
 
 STUB = r'''#!/usr/bin/env python3
 import sys
-mode = sys.argv[1]  # ok | wrongpw | nopw | hostkey
+mode = sys.argv[1]  # ok | wrongpw | nopw | hostkey | unclassified
 if mode == "nopw":
     sys.stderr.write("admin@nas: Permission denied (publickey).\n")
     sys.exit(255)
@@ -170,6 +170,15 @@ if mode == "hostkey":
 sys.stderr.write("admin@nas's password: ")
 sys.stderr.flush()
 pw = input()
+if mode == "unclassified":
+    # ssh accepted the password prompt, then failed for some other reason
+    # the classifier doesn't match — plus deliberately echo the password
+    # back to prove redaction of `detail` catches the case where something
+    # DID echo it (pty ECHO=off is the primary defense; this is the
+    # belt-and-braces test).
+    sys.stderr.write("echo-check:" + pw + "\n")
+    sys.stderr.write("bash: /nas/authorized_keys: Read-only file system\n")
+    sys.exit(1)
 if mode == "ok" and pw == "sekret":
     sys.exit(0)
 sys.stderr.write("Permission denied, please try again.\nadmin@nas's password: ")
@@ -213,6 +222,30 @@ def test_password_never_in_result_text(tmp_path):
     res = remote_setup.install_key_with_password(
         spawn_argv=_stub(tmp_path, "wrongpw"), password="hunter2", timeout=15)
     assert "hunter2" not in repr(res)
+
+
+def test_unclassified_failure_redacts_password_from_detail(tmp_path):
+    """An unclassified ssh failure (post-auth remote error) may include
+    output that echoed the password back — pty ECHO=off is the primary
+    defense, and detail redaction is the belt-and-braces backstop that
+    keeps the password out of the returned dict either way."""
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "unclassified"),
+        password="hunter2_secret_pw", timeout=15)
+    assert res["ok"] is False
+    assert res["error"] == "ssh_failed"
+    # Password must not appear anywhere in the returned dict — including detail.
+    assert "hunter2_secret_pw" not in repr(res)
+    assert "<redacted>" in res.get("detail", "")
+
+
+def test_platform_supported_reflects_sys_platform(monkeypatch):
+    """The wizard's mount enumeration only works on macOS today; the app
+    endpoint routes through this helper so tests can flip it cleanly."""
+    monkeypatch.setattr(remote_setup.sys, "platform", "darwin")
+    assert remote_setup.platform_supported() is True
+    monkeypatch.setattr(remote_setup.sys, "platform", "linux")
+    assert remote_setup.platform_supported() is False
 
 
 # --- Nonce share-locate + remote dir listing ------------------------------

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -1,6 +1,8 @@
 import os
+import socket
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -121,6 +123,119 @@ def test_ensure_vireo_key_raises_on_keygen_failure(tmp_path, monkeypatch):
     run = FakeRun(returncode=1)
     with pytest.raises(RuntimeError):
         remote_setup.ensure_vireo_key(run=run)
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="POSIX chmod bits are ignored on Windows")
+def test_ensure_vireo_key_recovers_missing_pub_from_existing_priv(
+        tmp_path, monkeypatch):
+    """If the .pub was deleted (or a prior generation was interrupted after
+    writing priv), rebuild the public key with ``ssh-keygen -y`` instead
+    of re-running ``ssh-keygen -f priv`` — the latter blocks forever on the
+    non-interactive overwrite prompt and the wizard cannot repair itself."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    priv, pub = remote_setup.vireo_key_paths()
+    os.makedirs(os.path.dirname(priv), exist_ok=True)
+    open(priv, "w").write("EXISTING PRIVATE KEY")
+    os.chmod(priv, 0o644)  # loose perms — must be normalized to 0600
+
+    calls = []
+
+    def fake_run(argv, **kw):
+        calls.append(argv)
+        return subprocess.CompletedProcess(
+            argv, 0, stdout="ssh-ed25519 AAAAREGENERATED\n", stderr="")
+
+    out_priv, out_pub = remote_setup.ensure_vireo_key(run=fake_run)
+    assert out_priv == priv and out_pub == pub
+    # Exactly one ssh-keygen invocation, and it's the non-interactive
+    # -y derivation — never the interactive -f overwrite path.
+    assert len(calls) == 1
+    assert calls[0][:2] == ["ssh-keygen", "-y"] and "-f" in calls[0]
+    assert "-t" not in calls[0]  # no regeneration attempted
+    # The rebuilt .pub carries the vireo comment for parity with fresh gen.
+    assert open(pub).read().strip() == "ssh-ed25519 AAAAREGENERATED vireo"
+    # Loose priv perms were tightened.
+    assert oct(os.stat(priv).st_mode & 0o777) == "0o600"
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="POSIX chmod bits are ignored on Windows")
+def test_ensure_vireo_key_raises_when_pub_derivation_fails(
+        tmp_path, monkeypatch):
+    """If ssh-keygen -y fails on a corrupted private key, surface the
+    error rather than silently overwriting the private key."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    priv, _ = remote_setup.vireo_key_paths()
+    os.makedirs(os.path.dirname(priv), exist_ok=True)
+    open(priv, "w").write("CORRUPTED")
+
+    def fake_run(argv, **kw):
+        return subprocess.CompletedProcess(
+            argv, 1, stdout="", stderr="Load key: invalid format")
+
+    with pytest.raises(RuntimeError, match="ssh-keygen -y failed"):
+        remote_setup.ensure_vireo_key(run=fake_run)
+
+
+def test_reverse_dns_worker_is_daemon(monkeypatch):
+    """Hung PTR queries must leave only daemon threads behind so process
+    shutdown never blocks. A ThreadPoolExecutor here would silently leak
+    non-daemon workers that Python's atexit hook then joins on exit."""
+    import threading as _t
+
+    spawned = []
+    real_start = _t.Thread.start
+
+    def spy_start(self):
+        spawned.append(self)
+        return real_start(self)
+
+    monkeypatch.setattr(_t.Thread, "start", spy_start)
+    # Fast fake resolver so the test doesn't spend real time waiting.
+    monkeypatch.setattr(remote_setup.socket, "gethostbyaddr",
+                        lambda ip: ("cachedname", [], [ip]))
+
+    assert remote_setup._reverse_dns("192.0.2.1") == "cachedname"
+    assert spawned, "no worker thread was spawned"
+    assert all(t.daemon for t in spawned), (
+        "reverse-DNS worker must be a daemon so a hung lookup can't block exit")
+
+
+def test_reverse_dns_times_out_when_lookup_hangs(monkeypatch):
+    """A hung ``gethostbyaddr`` must surface as ``TimeoutError`` and not
+    block on a shutdown(wait=True) after the guard fires."""
+    import threading as _t
+
+    def hang(_ip):
+        _t.Event().wait()  # simulates a PTR query that never returns
+
+    monkeypatch.setattr(remote_setup.socket, "gethostbyaddr", hang)
+    # Shrink the 2s guard so the test doesn't sit on it.
+    real_get = remote_setup._queue.Queue.get
+
+    def quick_get(self, timeout=None):
+        return real_get(self, timeout=0.05)
+
+    monkeypatch.setattr(remote_setup._queue.Queue, "get", quick_get)
+
+    start = time.monotonic()
+    with pytest.raises(TimeoutError):
+        remote_setup._reverse_dns("192.0.2.1")
+    # If the code had done shutdown(wait=True), this would take much longer;
+    # the daemon-thread + queue approach returns as soon as the wait expires.
+    assert time.monotonic() - start < 1.0
+
+
+def test_reverse_dns_propagates_lookup_error(monkeypatch):
+    """Real resolver errors (e.g. no PTR record) must surface as an
+    exception so ``friendly_host_name`` can fall back to the raw host."""
+    def boom(_ip):
+        raise socket.gaierror("no PTR")
+
+    monkeypatch.setattr(remote_setup.socket, "gethostbyaddr", boom)
+    with pytest.raises(socket.gaierror):
+        remote_setup._reverse_dns("192.0.2.1")
 
 
 def test_key_auth_works_builds_batchmode_ssh(tmp_path):

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -199,6 +199,69 @@ def test_password_never_in_result_text(tmp_path):
     assert "hunter2" not in repr(res)
 
 
+# --- Nonce share-locate + remote dir listing ------------------------------
+
+
+def test_locate_share_writes_nonce_probes_and_cleans_up(tmp_path):
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+    seen = {}
+
+    def fake_run(argv, **kw):
+        seen["cmd"] = argv[-1]
+        # Server-side: pretend /volume1/Photography contains the nonce.
+        return subprocess.CompletedProcess(
+            argv, 0, stdout="FOUND:/volume1/Photography\n", stderr="")
+
+    path = remote_setup.locate_share(
+        mount_point=str(mount), share="Photography",
+        host="nas", user="admin", port=22, key="/k", ssh_bin="ssh",
+        run=fake_run)
+    assert path == "/volume1/Photography"
+    assert ".vireo-probe-" in seen["cmd"] and "/volume*/" in seen["cmd"]
+    assert list(mount.iterdir()) == []          # nonce cleaned up
+
+
+def test_locate_share_no_match_returns_none_and_cleans_up(tmp_path):
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+    fake_run = FakeRun(stdout="")               # no candidate matched
+    assert remote_setup.locate_share(
+        mount_point=str(mount), share="Photography", host="nas",
+        user="admin", port=22, key="/k", ssh_bin="ssh", run=fake_run) is None
+    assert list(mount.iterdir()) == []
+
+
+@pytest.mark.skipif(hasattr(os, "geteuid") and os.geteuid() == 0,
+                    reason="root ignores directory write bits")
+def test_locate_share_readonly_mount_raises(tmp_path):
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+    mount.chmod(0o500)          # no write bit — nonce write must fail cleanly
+    try:
+        with pytest.raises(remote_setup.MountNotWritable):
+            remote_setup.locate_share(
+                mount_point=str(mount), share="S", host="h", user="u",
+                port=22, key="", ssh_bin="ssh", run=FakeRun())
+    finally:
+        mount.chmod(0o700)      # let pytest clean tmp_path up
+
+
+def test_list_remote_dirs_parses_and_quotes(tmp_path):
+    run = FakeRun(stdout="Raw Files\nExports\n")
+    dirs = remote_setup.list_remote_dirs(
+        path="/volume1/My Photos", host="nas", user="admin", port=22,
+        key="", ssh_bin="ssh", run=run)
+    assert dirs == ["Exports", "Raw Files"]
+    assert "'/volume1/My Photos'" in run.calls[0][-1]
+
+
+def test_list_remote_dirs_empty_on_error():
+    assert remote_setup.list_remote_dirs(
+        path="/nope", host="h", user="u", port=22, key="", ssh_bin="ssh",
+        run=FakeRun(returncode=255)) == []
+
+
 def test_build_install_argv_no_batchmode_and_idempotent_append():
     argv = remote_setup.build_install_argv(
         host="nas", user="admin", port=22,

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -116,6 +116,29 @@ def test_list_network_mounts_caches_reverse_dns_per_host():
     assert sorted(calls) == ["100.80.236.59", "100.80.236.60"]
 
 
+def test_pty_helper_prefix_uses_c_snippet_in_dev(monkeypatch):
+    """In a normal Python run, sys.executable IS a python interpreter, so
+    the pty helper is passed via ``-c`` — no separate file needed at
+    runtime, no dependency on the frozen build's subcommand handler."""
+    monkeypatch.delattr(remote_setup.sys, "frozen", raising=False)
+    prefix = remote_setup._pty_helper_prefix()
+    assert prefix[0] == remote_setup.sys.executable
+    assert prefix[1] == "-c"
+    assert "TIOCSCTTY" in prefix[2]  # the actual helper snippet
+
+
+def test_pty_helper_prefix_uses_subcommand_in_frozen_build(monkeypatch):
+    """In a PyInstaller --onefile build (the production packaging via
+    scripts/build_sidecar.py), sys.executable is the frozen ``vireo-server``
+    binary, not python — ``-c`` would relaunch the whole app with an
+    unrecognized flag and never reach ssh. The prefix routes through the
+    ``--pty-spawn-helper`` subcommand instead, which app.py dispatches
+    before argparse sees the ssh argv."""
+    monkeypatch.setattr(remote_setup.sys, "frozen", True, raising=False)
+    prefix = remote_setup._pty_helper_prefix()
+    assert prefix == [remote_setup.sys.executable, "--pty-spawn-helper"]
+
+
 def test_friendly_host_passthrough_for_hostnames_and_failed_reverse():
     # Non-IP hosts pass through; resolver failures fall back to the raw host.
     assert remote_setup.friendly_host_name("mynas.local", resolver=None) == "mynas.local"

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -137,3 +137,77 @@ def test_key_auth_works_false_on_denied(tmp_path):
     assert remote_setup.key_auth_works(
         host="nas", user="admin", port=22, key="", ssh_bin="ssh",
         run=run) is False
+
+
+# --- Password-driven key install (pty) ------------------------------------
+
+
+STUB = r'''#!/usr/bin/env python3
+import sys
+mode = sys.argv[1]  # ok | wrongpw | nopw | hostkey
+if mode == "nopw":
+    sys.stderr.write("admin@nas: Permission denied (publickey).\n")
+    sys.exit(255)
+if mode == "hostkey":
+    sys.stderr.write("Host key verification failed.\n")
+    sys.exit(255)
+sys.stderr.write("admin@nas's password: ")
+sys.stderr.flush()
+pw = input()
+if mode == "ok" and pw == "sekret":
+    sys.exit(0)
+sys.stderr.write("Permission denied, please try again.\nadmin@nas's password: ")
+sys.stderr.flush()
+sys.exit(255)
+'''
+
+
+def _stub(tmp_path, mode):
+    p = tmp_path / "fake_ssh.py"
+    p.write_text(STUB)
+    p.chmod(0o755)
+    return [sys.executable, str(p), mode]
+
+
+def test_install_key_success(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "ok"), password="sekret", timeout=15)
+    assert res == {"ok": True, "error": None}
+
+
+def test_install_key_wrong_password(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "wrongpw"), password="nope", timeout=15)
+    assert res["ok"] is False and res["error"] == "wrong_password"
+
+
+def test_install_key_password_auth_disabled(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "nopw"), password="x", timeout=15)
+    assert res["ok"] is False and res["error"] == "password_auth_disabled"
+
+
+def test_install_key_host_key_rejected(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "hostkey"), password="x", timeout=15)
+    assert res["ok"] is False and res["error"] == "host_key"
+
+
+def test_password_never_in_result_text(tmp_path):
+    res = remote_setup.install_key_with_password(
+        spawn_argv=_stub(tmp_path, "wrongpw"), password="hunter2", timeout=15)
+    assert "hunter2" not in repr(res)
+
+
+def test_build_install_argv_no_batchmode_and_idempotent_append():
+    argv = remote_setup.build_install_argv(
+        host="nas", user="admin", port=22,
+        key_pub_line="ssh-ed25519 AAAA vireo", ssh_bin="/usr/bin/ssh")
+    assert argv[0] == "/usr/bin/ssh"
+    assert "BatchMode=yes" not in argv          # password prompt must reach the pty
+    assert "StrictHostKeyChecking=accept-new" in argv
+    assert argv[-2] == "admin@nas"
+    snippet = argv[-1]
+    assert "umask 077" in snippet and "mkdir -p ~/.ssh" in snippet
+    assert "grep -qxF" in snippet and "authorized_keys" in snippet
+    assert "ssh-ed25519 AAAA vireo" in snippet

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -80,3 +80,60 @@ def test_friendly_host_passthrough_for_hostnames_and_failed_reverse():
         raise OSError("no PTR")
 
     assert remote_setup.friendly_host_name("100.80.236.59", resolver=boom) == "100.80.236.59"
+
+
+# --- Vireo key management -------------------------------------------------
+
+
+def test_key_paths_under_vireo_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    priv, pub = remote_setup.vireo_key_paths()
+    assert priv == str(tmp_path / ".vireo" / "ssh" / "vireo_ed25519")
+    assert pub == priv + ".pub"
+
+
+def test_ensure_vireo_key_generates_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    calls = []
+
+    def fake_run(argv, **kw):
+        calls.append(argv)
+        priv, pub = remote_setup.vireo_key_paths()
+        open(priv, "w").write("KEY")
+        open(pub, "w").write("ssh-ed25519 AAAA vireo")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    priv, pub = remote_setup.ensure_vireo_key(run=fake_run)
+    assert calls and calls[0][0] == "ssh-keygen"
+    assert "-N" in calls[0] and "-t" in calls[0]
+    assert oct(os.stat(os.path.dirname(priv)).st_mode & 0o777) == "0o700"
+    # Second call: key exists, no regeneration.
+    remote_setup.ensure_vireo_key(run=fake_run)
+    assert len(calls) == 1
+
+
+def test_ensure_vireo_key_raises_on_keygen_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    run = FakeRun(returncode=1)
+    with pytest.raises(RuntimeError):
+        remote_setup.ensure_vireo_key(run=run)
+
+
+def test_key_auth_works_builds_batchmode_ssh(tmp_path):
+    run = FakeRun(stdout="vireo_ok\n")
+    ok = remote_setup.key_auth_works(
+        host="nas", user="admin", port=2222, key="/k", ssh_bin="/usr/bin/ssh",
+        run=run)
+    assert ok is True
+    argv = run.calls[0]
+    assert argv[0] == "/usr/bin/ssh"
+    assert "BatchMode=yes" in argv
+    assert "-p" in argv and "2222" in argv and "-i" in argv and "/k" in argv
+    assert argv[-2:] == ["admin@nas", "echo vireo_ok"]
+
+
+def test_key_auth_works_false_on_denied(tmp_path):
+    run = FakeRun(stdout="", returncode=255)
+    assert remote_setup.key_auth_works(
+        host="nas", user="admin", port=22, key="", ssh_bin="ssh",
+        run=run) is False

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -139,6 +139,22 @@ def test_key_auth_works_false_on_denied(tmp_path):
         run=run) is False
 
 
+def test_port_reachable(monkeypatch):
+    class FakeSock:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(remote_setup.socket, "create_connection",
+                        lambda addr, timeout: FakeSock())
+    assert remote_setup.port_reachable("nas", 22) is True
+
+    def refuse(addr, timeout):
+        raise OSError("refused")
+
+    monkeypatch.setattr(remote_setup.socket, "create_connection", refuse)
+    assert remote_setup.port_reachable("nas", 22) is False
+
+
 # --- Password-driven key install (pty) ------------------------------------
 
 

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -371,6 +371,7 @@ def test_password_never_in_result_text(tmp_path):
     assert "hunter2" not in repr(res)
 
 
+@pytestmark_pty
 def test_unclassified_failure_redacts_password_from_detail(tmp_path):
     """An unclassified ssh failure (post-auth remote error) may include
     output that echoed the password back — pty ECHO=off is the primary

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -59,7 +59,10 @@ def test_parse_afpfs_and_ipv6_hosts():
     v6 = "//admin@[fe80::1%25en0]/Backup on /Volumes/Backup (smbfs, nodev, nosuid, mounted by julius)"
     rows = remote_setup.parse_mount_output(afp + "\n" + v6)
     assert rows[0]["fs_type"] == "afpfs" and rows[0]["share"] == "Media"
-    assert rows[1]["host"] == "[fe80::1%en0]" and rows[1]["share"] == "Backup"
+    # Brackets are the URL-authority spelling; socket.create_connection and
+    # friendly_host_name want the plain address, so parse_mount_output strips
+    # them while preserving the scope id.
+    assert rows[1]["host"] == "fe80::1%en0" and rows[1]["share"] == "Backup"
 
 
 def test_list_network_mounts_runs_mount_and_resolves():
@@ -130,7 +133,22 @@ def test_key_auth_works_builds_batchmode_ssh(tmp_path):
     assert argv[0] == "/usr/bin/ssh"
     assert "BatchMode=yes" in argv
     assert "-p" in argv and "2222" in argv and "-i" in argv and "/k" in argv
+    # IdentitiesOnly=yes prevents an ambient ssh-agent identity from making
+    # the probe pass on the agent's key instead of the wizard-managed one.
+    assert "IdentitiesOnly=yes" in argv
     assert argv[-2:] == ["admin@nas", "echo vireo_ok"]
+
+
+def test_key_auth_works_omits_identities_only_when_no_key():
+    """When no key is passed the probe shouldn't force IdentitiesOnly — the
+    install-key path uses this shape (key='') and must remain free to
+    negotiate password auth."""
+    run = FakeRun(stdout="", returncode=255)
+    remote_setup.key_auth_works(
+        host="nas", user="admin", port=22, key="", ssh_bin="ssh", run=run)
+    argv = run.calls[0]
+    assert "IdentitiesOnly=yes" not in argv
+    assert "-i" not in argv
 
 
 def test_key_auth_works_false_on_denied(tmp_path):

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -492,3 +492,27 @@ def test_build_install_argv_no_batchmode_and_idempotent_append():
     assert "umask 077" in snippet and "mkdir -p ~/.ssh" in snippet
     assert "grep -qxF" in snippet and "authorized_keys" in snippet
     assert "ssh-ed25519 AAAA vireo" in snippet
+
+
+def test_build_install_argv_forces_password_only_auth():
+    """An encrypted ~/.ssh/id_* would otherwise trigger a passphrase prompt
+    ("Enter passphrase for key ..."), which the pty driver's
+    _PASSWORD_PROMPT_RE doesn't match, hanging the wizard until the 30s
+    timeout. Disabling pubkey auth for this one bootstrap invocation makes
+    ssh go straight to the password prompt the driver is designed to answer."""
+    argv = remote_setup.build_install_argv(
+        host="nas", user="admin", port=22,
+        key_pub_line="ssh-ed25519 AAAA vireo", ssh_bin="ssh")
+    assert "PubkeyAuthentication=no" in argv
+    assert "PreferredAuthentications=password" in argv
+
+
+def test_key_auth_works_argv_still_negotiates_pubkey():
+    """The pubkey probe must NOT inherit the install-key path's password-only
+    lockdown — that would make every key_auth_works() call return False."""
+    run = FakeRun(stdout="vireo_ok\n")
+    remote_setup.key_auth_works(
+        host="nas", user="admin", port=22, key="/k", ssh_bin="ssh", run=run)
+    argv = run.calls[0]
+    assert "PubkeyAuthentication=no" not in argv
+    assert "PreferredAuthentications=password" not in argv

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -95,6 +95,27 @@ def test_list_network_mounts_runs_mount_and_resolves():
     assert rows[0]["display_name"] == "synology-nas"
 
 
+def test_list_network_mounts_caches_reverse_dns_per_host():
+    # Two shares on the same IP-based NAS + one share on a different NAS:
+    # the resolver must be called exactly once per unique host so that a
+    # slow (2s-capped) PTR lookup can't stall the wizard by N × 2s.
+    same_host_a = "//u@100.80.236.59/Photography on /Volumes/Photography (smbfs, nodev, nosuid, mounted by j)"
+    same_host_b = "//u@100.80.236.59/Video on /Volumes/Video (smbfs, nodev, nosuid, mounted by j)"
+    other_host = "//u@100.80.236.60/Backup on /Volumes/Backup (smbfs, nodev, nosuid, mounted by j)"
+    run = FakeRun(stdout="\n".join([same_host_a, same_host_b, other_host]))
+    calls = []
+
+    def resolver(ip):
+        calls.append(ip)
+        return {"100.80.236.59": "nas-a.ts.net",
+                "100.80.236.60": "nas-b.ts.net"}[ip]
+
+    rows = remote_setup.list_network_mounts(run=run, resolver=resolver)
+    assert [r["friendly_host"] for r in rows] == [
+        "nas-a.ts.net", "nas-a.ts.net", "nas-b.ts.net"]
+    assert sorted(calls) == ["100.80.236.59", "100.80.236.60"]
+
+
 def test_friendly_host_passthrough_for_hostnames_and_failed_reverse():
     # Non-IP hosts pass through; resolver failures fall back to the raw host.
     assert remote_setup.friendly_host_name("mynas.local", resolver=None) == "mynas.local"

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -1,0 +1,82 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import remote_setup
+
+
+SMB = "//julius_admin@100.80.236.59/Photography on /Volumes/Photography (smbfs, nodev, nosuid, mounted by julius)"
+SMB_SPACES = "//guest@My%20NAS._smb._tcp.local/Photo%20Library on /Volumes/Photo Library (smbfs, nodev, nosuid, mounted by julius)"
+NFS = "truenas:/mnt/tank/photos on /Volumes/photos (nfs, nodev, nosuid, mounted by julius)"
+LOCAL = "/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)"
+AUTOFS = "map auto_home on /System/Volumes/Data/home (autofs, automounted, nobrowse)"
+
+
+class FakeRun:
+    def __init__(self, stdout="", returncode=0):
+        self.calls = []
+        self.stdout, self.returncode = stdout, returncode
+
+    def __call__(self, argv, **kw):
+        self.calls.append(argv)
+        return subprocess.CompletedProcess(argv, self.returncode,
+                                           stdout=self.stdout, stderr="")
+
+
+def test_parse_smbfs_mount():
+    rows = remote_setup.parse_mount_output(SMB + "\n" + LOCAL + "\n" + AUTOFS)
+    assert rows == [{
+        "fs_type": "smbfs", "host": "100.80.236.59",
+        "share": "Photography", "mount_point": "/Volumes/Photography",
+        "user": "julius_admin",
+    }]
+
+
+def test_parse_smbfs_url_encoding_and_spaces():
+    (row,) = remote_setup.parse_mount_output(SMB_SPACES)
+    assert row["share"] == "Photo Library"
+    assert row["host"] == "My NAS._smb._tcp.local"
+    assert row["mount_point"] == "/Volumes/Photo Library"
+    assert row["user"] == "guest"
+
+
+def test_parse_nfs_mount():
+    (row,) = remote_setup.parse_mount_output(NFS)
+    assert row == {"fs_type": "nfs", "host": "truenas",
+                   "share": "photos", "mount_point": "/Volumes/photos",
+                   "user": ""}
+
+
+def test_parse_ignores_non_network_and_garbage():
+    assert remote_setup.parse_mount_output(LOCAL + "\nnot a mount line\n") == []
+
+
+def test_parse_afpfs_and_ipv6_hosts():
+    afp = "//julius@mynas._afpovertcp._tcp.local/Media on /Volumes/Media (afpfs, nodev, nosuid, mounted by julius)"
+    v6 = "//admin@[fe80::1%25en0]/Backup on /Volumes/Backup (smbfs, nodev, nosuid, mounted by julius)"
+    rows = remote_setup.parse_mount_output(afp + "\n" + v6)
+    assert rows[0]["fs_type"] == "afpfs" and rows[0]["share"] == "Media"
+    assert rows[1]["host"] == "[fe80::1%en0]" and rows[1]["share"] == "Backup"
+
+
+def test_list_network_mounts_runs_mount_and_resolves():
+    run = FakeRun(stdout=SMB)
+    rows = remote_setup.list_network_mounts(
+        run=run, resolver=lambda ip: "synology-nas.tail1234.ts.net")
+    assert run.calls == [["mount"]]
+    assert rows[0]["friendly_host"] == "synology-nas.tail1234.ts.net"
+    assert rows[0]["display_name"] == "synology-nas"
+
+
+def test_friendly_host_passthrough_for_hostnames_and_failed_reverse():
+    # Non-IP hosts pass through; resolver failures fall back to the raw host.
+    assert remote_setup.friendly_host_name("mynas.local", resolver=None) == "mynas.local"
+
+    def boom(ip):
+        raise OSError("no PTR")
+
+    assert remote_setup.friendly_host_name("100.80.236.59", resolver=boom) == "100.80.236.59"

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -67,6 +67,25 @@ def test_parse_afpfs_and_ipv6_hosts():
     assert rows[1]["host"] == "fe80::1%en0" and rows[1]["share"] == "Backup"
 
 
+def test_parse_nfs_ipv6_mount():
+    # IPv6 NFS mounts wrap the host in brackets to keep the host/path split
+    # unambiguous (`[fe80::1]:/exports/photos`). NFS sources aren't
+    # URL-encoded the way smbfs URLs are, so the scope id appears verbatim.
+    # Without accepting the bracketed form the mount is silently dropped
+    # from the wizard.
+    v6 = "[fe80::1%en0]:/exports/photos on /Volumes/photos (nfs, nodev, nosuid, mounted by julius)"
+    plain = "[2001:db8::5]:/mnt/tank/backup on /Volumes/backup (nfs, nodev, nosuid, mounted by julius)"
+    rows = remote_setup.parse_mount_output(v6 + "\n" + plain)
+    assert rows[0] == {
+        "fs_type": "nfs", "host": "fe80::1%en0",
+        "share": "photos", "mount_point": "/Volumes/photos", "user": "",
+    }
+    assert rows[1] == {
+        "fs_type": "nfs", "host": "2001:db8::5",
+        "share": "backup", "mount_point": "/Volumes/backup", "user": "",
+    }
+
+
 def test_list_network_mounts_runs_mount_and_resolves():
     run = FakeRun(stdout=SMB)
     rows = remote_setup.list_network_mounts(

--- a/vireo/tests/test_remote_setup.py
+++ b/vireo/tests/test_remote_setup.py
@@ -8,7 +8,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import remote_setup
 
-
 SMB = "//julius_admin@100.80.236.59/Photography on /Volumes/Photography (smbfs, nodev, nosuid, mounted by julius)"
 SMB_SPACES = "//guest@My%20NAS._smb._tcp.local/Photo%20Library on /Volumes/Photo Library (smbfs, nodev, nosuid, mounted by julius)"
 NFS = "truenas:/mnt/tank/photos on /Volumes/photos (nfs, nodev, nosuid, mounted by julius)"
@@ -92,6 +91,8 @@ def test_key_paths_under_vireo_home(tmp_path, monkeypatch):
     assert pub == priv + ".pub"
 
 
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="POSIX chmod bits are ignored on Windows")
 def test_ensure_vireo_key_generates_once(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     calls = []
@@ -157,6 +158,14 @@ def test_port_reachable(monkeypatch):
 
 # --- Password-driven key install (pty) ------------------------------------
 
+# install_key_with_password uses the `pty` module, which is POSIX-only
+# (Windows Python raises ModuleNotFoundError: No module named 'termios'),
+# so these tests only run on POSIX platforms — the feature itself is
+# macOS-only in production.
+pytestmark_pty = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="pty/termios are POSIX-only; install-key runs on macOS")
+
 
 STUB = r'''#!/usr/bin/env python3
 import sys
@@ -194,30 +203,35 @@ def _stub(tmp_path, mode):
     return [sys.executable, str(p), mode]
 
 
+@pytestmark_pty
 def test_install_key_success(tmp_path):
     res = remote_setup.install_key_with_password(
         spawn_argv=_stub(tmp_path, "ok"), password="sekret", timeout=15)
     assert res == {"ok": True, "error": None}
 
 
+@pytestmark_pty
 def test_install_key_wrong_password(tmp_path):
     res = remote_setup.install_key_with_password(
         spawn_argv=_stub(tmp_path, "wrongpw"), password="nope", timeout=15)
     assert res["ok"] is False and res["error"] == "wrong_password"
 
 
+@pytestmark_pty
 def test_install_key_password_auth_disabled(tmp_path):
     res = remote_setup.install_key_with_password(
         spawn_argv=_stub(tmp_path, "nopw"), password="x", timeout=15)
     assert res["ok"] is False and res["error"] == "password_auth_disabled"
 
 
+@pytestmark_pty
 def test_install_key_host_key_rejected(tmp_path):
     res = remote_setup.install_key_with_password(
         spawn_argv=_stub(tmp_path, "hostkey"), password="x", timeout=15)
     assert res["ok"] is False and res["error"] == "host_key"
 
 
+@pytestmark_pty
 def test_password_never_in_result_text(tmp_path):
     res = remote_setup.install_key_with_password(
         spawn_argv=_stub(tmp_path, "wrongpw"), password="hunter2", timeout=15)
@@ -283,6 +297,8 @@ def test_locate_share_no_match_returns_none_and_cleans_up(tmp_path):
 
 @pytest.mark.skipif(hasattr(os, "geteuid") and os.geteuid() == 0,
                     reason="root ignores directory write bits")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Windows ignores POSIX chmod, so read-only bit does not apply")
 def test_locate_share_readonly_mount_raises(tmp_path):
     mount = tmp_path / "mnt"
     mount.mkdir()

--- a/vireo/tests/test_remote_setup_api.py
+++ b/vireo/tests/test_remote_setup_api.py
@@ -182,3 +182,55 @@ def test_disk_free_endpoint(app_and_db, tmp_path):
     bad = app.test_client().get(
         "/api/remote-setup/disk-free", query_string={"path": "not/absolute"})
     assert bad.status_code == 400
+
+
+def test_check_archive_root_flags_alias_into_mount(app_and_db, tmp_path):
+    """The endpoint must catch a symlinked archive that resolves inside the
+    mount — the whole point of adding it is that a lexical prefix check on
+    the client misses aliases and the save-time validator would then
+    silently blank local_archive_root."""
+    app, _db = app_and_db
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        os.symlink(str(mount), str(alias))
+    except (OSError, NotImplementedError):
+        import pytest
+        pytest.skip("symlink not supported on this filesystem")
+    res = app.test_client().post(
+        "/api/remote-setup/check-archive-root",
+        json={"path": str(alias), "mount_path": str(mount)})
+    assert res.status_code == 200
+    assert res.get_json() == {"inside_mount": True}
+
+
+def test_check_archive_root_accepts_separate_path(app_and_db, tmp_path):
+    app, _db = app_and_db
+    mount = tmp_path / "mnt"
+    mount.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    res = app.test_client().post(
+        "/api/remote-setup/check-archive-root",
+        json={"path": str(outside), "mount_path": str(mount)})
+    assert res.status_code == 200
+    assert res.get_json() == {"inside_mount": False}
+
+
+def test_check_archive_root_validates_inputs(app_and_db):
+    app, _db = app_and_db
+    c = app.test_client()
+    assert c.post("/api/remote-setup/check-archive-root",
+                  json={"path": "", "mount_path": "/mnt"}).status_code == 400
+    assert c.post("/api/remote-setup/check-archive-root",
+                  json={"path": "rel", "mount_path": "/mnt"}).status_code == 400
+
+
+def test_check_archive_root_rejects_non_loopback(app_and_db, tmp_path):
+    app, _db = app_and_db
+    res = app.test_client().post(
+        "/api/remote-setup/check-archive-root",
+        json={"path": str(tmp_path), "mount_path": str(tmp_path)},
+        environ_overrides={"REMOTE_ADDR": "192.168.1.50"})
+    assert res.status_code == 403

--- a/vireo/tests/test_remote_setup_api.py
+++ b/vireo/tests/test_remote_setup_api.py
@@ -10,6 +10,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 def test_mounts_endpoint_returns_parsed_mounts(app_and_db, monkeypatch):
+    # The endpoint only enumerates mounts on macOS (mount-line format is
+    # platform-specific); force the darwin branch so CI on Linux/Windows
+    # exercises the same code path.
+    monkeypatch.setattr(sys, "platform", "darwin")
     app, _db = app_and_db
     import remote_setup
     monkeypatch.setattr(remote_setup, "platform_supported", lambda: True)

--- a/vireo/tests/test_remote_setup_api.py
+++ b/vireo/tests/test_remote_setup_api.py
@@ -1,0 +1,165 @@
+"""Endpoint tests for /api/remote-setup/* (NAS setup wizard backend).
+
+The endpoints stay thin — remote_setup functions are monkeypatched so no
+test ever spawns a real ssh."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_mounts_endpoint_returns_parsed_mounts(app_and_db, monkeypatch):
+    app, _db = app_and_db
+    import remote_setup
+    monkeypatch.setattr(remote_setup, "list_network_mounts", lambda **kw: [
+        {"fs_type": "smbfs", "host": "1.2.3.4", "friendly_host": "nas.ts.net",
+         "display_name": "nas", "share": "Photos",
+         "mount_point": "/Volumes/Photos", "user": "admin"}])
+    res = app.test_client().get("/api/remote-setup/mounts")
+    assert res.status_code == 200
+    assert res.get_json()["mounts"][0]["share"] == "Photos"
+
+
+def test_mounts_endpoint_rejects_non_loopback(app_and_db):
+    app, _db = app_and_db
+    res = app.test_client().get(
+        "/api/remote-setup/mounts",
+        environ_overrides={"REMOTE_ADDR": "192.168.1.50"})
+    assert res.status_code == 403
+
+
+def test_ssh_check_reports_port_auth_and_pubkey(app_and_db, monkeypatch, tmp_path):
+    # ssh-check ensures the Vireo key exists (idempotent, local-only) and
+    # returns its public line — the Terminal-fallback expander needs it
+    # WITHOUT ever calling install-key (no password submitted).
+    app, _db = app_and_db
+    import remote_setup
+    pub = tmp_path / "vireo_ed25519.pub"
+    pub.write_text("ssh-ed25519 AAAA vireo\n")
+    monkeypatch.setattr(remote_setup, "port_reachable",
+                        lambda host, port, timeout=5: True)
+    monkeypatch.setattr(remote_setup, "ensure_vireo_key",
+                        lambda **kw: (str(tmp_path / "vireo_ed25519"), str(pub)))
+    monkeypatch.setattr(remote_setup, "key_auth_works", lambda **kw: False)
+    res = app.test_client().post("/api/remote-setup/ssh-check",
+                                 json={"host": "nas", "port": 22, "user": "admin"})
+    body = res.get_json()
+    assert body["port_open"] is True and body["key_auth_ok"] is False
+    assert body["pub_key_line"] == "ssh-ed25519 AAAA vireo"
+
+
+def test_ssh_check_validates_input(app_and_db):
+    app, _db = app_and_db
+    c = app.test_client()
+    assert c.post("/api/remote-setup/ssh-check",
+                  json={"host": "", "user": "a"}).status_code == 400
+    assert c.post("/api/remote-setup/ssh-check",
+                  json={"host": "nas", "user": "a",
+                        "port": 99999}).status_code == 400
+
+
+def test_install_key_rejects_non_loopback(app_and_db):
+    app, _db = app_and_db
+    res = app.test_client().post(
+        "/api/remote-setup/install-key",
+        json={"host": "nas", "user": "a", "port": 22, "password": "x"},
+        environ_overrides={"REMOTE_ADDR": "192.168.1.50"})
+    assert res.status_code == 403
+
+
+def test_install_key_happy_path_never_echoes_password(app_and_db, monkeypatch, tmp_path):
+    app, _db = app_and_db
+    import remote_setup
+    pub = tmp_path / "k.pub"
+    pub.write_text("ssh-ed25519 AAAA vireo\n")
+    monkeypatch.setattr(remote_setup, "ensure_vireo_key",
+                        lambda **kw: (str(tmp_path / "k"), str(pub)))
+    monkeypatch.setattr(remote_setup, "build_install_argv",
+                        lambda **kw: ["ssh"])
+    monkeypatch.setattr(remote_setup, "install_key_with_password",
+                        lambda **kw: {"ok": True, "error": None})
+    monkeypatch.setattr(remote_setup, "key_auth_works", lambda **kw: True)
+    res = app.test_client().post(
+        "/api/remote-setup/install-key",
+        json={"host": "nas", "user": "a", "port": 22, "password": "hunter2"})
+    body = res.get_json()
+    assert body["ok"] is True
+    assert "hunter2" not in res.get_data(as_text=True)
+
+
+def test_install_key_wrong_password_maps_cleanly(app_and_db, monkeypatch, tmp_path):
+    app, _db = app_and_db
+    import remote_setup
+    pub = tmp_path / "k.pub"
+    pub.write_text("ssh-ed25519 AAAA vireo\n")
+    monkeypatch.setattr(remote_setup, "ensure_vireo_key",
+                        lambda **kw: (str(tmp_path / "k"), str(pub)))
+    monkeypatch.setattr(remote_setup, "build_install_argv",
+                        lambda **kw: ["ssh"])
+    monkeypatch.setattr(remote_setup, "install_key_with_password",
+                        lambda **kw: {"ok": False, "error": "wrong_password"})
+    res = app.test_client().post(
+        "/api/remote-setup/install-key",
+        json={"host": "nas", "user": "a", "port": 22, "password": "nope"})
+    body = res.get_json()
+    assert body["ok"] is False and body["error"] == "wrong_password"
+
+
+def test_locate_share_endpoint(app_and_db, monkeypatch, tmp_path):
+    app, _db = app_and_db
+    import remote_setup
+    monkeypatch.setattr(remote_setup, "locate_share",
+                        lambda **kw: "/volume1/Photos")
+    res = app.test_client().post(
+        "/api/remote-setup/locate-share",
+        json={"mount_path": str(tmp_path), "share": "Photos",
+              "host": "nas", "user": "a", "port": 22})
+    assert res.get_json()["remote_path"] == "/volume1/Photos"
+
+
+def test_locate_share_readonly_mount_is_clean_error(app_and_db, monkeypatch, tmp_path):
+    app, _db = app_and_db
+    import remote_setup
+
+    def boom(**kw):
+        raise remote_setup.MountNotWritable("read-only")
+
+    monkeypatch.setattr(remote_setup, "locate_share", boom)
+    res = app.test_client().post(
+        "/api/remote-setup/locate-share",
+        json={"mount_path": str(tmp_path), "share": "P", "host": "n",
+              "user": "a", "port": 22})
+    body = res.get_json()
+    assert res.status_code == 400 and "writable" in body["error"].lower()
+
+
+def test_locate_share_validates_mount_path(app_and_db):
+    app, _db = app_and_db
+    res = app.test_client().post(
+        "/api/remote-setup/locate-share",
+        json={"mount_path": "relative/path", "share": "P", "host": "n",
+              "user": "a", "port": 22})
+    assert res.status_code == 400
+
+
+def test_list_remote_dirs_endpoint(app_and_db, monkeypatch):
+    app, _db = app_and_db
+    import remote_setup
+    monkeypatch.setattr(remote_setup, "list_remote_dirs",
+                        lambda **kw: ["Exports", "Raw Files"])
+    res = app.test_client().post(
+        "/api/remote-setup/list-remote-dirs",
+        json={"path": "/volume1", "host": "n", "user": "a", "port": 22})
+    assert res.get_json()["dirs"] == ["Exports", "Raw Files"]
+
+
+def test_disk_free_endpoint(app_and_db, tmp_path):
+    app, _db = app_and_db
+    res = app.test_client().get(
+        "/api/remote-setup/disk-free", query_string={"path": str(tmp_path)})
+    assert res.status_code == 200
+    assert res.get_json()["free_bytes"] > 0
+    bad = app.test_client().get(
+        "/api/remote-setup/disk-free", query_string={"path": "not/absolute"})
+    assert bad.status_code == 400

--- a/vireo/tests/test_remote_setup_api.py
+++ b/vireo/tests/test_remote_setup_api.py
@@ -47,6 +47,7 @@ def test_ssh_check_reports_port_auth_and_pubkey(app_and_db, monkeypatch, tmp_pat
     body = res.get_json()
     assert body["port_open"] is True and body["key_auth_ok"] is False
     assert body["pub_key_line"] == "ssh-ed25519 AAAA vireo"
+    assert body["key_path"] == str(tmp_path / "vireo_ed25519")
 
 
 def test_ssh_check_validates_input(app_and_db):

--- a/vireo/tests/test_remote_setup_api.py
+++ b/vireo/tests/test_remote_setup_api.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 def test_mounts_endpoint_returns_parsed_mounts(app_and_db, monkeypatch):
     app, _db = app_and_db
     import remote_setup
+    monkeypatch.setattr(remote_setup, "platform_supported", lambda: True)
     monkeypatch.setattr(remote_setup, "list_network_mounts", lambda **kw: [
         {"fs_type": "smbfs", "host": "1.2.3.4", "friendly_host": "nas.ts.net",
          "display_name": "nas", "share": "Photos",
@@ -19,6 +20,19 @@ def test_mounts_endpoint_returns_parsed_mounts(app_and_db, monkeypatch):
     res = app.test_client().get("/api/remote-setup/mounts")
     assert res.status_code == 200
     assert res.get_json()["mounts"][0]["share"] == "Photos"
+
+
+def test_mounts_endpoint_reports_unsupported_platform(app_and_db, monkeypatch):
+    """Endpoint short-circuits with unsupported_platform where the wizard's
+    mount parsing doesn't apply (Linux/Windows), even if `list_network_mounts`
+    is available — the gate is on `platform_supported()`."""
+    app, _db = app_and_db
+    import remote_setup
+    monkeypatch.setattr(remote_setup, "platform_supported", lambda: False)
+    res = app.test_client().get("/api/remote-setup/mounts")
+    body = res.get_json()
+    assert res.status_code == 200
+    assert body == {"mounts": [], "unsupported_platform": True}
 
 
 def test_mounts_endpoint_rejects_non_loopback(app_and_db):


### PR DESCRIPTION
## What

A guided five-step wizard on Settings → Remote targets that takes a user from a Finder-mounted NAS share to a tested, saved remote target — no Terminal, no hand-typed absolute paths. This closes the setup cliff in front of the chained import → process → move-to-NAS workflow (#1314).

**Spec:** `docs/superpowers/specs/2026-07-26-nas-setup-wizard-design.md`
**Plan:** `docs/superpowers/plans/2026-07-26-nas-setup-wizard.md`

### The five steps

1. **Pick your NAS volume** — enumerates mounted network shares (`mount` parsing: smbfs/nfs/afpfs, URL-decoding, IPv6), reverse-resolves IPs to friendly names (Tailscale MagicDNS/mDNS/DNS).
2. **Connect over SSH** — TCP probe with brand-aware enable-SSH help; generates a dedicated key (`~/.vireo/ssh/vireo_ed25519`, never touches `~/.ssh` keys); installs it using the NAS password **once** (plain `ssh` driven through a pty — password is request-scoped, never stored or logged), with a copy-paste Terminal fallback for users who won't type a password into an app.
3. **Locate the share** — writes a nonce file through the mount and finds it over SSH among candidate roots (`/volume*`, `/share(s)`, `/mnt/*`, `/srv/*`). Proof, not a heuristic: the chained move deletes local originals, so a same-named share on the wrong volume must be impossible. Falls back to an SSH-backed remote browser.
4. **Local archive root** — folder picker with a suggested `~/Pictures/Vireo Archive`, create-and-use, and a free-space readout.
5. **Review and test** — auto-runs the existing Test connection; saves through the existing config path and `_coerce_remote_target` validation.

The Import page's "Move to NAS unavailable" hint now links to `/settings#nas-setup` (deep link opens the wizard).

### Backend

New `vireo/remote_setup.py` (pure logic, injectable runner — no test spawns a real ssh) + six loopback-only synchronous routes: `mounts`, `ssh-check` (also returns `pub_key_line` so the Terminal fallback works without ever submitting a password), `install-key`, `locate-share`, `list-remote-dirs`, `disk-free`. `install-key` refuses non-loopback callers (defense in depth on top of the waitress 127.0.0.1 bind).

## Tests

- 24 unit tests (`vireo/tests/test_remote_setup.py`): mount parsing fixtures (smbfs/nfs/afpfs, spaces, IPv6), key management, pty driver against a stub ssh (success / wrong password / password-auth disabled / host-key rejected; asserts the password never appears in results), nonce probe cleanup on all paths.
- 12 endpoint tests (`vireo/tests/test_remote_setup_api.py`): validation, loopback guard, password never echoed, MountNotWritable → clean 400.
- 2 e2e tests (`tests/e2e/test_nas_setup_wizard.py`): full wizard walk (password path) and Terminal-fallback branch (asserts install-key is never called), with `remote_setup` monkeypatched in the in-process server.
- Required suite: `tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` + the two new files: **1981 passed, 14 skipped, 1 pre-existing failure** (`test_api_exiftool_status_reports_missing` — fails on the unmodified tree too; environment-dependent, exiftool installed locally).
- Manually verified against a real Synology NAS over Tailscale: mount detection (+ correct exclusion of a mounted camera card), MagicDNS reverse resolution, port probe, key generation with 0600 perms, `pub_key_line`, disk-free. (install-key/locate-share exercised via mocks only — they need the NAS password.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided “NAS setup wizard” in Settings to discover mounted volumes, authorize SSH, locate the NAS share, choose an archive folder, test the connection, and save the remote target.
  * Included a manual remote-directory browser fallback and a deep link that opens the wizard via `/settings#nas-setup`.
* **Bug Fixes**
  * Updated the “Then move to NAS” unavailable state to direct users to the wizard, and improved safety so sensitive password input is not returned in responses.
* **Tests**
  * Added backend, API, and end-to-end coverage for the wizard flow, including non-install and password-authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->