### PR TITLE
Harden upgrade safety and settings-export privacy for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to Vireo are documented in this file.
 ## Unreleased
 
 ### Added
+- **Automatic catalog backup before upgrades.** When a new Vireo version
+  needs to migrate the database, a snapshot is saved next to it (e.g.
+  `vireo.db.pre-v8.bak`) before any migration runs. Only the most recent
+  pre-upgrade snapshot is kept.
 - **Advanced color and tone editing.** The non-destructive photo editor now
   includes a five-point tone curve, an eight-color hue/saturation/luminance
   mixer, and independent shadow, midtone, and highlight color grading. These
@@ -20,6 +24,18 @@ All notable changes to Vireo are documented in this file.
   updater, and uninstall-preservation gates before publication.
 
 ### Fixed
+- Opening a catalog that was already migrated by a newer Vireo (for example
+  after reinstalling an older build) now shows clear "update Vireo to open
+  this catalog" guidance instead of a crash — and no longer suggests moving
+  the database aside, which would have orphaned the newer catalog.
+- A corrupt `~/.vireo/config.json` is now preserved as `config.json.corrupt`
+  before Vireo falls back to defaults, instead of being silently overwritten
+  on the next settings change.
+
+- Settings export no longer includes secret values (iNaturalist token,
+  Hugging Face token, Google Maps API key); the exported file lists which
+  keys were omitted. Importing a backup keeps the secrets already configured
+  on the machine unless the file explicitly provides them.
 - After-import classification now pauses with an actionable label-download
   message when the selected model cannot run without a species list, instead
   of enqueueing a pipeline job guaranteed to fail.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -217,15 +217,19 @@ pub fn run() {
                             }
                         }
                     }
-                    Err(SidecarStartError::IncompatibleDatabase { db_path, reason }) => {
+                    Err(SidecarStartError::IncompatibleDatabase { db_path, reason, newer }) => {
                         // The Python sidecar refused to open the DB because
-                        // its schema predates a non-migratable change. Surface
+                        // its schema version doesn't match this build. Surface
                         // an actionable dialog before exiting — without this
                         // the user just sees the WKWebView fail to load and
                         // has no way to tell whether to delete the DB, file a
-                        // bug, or reinstall.
+                        // bug, or reinstall. The remediation depends on the
+                        // direction of the mismatch: an older DB can be moved
+                        // aside to start fresh, but a NEWER DB (downgraded
+                        // install) must not be discarded — updating Vireo
+                        // opens it intact.
                         log::error!(
-                            "Incompatible database at {}: {}. Back up this file and relaunch.",
+                            "Incompatible database at {}: {}",
                             db_path, reason
                         );
                         eprintln!(
@@ -237,12 +241,20 @@ pub fn run() {
                             .app_log_dir()
                             .map(|path| path.display().to_string())
                             .unwrap_or_else(|_| "the Vireo application log directory".into());
-                        app.handle()
-                            .dialog()
-                            .message(format!(
+                        let message = if newer {
+                            format!(
+                                "Vireo can't open the database at:\n\n{}\n\nIt was created by a newer version of Vireo than the one you're running. Update Vireo to its latest version to open this catalog — don't delete or move the file; your photos and edits are intact.\n\nDetails: {}\n\nLogs: {}",
+                                db_path, reason, log_dir
+                            )
+                        } else {
+                            format!(
                                 "Vireo can't open the database at:\n\n{}\n\nIt's from an incompatible older version of Vireo. To start fresh, move this file aside (for example, rename it with a `.bak` suffix) and relaunch.\n\nDetails: {}\n\nLogs: {}",
                                 db_path, reason, log_dir
-                            ))
+                            )
+                        };
+                        app.handle()
+                            .dialog()
+                            .message(message)
                             .title("Incompatible Vireo Database")
                             .kind(MessageDialogKind::Error)
                             .blocking_show();

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -34,7 +34,9 @@ pub enum SidecarStartError {
 impl std::fmt::Display for SidecarStartError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::IncompatibleDatabase { db_path, reason, .. } => {
+            Self::IncompatibleDatabase {
+                db_path, reason, ..
+            } => {
                 write!(f, "Incompatible database at {}: {}", db_path, reason)
             }
             Self::Generic(msg) => f.write_str(msg),
@@ -596,7 +598,11 @@ mod tests {
     fn parse_structured_error_recognizes_incompatible_database() {
         let line = r#"{"error":"incompatible_database","db_path":"/home/u/.vireo/vireo.db","reason":"no such column: classifier_model"}"#;
         match parse_structured_error(line) {
-            Some(SidecarStartError::IncompatibleDatabase { db_path, reason, newer }) => {
+            Some(SidecarStartError::IncompatibleDatabase {
+                db_path,
+                reason,
+                newer,
+            }) => {
                 assert_eq!(db_path, "/home/u/.vireo/vireo.db");
                 assert!(reason.contains("classifier_model"));
                 assert!(!newer);

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -19,8 +19,14 @@ const GUI_CLIENTS_DIR: &str = ".vireo/gui-clients";
 pub enum SidecarStartError {
     /// The sidecar exited with a structured `incompatible_database` signal
     /// on stderr. The launcher surfaces `db_path` so the user knows which
-    /// file to back up.
-    IncompatibleDatabase { db_path: String, reason: String },
+    /// file to back up. `newer` means the database was migrated by a newer
+    /// Vireo than this build — the remedy is updating the app, NOT moving
+    /// the file aside.
+    IncompatibleDatabase {
+        db_path: String,
+        reason: String,
+        newer: bool,
+    },
     /// Any other failure (spawn error, generic early exit, health timeout).
     Generic(String),
 }
@@ -28,7 +34,7 @@ pub enum SidecarStartError {
 impl std::fmt::Display for SidecarStartError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::IncompatibleDatabase { db_path, reason } => {
+            Self::IncompatibleDatabase { db_path, reason, .. } => {
                 write!(f, "Incompatible database at {}: {}", db_path, reason)
             }
             Self::Generic(msg) => f.write_str(msg),
@@ -43,6 +49,7 @@ struct SidecarErrorPayload {
     error: String,
     db_path: Option<String>,
     reason: Option<String>,
+    newer: Option<bool>,
 }
 
 /// Parse a single line of sidecar stderr looking for a structured startup
@@ -61,6 +68,7 @@ fn parse_structured_error(line: &str) -> Option<SidecarStartError> {
         "incompatible_database" => Some(SidecarStartError::IncompatibleDatabase {
             db_path: payload.db_path.unwrap_or_default(),
             reason: payload.reason.unwrap_or_else(|| "no details".into()),
+            newer: payload.newer.unwrap_or(false),
         }),
         "startup_failed" => {
             let reason = payload
@@ -588,10 +596,30 @@ mod tests {
     fn parse_structured_error_recognizes_incompatible_database() {
         let line = r#"{"error":"incompatible_database","db_path":"/home/u/.vireo/vireo.db","reason":"no such column: classifier_model"}"#;
         match parse_structured_error(line) {
-            Some(SidecarStartError::IncompatibleDatabase { db_path, reason }) => {
+            Some(SidecarStartError::IncompatibleDatabase { db_path, reason, newer }) => {
                 assert_eq!(db_path, "/home/u/.vireo/vireo.db");
                 assert!(reason.contains("classifier_model"));
+                assert!(!newer);
             }
+            other => panic!("expected IncompatibleDatabase, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_structured_error_carries_newer_database_flag() {
+        let line = r#"{"error":"incompatible_database","db_path":"/tmp/x.db","reason":"schema version 99 is newer than supported 8","newer":true}"#;
+        match parse_structured_error(line) {
+            Some(SidecarStartError::IncompatibleDatabase { newer, .. }) => assert!(newer),
+            other => panic!("expected IncompatibleDatabase, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_structured_error_defaults_newer_flag_to_false() {
+        // Older sidecar builds don't emit the field at all.
+        let line = r#"{"error":"incompatible_database","db_path":"/tmp/x.db","reason":"r"}"#;
+        match parse_structured_error(line) {
+            Some(SidecarStartError::IncompatibleDatabase { newer, .. }) => assert!(!newer),
             other => panic!("expected IncompatibleDatabase, got {:?}", other),
         }
     }

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3665,7 +3665,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not expected:
             # No token configured → deny all v1 traffic.
             return json_error("API token not configured", 401)
-        if request.headers.get("X-Vireo-Token") != expected:
+        supplied = request.headers.get("X-Vireo-Token", "")
+        if not secrets.compare_digest(supplied, expected):
             return json_error("Invalid or missing X-Vireo-Token", 401)
         return None
 
@@ -15668,8 +15669,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         import datetime as _datetime
 
+        import config_schema as schema
+
         raw = _read_raw_config_file()
         raw.pop("_migrations_applied", None)
+        # Never ship secret values in a settings backup — these files get
+        # attached to bug reports and shared machines. Import leaves this
+        # machine's stored secrets alone when the payload omits them, and
+        # ``_secrets_omitted`` tells the user what to re-enter after
+        # importing on a fresh machine.
+        _ABSENT = object()
+        omitted = []
+        for secret_key in schema.secret_keys():
+            val = schema.get_dotted(raw, secret_key, default=_ABSENT)
+            if val is _ABSENT:
+                continue
+            schema.delete_dotted(raw, secret_key)
+            if val:
+                omitted.append(secret_key)
+        if omitted:
+            raw["_secrets_omitted"] = sorted(omitted)
         # ``pipeline.default_process_id`` points into ``saved_processes``,
         # whose rows are DB-local — the ids don't transfer across databases.
         # If the same integer id happens to exist in the target DB it points
@@ -15729,6 +15748,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(f"invalid JSON: {e}", status=400)
         if not isinstance(payload, dict):
             return json_error("payload must be a JSON object", status=400)
+
+        # Bookkeeping marker written by /api/settings/export; never persist it.
+        payload.pop("_secrets_omitted", None)
 
         # Translate the legacy ``pipeline.default_strategy`` (hardcoded strategy
         # name) to the current ``pipeline.default_process_id`` before schema
@@ -15903,6 +15925,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return jsonify({"error": "validation failed", "errors": errors}), 400
 
         with _settings_write_lock:
+            # Exports omit secret values (see /api/settings/export), so a
+            # restored backup must not wipe the tokens already configured on
+            # this machine: absent secret keys keep their current on-disk
+            # value; explicitly supplied ones write through.
+            current_raw = _read_raw_config_file()
+            for secret_key in schema.secret_keys():
+                if schema.get_dotted(payload, secret_key, default=_MISSING) is not _MISSING:
+                    continue
+                existing = schema.get_dotted(current_raw, secret_key, default=_MISSING)
+                if existing is not _MISSING:
+                    schema.set_dotted(payload, secret_key, existing)
             cfg.save(payload)
             _settings_post_save_side_effects(cfg.load())
         return jsonify({"ok": True})
@@ -30955,16 +30988,25 @@ def main():
         # registered above releases the single-instance lock and runtime.json
         # on this exit, so a retry isn't blocked by a stale reservation.
         import sys as _sys
-        log.error(
-            "Cannot open database at %s: it is from an incompatible older "
-            "version of Vireo. Back it up and remove it to start fresh "
-            "(e.g. `mv %s %s.bak`), then relaunch. Underlying error: %s",
-            e.db_path, e.db_path, e.db_path, e.cause,
-        )
+        if getattr(e, "newer", False):
+            log.error(
+                "Cannot open database at %s: it was created by a newer "
+                "version of Vireo than this build supports. Update Vireo to "
+                "its latest version to open this catalog. Underlying error: %s",
+                e.db_path, e.cause,
+            )
+        else:
+            log.error(
+                "Cannot open database at %s: it is from an incompatible older "
+                "version of Vireo. Back it up and remove it to start fresh "
+                "(e.g. `mv %s %s.bak`), then relaunch. Underlying error: %s",
+                e.db_path, e.db_path, e.db_path, e.cause,
+            )
         _sys.stderr.write(json.dumps({
             "error": "incompatible_database",
             "db_path": e.db_path,
             "reason": str(e),
+            "newer": getattr(e, "newer", False),
         }) + "\n")
         raise SystemExit(3) from e
     except Exception as e:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2825,7 +2825,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if (
             expected_api_token
             and supplied_api_token
-            and secrets.compare_digest(supplied_api_token, expected_api_token)
+            and secrets.compare_digest(
+                supplied_api_token.encode("utf-8"),
+                expected_api_token.encode("utf-8"),
+            )
         ):
             return None
 
@@ -2851,7 +2854,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         cookie_name = app.config["BROWSER_SESSION_COOKIE"]
         expected_token = app.config["BROWSER_SESSION_TOKEN"]
         if not secrets.compare_digest(
-            request.cookies.get(cookie_name, ""), expected_token,
+            request.cookies.get(cookie_name, "").encode("utf-8"),
+            expected_token.encode("utf-8"),
         ):
             return json_error(
                 "Browser session required",
@@ -3666,7 +3670,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # No token configured → deny all v1 traffic.
             return json_error("API token not configured", 401)
         supplied = request.headers.get("X-Vireo-Token", "")
-        if not secrets.compare_digest(supplied, expected):
+        # ``secrets.compare_digest`` raises ``TypeError`` when either str
+        # operand contains a non-ASCII code point, which would surface as a
+        # 500 for an attacker-supplied token — encode to bytes so a bogus
+        # header is a plain 401 like any other wrong value.
+        if not secrets.compare_digest(supplied.encode("utf-8"), expected.encode("utf-8")):
             return json_error("Invalid or missing X-Vireo-Token", 401)
         return None
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -30862,6 +30862,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     return app
 
 
+def _emit_incompatible_database_exit(e):
+    # Both --load-taxonomy and create_app open the catalog; either can trip
+    # ensure_schema's newer-DB guard, and both need the same guided exit so
+    # the desktop launcher gets a structured signal instead of a raw
+    # traceback.
+    import sys as _sys
+    if getattr(e, "newer", False):
+        log.error(
+            "Cannot open database at %s: it was created by a newer "
+            "version of Vireo than this build supports. Update Vireo to "
+            "its latest version to open this catalog. Underlying error: %s",
+            e.db_path, e.cause,
+        )
+    else:
+        log.error(
+            "Cannot open database at %s: it is from an incompatible older "
+            "version of Vireo. Back it up and remove it to start fresh "
+            "(e.g. `mv %s %s.bak`), then relaunch. Underlying error: %s",
+            e.db_path, e.db_path, e.db_path, e.cause,
+        )
+    _sys.stderr.write(json.dumps({
+        "error": "incompatible_database",
+        "db_path": e.db_path,
+        "reason": str(e),
+        "newer": getattr(e, "newer", False),
+    }) + "\n")
+    raise SystemExit(3) from e
+
+
 def main():
     _setup_file_logging()
 
@@ -30913,6 +30942,14 @@ def main():
     if args.load_taxonomy:
         from db import Database
         from taxonomy import fetch_common_names, load_taxonomy, seed_informal_groups
+        # Run the newer-schema guard before Database(args.db) executes any
+        # legacy DDL/ALTERs against a catalog stamped by a future Vireo build.
+        # create_app takes this same check through ensure_schema; keep the two
+        # entry points in sync so `--load-taxonomy` can't corrupt a newer DB.
+        try:
+            ensure_schema(args.db)
+        except IncompatibleDatabaseError as e:
+            _emit_incompatible_database_exit(e)
         db = Database(args.db)
         log.info("Loading taxonomy tree from iNaturalist...")
         stats = load_taxonomy(db)
@@ -30995,28 +31032,7 @@ def main():
         # as "did not become healthy within 30s"). The atexit/SIGTERM cleanup
         # registered above releases the single-instance lock and runtime.json
         # on this exit, so a retry isn't blocked by a stale reservation.
-        import sys as _sys
-        if getattr(e, "newer", False):
-            log.error(
-                "Cannot open database at %s: it was created by a newer "
-                "version of Vireo than this build supports. Update Vireo to "
-                "its latest version to open this catalog. Underlying error: %s",
-                e.db_path, e.cause,
-            )
-        else:
-            log.error(
-                "Cannot open database at %s: it is from an incompatible older "
-                "version of Vireo. Back it up and remove it to start fresh "
-                "(e.g. `mv %s %s.bak`), then relaunch. Underlying error: %s",
-                e.db_path, e.db_path, e.db_path, e.cause,
-            )
-        _sys.stderr.write(json.dumps({
-            "error": "incompatible_database",
-            "db_path": e.db_path,
-            "reason": str(e),
-            "newer": getattr(e, "newer", False),
-        }) + "\n")
-        raise SystemExit(3) from e
+        _emit_incompatible_database_exit(e)
     except Exception as e:
         # Any other failure to build the app is still a fatal startup error
         # (corrupt-but-not-stale DB, missing/locked resource, an unexpected

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15526,6 +15526,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         Unlike cfg.load(), this does NOT merge DEFAULTS — so it contains
         only the keys the user has actually set. Used by write paths so the
         on-disk file stays minimal.
+
+        Preserves a `.corrupt` backup on unreadable/non-dict content before
+        returning `{}` — otherwise the very next PATCH/DELETE via the
+        schema-driven settings routes would call `cfg.save()` on the empty
+        dict and silently overwrite whatever the user had.
         """
         import config as cfg
 
@@ -15534,9 +15539,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             with open(cfg.CONFIG_PATH) as f:
                 raw = json.load(f)
-            return raw if isinstance(raw, dict) else {}
         except (OSError, json.JSONDecodeError):
+            cfg._preserve_corrupt_config()
             return {}
+        if not isinstance(raw, dict):
+            cfg._preserve_corrupt_config()
+            return {}
+        return raw
 
     # Serializes read-modify-write of ~/.vireo/config.json and the active
     # workspace's config_overrides across the schema-driven settings

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import copy
+import filecmp
 import json
 import logging
 import os
@@ -243,11 +244,13 @@ def _preserve_corrupt_config():
     which would otherwise silently destroy whatever the user had."""
     backup = CONFIG_PATH + ".corrupt"
     try:
-        # copy2 preserves mtime, so an already-preserved copy of this exact
-        # corruption is skipped instead of re-copied on every load().
-        if os.path.exists(backup) and (
-            os.path.getmtime(backup) >= os.path.getmtime(CONFIG_PATH)
-        ):
+        # Skip only when the current corrupt file is byte-for-byte the same
+        # as the existing backup. mtime comparison isn't safe here: a
+        # restored-from-history file, a coarse-resolution filesystem, or an
+        # editor that resets mtime can leave the current corruption with an
+        # equal-or-older timestamp than an unrelated older backup, and the
+        # current bytes would then be discarded.
+        if os.path.exists(backup) and filecmp.cmp(backup, CONFIG_PATH, shallow=False):
             return
         shutil.copy2(CONFIG_PATH, backup)
         log.warning("Config file is unreadable; preserved a copy at %s", backup)

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -5,6 +5,7 @@ import copy
 import json
 import logging
 import os
+import shutil
 import sys
 import tempfile
 import threading
@@ -236,6 +237,24 @@ def _deep_merge(base, override):
     return result
 
 
+def _preserve_corrupt_config():
+    """Copy an unreadable config file to ``<path>.corrupt`` before callers
+    fall back to defaults — the next ``save()`` overwrites the original,
+    which would otherwise silently destroy whatever the user had."""
+    backup = CONFIG_PATH + ".corrupt"
+    try:
+        # copy2 preserves mtime, so an already-preserved copy of this exact
+        # corruption is skipped instead of re-copied on every load().
+        if os.path.exists(backup) and (
+            os.path.getmtime(backup) >= os.path.getmtime(CONFIG_PATH)
+        ):
+            return
+        shutil.copy2(CONFIG_PATH, backup)
+        log.warning("Config file is unreadable; preserved a copy at %s", backup)
+    except OSError:
+        pass
+
+
 def load():
     """Load config, returning defaults for any missing keys."""
     config = copy.deepcopy(DEFAULTS)
@@ -245,6 +264,7 @@ def load():
                 config = _deep_merge(config, json.load(f))
         except Exception:
             log.warning("Failed to read config, using defaults")
+            _preserve_corrupt_config()
     return config
 
 
@@ -336,8 +356,14 @@ def _read_raw():
         with open(CONFIG_PATH) as f:
             raw = json.load(f)
     except (OSError, json.JSONDecodeError):
+        # Callers (the config migrations) save() right after this read, so an
+        # unpreserved corrupt file would be clobbered with near-defaults.
+        _preserve_corrupt_config()
         return {}
-    return raw if isinstance(raw, dict) else {}
+    if not isinstance(raw, dict):
+        _preserve_corrupt_config()
+        return {}
+    return raw
 
 
 def _migrations_applied(raw):

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -715,6 +715,16 @@ def is_excluded(dotted_key):
     return any(dotted_key == p or dotted_key.startswith(p + ".") for p in EXCLUDED)
 
 
+def secret_keys():
+    """Dotted keys of every secret-typed setting (tokens/API keys).
+
+    Their *values* must never leave the machine in a settings export — the
+    export/import endpoints use this list to omit them on the way out and to
+    preserve the local values on the way back in.
+    """
+    return [k for k, spec in SCHEMA.items() if spec.get("type") == "secret"]
+
+
 def schema_parent_prefixes():
     """Return the set of dotted prefixes that are parents of any SCHEMA key.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -41,16 +41,26 @@ class IncompatibleDatabaseError(RuntimeError):
 
     ``db_path`` is the offending file; ``cause`` is the original SQLite error
     text, preserved so genuine schema bugs (vs. legitimately old DBs) stay
-    diagnosable.
+    diagnosable. ``newer=True`` means the reverse mismatch — the file's
+    schema version is ahead of this build (a downgraded install opening a
+    catalog a newer Vireo already migrated) — where the remedy is updating
+    the app, not discarding the database.
     """
 
-    def __init__(self, db_path, cause=None):
+    def __init__(self, db_path, cause=None, newer=False):
         self.db_path = db_path
         self.cause = cause
-        msg = (
-            f"The database at {db_path} is from an incompatible older version "
-            f"of Vireo and cannot be opened by this build"
-        )
+        self.newer = newer
+        if newer:
+            msg = (
+                f"The database at {db_path} was created by a newer version "
+                f"of Vireo than this build supports"
+            )
+        else:
+            msg = (
+                f"The database at {db_path} is from an incompatible older "
+                f"version of Vireo and cannot be opened by this build"
+            )
         if cause:
             msg += f" ({cause})"
         super().__init__(msg)

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -7,13 +7,19 @@ web requests open an initialized database and never perform schema work.
 
 from __future__ import annotations
 
+import contextlib
+import glob
 import json
+import logging
+import os
 import sqlite3
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from db import Database
+from db import Database, IncompatibleDatabaseError
+
+log = logging.getLogger(__name__)
 
 _SCHEMA_LOCK = threading.Lock()
 
@@ -923,7 +929,77 @@ def _apply_pending(conn):
         current = migration.version
 
 
+def _existing_user_version(db_path):
+    """``PRAGMA user_version`` of an existing database file, or None for a
+    fresh install (missing/empty file)."""
+    if not os.path.exists(db_path) or os.path.getsize(db_path) == 0:
+        return None
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        return conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def _backup_path(db_path, target_version):
+    return f"{db_path}.pre-v{target_version}.bak"
+
+
+def _snapshot_before_migrations(db_path, target_version):
+    """Snapshot the database before pending migrations touch it.
+
+    ``VACUUM INTO`` produces a consistent single-file copy even under WAL.
+    A snapshot from an earlier (possibly failed) attempt at the same target
+    version is kept as-is — it reflects an older, safer state than whatever
+    partial progress the failed run left behind. Backup failure (disk full,
+    read-only volume) is logged but never blocks startup: per-migration
+    transactions still protect the live file.
+    """
+    backup = _backup_path(db_path, target_version)
+    if os.path.exists(backup):
+        return
+    tmp = backup + ".tmp"
+    with contextlib.suppress(OSError):
+        os.remove(tmp)
+    try:
+        with contextlib.closing(sqlite3.connect(db_path)) as conn:
+            conn.execute("VACUUM INTO ?", (tmp,))
+        os.replace(tmp, backup)
+        log.info("Backed up database to %s before schema migration", backup)
+    except (sqlite3.Error, OSError):
+        log.warning(
+            "Could not back up %s before schema migration; continuing without "
+            "a snapshot", db_path, exc_info=True,
+        )
+        with contextlib.suppress(OSError):
+            os.remove(tmp)
+
+
+def _prune_stale_backups(db_path, keep_version):
+    keep = _backup_path(db_path, keep_version)
+    for path in glob.glob(glob.escape(db_path) + ".pre-v*.bak"):
+        if path != keep:
+            with contextlib.suppress(OSError):
+                os.remove(path)
+
+
 def ensure_schema(db_path):
     """Initialize and migrate ``db_path`` once before request handling."""
-    with _SCHEMA_LOCK, Database(db_path) as db:
-        _apply_pending(db.conn)
+    with _SCHEMA_LOCK:
+        latest = MIGRATIONS[-1].version if MIGRATIONS else 0
+        current = _existing_user_version(db_path)
+        # Refuse a database stamped by a newer Vireo before Database.__init__
+        # runs its legacy ALTERs against it. IncompatibleDatabaseError (rather
+        # than the bare RuntimeError _apply_pending raises) reaches main()'s
+        # guided-exit handler, so the user gets "update Vireo" instead of a
+        # raw traceback.
+        if current is not None and current > latest:
+            raise IncompatibleDatabaseError(
+                db_path,
+                cause=f"schema version {current} is newer than supported {latest}",
+                newer=True,
+            )
+        upgrading = current is not None and current < latest
+        if upgrading:
+            _snapshot_before_migrations(db_path, latest)
+        with Database(db_path) as db:
+            _apply_pending(db.conn)
+        if upgrading:
+            _prune_stale_backups(db_path, latest)

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -973,7 +973,12 @@ def _snapshot_before_migrations(db_path, target_version):
 
 
 def _prune_stale_backups(db_path, keep_version):
+    # If the target-version snapshot never landed (VACUUM INTO failed, the
+    # volume filled up, etc.), keep every older `.pre-v*.bak` — deleting them
+    # would leave the upgraded database with no recovery snapshot at all.
     keep = _backup_path(db_path, keep_version)
+    if not os.path.exists(keep):
+        return
     for path in glob.glob(glob.escape(db_path) + ".pre-v*.bak"):
         if path != keep:
             with contextlib.suppress(OSError):

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -12,6 +12,7 @@ import glob
 import json
 import logging
 import os
+import re
 import sqlite3
 import threading
 from collections.abc import Callable
@@ -972,6 +973,9 @@ def _snapshot_before_migrations(db_path, target_version):
             os.remove(tmp)
 
 
+_BACKUP_SUFFIX_RE = re.compile(r"\.pre-v(\d+)\.bak\Z")
+
+
 def _prune_stale_backups(db_path, keep_version):
     # If the target-version snapshot never landed (VACUUM INTO failed, the
     # volume filled up, etc.), keep every older `.pre-v*.bak` — deleting them
@@ -979,10 +983,27 @@ def _prune_stale_backups(db_path, keep_version):
     keep = _backup_path(db_path, keep_version)
     if not os.path.exists(keep):
         return
-    for path in glob.glob(glob.escape(db_path) + ".pre-v*.bak"):
-        if path != keep:
-            with contextlib.suppress(OSError):
-                os.remove(path)
+    prefix = db_path
+    for path in glob.glob(glob.escape(prefix) + ".pre-v*.bak"):
+        if path == keep:
+            continue
+        # Only prune snapshots for schema versions strictly older than the one
+        # we're keeping. A `.pre-v{N}.bak` where N > keep_version was produced
+        # by a newer build (e.g. after the user restored an older live catalog
+        # while a later-version backup remained on disk) and may hold the
+        # user's only copy of edits made under that later schema.
+        suffix = path[len(prefix):]
+        match = _BACKUP_SUFFIX_RE.match(suffix)
+        if match is None:
+            continue
+        try:
+            version = int(match.group(1))
+        except ValueError:
+            continue
+        if version >= keep_version:
+            continue
+        with contextlib.suppress(OSError):
+            os.remove(path)
 
 
 def ensure_schema(db_path):

--- a/vireo/tests/test_api_v1_auth.py
+++ b/vireo/tests/test_api_v1_auth.py
@@ -13,6 +13,17 @@ def test_api_v1_wrong_token_rejected(app_and_db):
     assert resp.status_code == 401
 
 
+def test_api_v1_non_ascii_token_rejected_as_401(app_and_db):
+    """A bogus token containing non-ASCII characters must be a plain 401.
+    ``secrets.compare_digest`` raises ``TypeError`` on non-ASCII ``str``
+    operands, which previously surfaced as a 500 for attacker-controlled
+    header values."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/v1/health", headers={"X-Vireo-Token": "wröng"})
+    assert resp.status_code == 401
+
+
 def test_api_v1_correct_token_accepted(app_and_db):
     app, _ = app_and_db
     client = app.test_client()

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -1715,3 +1715,31 @@ def test_read_raw_preserves_corrupt_file_copy(tmp_path):
     assert cfg._read_raw() == {}
     with open(cfg.CONFIG_PATH + ".corrupt") as f:
         assert f.read() == corrupt_body
+
+
+def test_load_preserves_current_corrupt_over_older_backup_with_newer_mtime(tmp_path):
+    """A pre-existing `.corrupt` file with an equal-or-newer mtime must not
+    trick the preserve step into discarding the *current* corrupt bytes.
+    Real triggers: restoring the backup from history, coarse-mtime
+    filesystems (FAT/some NFS), or an editor that resets timestamps."""
+    import os
+
+    import config as cfg
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    backup_path = cfg.CONFIG_PATH + ".corrupt"
+    old_backup = "{ old-corruption"
+    with open(backup_path, "w") as f:
+        f.write(old_backup)
+    current_body = "{ different-current-corruption"
+    with open(cfg.CONFIG_PATH, "w") as f:
+        f.write(current_body)
+    # Force the backup's mtime to look newer than the current file so a
+    # timestamp-based check would incorrectly skip preservation.
+    now = os.path.getmtime(cfg.CONFIG_PATH)
+    os.utime(backup_path, (now + 10, now + 10))
+
+    cfg.load()
+
+    with open(backup_path) as f:
+        assert f.read() == current_body

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -1660,3 +1660,58 @@ def test_remote_target_archive_root_inside_mount_via_case_alias_is_blanked(
     assert coerced is not None
     assert coerced["local_archive_root"] == ""
     assert coerced["mount_path"] == str(mount)
+
+
+def test_load_preserves_corrupt_file_copy(tmp_path):
+    """A corrupt config file is preserved next to the original before the app
+    falls back to defaults, so a later save() can't silently destroy whatever
+    the user had."""
+    import config as cfg
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    corrupt_body = "not valid json {{{"
+    with open(cfg.CONFIG_PATH, "w") as f:
+        f.write(corrupt_body)
+
+    loaded = cfg.load()
+
+    assert loaded == cfg.DEFAULTS
+    backup_path = cfg.CONFIG_PATH + ".corrupt"
+    assert os.path.exists(backup_path)
+    with open(backup_path) as f:
+        assert f.read() == corrupt_body
+
+
+def test_set_after_corrupt_load_keeps_backup(tmp_path):
+    """set() on a corrupt config overwrites the main file with defaults+key,
+    but the preserved .corrupt copy keeps the user's original bytes."""
+    import json
+
+    import config as cfg
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    corrupt_body = '{"classification_threshold": 0.9, TRUNCATED'
+    with open(cfg.CONFIG_PATH, "w") as f:
+        f.write(corrupt_body)
+
+    cfg.set("photos_per_page", 25)
+
+    with open(cfg.CONFIG_PATH) as f:
+        assert json.load(f)["photos_per_page"] == 25
+    with open(cfg.CONFIG_PATH + ".corrupt") as f:
+        assert f.read() == corrupt_body
+
+
+def test_read_raw_preserves_corrupt_file_copy(tmp_path):
+    """_read_raw (the migration read path) also preserves a corrupt file —
+    migrations call save() right after, which would otherwise clobber it."""
+    import config as cfg
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    corrupt_body = "[1, 2,"
+    with open(cfg.CONFIG_PATH, "w") as f:
+        f.write(corrupt_body)
+
+    assert cfg._read_raw() == {}
+    with open(cfg.CONFIG_PATH + ".corrupt") as f:
+        assert f.read() == corrupt_body

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -1426,3 +1426,76 @@ def test_legacy_merge_null_species_predictions_collapse_to_one_row(tmp_path):
         assert review is not None
         assert review["status"] == "accepted"
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_ensure_schema_backs_up_before_pending_migrations(tmp_path):
+    """An existing DB with pending registry migrations is snapshotted before
+    any migration runs, so a bad migration can't destroy the only copy."""
+    import os
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    latest = schema.MIGRATIONS[-1].version
+    backup_path = f"{db_path}.pre-v{latest}.bak"
+    assert os.path.exists(backup_path)
+    # The snapshot reflects the pre-migration state.
+    with sqlite3.connect(backup_path) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 7
+        assert conn.execute("SELECT COUNT(*) FROM workspaces").fetchone()[0] >= 1
+
+
+def test_ensure_schema_no_backup_for_fresh_or_current_db(tmp_path):
+    """No snapshot for a brand-new DB, and none when the schema is already
+    at the latest version (normal startup must not accrete backups)."""
+    import glob
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+    assert glob.glob(f"{db_path}*.bak") == []
+
+    schema.ensure_schema(db_path)
+    assert glob.glob(f"{db_path}*.bak") == []
+
+
+def test_ensure_schema_prunes_older_backups(tmp_path):
+    """Only the most recent pre-migration snapshot is kept."""
+    import os
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+    latest = schema.MIGRATIONS[-1].version
+    stale_backup = f"{db_path}.pre-v{latest - 1}.bak"
+    with open(stale_backup, "w") as f:
+        f.write("old snapshot")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    assert os.path.exists(f"{db_path}.pre-v{latest}.bak")
+    assert not os.path.exists(stale_backup)
+
+
+def test_ensure_schema_newer_db_raises_incompatible_database_error(tmp_path):
+    """Opening a DB stamped by a newer Vireo raises the friendly
+    IncompatibleDatabaseError (caught by main's guided-exit handler) instead
+    of an anonymous RuntimeError crash — and does not mutate the file."""
+    from db import IncompatibleDatabaseError
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 99")
+
+    with pytest.raises(IncompatibleDatabaseError) as excinfo:
+        schema.ensure_schema(db_path)
+
+    assert "newer" in str(excinfo.value)
+    assert excinfo.value.db_path == db_path
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 99

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -1525,3 +1525,44 @@ def test_ensure_schema_newer_db_raises_incompatible_database_error(tmp_path):
     assert excinfo.value.db_path == db_path
     with sqlite3.connect(db_path) as conn:
         assert conn.execute("PRAGMA user_version").fetchone()[0] == 99
+
+
+def test_load_taxonomy_cli_refuses_newer_db(tmp_path, monkeypatch, capsys):
+    """``--load-taxonomy`` must not run legacy DDL against a catalog stamped
+    by a newer Vireo. Previously it bypassed ensure_schema and constructed
+    Database(args.db) directly, mutating the file and burying the version
+    mismatch in an OperationalError; the guided-exit handler should now fire
+    the same structured signal here as it does for the normal startup path."""
+    import json as _json
+
+    import app as vireo_app
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 99")
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["vireo", "--db", db_path, "--thumb-dir", str(tmp_path / "thumbs"),
+         "--load-taxonomy"],
+    )
+    # Guard against actually touching the DB or the network if the fix
+    # regresses and control ever reaches Database(args.db)/load_taxonomy.
+    def _boom(*_a, **_kw):  # pragma: no cover - regression guard
+        raise AssertionError("--load-taxonomy touched the DB before ensure_schema")
+
+    monkeypatch.setattr("db.Database", _boom)
+
+    with pytest.raises(SystemExit) as excinfo:
+        vireo_app.main()
+    assert excinfo.value.code == 3
+
+    captured = capsys.readouterr()
+    payload = _json.loads(captured.err.strip().splitlines()[-1])
+    assert payload["error"] == "incompatible_database"
+    assert payload["newer"] is True
+    assert payload["db_path"] == db_path
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 99

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -1566,3 +1566,30 @@ def test_load_taxonomy_cli_refuses_newer_db(tmp_path, monkeypatch, capsys):
 
     with sqlite3.connect(db_path) as conn:
         assert conn.execute("PRAGMA user_version").fetchone()[0] == 99
+
+
+def test_ensure_schema_keeps_later_version_snapshots(tmp_path):
+    """Restoring an older live database while a later-version backup remains
+    (e.g. `.pre-v9.bak` beside a v7 file, then launching this v8 build) must
+    keep the newer snapshot — it may hold the user's only copy of edits made
+    under that later schema. Only strictly older snapshots may be pruned."""
+    import os
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+    latest = schema.MIGRATIONS[-1].version
+    older_backup = f"{db_path}.pre-v{latest - 1}.bak"
+    newer_backup = f"{db_path}.pre-v{latest + 1}.bak"
+    with open(older_backup, "w") as f:
+        f.write("older snapshot")
+    with open(newer_backup, "w") as f:
+        f.write("later-version snapshot")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    assert os.path.exists(f"{db_path}.pre-v{latest}.bak")
+    assert not os.path.exists(older_backup)
+    # The later-version backup must survive — it may be irreplaceable.
+    assert os.path.exists(newer_backup)

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -1481,6 +1481,32 @@ def test_ensure_schema_prunes_older_backups(tmp_path):
     assert not os.path.exists(stale_backup)
 
 
+def test_ensure_schema_keeps_older_backups_when_snapshot_fails(tmp_path, monkeypatch):
+    """If the pre-migration snapshot can't be written (VACUUM INTO fails,
+    volume full, etc.), an older `.pre-v*.bak` from a previous successful
+    run must survive — otherwise the upgrade completes with no recovery
+    snapshot at all."""
+    import os
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+    latest = schema.MIGRATIONS[-1].version
+    stale_backup = f"{db_path}.pre-v{latest - 1}.bak"
+    with open(stale_backup, "w") as f:
+        f.write("older snapshot")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    # Simulate _snapshot_before_migrations failing silently (its except
+    # branch already swallows sqlite3.Error / OSError and logs a warning).
+    monkeypatch.setattr(schema, "_snapshot_before_migrations", lambda *a, **k: None)
+
+    schema.ensure_schema(db_path)
+
+    assert not os.path.exists(f"{db_path}.pre-v{latest}.bak")
+    assert os.path.exists(stale_backup)
+
+
 def test_ensure_schema_newer_db_raises_incompatible_database_error(tmp_path):
     """Opening a DB stamped by a newer Vireo raises the friendly
     IncompatibleDatabaseError (caught by main's guided-exit handler) instead

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -1217,3 +1217,85 @@ def test_concurrent_global_patch_does_not_drop_writes(app_and_db):
     values = client.get("/api/settings/values").get_json()
     assert values["global"]["classification_threshold"] == 0.31
     assert values["global"]["similarity_threshold"] == 0.77
+
+
+# ---------------------------------------------------------------------------
+# Secrets in export/import
+# ---------------------------------------------------------------------------
+
+
+def test_export_omits_secret_values(app_and_db):
+    """Exported settings must not carry API tokens/keys — users attach these
+    files to bug reports. Omitted keys are listed so the user knows what to
+    re-enter after an import."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("hf_token", "hf_SECRET")
+    cfg.set("inat_token", "inat_SECRET")
+    cfg.set("classification_threshold", 0.7)
+
+    client = app.test_client()
+    resp = client.get("/api/settings/export")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "hf_SECRET" not in body
+    assert "inat_SECRET" not in body
+    data = json.loads(body)
+    assert "hf_token" not in data
+    assert "inat_token" not in data
+    assert data["classification_threshold"] == 0.7
+    assert set(data["_secrets_omitted"]) == {"hf_token", "inat_token"}
+
+
+def test_import_preserves_existing_secrets_when_payload_omits_them(app_and_db):
+    """Restoring a (secret-free) exported backup must not wipe tokens the
+    user already has configured on this machine."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("hf_token", "hf_KEEP")
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"classification_threshold": 0.5})},
+    )
+    assert resp.status_code == 200
+    loaded = cfg.load()
+    assert loaded["hf_token"] == "hf_KEEP"
+    assert loaded["classification_threshold"] == 0.5
+
+
+def test_import_explicit_secret_value_wins(app_and_db):
+    """A payload that explicitly carries a secret key writes it through."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("inat_token", "old")
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/settings/import",
+        json={"json": json.dumps({"inat_token": "new-token"})},
+    )
+    assert resp.status_code == 200
+    assert cfg.load()["inat_token"] == "new-token"
+
+
+def test_export_import_round_trip_keeps_secrets_and_omits_marker(app_and_db):
+    """Export → import on the same machine keeps the local tokens, and the
+    _secrets_omitted marker doesn't leak into the config file."""
+    app, _ = app_and_db
+    import config as cfg
+
+    cfg.set("google_maps_api_key", "maps_LOCAL")
+    client = app.test_client()
+
+    exported = client.get("/api/settings/export").get_data(as_text=True)
+    resp = client.post("/api/settings/import", json={"json": exported})
+    assert resp.status_code == 200
+
+    raw = cfg._read_raw()
+    assert raw.get("google_maps_api_key") == "maps_LOCAL"
+    assert "_secrets_omitted" not in raw

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -1299,3 +1299,51 @@ def test_export_import_round_trip_keeps_secrets_and_omits_marker(app_and_db):
     raw = cfg._read_raw()
     assert raw.get("google_maps_api_key") == "maps_LOCAL"
     assert "_secrets_omitted" not in raw
+
+
+# ---------------------------------------------------------------------------
+# Corrupt-config preservation via schema-driven write paths
+# ---------------------------------------------------------------------------
+
+
+def test_patch_global_preserves_corrupt_config_before_overwrite(app_and_db):
+    """If ``config.json`` becomes corrupt while Vireo is running, the next
+    PATCH must copy the current bytes to ``config.json.corrupt`` before the
+    read-modify-write path overwrites the file — otherwise the user's
+    original settings are silently lost."""
+    app, _ = app_and_db
+    import config as cfg
+
+    corrupt_body = '{"classification_threshold": 0.9, TRUNCATED'
+    with open(cfg.CONFIG_PATH, "w") as f:
+        f.write(corrupt_body)
+
+    client = app.test_client()
+    resp = client.patch(
+        "/api/settings/global",
+        json={"key": "classification_threshold", "value": 0.31},
+    )
+    assert resp.status_code == 200
+    # New value landed on disk.
+    assert cfg.load()["classification_threshold"] == 0.31
+    # The pre-corruption bytes survive next to the file so the user isn't
+    # left with only near-defaults.
+    with open(cfg.CONFIG_PATH + ".corrupt") as f:
+        assert f.read() == corrupt_body
+
+
+def test_delete_global_preserves_corrupt_config_before_overwrite(app_and_db):
+    """DELETE uses the same read-modify-write path — a corrupt file must be
+    preserved before it's silently rewritten to defaults."""
+    app, _ = app_and_db
+    import config as cfg
+
+    corrupt_body = "not json at all }}}"
+    with open(cfg.CONFIG_PATH, "w") as f:
+        f.write(corrupt_body)
+
+    client = app.test_client()
+    resp = client.delete("/api/settings/global/classification_threshold")
+    assert resp.status_code == 200
+    with open(cfg.CONFIG_PATH + ".corrupt") as f:
+        assert f.read() == corrupt_body


### PR DESCRIPTION
## What changed

First batch of production-readiness fixes from the multi-user readiness audit — the data-safety and privacy items where a single bad upgrade or shared settings file could cost a new user their catalog or their API tokens.

### Database upgrade safety
- **Pre-migration backup** (`vireo/schema.py`): when an existing database has pending registry migrations, `ensure_schema` snapshots it first via `VACUUM INTO` (consistent under WAL) to `<db>.pre-vN.bak`. A snapshot from an earlier failed attempt at the same target version is kept rather than overwritten; only the most recent snapshot survives a successful upgrade; backup failure logs a warning but never blocks startup.
- **Friendly downgrade error**: a database stamped by a newer Vireo now raises `IncompatibleDatabaseError(newer=True)` *before* `Database.__init__` runs its legacy ALTERs against it, instead of a bare `RuntimeError` that escaped `main()`'s guided-exit handler as a raw crash. The stderr JSON now carries a `newer` flag, and the Tauri launcher (`src-tauri/src/lib.rs`) shows "update Vireo to open this catalog — don't delete or move the file" instead of the older-DB advice to move the database aside, which would have orphaned a healthy newer catalog.

### Config safety
- A corrupt `~/.vireo/config.json` is preserved as `config.json.corrupt` (in both `load()` and the migration-path `_read_raw()`) before the app falls back to defaults — previously the next `set()` or config migration silently overwrote the user's settings with defaults.

### Secrets
- `/api/settings/export` omits secret-typed values (`inat_token`, `hf_token`, `google_maps_api_key`) — these files get attached to bug reports. The export lists omitted keys in `_secrets_omitted` so the user knows what to re-enter.
- `/api/settings/import` keeps the machine's existing secrets when the payload omits them (so export→import round-trips don't wipe tokens), while explicitly supplied secret values still write through.
- `/api/v1` token check now uses `secrets.compare_digest` (the browser-surface path already did).

Deliberately deferred: redacting secrets from `GET /api/config` — the browser legitimately needs `google_maps_api_key`, and the settings UI populates secret inputs from that endpoint, so it needs coordinated frontend changes.

## Tests

New tests (written first, watched fail):
- `test_schema.py`: backup created with pre-migration state, no backup for fresh/current DBs, stale backups pruned, newer-DB raises `IncompatibleDatabaseError` without mutating the file.
- `test_config.py`: corrupt file preserved by `load()` and `_read_raw()`, `.corrupt` copy survives a subsequent `set()`.
- `test_settings_api.py`: export omits secrets and lists them, import preserves absent secrets, explicit secret values win, export→import round-trip.
- `sidecar.rs`: structured-error parser carries the `newer` flag and defaults it to false for older sidecar builds.

Results:
- `test_config.py test_schema.py test_settings_api.py test_api_v1_auth.py`: **185 passed**
- Required pre-PR suites (`tests/test_workspaces.py`, `vireo/tests/test_db.py test_app.py test_photos_api.py test_edits_api.py test_jobs_api.py test_darktable_api.py`): **1870 passed, 14 skipped, 1 failed** — the failure is `test_api_exiftool_status_reports_missing`, which also fails on a clean checkout of `main` on this machine (exiftool is installed locally; pre-existing environment issue, unrelated to this change).
- `cargo test --lib` in `src-tauri`: **24 passed**
- `ruff check` on all changed Python files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalogs are automatically backed up before upgrades, retaining the latest pre-upgrade snapshot.
  * Settings exports now exclude secret values and identify omitted keys.

* **Bug Fixes**
  * Catalogs created by newer versions now show guidance to update instead of failing or recommending deletion.
  * Corrupt configuration files are preserved as `.corrupt` backups.
  * Importing settings preserves existing secrets unless replacements are explicitly provided.
  * Invalid authentication tokens now return a proper unauthorized response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->