### PR TITLE
Stop re-reading known duplicates when linking their archive folders

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1834,9 +1834,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # re-read just to link their folder, and the walk is
                     # slow enough that silence reads as a hang. See the
                     # module docstring.
-                    _emit(
-                        _dup_link_phase(lex_dup_dirs), emitted, discovered,
-                    )
+                    _phase_prefix = _dup_link_phase(lex_dup_dirs)
+                    _emit(_phase_prefix, emitted, discovered)
                     scan(
                         destination, db,
                         restrict_dirs=sorted(lex_dup_dirs),
@@ -1845,9 +1844,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         thumb_cache_dir=params.thumb_cache_dir,
                         skip_working_copies=True,
                         cancel_check=lambda: runner.is_cancelled(job["id"]),
-                        status_callback=lambda msg, **kw: _emit(
-                            f"{_dup_link_phase(lex_dup_dirs)} — {msg}",
-                            emitted, discovered,
+                        status_callback=(
+                            lambda msg, _p=_phase_prefix, _e=emitted,
+                            _d=discovered, **kw: _emit(
+                                f"{_p} — {msg}", _e, _d,
+                            )
                         ),
                     )
                     linked_dup_dirs.update(lex_dup_dirs)
@@ -3179,9 +3180,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     # Name the phase and stream scanner's own discovery
                     # counter into it, or the UI sits on the batch's
                     # "N already present" line looking hung.
-                    _emit(
-                        _dup_link_phase(lex_dup_dirs), emitted, discovered,
-                    )
+                    _phase_prefix = _dup_link_phase(lex_dup_dirs)
+                    _emit(_phase_prefix, emitted, discovered)
                     # Same rationale as the fresh-batch scan above: pass
                     # ``vireo_dir`` / ``thumb_cache_dir`` so pairing keeps
                     # cache context, and defer per-batch WC extraction to
@@ -3194,9 +3194,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         thumb_cache_dir=params.thumb_cache_dir,
                         skip_working_copies=True,
                         cancel_check=lambda: runner.is_cancelled(job["id"]),
-                        status_callback=lambda msg, **kw: _emit(
-                            f"{_dup_link_phase(lex_dup_dirs)} — {msg}",
-                            emitted, discovered,
+                        status_callback=(
+                            lambda msg, _p=_phase_prefix, _e=emitted,
+                            _d=discovered, **kw: _emit(
+                                f"{_p} — {msg}", _e, _d,
+                            )
                         ),
                     )
                     linked_dup_dirs.update(lex_dup_dirs)

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -38,11 +38,16 @@ Reconnaissance notes (Task 2.0, verified 2026-07-04):
    enumerate the restricted dirs, so per-batch scan cost tracks the
    batch, not the archive tree. One deliberate deviation from the plan
    text: duplicate-matched folders are scanned in a SEPARATE
-   ``scan(restrict_dirs=…)`` call without ``restrict_files`` —
-   ``_ensure_folder`` only fires for *discovered* files, so folding
-   duplicate dirs into the fresh-copy call (whose ``restrict_files``
-   excludes their files) would create/link nothing for duplicate-only
-   imports.
+   ``scan(restrict_dirs=…, incremental=True)`` call without
+   ``restrict_files``, so that uncataloged strays sitting in a matched
+   folder get self-healed into the catalog. ``incremental=True`` is what
+   keeps that affordable: without it the call re-read and re-hashed
+   every file in the matched folders, so importing a card of pure
+   duplicates re-read the whole archive folder (see
+   ``test_duplicate_only_import_does_not_reread_unchanged_twins``).
+   Note the folder rows/workspace links do NOT depend on this call
+   discovering files — ``scanner._ensure_folder`` runs unconditionally
+   for every ``restrict_dirs`` entry (PR #752).
 """
 
 import contextlib
@@ -518,6 +523,20 @@ def _linkable_twin_dirs(rows, under_destination):
             continue
         dirs.add(folder_path)
     return dirs
+
+
+def _dup_link_phase(dup_dirs):
+    """Progress phase for the duplicate-folder link scan.
+
+    Says what the scan is actually walking — the archive folders that
+    already hold this card's photos — rather than a generic "scanning".
+    Wording mirrors the import preview's "N already in your library" so
+    the two screens describe the same files the same way.
+    """
+    n = len(dup_dirs)
+    return (
+        f"Checking {n} folder{'' if n == 1 else 's'} already in your library"
+    )
 
 
 def _run_remote_import_job(job, runner, db, workspace_id, params):
@@ -1809,13 +1828,27 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
 
             if lex_dup_dirs:
                 try:
+                    # ``incremental=True`` and the phase emits for the
+                    # same reasons as the local path's dup-link scan:
+                    # already-cataloged, unchanged twins must not be
+                    # re-read just to link their folder, and the walk is
+                    # slow enough that silence reads as a hang. See the
+                    # module docstring.
+                    _emit(
+                        _dup_link_phase(lex_dup_dirs), emitted, discovered,
+                    )
                     scan(
                         destination, db,
                         restrict_dirs=sorted(lex_dup_dirs),
+                        incremental=True,
                         vireo_dir=params.vireo_dir,
                         thumb_cache_dir=params.thumb_cache_dir,
                         skip_working_copies=True,
                         cancel_check=lambda: runner.is_cancelled(job["id"]),
+                        status_callback=lambda msg, **kw: _emit(
+                            f"{_dup_link_phase(lex_dup_dirs)} — {msg}",
+                            emitted, discovered,
+                        ),
                     )
                     linked_dup_dirs.update(lex_dup_dirs)
                     for d in sorted(lex_dup_dirs):
@@ -3041,11 +3074,17 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 wc_dest_folders.add(dest_folder)
 
         # --- Link duplicate-twin folders. Separate scan call WITHOUT
-        # restrict_files: scan only creates/links folder rows for files it
-        # discovers, so folding these dirs into the restricted call above
-        # would link nothing for duplicate-only batches. No restrict on
-        # files also means any uncataloged strays in these dirs get
-        # self-healed into the catalog.
+        # restrict_files so any uncataloged strays in these dirs get
+        # self-healed into the catalog — the restricted call above sees
+        # only what this batch landed. ``incremental=True`` bounds the
+        # cost to those strays: a twin that is already cataloged and
+        # unchanged is skipped on mtime instead of being re-opened and
+        # re-hashed. Without it, a card of pure duplicates re-read every
+        # byte of the matched archive folder(s) — hours over a network
+        # archive to import nothing. The folder rows and workspace links
+        # this block exists for do not depend on discovering any file:
+        # ``scanner._ensure_folder`` runs unconditionally per
+        # ``restrict_dirs`` entry (PR #752).
         new_dup_dirs = dup_dirs - linked_dup_dirs
         if new_dup_dirs:
             # Twin folders may be cataloged through a symlink alias while
@@ -3134,6 +3173,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
 
             if lex_dup_dirs:
                 try:
+                    # Walking the matched folders is the last thing this
+                    # job does and, on a network archive, by far the
+                    # slowest — the enumeration alone runs for minutes.
+                    # Name the phase and stream scanner's own discovery
+                    # counter into it, or the UI sits on the batch's
+                    # "N already present" line looking hung.
+                    _emit(
+                        _dup_link_phase(lex_dup_dirs), emitted, discovered,
+                    )
                     # Same rationale as the fresh-batch scan above: pass
                     # ``vireo_dir`` / ``thumb_cache_dir`` so pairing keeps
                     # cache context, and defer per-batch WC extraction to
@@ -3141,10 +3189,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     scan(
                         destination, db,
                         restrict_dirs=sorted(lex_dup_dirs),
+                        incremental=True,
                         vireo_dir=params.vireo_dir,
                         thumb_cache_dir=params.thumb_cache_dir,
                         skip_working_copies=True,
                         cancel_check=lambda: runner.is_cancelled(job["id"]),
+                        status_callback=lambda msg, **kw: _emit(
+                            f"{_dup_link_phase(lex_dup_dirs)} — {msg}",
+                            emitted, discovered,
+                        ),
                     )
                     linked_dup_dirs.update(lex_dup_dirs)
                     # Duplicate-link scan created/linked workspace_folders

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1660,8 +1660,15 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 # callers like pipeline_job's repair scan (``except
                 # (OSError, RuntimeError)``) keep their loud failure
                 # semantics — we deliberately don't catch that raise.
-                entries = list(safe_iter_dir(str(dp), onerror=_on_walk_error))
-                for f in entries:
+                #
+                # Consume the generator directly rather than materializing
+                # with ``list(...)``: on a slow network mount the scandir
+                # walk that backs safe_iter_dir takes minutes for a full
+                # day-folder, and materializing here would delay every
+                # heartbeat below until after that wait — the same silent
+                # hang the heartbeat exists to break (PR #1385 Codex /
+                # CodeRabbit review).
+                for f in safe_iter_dir(str(dp), onerror=_on_walk_error):
                     _check_cancelled()
                     checked += 1
                     if checked % 500 == 0 and status_callback:
@@ -1760,13 +1767,32 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             row["id"]: row["file_hash"]
             for row in db.conn.execute("SELECT id, file_hash FROM photos")
         }
-        # Build a path-based lookup: we need folder path + filename
+        # Path-based lookup keyed by absolute path, driving the
+        # incremental "skip on mtime" fast path. Queried GLOBALLY (not
+        # workspace-scoped, unlike ``db.get_photos()`` / ``db.get_folder_tree()``)
+        # so a twin already in the catalog still hits the skip path even
+        # when its folder is not yet linked as a ``workspace_folders``
+        # row in the active workspace. That is exactly the case the
+        # import job's duplicate-folder link scan exists to repair:
+        # scoping the lookup to the active workspace re-opened and
+        # re-hashed every already-known twin just to link the folder
+        # (PR #1385 Codex review). The sibling lookups above
+        # (``existing_file_hashes``, ``exif_extracted``,
+        # ``summary_needs_extract`` below) are already global for the
+        # same reason.
         existing_by_path = {}
-        folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
-        for p in all_photos:
-            folder_path = folders.get(p["folder_id"], "")
-            full_path = os.path.join(folder_path, p["filename"])
-            existing_by_path[full_path] = p
+        folder_paths = {
+            row["id"]: row["path"]
+            for row in db.conn.execute("SELECT id, path FROM folders")
+        }
+        for row in db.conn.execute(
+            "SELECT id, folder_id, filename, extension, file_size, "
+            "file_mtime, xmp_mtime, timestamp, width, height FROM photos"
+        ):
+            folder_path = folder_paths.get(row["folder_id"], "")
+            if not folder_path:
+                continue
+            existing_by_path[os.path.join(folder_path, row["filename"])] = row
         # Track which photos have had ExifTool metadata extracted (exif_data
         # is non-NULL). Photos with NULL exif_data need re-extraction.
         for row in db.conn.execute("SELECT id FROM photos WHERE exif_data IS NOT NULL"):

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1619,6 +1619,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         # Only enumerate files in the specified directories (non-recursive).
         # root is still used as the folder hierarchy root for _ensure_folder.
         restrict_files_set = set(restrict_files) if restrict_files is not None else None
+        # Heartbeat counter, same interval as the recursive branch below.
+        # A restricted dir is not necessarily small — the import job's
+        # duplicate-folder link scan points this at archive day-folders
+        # holding a whole card's worth of files, and on a network mount
+        # that enumeration runs for minutes. Without the emit the caller
+        # has nothing to show between "Discovering files..." and the
+        # finished count.
+        checked = 0
         for d in restrict_dirs:
             _check_cancelled()
             dp = Path(d)
@@ -1655,6 +1663,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 entries = list(safe_iter_dir(str(dp), onerror=_on_walk_error))
                 for f in entries:
                     _check_cancelled()
+                    checked += 1
+                    if checked % 500 == 0 and status_callback:
+                        _emit_status(
+                            f"Discovering files... ({len(image_files)} found)"
+                        )
                     if (f.is_file()
                             and f.suffix.lower() in SUPPORTED_EXTENSIONS
                             and not f.name.startswith(".")

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -202,6 +202,192 @@ def test_duplicate_only_import_links_matched_folders(tmp_path):
     assert len(_photo_rows(db)) == 1
 
 
+def _mark_exif_extracted(db):
+    """Stand in for a successful ExifTool pass over the cataloged rows.
+
+    ExifTool isn't installed in CI, so rows scanned there keep
+    ``exif_data`` NULL — which scanner reads as "metadata was never
+    extracted" and re-processes on the next incremental scan whatever
+    the mtime says. That retry path is deliberate and tested in
+    test_scanner.py; the tests below are about the duplicate-link scan,
+    so give the rows the marker a real extraction would have written.
+    """
+    db.conn.execute(
+        "UPDATE photos SET exif_data = '{}' WHERE exif_data IS NULL",
+    )
+    db.conn.commit()
+
+
+def _count_feature_computations(monkeypatch):
+    """Record every file scanner re-reads to derive phash/file_hash.
+
+    ``_compute_file_features`` opens the image and hashes every byte, so
+    it is the direct proxy for "did the scan actually read this file off
+    the archive volume".
+    """
+    import scanner
+
+    read_paths = []
+    real = scanner._compute_file_features
+
+    def _counting(path_str):
+        read_paths.append(path_str)
+        return real(path_str)
+
+    monkeypatch.setattr(scanner, "_compute_file_features", _counting)
+    return read_paths
+
+
+def test_duplicate_only_import_does_not_reread_unchanged_twins(
+    tmp_path, monkeypatch,
+):
+    """The duplicate-folder link scan must not re-read twins that are
+    already cataloged and unchanged.
+
+    The link scan exists to create/link the matched folders and to
+    self-heal uncataloged strays — neither needs the bytes of a file the
+    catalog already knows. Running it non-incrementally re-hashed every
+    file in the matched archive folder, so importing a card of pure
+    duplicates re-read the whole folder: on a network archive that turned
+    a zero-copy import into an hours-long rescan.
+    """
+    import shutil
+
+    import scanner
+    from import_job import ImportParams, run_import_job
+
+    archive = tmp_path / "archive"
+    twin_dir = archive / "2026" / "2026-07-03"
+    twin_dir.mkdir(parents=True)
+    names = ["IMG_0400.jpg", "IMG_0401.jpg", "IMG_0402.jpg"]
+    for i, name in enumerate(names):
+        Image.new("RGB", (16, 16), ("red", "green", "blue")[i]).save(
+            str(twin_dir / name),
+        )
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Catalog the archive exactly as a normal scan would, so the rows
+    # carry the file_mtime/metadata an incremental pass needs to skip on.
+    scanner.scan(str(archive), db)
+    _mark_exif_extracted(db)
+    assert len(_photo_rows(db)) == 3
+
+    # The card holds byte-identical copies of all three cataloged files.
+    card = tmp_path / "card"
+    card.mkdir()
+    for name in names:
+        shutil.copy2(str(twin_dir / name), str(card / name))
+
+    read_paths = _count_feature_computations(monkeypatch)
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 3
+    assert result["failed"] == 0
+    # The folder is still linked — the scan did its actual job.
+    assert str(twin_dir) in _ws_linked_folder_paths(db, ws_id)
+    assert read_paths == [], (
+        "duplicate-only import re-read already-cataloged, unchanged twins: "
+        f"{read_paths}"
+    )
+
+
+def test_duplicate_only_import_reports_the_link_scan_phase(tmp_path):
+    """The dup-link scan walks the matched archive folders, which on a
+    network archive takes minutes. It must say so: without a phase emit
+    the UI sits on the last copy message while the job looks hung."""
+    import shutil
+
+    import scanner
+    from import_job import ImportParams, run_import_job
+
+    archive = tmp_path / "archive"
+    twin_dir = archive / "2026" / "2026-07-03"
+    twin_dir.mkdir(parents=True)
+    twin_file = twin_dir / "IMG_0600.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(twin_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    scanner.scan(str(archive), db)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    shutil.copy2(str(twin_file), str(card / "IMG_0600.jpg"))
+
+    runner = FakeRunner()
+    result = run_import_job(
+        _make_job(), runner, db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+    assert result["skipped_duplicate"] == 1
+
+    phases = [
+        data.get("phase", "")
+        for _jid, kind, data in runner.events if kind == "progress"
+    ]
+    assert any("already in your library" in p for p in phases), (
+        "import must report the duplicate-folder link scan as its own "
+        f"phase; got {phases}"
+    )
+
+
+def test_duplicate_only_import_still_catalogs_stray_in_twin_folder(
+    tmp_path, monkeypatch,
+):
+    """Skipping unchanged twins must not cost the link scan its other
+    job: a file sitting in the matched folder that the catalog has never
+    seen still gets self-healed in, and it is the ONLY file re-read."""
+    import shutil
+
+    import scanner
+    from import_job import ImportParams, run_import_job
+
+    archive = tmp_path / "archive"
+    twin_dir = archive / "2026" / "2026-07-03"
+    twin_dir.mkdir(parents=True)
+    twin_file = twin_dir / "IMG_0500.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(twin_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    scanner.scan(str(archive), db)
+    _mark_exif_extracted(db)
+
+    # A stray lands in the twin folder AFTER the catalog was built.
+    stray = twin_dir / "IMG_0501.jpg"
+    Image.new("RGB", (16, 16), "green").save(str(stray))
+
+    card = tmp_path / "card"
+    card.mkdir()
+    shutil.copy2(str(twin_file), str(card / "IMG_0500.jpg"))
+
+    read_paths = _count_feature_computations(monkeypatch)
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    assert result["skipped_duplicate"] == 1
+    row_paths = {
+        os.path.join(r["folder_path"], r["filename"]) for r in _photo_rows(db)
+    }
+    assert str(stray) in row_paths, (
+        "link scan must still self-heal uncataloged strays in the twin folder"
+    )
+    assert read_paths == [str(stray)], (
+        "only the uncataloged stray should be read off the archive: "
+        f"{read_paths}"
+    )
+
+
 def test_duplicate_only_import_links_alias_spelled_twin(tmp_path):
     """When a twin folder is cataloged through a symlink alias but the
     import ``destination`` resolves to a different (real) spelling, the
@@ -5139,6 +5325,59 @@ def test_remote_import_links_verified_twin_folder_in_other_layout(
         "before": sorted(linked_before), "after": sorted(linked_after),
         "twin_folder": twin_folder,
     }
+
+
+def test_remote_import_dup_link_scan_does_not_reread_unchanged_twins(
+        tmp_path, monkeypatch):
+    """Remote mirror of
+    ``test_duplicate_only_import_does_not_reread_unchanged_twins``: the
+    remote path runs its own dup-link scan, and it must skip already-
+    cataloged, unchanged twins too."""
+    from import_job import ImportParams, run_import_job
+
+    import scanner
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    twin_folder = os.path.join(ra["mount_base"], "unsorted")
+    os.makedirs(twin_folder, exist_ok=True)
+    import shutil as _shutil
+    for name in ("DSC_0001.jpg", "DSC_0002.jpg"):
+        _shutil.copy2(str(card / name), os.path.join(twin_folder, name))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Catalog the twins the way a real scan would, so the rows carry the
+    # file_mtime/metadata an incremental pass needs to skip on.
+    scanner.scan(ra["mount_base"], db)
+    _mark_exif_extracted(db)
+    assert len(_photo_rows(db)) == 2
+
+    read_paths = _count_feature_computations(monkeypatch)
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert calls["rsync"] == [], calls["rsync"]
+    assert result["skipped_duplicate"] == 2, result
+    assert result["failed"] == 0, result
+    assert twin_folder in _ws_linked_folder_paths(db, ws_id)
+    assert read_paths == [], (
+        "remote duplicate-only import re-read already-cataloged, unchanged "
+        f"twins: {read_paths}"
+    )
 
 
 def test_remote_import_scans_adopted_duplicate_in_mixed_batch(

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5333,9 +5333,8 @@ def test_remote_import_dup_link_scan_does_not_reread_unchanged_twins(
     ``test_duplicate_only_import_does_not_reread_unchanged_twins``: the
     remote path runs its own dup-link scan, and it must skip already-
     cataloged, unchanged twins too."""
-    from import_job import ImportParams, run_import_job
-
     import scanner
+    from import_job import ImportParams, run_import_job
 
     ra = _remote_archive_for(tmp_path)
     calls = _remote_calls(ra)

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -388,6 +388,78 @@ def test_duplicate_only_import_still_catalogs_stray_in_twin_folder(
     )
 
 
+def test_duplicate_only_import_skips_twins_cataloged_in_other_workspace(
+    tmp_path, monkeypatch,
+):
+    """The dup-link scan must skip twins whose folder is cataloged but
+    not yet linked to the active workspace — the exact case this scan
+    exists to repair.
+
+    Regression for PR #1385 Codex review. The scan initially scoped its
+    incremental "skip on mtime" lookup to the active workspace, so a
+    folder cataloged in a different workspace (or previously known but
+    not yet workspace-linked here) would still be re-opened and
+    re-hashed on every file inside it, defeating the fix for the very
+    "cataloged, unchanged twins" case the PR targets. The sibling test
+    ``test_duplicate_only_import_does_not_reread_unchanged_twins``
+    happens to also link the twin folder to the active workspace during
+    setup, so this test forces the "cataloged elsewhere" state
+    explicitly by seeding in one workspace and running the import from
+    a fresh one.
+    """
+    import shutil
+
+    import scanner
+    from import_job import ImportParams, run_import_job
+
+    archive = tmp_path / "archive"
+    twin_dir = archive / "2026" / "2026-07-03"
+    twin_dir.mkdir(parents=True)
+    names = ["IMG_0700.jpg", "IMG_0701.jpg", "IMG_0702.jpg"]
+    for i, name in enumerate(names):
+        Image.new("RGB", (16, 16), ("red", "green", "blue")[i]).save(
+            str(twin_dir / name),
+        )
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    seed_ws = db._active_workspace_id
+    # Seed the catalog by scanning under the default workspace so rows
+    # carry the file_mtime/metadata an incremental pass needs to skip on.
+    scanner.scan(str(archive), db)
+    _mark_exif_extracted(db)
+    assert len(_photo_rows(db)) == 3
+    assert str(twin_dir) in _ws_linked_folder_paths(db, seed_ws)
+
+    # A fresh workspace has never seen this folder — the exact state the
+    # dup-link scan is intended to repair.
+    fresh_ws = db.create_workspace("Fresh")
+    assert str(twin_dir) not in _ws_linked_folder_paths(db, fresh_ws)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    for name in names:
+        shutil.copy2(str(twin_dir / name), str(card / name))
+
+    read_paths = _count_feature_computations(monkeypatch)
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, fresh_ws,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 3, result
+    assert result["failed"] == 0, result
+    # The folder is now linked to the fresh workspace — the scan did its
+    # actual job of workspace-linking the matched folder.
+    assert str(twin_dir) in _ws_linked_folder_paths(db, fresh_ws)
+    assert read_paths == [], (
+        "duplicate-only import re-read twins whose folder was cataloged "
+        "but not yet linked to the active workspace: "
+        f"{read_paths}"
+    )
+
+
 def test_duplicate_only_import_links_alias_spelled_twin(tmp_path):
     """When a twin folder is cataloged through a symlink alias but the
     import ``destination`` resolves to a different (real) spelling, the

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2536,41 +2536,79 @@ def test_incremental_rescan_skips_small_jpeg_dims_not_raw(tmp_path, monkeypatch)
     assert all(image_path not in batch for batch in called_with)
 
 
-def test_restricted_scan_reports_discovery_progress(tmp_path):
-    """Enumerating a restricted dir must emit a discovery heartbeat.
+def test_restricted_scan_reports_discovery_progress(tmp_path, monkeypatch):
+    """Enumerating a restricted dir must emit a discovery heartbeat
+    WHILE the enumeration is still running, not only after it finishes.
 
-    The recursive/non-recursive branches already do. The restrict_dirs
-    branch did not, so a caller that streams status to a UI (the import
-    job's duplicate-folder link scan) showed nothing at all while the
-    enumeration ran — minutes of apparent hang on a network archive with
-    a folder of ~1000 files.
+    The recursive/non-recursive branches already emit heartbeats. The
+    restrict_dirs branch did not, so a caller that streams status to a
+    UI (the import job's duplicate-folder link scan) showed nothing at
+    all while the enumeration ran — minutes of apparent hang on a
+    network archive with a folder of ~1000 files.
+
+    A materialized-then-iterate variant (``list(safe_iter_dir(...))``)
+    would emit heartbeats too, but only after the whole slow scandir
+    finishes — the exact silence this exists to break. The spy below
+    records how many entries the underlying iterator had yielded at the
+    moment each heartbeat fired: at least one heartbeat must fire before
+    the iterator is exhausted (PR #1385 Codex / CodeRabbit review).
     """
     import scanner
     from db import Database
+    from image_loader import safe_iter_dir as real_safe_iter_dir
 
     root = tmp_path / "archive"
     day = root / "2026-07-03"
     day.mkdir(parents=True)
     # One real image (the only file the scan is allowed to process) plus
-    # enough same-extension siblings to cross the heartbeat interval.
+    # enough same-extension siblings to cross the heartbeat interval
+    # multiple times.
     real = day / "IMG_0000.jpg"
     Image.new("RGB", (16, 16), color="red").save(str(real), "JPEG")
-    for i in range(1, 601):
+    for i in range(1, 1201):
         (day / f"IMG_{i:04d}.jpg").touch()
 
+    yields = [0]
+
+    def spy_iter_dir(top, onerror=None):
+        for entry in real_safe_iter_dir(top, onerror=onerror):
+            yields[0] += 1
+            yield entry
+
+    monkeypatch.setattr(scanner, "safe_iter_dir", spy_iter_dir)
+
     db = Database(str(tmp_path / "test.db"))
-    statuses = []
+    statuses = []  # list of (msg, yields_when_emitted)
     scanner.scan(
         str(root), db,
         restrict_dirs=[str(day)],
         restrict_files={str(real)},
-        status_callback=lambda msg, **kw: statuses.append(msg),
+        status_callback=lambda msg, **kw: statuses.append((msg, yields[0])),
     )
 
-    discovery = [s for s in statuses if s.startswith("Discovering files")]
+    total_yielded = yields[0]
+    discovery = [
+        (msg, at) for msg, at in statuses
+        if msg.startswith("Discovering files")
+    ]
     assert len(discovery) >= 2, (
         "restricted discovery must emit progress while it enumerates, not "
         f"just a single opening message; got {statuses}"
+    )
+    # At least one heartbeat must have fired mid-enumeration — after the
+    # generator started yielding but before it was exhausted. The scan
+    # emits an "opening" heartbeat before any yield (at ``yields == 0``),
+    # so that one doesn't count; the "closing" heartbeats after
+    # enumeration is done (``at == total_yielded``) don't count either.
+    # A materialized-then-iterate variant would only land in those two
+    # buckets — no true in-flight ticks — leaving the UI silent through
+    # the entire slow scandir walk this heartbeat exists to break.
+    in_flight = [at for _, at in discovery if 0 < at < total_yielded]
+    assert in_flight, (
+        "heartbeats never fired mid-enumeration — the UI would be silent "
+        "through the whole slow scandir walk this heartbeat exists to "
+        f"break (iterator total: {total_yielded}, heartbeats at: "
+        f"{[at for _, at in discovery]})"
     )
 
 

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2536,6 +2536,44 @@ def test_incremental_rescan_skips_small_jpeg_dims_not_raw(tmp_path, monkeypatch)
     assert all(image_path not in batch for batch in called_with)
 
 
+def test_restricted_scan_reports_discovery_progress(tmp_path):
+    """Enumerating a restricted dir must emit a discovery heartbeat.
+
+    The recursive/non-recursive branches already do. The restrict_dirs
+    branch did not, so a caller that streams status to a UI (the import
+    job's duplicate-folder link scan) showed nothing at all while the
+    enumeration ran — minutes of apparent hang on a network archive with
+    a folder of ~1000 files.
+    """
+    import scanner
+    from db import Database
+
+    root = tmp_path / "archive"
+    day = root / "2026-07-03"
+    day.mkdir(parents=True)
+    # One real image (the only file the scan is allowed to process) plus
+    # enough same-extension siblings to cross the heartbeat interval.
+    real = day / "IMG_0000.jpg"
+    Image.new("RGB", (16, 16), color="red").save(str(real), "JPEG")
+    for i in range(1, 601):
+        (day / f"IMG_{i:04d}.jpg").touch()
+
+    db = Database(str(tmp_path / "test.db"))
+    statuses = []
+    scanner.scan(
+        str(root), db,
+        restrict_dirs=[str(day)],
+        restrict_files={str(real)},
+        status_callback=lambda msg, **kw: statuses.append(msg),
+    )
+
+    discovery = [s for s in statuses if s.startswith("Discovering files")]
+    assert len(discovery) >= 2, (
+        "restricted discovery must emit progress while it enumerates, not "
+        f"just a single opening message; got {statuses}"
+    )
+
+
 def test_scan_restrict_files_ignores_files_not_in_list(tmp_path, monkeypatch):
     """When scan is called with restrict_files, files in restrict_dirs
     that are not in the list are left untouched — even if they're brand


### PR DESCRIPTION
## The bug

Importing a card whose files are already in the library re-read and re-hashed **every file in the matched archive folder**. The duplicate-folder link scan ran without `incremental=True`, so scanner's skip-unchanged fast path (`scanner.py:1959`) never fired and all already-cataloged twins went through `_compute_file_features` — a full open + sha256 of each file.

Reported from a real run: a 985-file card where 984 were duplicates and **1** was new.

```
18:42:17  import starts
18:43:30  Discovering files in /Volumes/Photography/Raw Files/USA/2026
18:48:46  Found 984 images                      <- 5m16s just to enumerate
20:35:00  ERROR Linking duplicate-matched folders failed
            import_job.py:3141 -> scanner.py:2114 (pool.submit)
            BrokenPipeError: [Errno 32] Broken pipe
          ...retried from scratch, once per 200-file batch...
22:25:36  job cancelled after 13399.3s (3.7h), 0 copied
```

That archive is an SMB mount over Tailscale, so each of those reads is a network round trip. The traceback lands on `import_job.py:3141` — the exact call this PR changes — and on `scanner.py:2114`, the process pool spun up to hash the 984 files.

Note the amplification: the scan crashed, the `except` branch left `linked_dup_dirs` un-updated, so the **next batch re-ran the whole thing**. Three full 984-file rescans before the user gave up.

## The fix

Pass `incremental=True` to the dup-link scan (local and remote paths).

That scan exists to (a) create/link the matched folders and (b) self-heal uncataloged strays. Neither needs the bytes of a file the catalog already knows:

- unchanged twins skip on mtime — zero reads
- strays are still discovered and cataloged — self-heal preserved
- folder rows/workspace links are unaffected: `scanner._ensure_folder` runs unconditionally per `restrict_dirs` entry

It also removes the crash. With nothing to hash, `_iter_features` never spawns a process pool, so the `BrokenPipeError` and the per-batch retry storm go with it.

### Stale comment corrected

The module docstring claimed the dup dirs need their own unrestricted scan because "`_ensure_folder` only fires for *discovered* files". That has been false since **#752** (May 3) made it run unconditionally per `restrict_dirs` entry — two months before `import_job.py` was written in #1107. The real reason for the separate call is stray self-heal, and the docstring now says so.

## Two supporting fixes (UI transparency)

Per `CORE_PHILOSOPHY.md`'s no-black-boxes rule — the reason this was mysterious is that the job said nothing for hours:

1. **The import now names the phase.** Its last message used to be the batch's `"N already present"` line, then silence for the whole walk. It now emits `"Checking N folders already in your library"` and streams scanner's discovery status into it. (Wording mirrors the import preview's "N already in your library" so both screens describe the same files the same way.)
2. **scanner's `restrict_dirs` discovery branch had no progress heartbeat**, unlike its recursive/non-recursive siblings — so there was nothing to stream. It now emits every 500 entries, same interval as the other branches.

## Tests

TDD throughout — each test was watched failing first, for the right reason.

| Test | Guards |
|---|---|
| `test_duplicate_only_import_does_not_reread_unchanged_twins` | zero reads of cataloged twins (local) |
| `test_remote_import_dup_link_scan_does_not_reread_unchanged_twins` | same, remote path |
| `test_duplicate_only_import_still_catalogs_stray_in_twin_folder` | self-heal preserved, and the stray is the **only** file read |
| `test_duplicate_only_import_reports_the_link_scan_phase` | the phase emit |
| `test_restricted_scan_reports_discovery_progress` | the scanner heartbeat |

The tests spy on `scanner._compute_file_features` — the direct proxy for "did this actually read the file off the volume".

They seed the `exif_data` marker after the setup scan, mirroring the existing pattern in `test_scanner.py`: without ExifTool (as in CI) rows keep `exif_data` NULL, which scanner reads as "metadata never extracted" and re-processes regardless of mtime. **Verified passing both with and without ExifTool on PATH.**

### Results

- `vireo/tests/test_scanner.py` + `test_import_job.py`: **244 passed, 1 skipped in 19.68s** (baseline on `origin/main`: 239 passed, 1 skipped in 19.25s — 5 more tests, same runtime, no regression and no slowdown)
- CLAUDE.md's pre-PR suite list: **1949 passed**, 1 failure (`test_api_exiftool_status_reports_missing`, fails identically on a clean tree here)
- `vireo/tests/{test_import_dedup,test_import_chain,test_importer,test_rescan_scope,test_multi_root_scan,test_folder_rescan_api}.py`: **199 passed**
- `tests/` excluding e2e: **167 passed**
- `tests/e2e/test_import_page.py`: **30 passed**

Baseline for the full `vireo/tests/` tree on clean `origin/main` is **4 failed, 5399 passed, 81 skipped in 23:04** — the four (`test_api_exiftool_status_reports_missing`, `test_pipeline_model_ids_back_compat_with_model_id`, and two `test_userfirst_scenarios`) are pre-existing. I could not complete the equivalent full-tree run on this branch: repeated runs filled the disk with ~26 GB of pytest temp dirs and later tests began failing on space. Everything the change touches is covered by the targeted runs above.

## Real-world validation

Checked against the reporting user's actual database: all 984 rows carry `file_mtime`, non-NULL `exif_data`, non-NULL `timestamp`, and none are flagged for EXIF re-extraction — so the incremental pass skips **every one of them**. This fix resolves the reported case, not just a synthetic one.

## Follow-up not taken here

When the dup-link scan fails, `linked_dup_dirs` isn't updated, so the next batch retries the whole scan — that's what turned one crash into three full rescans. The root cause is removed by this PR, but the retry amplification is still there for other failure modes. Changing it would alter the failure semantics that `test_dup_link_scan_failure_marks_unsafe` encodes, so I left it alone; worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Duplicate-folder imports now avoid reprocessing unchanged files, improving import efficiency.
  * Uncataloged files found in matched duplicate folders are still added to the library.
  * Duplicate-folder linking now displays a dedicated progress phase.
  * Restricted scans provide ongoing discovery progress updates during large directory searches.
* **Bug Fixes**
  * Improved duplicate-folder import behavior for both local and remote sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->