### PR TITLE
Prevent false backend startup timeouts

### DIFF
--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -7,13 +7,18 @@ use tauri_plugin_shell::ShellExt;
 
 const RUNTIME_HEALTH_TIMEOUT: Duration = Duration::from_millis(500);
 const RUNTIME_BOOT_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
-const RUNTIME_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 const RUNTIME_BOOT_WAIT_INTERVAL: Duration = Duration::from_millis(200);
 // A signed PyInstaller one-file build can spend tens of seconds unpacking
 // native dependencies before Python starts, then still have legitimate
 // one-time startup migrations to finish. Keep this comfortably above the
 // observed cold-start cost while retaining a finite failure boundary.
 const SIDECAR_HEALTH_TIMEOUT: Duration = Duration::from_secs(90);
+// Peer discovery must cover the full window a legitimately initializing
+// backend may hold `runtime.lock` for; otherwise a second GUI gives up
+// mid-startup, launches a competing child that loses
+// `acquire_single_instance()`, and surfaces a spurious startup failure.
+// Keep this tied to `SIDECAR_HEALTH_TIMEOUT` so the two can never drift.
+const RUNTIME_LOCK_WAIT_TIMEOUT: Duration = SIDECAR_HEALTH_TIMEOUT;
 const GUI_CLIENTS_DIR: &str = ".vireo/gui-clients";
 
 /// Typed failure modes for `start_sidecar`. The launcher matches on these

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -8,6 +8,7 @@ use tauri_plugin_shell::ShellExt;
 const RUNTIME_HEALTH_TIMEOUT: Duration = Duration::from_millis(500);
 const RUNTIME_BOOT_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 const RUNTIME_BOOT_WAIT_INTERVAL: Duration = Duration::from_millis(200);
+const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 // A signed PyInstaller one-file build can spend tens of seconds unpacking
 // native dependencies before Python starts, then still have legitimate
 // one-time startup migrations to finish. Keep this comfortably above the
@@ -190,15 +191,30 @@ fn wait_for_health(
         if let Some(err) = early_exit.lock().unwrap_or_else(|e| e.into_inner()).clone() {
             return Err(err);
         }
-        if start.elapsed() > timeout {
+        let elapsed = start.elapsed();
+        if elapsed >= timeout {
             return Err(SidecarStartError::Generic(format!(
                 "Sidecar did not become healthy within {}s",
                 timeout.as_secs()
             )));
         }
-        match ureq::get(&url).call() {
+        // Bound every synchronous probe by both the short per-request cap
+        // and the remaining overall startup budget. Without this, a process
+        // that accepts TCP but never responds can block this loop forever
+        // and prevent the timeout path from killing the child.
+        let probe_timeout = std::cmp::min(HEALTH_PROBE_TIMEOUT, timeout - elapsed);
+        let agent = ureq::AgentBuilder::new()
+            .timeout_connect(probe_timeout)
+            .timeout(probe_timeout)
+            .build();
+        match agent.get(&url).call() {
             Ok(resp) if resp.status() == 200 => return Ok(()),
-            _ => std::thread::sleep(Duration::from_millis(200)),
+            _ => {
+                let remaining = timeout.saturating_sub(start.elapsed());
+                if !remaining.is_zero() {
+                    std::thread::sleep(std::cmp::min(RUNTIME_BOOT_WAIT_INTERVAL, remaining));
+                }
+            }
         }
     }
 }
@@ -701,5 +717,26 @@ mod tests {
 
         let _ = std::fs::remove_file(path);
         let _ = std::fs::remove_dir(dir);
+    }
+
+    #[test]
+    fn wait_for_health_bounds_a_stalled_probe_by_the_startup_budget() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            std::thread::sleep(Duration::from_secs(1));
+        });
+        let early_exit = Arc::new(Mutex::new(None));
+        let start = std::time::Instant::now();
+
+        let error = wait_for_health(port, Duration::from_millis(100), early_exit).unwrap_err();
+
+        assert!(matches!(error, SidecarStartError::Generic(_)));
+        assert!(
+            start.elapsed() < Duration::from_millis(500),
+            "a stalled HTTP response must not outlive the startup budget"
+        );
+        server.join().unwrap();
     }
 }

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -9,6 +9,11 @@ const RUNTIME_HEALTH_TIMEOUT: Duration = Duration::from_millis(500);
 const RUNTIME_BOOT_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 const RUNTIME_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 const RUNTIME_BOOT_WAIT_INTERVAL: Duration = Duration::from_millis(200);
+// A signed PyInstaller one-file build can spend tens of seconds unpacking
+// native dependencies before Python starts, then still have legitimate
+// one-time startup migrations to finish. Keep this comfortably above the
+// observed cold-start cost while retaining a finite failure boundary.
+const SIDECAR_HEALTH_TIMEOUT: Duration = Duration::from_secs(90);
 const GUI_CLIENTS_DIR: &str = ".vireo/gui-clients";
 
 /// Typed failure modes for `start_sidecar`. The launcher matches on these
@@ -503,18 +508,24 @@ pub fn start_sidecar(app: &AppHandle) -> Result<SidecarState, SidecarStartError>
         }
     });
 
-    // Wait up to 30 seconds for the sidecar to be healthy, but bail out
-    // early if the supervisor sees a structured failure or termination.
-    wait_for_health(port, Duration::from_secs(30), early_exit)?;
+    // Wait for the sidecar to be healthy, but bail out early if the
+    // supervisor sees a structured failure or termination. If readiness
+    // fails, explicitly kill the child before returning: otherwise the
+    // launcher exits while a late-starting backend remains orphaned.
+    if let Err(error) = wait_for_health(port, SIDECAR_HEALTH_TIMEOUT, early_exit) {
+        let _ = child.kill();
+        return Err(error);
+    }
 
     let runtime = runtime_json_path()
         .and_then(|path| read_runtime_json(&path))
-        .filter(|runtime| runtime.port == port)
-        .ok_or_else(|| {
-            SidecarStartError::Generic(
-                "Backend became healthy without publishing its runtime token".to_string(),
-            )
-        })?;
+        .filter(|runtime| runtime.port == port);
+    let Some(runtime) = runtime else {
+        let _ = child.kill();
+        return Err(SidecarStartError::Generic(
+            "Backend became healthy without publishing its runtime token".to_string(),
+        ));
+    };
 
     Ok(SidecarState::owned(child, port, runtime.token))
 }

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3847,6 +3847,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             repaired_location_ancestors,
         )
 
+    # Parsing taxonomy.json is expensive for a full iNaturalist download.
+    # Cache the startup instance so overlapping one-time migrations and the
+    # immediate background species pass do not each parse it independently.
+    _taxonomy_not_loaded = object()
+    _startup_taxonomy = _taxonomy_not_loaded
+
+    def _load_startup_taxonomy():
+        nonlocal _startup_taxonomy
+        # Do not cache a miss: a concurrent first-run taxonomy download can
+        # make the file available before the background retry starts.
+        if (
+            _startup_taxonomy is _taxonomy_not_loaded
+            or _startup_taxonomy is None
+        ):
+            from taxonomy import load_local_taxonomy
+
+            _startup_taxonomy = load_local_taxonomy()
+        return _startup_taxonomy
+
     def _sync_mark_species_only(db, log_label):
         """Load taxonomy and run mark_species_keywords synchronously.
 
@@ -3856,9 +3875,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         that depends on hierarchy leaves being correctly typed as
         taxonomy/is_species.
         """
-        from taxonomy import load_local_taxonomy
-
-        tax = load_local_taxonomy()
+        tax = _load_startup_taxonomy()
         if tax is None:
             log.debug(
                 "[%s] taxonomy not loaded; deferring species marking",
@@ -3895,7 +3912,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # association remains permanently skipped. When taxonomy isn't
     # loaded yet (or marking fails), defer the repair to a later boot
     # rather than stamping the marker over an unmarked hierarchy.
-    if _sync_mark_species_only(init_db, "sync-startup-species-mark"):
+    duplicate_repair_key = Database._DUPLICATE_PHOTO_SPECIES_REPAIR_KEY
+    duplicate_repair_pending = init_db.get_meta(duplicate_repair_key) != "1"
+    if duplicate_repair_pending:
+        # The legacy bug always left a typed top-level species/taxonomy tag
+        # beside another tag on the same photo. If no such pair exists, the
+        # repair is structurally impossible and it is safe to stamp the
+        # one-shot marker without parsing a potentially huge taxonomy file.
+        possible_duplicate = init_db.conn.execute(
+            """SELECT 1
+               FROM photo_keywords species_pk
+               JOIN keywords species_k
+                 ON species_k.id = species_pk.keyword_id
+               WHERE (species_k.is_species = 1
+                      OR species_k.type = 'taxonomy')
+                 AND EXISTS (
+                     SELECT 1
+                     FROM photo_keywords other_pk
+                     WHERE other_pk.photo_id = species_pk.photo_id
+                       AND other_pk.keyword_id != species_pk.keyword_id
+                 )
+               LIMIT 1"""
+        ).fetchone()
+        if possible_duplicate is None:
+            init_db.set_meta(duplicate_repair_key, "1")
+            duplicate_repair_pending = False
+            log.info(
+                "Skipped duplicate-species startup repair: "
+                "no possible duplicate associations"
+            )
+
+    if (
+        duplicate_repair_pending
+        and _sync_mark_species_only(init_db, "sync-startup-species-mark")
+    ):
         init_db.repair_duplicate_photo_species()
     # One-time rewrite of the previous miss-threshold defaults (0.25 / 0.15)
     # to the new defaults (0.20 / 0.12) in both ~/.vireo/config.json and
@@ -3978,9 +4028,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """Load taxonomy, mark species keywords, and run the one-shot
         Wildlife backfill. Returns silently on any failure so callers
         can choose between sync (block startup) and async (log only)."""
-        from taxonomy import load_local_taxonomy
-
-        tax = load_local_taxonomy()
+        tax = _load_startup_taxonomy()
         if tax is None:
             # No taxonomy yet — leave the marker unset so the backfill
             # retries on a future boot once taxonomy is downloaded.
@@ -4030,7 +4078,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         finally:
             bg_db.close()
 
-    threading.Thread(target=_mark_species, daemon=True).start()
+    if not os.environ.get("VIREO_DISABLE_STARTUP_BACKFILL_TIMERS"):
+        threading.Thread(target=_mark_species, daemon=True).start()
 
     def _folder_health_loop():
         """Periodically check folder health."""

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -7144,13 +7144,63 @@ def test_create_app_repairs_duplicate_species_after_taxonomy_marking(
     fake_tax.lookup.side_effect = lambda name: (
         {"taxon_id": 2912} if name == "Verdin" else None
     )
-    with patch("taxonomy.load_local_taxonomy", return_value=fake_tax):
+    with patch(
+        "taxonomy.load_local_taxonomy", return_value=fake_tax,
+    ) as load_taxonomy:
         create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test")
 
+    assert load_taxonomy.call_count == 1, (
+        "overlapping synchronous startup migrations must share one taxonomy parse"
+    )
     db2 = Database(db_path, initialize_schema=False)
     tagged_ids = {row["id"] for row in db2.get_photo_keywords(pid)}
     assert nested in tagged_ids
     assert root not in tagged_ids
+    assert db2.get_meta(Database._DUPLICATE_PHOTO_SPECIES_REPAIR_KEY) == "1"
+    db2.close()
+
+
+def test_create_app_skips_taxonomy_when_duplicate_repair_is_impossible(
+    tmp_path, monkeypatch,
+):
+    """An empty/non-species catalog must not parse taxonomy.json merely to
+    stamp the one-time duplicate-species repair marker."""
+    from unittest.mock import patch
+
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    db.set_meta(Database._WILDLIFE_BACKFILL_DONE_KEY, "1")
+    db.conn.execute(
+        "DELETE FROM db_meta WHERE key = ?",
+        (Database._DUPLICATE_PHOTO_SPECIES_REPAIR_KEY,),
+    )
+    db.conn.commit()
+    db.close()
+
+    with patch("taxonomy.load_local_taxonomy") as load_taxonomy:
+        app = create_app(
+            db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test",
+        )
+        assert app is not None
+
+    load_taxonomy.assert_not_called()
+    db2 = Database(db_path, initialize_schema=False)
     assert db2.get_meta(Database._DUPLICATE_PHOTO_SPECIES_REPAIR_KEY) == "1"
     db2.close()
 


### PR DESCRIPTION
Extends the packaged backend health timeout to accommodate cold PyInstaller starts and kills spawned children when readiness or runtime-token publication fails. Avoids parsing the large taxonomy file when duplicate-species repair is structurally impossible, and reuses a single taxonomy parse across overlapping startup maintenance. Adds regression coverage for both the migration fast path and taxonomy reuse. Verified with 24 Rust library tests, 4 create_app startup tests, and 80 runtime/taxonomy tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidecar startup reliability with a longer health-check window and cleanup when startup fails.
  * Added clearer handling when the backend is healthy but does not provide its runtime token.
  * Prevented unnecessary duplicate-species repair work when the catalog cannot support it.
  * Avoided repeated taxonomy loading during startup migrations.

* **Performance**
  * Startup background processing can now be disabled through configuration when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->