### PR TITLE
Explain embedding precompute failures

### DIFF
--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2642,7 +2642,16 @@ async function startBackgroundEmbeddingPrecompute(precompute, opts) {
           }
           if (progressFill) progressFill.style.width = '100%';
         } else if (status) {
-          status.textContent = 'Species list downloaded; embedding precompute failed.';
+          var detail = (
+            (result.errors && result.errors[0]) ||
+            (result.failure && result.failure.message) ||
+            'Unknown error'
+          );
+          // Keep the actionable explanation while hiding the usually long
+          // ONNXRuntime diagnostic that follows it. The complete exception
+          // remains available in Jobs and Logs.
+          detail = detail.split(' Underlying error:')[0];
+          status.textContent = 'Species list downloaded, but embedding precompute failed: ' + detail;
           status.style.color = 'var(--warning)';
         }
         loadEmbeddingMatrix();

--- a/vireo/tests/test_welcome.py
+++ b/vireo/tests/test_welcome.py
@@ -262,6 +262,21 @@ def test_settings_page_has_setup_link(app_and_db):
     assert b"/welcome?force=1" in resp.data
 
 
+def test_settings_embedding_precompute_failure_shows_job_error(app_and_db):
+    """A failed embedding warm-up should explain the cause, not just fail."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "(result.errors && result.errors[0])" in html
+    assert "result.failure && result.failure.message" in html
+    assert (
+        "Species list downloaded, but embedding precompute failed: "
+        in html
+    )
+
+
 def test_download_model_endpoint_exists(app_and_db):
     """POST /api/jobs/download-model returns 400 when model_id missing (not 404)."""
     app, _ = app_and_db


### PR DESCRIPTION
Shows the underlying job error when species-label embedding precomputation fails instead of displaying only a generic warning. It preserves the actionable explanation while trimming the noisy low-level ONNXRuntime diagnostic, which remains available in Jobs and Logs. Adds regression coverage for both the errors-array and structured-failure response paths. Validated with `python -m pytest vireo/tests/test_welcome.py -q`, Ruff, and `git diff --check`.