### PR TITLE
Add a "Hide duplicates" filter to the import preview grid

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -174,6 +174,92 @@ def run_two_file_preview(live_server, page):
     )
 
 
+# Stubs a four-file copy-mode preview split across two subfolders:
+# card-a (both files are duplicates) and card-b (one duplicate, one new).
+# The mixed layout is what exercises the "one folder is entirely duplicates
+# while another still has content" case for the hide-duplicates filter.
+MULTI_FOLDER_MIXED_PREVIEW_STUB = """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.__fullPreviewCalls = 0;
+          window.__dupCalls = 0;
+          window.__destCalls = 0;
+          const THUMB = 'data:image/gif;base64,R0lGODlhAQABAAAAACw=';
+          const FILES = [
+            {path: '/tmp/cards/card-a/A1.jpg', filename: 'A1.jpg', subfolder: 'card-a', size: 1234, extension: '.jpg', thumb_url: THUMB},
+            {path: '/tmp/cards/card-a/A2.jpg', filename: 'A2.jpg', subfolder: 'card-a', size: 1234, extension: '.jpg', thumb_url: THUMB},
+            {path: '/tmp/cards/card-b/B1.jpg', filename: 'B1.jpg', subfolder: 'card-b', size: 1234, extension: '.jpg', thumb_url: THUMB},
+            {path: '/tmp/cards/card-b/B2.jpg', filename: 'B2.jpg', subfolder: 'card-b', size: 1234, extension: '.jpg', thumb_url: THUMB},
+          ];
+          const DUPES = [
+            '/tmp/cards/card-a/A1.jpg',
+            '/tmp/cards/card-a/A2.jpg',
+            '/tmp/cards/card-b/B2.jpg',
+          ];
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/import/folder-preview') === 0) {
+              const body = JSON.parse(init.body || '{}');
+              if (body.summary_only) {
+                return Promise.resolve(new Response(JSON.stringify({
+                  total_count: 4,
+                  total_size: 4936,
+                  type_breakdown: {'.jpg': 4},
+                  duplicate_count: 0,
+                  files: [],
+                }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+              }
+              window.__fullPreviewCalls += 1;
+              return Promise.resolve(new Response(JSON.stringify({
+                total_count: 4,
+                total_size: 4936,
+                type_breakdown: {'.jpg': 4},
+                duplicate_count: 0,
+                files: FILES,
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            if (target && target.indexOf('/api/import/check-duplicates') === 0) {
+              window.__dupCalls += 1;
+              const frame = 'data: ' + JSON.stringify({
+                duplicates: DUPES, checked: FILES.length, total: FILES.length,
+              }) + '\\n\\n' + 'data: ' + JSON.stringify({
+                done: true, duplicate_count: DUPES.length, checked: FILES.length, total: FILES.length,
+              }) + '\\n\\n';
+              return Promise.resolve(new Response(frame, {
+                status: 200,
+                headers: {'Content-Type': 'text/event-stream'},
+              }));
+            }
+            if (target && target.indexOf('/api/import/destination-preview') === 0) {
+              window.__destCalls += 1;
+              return Promise.resolve(new Response(JSON.stringify({
+                folders: [{path: '2026/2026-07-11', full_path: '/archive/2026/2026-07-11', count: 1, exists: false}],
+                total_photos: 1, total_folders: 1, new_folders: 1, existing_folders: 0, managed_archive: null,
+                files: [{path: '/tmp/cards/card-b/B1.jpg', folder: '2026/2026-07-11', full_folder: '/archive/2026/2026-07-11'}],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+
+
+def run_multi_folder_mixed_preview(live_server, page):
+    """Load /import with the multi-folder stub and wait for it to settle."""
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate(MULTI_FOLDER_MIXED_PREVIEW_STUB)
+
+    page.locator("#modeCopy").check()
+    page.locator("#destInput").fill("/archive")
+    page.locator("#sourceInput").fill("/tmp/cards")
+    page.locator("#btnAddSource").click()
+
+    page.wait_for_function(
+        "window.__fullPreviewCalls >= 1 && window.__dupCalls >= 1 && window.__destCalls >= 1"
+    )
+
+
 def test_import_preview_runs_automatically_after_source_selection(live_server, page):
     run_two_file_preview(live_server, page)
 
@@ -513,6 +599,54 @@ def test_hide_duplicates_survives_a_repreview_that_still_has_duplicates(
     expect(page.locator("#importPreviewGrid")).not_to_contain_text(
         "IMG_0002.jpg",
     )
+
+
+def test_hide_duplicates_keeps_all_duplicate_folder_headers_visible(
+    live_server, page,
+):
+    """When one folder of a multi-folder preview is made entirely of
+    duplicates, enabling the filter must not silently drop that folder.
+
+    Otherwise the surviving folders' headers own their hidden files, but
+    the all-duplicate folder disappears without a trace — the user is
+    given no evidence the folder or its duplicate count ever existed. The
+    header stays visible as "folder (0) · N duplicates hidden" so the
+    hidden count is always accounted for somewhere the user can see.
+    """
+    run_multi_folder_mixed_preview(live_server, page)
+
+    grid = page.locator("#importPreviewGrid")
+    # Off (default): both headers with full counts and all four tiles.
+    expect(grid).to_contain_text("card-a (2)")
+    expect(grid).to_contain_text("card-b (2)")
+    expect(grid).to_contain_text("A1.jpg")
+    expect(grid).to_contain_text("A2.jpg")
+    expect(grid).to_contain_text("B1.jpg")
+    expect(grid).to_contain_text("B2.jpg")
+
+    page.locator("#chkHideDuplicates").check()
+
+    # card-a is entirely duplicates — the header must survive with (0) and
+    # the hidden count so the folder never silently vanishes.
+    expect(grid).to_contain_text("card-a (0) · 2 duplicates hidden")
+    # card-b keeps only its non-duplicate tile plus its hidden count.
+    expect(grid).to_contain_text("card-b (1) · 1 duplicate hidden")
+    expect(grid).to_contain_text("B1.jpg")
+    expect(grid).not_to_contain_text("A1.jpg")
+    expect(grid).not_to_contain_text("A2.jpg")
+    expect(grid).not_to_contain_text("B2.jpg")
+
+    # The global "all N are duplicates" empty state is reserved for the
+    # case where every folder went to zero — a partially filtered preview
+    # like this one still has visible tiles, so it must not fire.
+    expect(grid).not_to_contain_text("All 4 files are duplicates")
+
+    # Unchecking restores the full multi-folder grid unchanged.
+    page.locator("#chkHideDuplicates").uncheck()
+    expect(grid).to_contain_text("card-a (2)")
+    expect(grid).to_contain_text("card-b (2)")
+    expect(grid).to_contain_text("A1.jpg")
+    expect(grid).to_contain_text("B2.jpg")
 
 
 def test_import_auto_preview_clears_grid_when_selection_becomes_invalid(

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -72,6 +72,18 @@ TWO_FILE_PREVIEW_STUB = """
                 }), {status: 200, headers: {'Content-Type': 'application/json'}}));
               }
               window.__fullPreviewCalls += 1;
+              // Tests flip __emptyPreview to simulate a source that comes
+              // back with zero importable files (e.g. an empty card or a
+              // filter that excludes everything).
+              if (window.__emptyPreview) {
+                return Promise.resolve(new Response(JSON.stringify({
+                  total_count: 0,
+                  total_size: 0,
+                  type_breakdown: {},
+                  duplicate_count: 0,
+                  files: [],
+                }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+              }
               return Promise.resolve(new Response(JSON.stringify({
                 total_count: 2,
                 total_size: 2468,
@@ -281,6 +293,41 @@ def test_hide_duplicates_resets_when_the_last_source_is_removed(
     page.locator("#sourceInput").fill("/tmp/card-a")
     page.locator("#btnAddSource").click()
     page.wait_for_function(f"window.__dupCalls > {dup_calls}")
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+    expect(page.locator("#importPreviewGrid")).to_contain_text("IMG_0002.jpg")
+
+
+def test_hide_duplicates_resets_when_a_preview_settles_with_no_files(
+    live_server, page,
+):
+    """A completed preview that returns zero files settles the picture too.
+
+    The `!files.length` branch hides the row without ever running the
+    duplicate check, so a filter left checked is invisible there — and
+    the next card that does surface duplicates would be filtered on
+    arrival without the user opting in for it.
+    """
+    run_two_file_preview(live_server, page)
+    page.locator("#chkHideDuplicates").check()
+
+    # Next preview finds nothing to import (e.g. an empty source card).
+    preview_calls = page.evaluate("window.__fullPreviewCalls")
+    page.evaluate("window.__emptyPreview = true")
+    page.locator("#btnPreview").click()
+    page.wait_for_function(f"window.__fullPreviewCalls > {preview_calls}")
+
+    expect(page.locator("#previewSummary")).to_contain_text(
+        "No importable files found.",
+    )
+    expect(page.locator("#hideDuplicatesRow")).to_be_hidden()
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+
+    # ...so a later duplicate-bearing card starts unfiltered again.
+    page.evaluate("window.__emptyPreview = false")
+    dup_calls = page.evaluate("window.__dupCalls")
+    page.locator("#btnPreview").click()
+    page.wait_for_function(f"window.__dupCalls > {dup_calls}")
+    expect(page.locator("#hideDuplicatesRow")).to_be_visible()
     expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
     expect(page.locator("#importPreviewGrid")).to_contain_text("IMG_0002.jpg")
 

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -185,6 +185,10 @@ def test_import_preview_hide_duplicates_checkbox_filters_grid(live_server, page)
     expect(page.locator("#hideDuplicatesLabel")).to_have_text("Hide duplicates (1)")
     expect(grid).to_contain_text("IMG_0002.jpg")
 
+    calls_before = page.evaluate(
+        "[window.__fullPreviewCalls, window.__dupCalls, window.__destCalls]",
+    )
+
     checkbox.check()
     expect(grid).to_contain_text("IMG_0001.jpg")
     expect(grid).not_to_contain_text("IMG_0002.jpg")
@@ -196,6 +200,14 @@ def test_import_preview_hide_duplicates_checkbox_filters_grid(live_server, page)
     checkbox.uncheck()
     expect(grid).to_contain_text("IMG_0002.jpg")
     expect(grid).to_contain_text("Duplicate")
+
+    # Toggling re-renders from the last preview result and must never
+    # re-run discovery, the duplicate check, or the destination preview —
+    # on a real card those are the slow calls the filter exists to avoid
+    # repeating.
+    assert page.evaluate(
+        "[window.__fullPreviewCalls, window.__dupCalls, window.__destCalls]",
+    ) == calls_before
 
 
 def test_hide_duplicates_resets_once_a_check_finds_no_duplicates(
@@ -243,6 +255,31 @@ def test_hide_duplicates_resets_when_dedup_is_turned_off(live_server, page):
 
     dup_calls = page.evaluate("window.__dupCalls")
     page.locator("#chkSkipDuplicates").check()
+    page.wait_for_function(f"window.__dupCalls > {dup_calls}")
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+    expect(page.locator("#importPreviewGrid")).to_contain_text("IMG_0002.jpg")
+
+
+def test_hide_duplicates_resets_when_the_last_source_is_removed(
+    live_server, page,
+):
+    """Emptying the source list ends this card's session.
+
+    The row is hidden at that point, so a filter left checked is invisible
+    — and the next card added would be filtered on arrival without the
+    user opting in for it.
+    """
+    run_two_file_preview(live_server, page)
+    page.locator("#chkHideDuplicates").check()
+
+    page.locator("#sourceList button", has_text="×").first.click()
+    expect(page.locator("#hideDuplicatesRow")).to_be_hidden()
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+
+    # A different card arrives and starts unfiltered.
+    dup_calls = page.evaluate("window.__dupCalls")
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
     page.wait_for_function(f"window.__dupCalls > {dup_calls}")
     expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
     expect(page.locator("#importPreviewGrid")).to_contain_text("IMG_0002.jpg")

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -50,11 +50,9 @@ def test_import_source_browse_button_shows_quick_photo_count(live_server, page):
     expect(source_list.locator(".source-meta")).to_have_text("42 photos")
 
 
-def test_import_preview_runs_automatically_after_source_selection(live_server, page):
-    url = live_server["url"]
-    page.goto(f"{url}/import")
-    page.evaluate(
-        """
+# Stubs a two-file copy-mode preview where IMG_0002.jpg comes back flagged as
+# a duplicate. Shared by the tests that exercise the preview grid.
+TWO_FILE_PREVIEW_STUB = """
         () => {
           const originalFetch = window.fetch.bind(window);
           window.__fullPreviewCalls = 0;
@@ -141,7 +139,13 @@ def test_import_preview_runs_automatically_after_source_selection(live_server, p
           };
         }
         """
-    )
+
+
+def run_two_file_preview(live_server, page):
+    """Load /import with the stub above and wait for the preview to settle."""
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate(TWO_FILE_PREVIEW_STUB)
 
     page.locator("#modeCopy").check()
     page.locator("#destInput").fill("/archive")
@@ -151,6 +155,11 @@ def test_import_preview_runs_automatically_after_source_selection(live_server, p
     page.wait_for_function(
         "window.__fullPreviewCalls >= 1 && window.__dupCalls >= 1 && window.__destCalls >= 1"
     )
+
+
+def test_import_preview_runs_automatically_after_source_selection(live_server, page):
+    run_two_file_preview(live_server, page)
+
     expect(page.locator("#previewSummary")).to_contain_text("1 already in your library")
     grid = page.locator("#importPreviewGrid")
     expect(grid).to_be_visible()
@@ -158,6 +167,30 @@ def test_import_preview_runs_automatically_after_source_selection(live_server, p
     expect(grid).to_contain_text("IMG_0002.jpg")
     expect(grid).to_contain_text("Duplicate")
     expect(grid).to_contain_text("To: 2026/2026-07-11")
+
+
+def test_import_preview_hide_duplicates_checkbox_filters_grid(live_server, page):
+    run_two_file_preview(live_server, page)
+
+    grid = page.locator("#importPreviewGrid")
+    checkbox = page.locator("#chkHideDuplicates")
+    # Defaults to off: every discovered file is visible until the user opts in.
+    expect(page.locator("#hideDuplicatesRow")).to_be_visible()
+    expect(checkbox).not_to_be_checked()
+    expect(page.locator("#hideDuplicatesLabel")).to_have_text("Hide duplicates (1)")
+    expect(grid).to_contain_text("IMG_0002.jpg")
+
+    checkbox.check()
+    expect(grid).to_contain_text("IMG_0001.jpg")
+    expect(grid).not_to_contain_text("IMG_0002.jpg")
+    expect(grid).to_contain_text("1 duplicate hidden")
+    # The summary still reports the full picture — hiding is a view filter,
+    # not a change to what the import will do.
+    expect(page.locator("#previewSummary")).to_contain_text("1 already in your library")
+
+    checkbox.uncheck()
+    expect(grid).to_contain_text("IMG_0002.jpg")
+    expect(grid).to_contain_text("Duplicate")
 
 
 def test_import_auto_preview_clears_grid_when_selection_becomes_invalid(

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -99,13 +99,18 @@ TWO_FILE_PREVIEW_STUB = """
             }
             if (target && target.indexOf('/api/import/check-duplicates') === 0) {
               window.__dupCalls += 1;
+              // Tests flip __noDupes to simulate the next card coming back
+              // clean, which is how the preview reaches a completed check
+              // with zero duplicates.
+              const dupes = window.__noDupes
+                ? [] : ['/tmp/card-a/IMG_0002.jpg'];
               const frame = 'data: ' + JSON.stringify({
-                duplicates: ['/tmp/card-a/IMG_0002.jpg'],
+                duplicates: dupes,
                 checked: 2,
                 total: 2,
               }) + '\\n\\n' + 'data: ' + JSON.stringify({
                 done: true,
-                duplicate_count: 1,
+                duplicate_count: dupes.length,
                 checked: 2,
                 total: 2,
               }) + '\\n\\n';
@@ -191,6 +196,79 @@ def test_import_preview_hide_duplicates_checkbox_filters_grid(live_server, page)
     checkbox.uncheck()
     expect(grid).to_contain_text("IMG_0002.jpg")
     expect(grid).to_contain_text("Duplicate")
+
+
+def test_hide_duplicates_resets_once_a_check_finds_no_duplicates(
+    live_server, page,
+):
+    """A completed check that finds nothing to hide retires the opt-in.
+
+    Otherwise the checkbox stays silently checked while its row is hidden,
+    and the next card that does have duplicates gets filtered without the
+    user asking for it this time.
+    """
+    run_two_file_preview(live_server, page)
+    page.locator("#chkHideDuplicates").check()
+    expect(page.locator("#importPreviewGrid")).not_to_contain_text(
+        "IMG_0002.jpg",
+    )
+
+    # Next preview comes back clean, so the control has nothing to offer.
+    page.evaluate("window.__noDupes = true")
+    page.locator("#btnPreview").click()
+    expect(page.locator("#hideDuplicatesRow")).to_be_hidden()
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+
+    # ...so a later duplicate-bearing card starts unfiltered again.
+    page.evaluate("window.__noDupes = false")
+    page.locator("#btnPreview").click()
+    expect(page.locator("#hideDuplicatesRow")).to_be_visible()
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+    expect(page.locator("#importPreviewGrid")).to_contain_text("IMG_0002.jpg")
+
+
+def test_hide_duplicates_resets_when_dedup_is_turned_off(live_server, page):
+    """Turning off "Skip duplicates" settles the picture too: nothing will
+    be skipped, so the filter has nothing to hide and the opt-in retires
+    rather than lying in wait for the next dedup-enabled preview."""
+    run_two_file_preview(live_server, page)
+    page.locator("#chkHideDuplicates").check()
+
+    page.locator("#chkSkipDuplicates").uncheck()
+    expect(page.locator("#previewSummary")).to_contain_text(
+        "duplicates will be copied",
+    )
+    expect(page.locator("#hideDuplicatesRow")).to_be_hidden()
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+
+    dup_calls = page.evaluate("window.__dupCalls")
+    page.locator("#chkSkipDuplicates").check()
+    page.wait_for_function(f"window.__dupCalls > {dup_calls}")
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+    expect(page.locator("#importPreviewGrid")).to_contain_text("IMG_0002.jpg")
+
+
+def test_hide_duplicates_survives_a_repreview_that_still_has_duplicates(
+    live_server, page,
+):
+    """Re-previewing must not silently drop the filter.
+
+    Any import-option change schedules a fresh preview, and each preview
+    renders the grid with an empty duplicate list before its check
+    finishes. Clearing the opt-in on every zero-count render would flip
+    the filter off mid-session and flood the grid back.
+    """
+    run_two_file_preview(live_server, page)
+    page.locator("#chkHideDuplicates").check()
+
+    dup_calls = page.evaluate("window.__dupCalls")
+    page.locator("#btnPreview").click()
+    page.wait_for_function(f"window.__dupCalls > {dup_calls}")
+
+    expect(page.locator("#chkHideDuplicates")).to_be_checked()
+    expect(page.locator("#importPreviewGrid")).not_to_contain_text(
+        "IMG_0002.jpg",
+    )
 
 
 def test_import_auto_preview_clears_grid_when_selection_becomes_invalid(

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -332,6 +332,32 @@ def test_hide_duplicates_resets_when_a_preview_settles_with_no_files(
     expect(page.locator("#importPreviewGrid")).to_contain_text("IMG_0002.jpg")
 
 
+def test_hide_duplicates_resets_when_the_preview_cannot_run(live_server, page):
+    """A preview that stops on a validation error is settled as well.
+
+    Clearing every file extension aborts before discovery, so nothing can
+    be hidden, and the opt-in must not survive behind the hidden row.
+    """
+    run_two_file_preview(live_server, page)
+    page.locator("#chkHideDuplicates").check()
+
+    page.locator("#fileTypePreset").select_option("custom")
+    exts = page.locator(".file-ext")
+    for i in range(exts.count()):
+        exts.nth(i).uncheck()
+
+    expect(page.locator("#importError")).to_contain_text(
+        "Choose at least one file extension.",
+    )
+    expect(page.locator("#hideDuplicatesRow")).to_be_hidden()
+    expect(page.locator("#chkHideDuplicates")).not_to_be_checked()
+
+    # Leave a valid selection behind. This test is the only one that puts
+    # the page in an unpreviewable state, and the preset is the kind of
+    # option later tests assume is sane.
+    page.locator("#fileTypePreset").select_option("both")
+
+
 def test_hide_duplicates_survives_a_repreview_that_still_has_duplicates(
     live_server, page,
 ):

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -358,6 +358,140 @@ def test_hide_duplicates_resets_when_the_preview_cannot_run(live_server, page):
     page.locator("#fileTypePreset").select_option("both")
 
 
+def test_hide_duplicates_preserves_first_occurrence_from_overlapping_sources(
+    live_server, page,
+):
+    """Overlapping sources yield the same path twice in the preview.
+
+    The `/api/import/check-duplicates` stream flags only the *later*
+    occurrence as an intra-import duplicate — the first is the tile that
+    will actually be copied and land in the archive. Hiding by path-set
+    membership would drop both tiles, silently claiming the to-copy file
+    is a duplicate too. Match the summary: hide one tile, keep the other.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.__fullPreviewCalls = 0;
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/import/folder-preview') === 0) {
+              const body = JSON.parse(init.body || '{}');
+              if (body.summary_only) {
+                return Promise.resolve(new Response(JSON.stringify({
+                  total_count: 2,
+                  total_size: 2468,
+                  type_breakdown: {'.jpg': 2},
+                  duplicate_count: 0,
+                  files: [],
+                }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+              }
+              window.__fullPreviewCalls += 1;
+              // Same path arrives twice — mimics scanning /card and
+              // /card/DCIM together, the exact overlap that surfaces this
+              // per-occurrence bug.
+              return Promise.resolve(new Response(JSON.stringify({
+                total_count: 2,
+                total_size: 2468,
+                type_breakdown: {'.jpg': 2},
+                duplicate_count: 0,
+                files: [
+                  {
+                    path: '/tmp/card/DCIM/IMG_0001.jpg',
+                    filename: 'IMG_0001.jpg',
+                    subfolder: 'card/DCIM',
+                    size: 1234,
+                    extension: '.jpg',
+                    thumb_url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+                  },
+                  {
+                    path: '/tmp/card/DCIM/IMG_0001.jpg',
+                    filename: 'IMG_0001.jpg',
+                    subfolder: 'card/DCIM',
+                    size: 1234,
+                    extension: '.jpg',
+                    thumb_url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+                  },
+                ],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            if (target && target.indexOf('/api/import/check-duplicates') === 0) {
+              // The real checker only flags the second occurrence as an
+              // intra-import duplicate, so the returned list carries the
+              // path exactly once.
+              const frame = 'data: ' + JSON.stringify({
+                duplicates: ['/tmp/card/DCIM/IMG_0001.jpg'],
+                checked: 2,
+                total: 2,
+              }) + '\\n\\n' + 'data: ' + JSON.stringify({
+                done: true,
+                duplicate_count: 1,
+                checked: 2,
+                total: 2,
+              }) + '\\n\\n';
+              return Promise.resolve(new Response(frame, {
+                status: 200,
+                headers: {'Content-Type': 'text/event-stream'},
+              }));
+            }
+            if (target && target.indexOf('/api/import/destination-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                folders: [{
+                  path: '2026/2026-07-11',
+                  full_path: '/archive/2026/2026-07-11',
+                  count: 1,
+                  exists: false,
+                }],
+                total_photos: 1,
+                total_folders: 1,
+                new_folders: 1,
+                existing_folders: 0,
+                managed_archive: null,
+                files: [{
+                  path: '/tmp/card/DCIM/IMG_0001.jpg',
+                  folder: '2026/2026-07-11',
+                  full_folder: '/archive/2026/2026-07-11',
+                }],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+    )
+
+    page.locator("#modeCopy").check()
+    page.locator("#destInput").fill("/archive")
+    page.locator("#sourceInput").fill("/tmp/card")
+    page.locator("#btnAddSource").click()
+    page.wait_for_function("window.__fullPreviewCalls >= 1")
+
+    grid = page.locator("#importPreviewGrid")
+    # Off by default: both occurrences render, one badged Duplicate.
+    expect(page.locator("#previewSummary")).to_contain_text(
+        "1 already in your library"
+    )
+    expect(page.locator("#hideDuplicatesLabel")).to_have_text(
+        "Hide duplicates (1)"
+    )
+    expect(grid.locator(".import-preview-thumb")).to_have_count(2)
+    expect(grid.locator(".import-preview-thumb.duplicate")).to_have_count(1)
+
+    # Turn on the filter: the second occurrence (the tile the server
+    # actually flagged) hides; the first stays, matching what the import
+    # will copy. Set-based hiding would erroneously drop both.
+    page.locator("#chkHideDuplicates").check()
+    expect(grid.locator(".import-preview-thumb")).to_have_count(1)
+    expect(grid.locator(".import-preview-thumb.duplicate")).to_have_count(0)
+    expect(grid).to_contain_text("1 duplicate hidden")
+    # Filter never claims "all X are duplicates" when a to-copy tile
+    # survives — that phrasing would contradict the summary line.
+    expect(grid).not_to_contain_text("are duplicates")
+
+
 def test_hide_duplicates_survives_a_repreview_that_still_has_duplicates(
     live_server, page,
 ):

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2370,6 +2370,12 @@ async function previewImport(opts) {
     if (!files.length) {
       summary.textContent = 'No importable files found.';
       clearImportPreviewGrid();
+      // A completed preview with zero files is a final "nothing to hide"
+      // state — like snapshot / in-place / dedup-off below — so retire the
+      // opt-in. Otherwise the row hides while the checkbox stays checked,
+      // and the next card that does surface duplicates gets filtered
+      // silently instead of opt-in.
+      retireHideDuplicatesOptIn();
       return;
     }
     renderImportPreviewGrid(files, [], null);

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -1981,6 +1981,33 @@ function importDestinationMap(destinationFiles) {
   return map;
 }
 
+// Duplicate identity is per-occurrence, not per-path. When source folders
+// overlap (e.g. `/card` and `/card/DCIM`) the same file path can appear
+// twice in `files`; the server's `check-duplicates` stream flags only the
+// *later* occurrence as an intra-import duplicate — the first is what will
+// actually be copied. A path-set membership test would tag both tiles as
+// duplicates, so enabling the filter would hide the to-copy file too and
+// the grid could claim every tile is a duplicate while the summary still
+// reports one file remaining. Match the server's ordering by walking
+// `files` in reverse and consuming duplicate-count credits per path.
+function computeDuplicateFlags(files, duplicatePaths) {
+  const flags = new Array(files.length).fill(false);
+  const remaining = new Map();
+  (duplicatePaths || []).forEach((p) => {
+    remaining.set(p, (remaining.get(p) || 0) + 1);
+  });
+  if (!remaining.size) return flags;
+  for (let i = files.length - 1; i >= 0; i -= 1) {
+    const p = files[i] && files[i].path;
+    const count = remaining.get(p) || 0;
+    if (count > 0) {
+      flags[i] = true;
+      remaining.set(p, count - 1);
+    }
+  }
+  return flags;
+}
+
 function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
   const grid = document.getElementById('importPreviewGrid');
   if (!grid) return;
@@ -1989,7 +2016,6 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
     importThumbSchedulerCancel = null;
   }
   grid.innerHTML = '';
-  const dupes = new Set(duplicatePaths || []);
   const destMap = importDestinationMap(destinationFiles);
   if (!files || !files.length) {
     lastImportPreviewRender = null;
@@ -2004,20 +2030,21 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
     duplicatePaths: duplicatePaths,
     destinationFiles: destinationFiles,
   };
-  const dupeCount = files.filter((f) => dupes.has(f.path)).length;
+  const duplicateFlags = computeDuplicateFlags(files, duplicatePaths);
+  const dupeCount = duplicateFlags.reduce((n, isDup) => n + (isDup ? 1 : 0), 0);
   updateHideDuplicatesControl(dupeCount);
   const hidingDuplicates = dupeCount > 0 && hideDuplicatesEnabled();
 
   const groups = {};
-  files.forEach((f) => {
+  files.forEach((f, i) => {
     const key = f.subfolder || 'Source';
     if (!groups[key]) groups[key] = [];
-    groups[key].push(f);
+    groups[key].push({ file: f, isDuplicate: duplicateFlags[i] });
   });
 
   Object.keys(groups).sort().forEach((subfolder) => {
     const all = groups[subfolder];
-    const shown = hidingDuplicates ? all.filter((f) => !dupes.has(f.path)) : all;
+    const shown = hidingDuplicates ? all.filter((e) => !e.isDuplicate) : all;
     if (!shown.length) return;
     const groupEl = document.createElement('div');
     groupEl.className = 'import-preview-folder';
@@ -2031,8 +2058,9 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
 
     const thumbsEl = document.createElement('div');
     thumbsEl.className = 'import-preview-thumbs';
-    shown.forEach((f) => {
-      const isDuplicate = dupes.has(f.path);
+    shown.forEach((entry) => {
+      const f = entry.file;
+      const isDuplicate = entry.isDuplicate;
       const isUnavailable = f.available === false;
       const card = document.createElement('div');
       card.className = 'import-preview-thumb' +

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2324,7 +2324,12 @@ async function previewImport(opts) {
   importPreviewSeq += 1;
   const requestSeq = importPreviewSeq;
   const summary = document.getElementById('previewSummary');
+  // Both bail-outs below are settled: the run stops before discovery, so
+  // nothing can be hidden and the opt-in must not linger behind the
+  // now-hidden row. (Contrast the in-flight path further down, which
+  // keeps the opt-in until the duplicate count is actually known.)
   if (!sources.length && newImagesSnapshotId === null) {
+    retireHideDuplicatesOptIn();
     summary.textContent = '';
     showError('Add at least one source folder.');
     return;
@@ -2332,6 +2337,7 @@ async function previewImport(opts) {
   const copyMode = newImagesSnapshotId === null && selectedImportMode() === 'copy';
   const fileTypes = copyMode ? selectedFileTypes() : 'both';
   if (copyMode && Array.isArray(fileTypes) && !fileTypes.length) {
+    retireHideDuplicatesOptIn();
     summary.textContent = '';
     showError('Choose at least one file extension.');
     return;

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -1944,6 +1944,20 @@ function hideDuplicatesEnabled() {
   return !!(el && el.checked);
 }
 
+// Drop the opt-in once a settled preview has nothing to hide, so the next
+// card that does carry duplicates starts unfiltered instead of inheriting
+// a choice made for a different card while the row was hidden.
+//
+// Only call this where the duplicate picture is FINAL. Every preview
+// renders the grid with an empty duplicate list before its check
+// finishes, so clearing on any zero count (including inside
+// updateHideDuplicatesControl) would silently flip the filter off every
+// time an import option change schedules a fresh preview.
+function retireHideDuplicatesOptIn() {
+  const el = document.getElementById('chkHideDuplicates');
+  if (el) el.checked = false;
+}
+
 // Re-run the last grid render with the current filter state. Purely a view
 // toggle — it never re-requests the preview or the duplicate check.
 function rerenderImportPreviewGrid() {
@@ -2352,7 +2366,13 @@ async function previewImport(opts) {
       return;
     }
     renderImportPreviewGrid(files, [], null);
+    // The three branches below all settle without a duplicate check —
+    // in-place/snapshot imports have no duplicate concept and a dedup-off
+    // copy skips nothing — so each is a final "nothing to hide" state and
+    // retires the opt-in. The fall-through path does NOT: its duplicate
+    // count is still unknown until the check below completes.
     if (snapshotMode) {
+      retireHideDuplicatesOptIn();
       const unavailable = Number(data.unavailable_count || 0);
       summary.textContent = Number(data.total_count || files.length).toLocaleString() +
         ' captured file' + (Number(data.total_count || files.length) === 1 ? '' : 's') +
@@ -2361,10 +2381,12 @@ async function previewImport(opts) {
       return;
     }
     if (!copyMode) {
+      retireHideDuplicatesOptIn();
       summary.textContent = files.length + ' files found · originals will stay in place';
       return;
     }
     if (!document.getElementById('chkSkipDuplicates').checked) {
+      retireHideDuplicatesOptIn();
       summary.textContent = files.length + ' files found · duplicates will be copied';
       // No dedup gate, so every discovered file lands — pass no exclusions
       // so the folder-structure counts match the full copy set.
@@ -2415,6 +2437,8 @@ async function previewImport(opts) {
       return;
     }
     const dupCount = duplicatePaths.length;
+    // The check ran to completion, so this count is final.
+    if (dupCount === 0) retireHideDuplicatesOptIn();
     summary.textContent = files.length + ' files found · ' + dupCount +
       ' already in your library (will be skipped) · ' +
       (files.length - dupCount) + ' to copy';

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -929,6 +929,13 @@ function renderSources() {
       hideDestStructure();
       if (!sources.length) {
         clearImportPreviewGrid();
+        // Emptying the source list ends this card's session, so the
+        // filter retires with it — the row is already hidden here, and
+        // carrying the choice into whatever card is added next would
+        // filter that one on arrival without the user opting in. Note
+        // this is deliberately NOT in clearImportPreviewGrid(): ordinary
+        // re-previews clear the grid too and must keep the opt-in.
+        retireHideDuplicatesOptIn();
         document.getElementById('previewSummary').textContent = '';
       }
       renderSources();

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -50,7 +50,9 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .recent-destination-list .btn { font-size: 11px; padding: 2px 8px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; }
 .input-fixed { max-width: 240px; flex: 0 1 240px; }
 .preview-summary { font-size: 12px; color: var(--text-secondary); margin-top: 6px; }
+.preview-filter { display: inline-flex; align-items: center; gap: 6px; margin-top: 8px; font-size: 12px; color: var(--text-secondary); }
 .import-preview-grid { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; max-height: 520px; overflow-y: auto; }
+.import-preview-empty { font-size: 12px; color: var(--text-secondary); }
 .import-preview-folder { display: flex; flex-direction: column; gap: 6px; }
 .import-preview-folder-header { font-size: 12px; font-weight: 600; color: var(--text-secondary); overflow-wrap: anywhere; }
 .import-preview-thumbs { display: grid; grid-template-columns: repeat(auto-fill, minmax(104px, 1fr)); gap: 8px; }
@@ -400,6 +402,10 @@ body { display: flex; flex-direction: column; height: 100vh; }
         <button class="btn btn-primary" id="btnStart" onclick="startImport()">Start import</button>
       </div>
       <div class="preview-summary" id="previewSummary"></div>
+      <label class="preview-filter" id="hideDuplicatesRow" style="display:none;">
+        <input type="checkbox" id="chkHideDuplicates" onchange="rerenderImportPreviewGrid()">
+        <span id="hideDuplicatesLabel">Hide duplicates</span>
+      </label>
       <div id="importPreviewGrid" class="import-preview-grid" style="display:none;"></div>
       <div id="importError"></div>
     </div>
@@ -484,6 +490,9 @@ let destStructureSeq = 0;
 let importPreviewSeq = 0;
 let importPreviewTimer = null;
 let importThumbSchedulerCancel = null;
+// Last args passed to renderImportPreviewGrid, so the "Hide duplicates"
+// filter can re-render locally.
+let lastImportPreviewRender = null;
 let importTags = [];
 let newImagesSnapshotId = null;
 let importExiftoolReady = null;
@@ -1910,10 +1919,37 @@ function clearImportPreviewGrid() {
     importThumbSchedulerCancel();
     importThumbSchedulerCancel = null;
   }
+  lastImportPreviewRender = null;
+  updateHideDuplicatesControl(0);
   const grid = document.getElementById('importPreviewGrid');
   if (!grid) return;
   grid.style.display = 'none';
   grid.innerHTML = '';
+}
+
+// The "Hide duplicates" row only makes sense once a preview has actually
+// flagged duplicates — before the duplicate check runs (or with dedup off)
+// there is nothing to hide, so the control stays hidden rather than
+// implying a filter that would do nothing.
+function updateHideDuplicatesControl(dupCount) {
+  const row = document.getElementById('hideDuplicatesRow');
+  const label = document.getElementById('hideDuplicatesLabel');
+  if (!row || !label) return;
+  row.style.display = dupCount > 0 ? '' : 'none';
+  label.textContent = 'Hide duplicates (' + dupCount.toLocaleString() + ')';
+}
+
+function hideDuplicatesEnabled() {
+  const el = document.getElementById('chkHideDuplicates');
+  return !!(el && el.checked);
+}
+
+// Re-run the last grid render with the current filter state. Purely a view
+// toggle — it never re-requests the preview or the duplicate check.
+function rerenderImportPreviewGrid() {
+  if (!lastImportPreviewRender) return;
+  const last = lastImportPreviewRender;
+  renderImportPreviewGrid(last.files, last.duplicatePaths, last.destinationFiles);
 }
 
 function importDestinationMap(destinationFiles) {
@@ -1935,9 +1971,21 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
   const dupes = new Set(duplicatePaths || []);
   const destMap = importDestinationMap(destinationFiles);
   if (!files || !files.length) {
+    lastImportPreviewRender = null;
+    updateHideDuplicatesControl(0);
     grid.style.display = 'none';
     return;
   }
+  // Remember the inputs so the filter toggle can re-render without
+  // re-running the preview or the duplicate check.
+  lastImportPreviewRender = {
+    files: files,
+    duplicatePaths: duplicatePaths,
+    destinationFiles: destinationFiles,
+  };
+  const dupeCount = files.filter((f) => dupes.has(f.path)).length;
+  updateHideDuplicatesControl(dupeCount);
+  const hidingDuplicates = dupeCount > 0 && hideDuplicatesEnabled();
 
   const groups = {};
   files.forEach((f) => {
@@ -1947,16 +1995,22 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
   });
 
   Object.keys(groups).sort().forEach((subfolder) => {
+    const all = groups[subfolder];
+    const shown = hidingDuplicates ? all.filter((f) => !dupes.has(f.path)) : all;
+    if (!shown.length) return;
     const groupEl = document.createElement('div');
     groupEl.className = 'import-preview-folder';
     const header = document.createElement('div');
     header.className = 'import-preview-folder-header';
-    header.textContent = subfolder + ' (' + groups[subfolder].length + ')';
+    const hiddenHere = all.length - shown.length;
+    header.textContent = subfolder + ' (' + shown.length + ')' +
+      (hiddenHere ? ' · ' + hiddenHere.toLocaleString() + ' duplicate' +
+        (hiddenHere === 1 ? '' : 's') + ' hidden' : '');
     groupEl.appendChild(header);
 
     const thumbsEl = document.createElement('div');
     thumbsEl.className = 'import-preview-thumbs';
-    groups[subfolder].forEach((f) => {
+    shown.forEach((f) => {
       const isDuplicate = dupes.has(f.path);
       const isUnavailable = f.available === false;
       const card = document.createElement('div');
@@ -2004,6 +2058,16 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
     groupEl.appendChild(thumbsEl);
     grid.appendChild(groupEl);
   });
+  // Every file was a duplicate, so the filter emptied the grid. Say so
+  // instead of leaving a blank panel that reads like "no files found".
+  if (!grid.children.length) {
+    const empty = document.createElement('div');
+    empty.className = 'import-preview-empty';
+    empty.textContent = 'All ' + files.length.toLocaleString() + ' file' +
+      (files.length === 1 ? ' is a duplicate' : 's are duplicates') +
+      ' — uncheck "Hide duplicates" to see them.';
+    grid.appendChild(empty);
+  }
   grid.style.display = '';
   setupImportThumbnailScheduler();
 }

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2042,20 +2042,34 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
     groups[key].push({ file: f, isDuplicate: duplicateFlags[i] });
   });
 
+  let anyTilesRendered = false;
+
   Object.keys(groups).sort().forEach((subfolder) => {
     const all = groups[subfolder];
     const shown = hidingDuplicates ? all.filter((e) => !e.isDuplicate) : all;
-    if (!shown.length) return;
+    const hiddenHere = all.length - shown.length;
+    // Nothing to show and nothing hidden — no reason to render a header.
+    // (Only reachable if a group somehow started empty, which shouldn't
+    // happen since groups are built from `files`.)
+    if (!shown.length && !hiddenHere) return;
     const groupEl = document.createElement('div');
     groupEl.className = 'import-preview-folder';
     const header = document.createElement('div');
     header.className = 'import-preview-folder-header';
-    const hiddenHere = all.length - shown.length;
     header.textContent = subfolder + ' (' + shown.length + ')' +
       (hiddenHere ? ' · ' + hiddenHere.toLocaleString() + ' duplicate' +
         (hiddenHere === 1 ? '' : 's') + ' hidden' : '');
     groupEl.appendChild(header);
 
+    // A folder made entirely of duplicates still gets its header — a
+    // silent drop would leave the user with no evidence the folder or its
+    // hidden count existed while other headers own their hidden files.
+    if (!shown.length) {
+      grid.appendChild(groupEl);
+      return;
+    }
+
+    anyTilesRendered = true;
     const thumbsEl = document.createElement('div');
     thumbsEl.className = 'import-preview-thumbs';
     shown.forEach((entry) => {
@@ -2107,9 +2121,11 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
     groupEl.appendChild(thumbsEl);
     grid.appendChild(groupEl);
   });
-  // Every file was a duplicate, so the filter emptied the grid. Say so
-  // instead of leaving a blank panel that reads like "no files found".
-  if (!grid.children.length) {
+  // Every folder ended up fully filtered, so replace the wall of
+  // "(0) · N hidden" headers with a single clearer message that also
+  // tells the user how to see the tiles again.
+  if (!anyTilesRendered) {
+    grid.innerHTML = '';
     const empty = document.createElement('div');
     empty.className = 'import-preview-empty';
     empty.textContent = 'All ' + files.length.toLocaleString() + ' file' +


### PR DESCRIPTION
Importing a card with 985 files where 984 are already in the library buries the one new photo in a wall of `DUPLICATE` tiles — you have to scroll the whole grid to find it.

## What changed

- New **"Hide duplicates (N)"** checkbox under the preview summary, **off by default**. Checking it filters the flagged files out of the preview grid.
- The control only appears once a preview has actually flagged duplicates (not in in-place/snapshot mode, not with "Skip duplicates" off) — otherwise there is nothing to hide and the checkbox would be a no-op.
- Toggling is purely a **view filter**: it re-renders from the last preview result, never re-running `/api/import/folder-preview` or `/api/import/check-duplicates`, and never changing what the import does.

## Transparency

Per `CORE_PHILOSOPHY.md`, the smaller grid must not read as "that is all there is":

- The summary line is untouched — still `985 files found · 984 already in your library (will be skipped) · 1 to copy`.
- The checkbox label carries the count being hidden: `Hide duplicates (984)`.
- Each folder header shows the visible count plus what it dropped: `104NCZ_8 (1) · 984 duplicates hidden`.
- If every file is a duplicate, the grid says `All 985 files are duplicates — uncheck "Hide duplicates" to see them.` instead of going blank.

## Screenshots

Off (default) → on:

`card-a (2)` with both tiles → `card-a (1) · 1 duplicate hidden` with only the new file.

## Tests

- New e2e case `test_import_preview_hide_duplicates_checkbox_filters_grid`: asserts the checkbox defaults to unchecked, that checking it removes the flagged file and shows the per-folder hidden count, that the summary still reports the full picture, and that unchecking restores the tile.
- Refactored the existing preview test onto a shared `TWO_FILE_PREVIEW_STUB` / `run_two_file_preview` helper rather than duplicating ~90 lines of fetch stubbing.
- `python -m pytest tests/e2e/test_import_page.py -q` → **31 passed**.
- `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → **1949 passed, 1 failed**. The failure is `test_api_exiftool_status_reports_missing`, which fails identically on a clean tree at this commit (local ExifTool environment) and is unrelated to this change.

Verified in a real browser via Playwright screenshots of both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Hide duplicates” option to import previews.
  * Duplicate items can now be hidden from the preview grid without changing the overall preview summary.
  * Duplicate counts now appear in the filter label and folder group headers.
  * Shows an empty-state message when all items are hidden.
* **Bug Fixes**
  * The duplicate filter now resets appropriately across preview cycles (including no-duplicate outcomes and non-copy/special preview modes) to prevent stale selections.
* **Tests**
  * Added end-to-end coverage for toggling the duplicate filter, repreview behavior, and restoring the full preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->