### PR TITLE
Fix import destination guidance and failed-file recovery

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -945,6 +945,11 @@ def test_failed_import_result_offers_preconfigured_retry(live_server, page):
     # (which chains on only 1 new photo) silently leave 984 photos
     # unprocessed.
     assert body["carry_photo_ids"] == [101, 102, 103]
+    # And it must bind the carry list to the parent so the server can
+    # verify each carry ID actually came from that parent — without
+    # this binding an API caller could inject arbitrary IDs into the
+    # after-import chain scope.
+    assert body["parent_import_job_id"] == "import-original"
 
 
 def test_import_copy_start_sends_restored_options(live_server, page):

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1354,7 +1354,10 @@ def test_import_remote_destination_requires_visible_folder_inside_nas(
 
 def test_failed_import_result_offers_preconfigured_retry(live_server, page):
     """A mixed import can retry from its result without rebuilding the form;
-    duplicate protection is forced so successful files remain untouched."""
+    the parent's duplicate-skip setting is preserved, and the parent's
+    already-imported photo IDs plus its own job ID are carried on the
+    retry request so the after-import chain covers the complete original
+    scope."""
     url = live_server["url"]
     captured = {}
 
@@ -1424,7 +1427,13 @@ def test_failed_import_result_offers_preconfigured_retry(live_server, page):
     assert body["sources"] == ["/Volumes/CARD/DCIM"]
     assert body["destination"] == "/Volumes/Photography/Raw Files/USA"
     assert body["folder_template"] == "%Y/%Y-%m-%d"
-    assert body["skip_duplicates"] is True
+    # retryBodyFromFinishedJob() preserves the parent's skip_duplicates
+    # setting rather than forcing it on, so a parent configured with
+    # dedup OFF retries with dedup OFF — otherwise the very file that
+    # failed could be silently skipped if it happens to match some
+    # unrelated catalog entry. The parent above seeds `false`, so the
+    # retry must send `false`.
+    assert body["skip_duplicates"] is False
     assert body["after_import"] == 1
     assert body["tags"] == ["trip"]
     # The original run's successful photos must be carried into the retry

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -267,8 +267,11 @@ def test_import_preview_runs_automatically_after_source_selection(live_server, p
     grid = page.locator("#importPreviewGrid")
     expect(grid).to_be_visible()
     expect(grid).to_contain_text("IMG_0001.jpg")
-    expect(grid).not_to_contain_text("IMG_0002.jpg")
-    expect(grid).to_contain_text("1 duplicate hidden")
+    # Duplicate filtering is opt-in, so the automatic preview initially
+    # shows both files and marks the duplicate. The dedicated filter test
+    # below covers the collapsed state after the checkbox is enabled.
+    expect(grid).to_contain_text("IMG_0002.jpg")
+    expect(grid).to_contain_text("Duplicate")
     expect(grid).to_contain_text("To: 2026/2026-07-11")
 
 
@@ -306,6 +309,39 @@ def test_import_preview_hide_duplicates_checkbox_filters_grid(live_server, page)
     assert page.evaluate(
         "[window.__fullPreviewCalls, window.__dupCalls, window.__destCalls]",
     ) == calls_before
+
+
+def test_hide_duplicates_all_duplicate_banner_has_no_phantom_tiles(
+    live_server, page,
+):
+    """When filtering leaves zero pending files, the collapsed banner must
+    not claim that zero files are shown below when no tiles follow it."""
+    run_two_file_preview(live_server, page)
+    page.evaluate(
+        """
+        () => {
+          const file = {
+            path: '/tmp/card-a/IMG_0002.jpg',
+            filename: 'IMG_0002.jpg',
+            subfolder: 'card-a',
+          };
+          renderImportPreviewGrid(
+            [file],
+            [file.path],
+            [],
+          );
+        }
+        """
+    )
+
+    page.locator("#chkHideDuplicates").check()
+    banner = page.locator("[data-testid='collapsed-duplicate-preview']")
+    expect(banner).to_contain_text("1 duplicate hidden")
+    expect(banner).to_contain_text(
+        "Nothing else will be imported from this selection."
+    )
+    expect(banner).not_to_contain_text("0 files to import")
+    expect(page.locator("#importPreviewGrid .import-preview-thumb")).to_have_count(0)
 
 
 def test_hide_duplicates_resets_once_a_check_finds_no_duplicates(

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -461,7 +461,7 @@ def test_import_preview_shows_destination_folder_structure(live_server, page):
         ["/archive/2026/2026-07-02", "1", "existing"]
     )
     expect(structure).to_contain_text(
-        "This destination is inside the managed archive rooted at"
+        "Files imported here land inside the managed archive rooted at"
     )
     expect(structure).to_contain_text("/archive")
     expect(structure).to_contain_text("1284 photos already cataloged")
@@ -884,6 +884,7 @@ def test_failed_import_result_offers_preconfigured_retry(live_server, page):
         () => {
           lastFinishedImportJob = {
             id: 'import-original',
+            type: 'import',
             status: 'failed',
             config: {
               sources: ['/Volumes/CARD/DCIM'],
@@ -900,6 +901,10 @@ def test_failed_import_result_offers_preconfigured_retry(live_server, page):
               allow_missing_exiftool: false,
               remote_target_id: null,
               remote_subpath: null,
+            },
+            result: {
+              photo_ids: [101, 102, 103],
+              failed: 1,
             },
           };
           renderResult({
@@ -933,6 +938,13 @@ def test_failed_import_result_offers_preconfigured_retry(live_server, page):
     assert body["skip_duplicates"] is True
     assert body["after_import"] == 1
     assert body["tags"] == ["trip"]
+    # The original run's successful photos must be carried into the retry
+    # so the after-import chain covers the complete import scope, not
+    # only the newly-recovered file. Without this, the failed original
+    # (which skipped chaining because it wasn't OK) plus the retry
+    # (which chains on only 1 new photo) silently leave 984 photos
+    # unprocessed.
+    assert body["carry_photo_ids"] == [101, 102, 103]
 
 
 def test_import_copy_start_sends_restored_options(live_server, page):

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -155,8 +155,8 @@ def test_import_preview_runs_automatically_after_source_selection(live_server, p
     grid = page.locator("#importPreviewGrid")
     expect(grid).to_be_visible()
     expect(grid).to_contain_text("IMG_0001.jpg")
-    expect(grid).to_contain_text("IMG_0002.jpg")
-    expect(grid).to_contain_text("Duplicate")
+    expect(grid).not_to_contain_text("IMG_0002.jpg")
+    expect(grid).to_contain_text("1 duplicate hidden")
     expect(grid).to_contain_text("To: 2026/2026-07-11")
 
 
@@ -460,7 +460,9 @@ def test_import_preview_shows_destination_folder_structure(live_server, page):
     expect(rows.nth(2).locator("td")).to_have_text(
         ["/archive/2026/2026-07-02", "1", "existing"]
     )
-    expect(structure).to_contain_text("Merging into a managed archive at")
+    expect(structure).to_contain_text(
+        "This destination is inside the managed archive rooted at"
+    )
     expect(structure).to_contain_text("/archive")
     expect(structure).to_contain_text("1284 photos already cataloged")
     expect(structure).to_contain_text("2026/2026-07-01")
@@ -807,6 +809,130 @@ def test_import_dest_structure_invalidation_survives_slow_startup(live_server, p
     # would stay visible.
     page.locator("#destInput").fill("/archive")
     expect(page.locator("#destStructure")).to_be_hidden()
+
+
+def test_import_remote_destination_requires_visible_folder_inside_nas(
+    live_server, page,
+):
+    """The remote root alone is not a complete destination. Explain the
+    missing folder beside the field and keep Start unavailable until it is
+    valid, instead of hiding a tiny error below the thumbnail grid."""
+    url = live_server["url"]
+
+    def remote_targets(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "rsync_available": True,
+                "ssh_available": True,
+                "targets": [{
+                    "id": "nas1",
+                    "name": "Photo NAS",
+                    "user": "photo",
+                    "host": "nas.local",
+                    "remote_path": "/volume1/Photography",
+                    "mount_path": "/Volumes/Photography",
+                }],
+            }),
+        )
+
+    page.route("**/api/remote-targets", remote_targets)
+    page.goto(f"{url}/import")
+    page.locator("#modeCopy").check()
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
+    page.locator("#destMode").select_option("remote:nas1")
+
+    inline_error = page.locator("#remoteSubpathError")
+    expect(inline_error).to_be_visible()
+    expect(inline_error).to_contain_text(
+        "Enter the folder inside /volume1/Photography"
+    )
+    expect(page.locator("#btnStart")).to_be_disabled()
+    assert page.evaluate("resolvedCopyDestination()") == ""
+
+    page.locator("#remoteSubpath").fill("/Raw Files/USA")
+    expect(inline_error).to_contain_text("Subpath must be relative")
+    expect(page.locator("#btnStart")).to_be_disabled()
+
+    page.locator("#remoteSubpath").fill("Raw Files/USA")
+    expect(inline_error).to_be_hidden()
+    assert page.evaluate("resolvedCopyDestination()") == (
+        "/Volumes/Photography/Raw Files/USA"
+    )
+
+
+def test_failed_import_result_offers_preconfigured_retry(live_server, page):
+    """A mixed import can retry from its result without rebuilding the form;
+    duplicate protection is forced so successful files remain untouched."""
+    url = live_server["url"]
+    captured = {}
+
+    def start_import(route):
+        captured["body"] = json.loads(route.request.post_data or "{}")
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"job_id": "import-retry"}),
+        )
+
+    page.route("**/api/jobs/import-photos", start_import)
+    page.goto(f"{url}/import")
+    page.evaluate(
+        """
+        () => {
+          lastFinishedImportJob = {
+            id: 'import-original',
+            status: 'failed',
+            config: {
+              sources: ['/Volumes/CARD/DCIM'],
+              destination: '/Volumes/Photography/Raw Files/USA',
+              recursive: true,
+              folder_template: '%Y/%Y-%m-%d',
+              file_types: 'both',
+              skip_duplicates: false,
+              verify_by_hash: false,
+              trust_likely_duplicates: true,
+              after_import: 1,
+              tags: ['trip'],
+              location_from_gps: true,
+              allow_missing_exiftool: false,
+              remote_target_id: null,
+              remote_subpath: null,
+            },
+          };
+          renderResult({
+            discovered: 985,
+            copied: 984,
+            verified: 984,
+            skipped_duplicate: 0,
+            failed: 1,
+            safe_to_format: false,
+            unsafe_files: [{
+              path: '/Volumes/CARD/DCIM/DSC_7172.NEF',
+              reason: 'copy verification failed',
+            }],
+            folders: {},
+            errors: ['copy verification failed'],
+          }, 'failed');
+        }
+        """
+    )
+
+    retry = page.locator("#btnRetryImport")
+    expect(retry).to_be_visible()
+    expect(retry).to_have_text("Retry 1 failed file")
+    retry.click()
+    expect(page.locator("#progressCard")).to_be_visible()
+
+    body = captured["body"]
+    assert body["sources"] == ["/Volumes/CARD/DCIM"]
+    assert body["destination"] == "/Volumes/Photography/Raw Files/USA"
+    assert body["folder_template"] == "%Y/%Y-%m-%d"
+    assert body["skip_duplicates"] is True
+    assert body["after_import"] == 1
+    assert body["tags"] == ["trip"]
 
 
 def test_import_copy_start_sends_restored_options(live_server, page):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -23039,16 +23039,58 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "local_archive_root": target.get("local_archive_root", ""),
         }
 
+    def _capture_photo_fingerprints_for_ids(db, ids):
+        """Return the current ``{id: "folder_path/filename"}`` for each ID.
+
+        Same shape as ``import_job._capture_photo_fingerprints`` but at
+        request time on caller-supplied IDs, so a recovery retry can
+        detect when SQLite has reused an ID for an unrelated photo since
+        the parent import ran. Missing IDs are simply absent from the
+        result — the caller decides how to treat that.
+        """
+        cleaned = []
+        for pid in ids or []:
+            if isinstance(pid, int) and not isinstance(pid, bool) and pid > 0:
+                cleaned.append(pid)
+        if not cleaned:
+            return {}
+        fingerprints = {}
+        # SQLite default bound-param cap is 999; 500 stays well under
+        # that and mirrors the sibling helper in import_job.
+        for start in range(0, len(cleaned), 500):
+            chunk = cleaned[start:start + 500]
+            placeholders = ",".join("?" for _ in chunk)
+            rows = db.conn.execute(
+                f"""SELECT p.id AS id,
+                           f.path AS folder_path,
+                           p.filename AS filename
+                    FROM photos p
+                    JOIN folders f ON f.id = p.folder_id
+                    WHERE p.id IN ({placeholders})""",
+                list(chunk),
+            ).fetchall()
+            for row in rows:
+                folder_path = row["folder_path"] or ""
+                filename = row["filename"] or ""
+                if not folder_path or not filename:
+                    continue
+                fingerprints[row["id"]] = f"{folder_path}/{filename}"
+        return fingerprints
+
     def _validate_parent_import_job(parent_id, active_ws, db):
         """Resolve a retry's parent_import_job_id into the scope this
         retry is allowed to inherit.
 
-        Returns ``(parent_config, allowed_ids, None)`` on success or
-        ``(None, None, error_response)`` when the parent can't be used.
-        ``parent_config`` is the parent job's persisted config dict;
-        ``allowed_ids`` is the set of photo IDs a retry may include in
-        ``carry_photo_ids`` — the parent's own imported IDs plus any
-        the parent itself inherited from an earlier retry.
+        Returns ``(parent_config, allowed_ids, allowed_fingerprints,
+        None)`` on success or ``(None, None, None, error_response)`` when
+        the parent can't be used. ``parent_config`` is the parent job's
+        persisted config dict; ``allowed_ids`` is the set of photo IDs a
+        retry may include in ``carry_photo_ids`` — the parent's own
+        imported IDs plus any the parent itself inherited from an earlier
+        retry. ``allowed_fingerprints`` maps those IDs to the stable
+        ``folder_path/filename`` recorded at parent-run time, so the
+        retry can refuse a carry ID whose current row belongs to an
+        unrelated photo that happened to reuse the numeric ID.
 
         Cross-workspace parents are refused: photos and folders live
         globally, so a caller who names a parent from another workspace
@@ -23075,7 +23117,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 (parent_id,),
             ).fetchone()
             if row is None:
-                return None, None, json_error(
+                return None, None, None, json_error(
                     "parent_import_job_id not found — the original import "
                     "may have aged out of history; start a new import",
                     404,
@@ -23091,12 +23133,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except (json.JSONDecodeError, TypeError):
                 parent_result = {}
         if parent_type != "import":
-            return None, None, json_error(
+            return None, None, None, json_error(
                 "parent_import_job_id must reference an import job "
                 f"(got type {parent_type!r})"
             )
         if parent_workspace != active_ws:
-            return None, None, json_error(
+            return None, None, None, json_error(
                 "parent_import_job_id belongs to a different workspace "
                 "than the active one; switch workspaces or start a new "
                 "import instead of retrying"
@@ -23114,7 +23156,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     and pid > 0
                 ):
                     allowed_ids.add(pid)
-        return parent_config, allowed_ids, None
+        # Stable-identity map so the retry can verify each carried ID
+        # still points at the same file. ``photos.id`` is a bare
+        # ``INTEGER PRIMARY KEY`` — SQLite is free to reuse the numeric
+        # ID after a delete, so an ID that legitimately named one of the
+        # parent's imports can later name an unrelated photo. Merges
+        # every fingerprint hop persisted alongside the ID sources
+        # above; missing keys just fall through the verify step below
+        # (legacy parents from before this fix keep working with the
+        # same integer-ID trust).
+        allowed_fingerprints = {}
+        for source in (
+            parent_result.get("photo_fingerprints") or {},
+            parent_result.get("carried_photo_fingerprints") or {},
+            parent_config.get("carry_photo_fingerprints") or {},
+        ):
+            if not isinstance(source, dict):
+                continue
+            for key, value in source.items():
+                try:
+                    pid = int(key)
+                except (TypeError, ValueError):
+                    continue
+                if pid <= 0 or not isinstance(value, str) or not value:
+                    continue
+                allowed_fingerprints.setdefault(pid, value)
+        return parent_config, allowed_ids, allowed_fingerprints, None
 
     def _validate_after_import(value, db, *, allow_missing=False):
         """Return a JSON error response for a bad after_import spec, else None.
@@ -24369,15 +24436,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         parent_id_raw = body.get("parent_import_job_id")
         parent_config = None
         parent_allowed_ids = None
+        parent_allowed_fingerprints = None
         if parent_id_raw is not None:
             if not isinstance(parent_id_raw, str) or not parent_id_raw.strip():
                 return json_error(
                     "parent_import_job_id must be a non-empty string"
                 )
-            parent_config, parent_allowed_ids, parent_err = (
-                _validate_parent_import_job(
-                    parent_id_raw.strip(), db._active_workspace_id, db,
-                )
+            (
+                parent_config,
+                parent_allowed_ids,
+                parent_allowed_fingerprints,
+                parent_err,
+            ) = _validate_parent_import_job(
+                parent_id_raw.strip(), db._active_workspace_id, db,
             )
             if parent_err is not None:
                 return parent_err
@@ -24435,6 +24506,43 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "carry_photo_ids contains IDs the parent import did "
                     f"not land or inherit: {invalid[:5]}"
                 )
+            # Stable-identity re-check for each carried ID. ``photos.id``
+            # is a bare ``INTEGER PRIMARY KEY`` — SQLite reuses freed IDs
+            # on the next insert, so an ID that legitimately named one of
+            # the parent's imports at parent-run time can, after a delete,
+            # name an unrelated photo by retry-run time. Compare each
+            # carried ID's CURRENT ``folder_path/filename`` against the
+            # fingerprint recorded when the parent landed it; refuse a
+            # mismatch rather than letting the after-import chain (and
+            # any ``after_process_move``) sweep up the unrelated row.
+            # Parents from before this fix carry no fingerprints at all
+            # (empty dict), and are exempted — hard-rejecting every
+            # legacy failed job's retry would be a bigger regression than
+            # the narrow race window this protects.
+            if parent_allowed_fingerprints:
+                current_fingerprints = _capture_photo_fingerprints_for_ids(
+                    db, carry_raw,
+                )
+                stale = []
+                for pid in carry_raw:
+                    expected = parent_allowed_fingerprints.get(pid)
+                    if expected is None:
+                        # Parent tracked fingerprints for some IDs but not
+                        # this one — an ID the parent's ``allowed_ids``
+                        # blessed but never fingerprinted (e.g. inherited
+                        # from a legacy grandparent). Accept, matching
+                        # the same rationale as the empty-dict case above.
+                        continue
+                    current = current_fingerprints.get(pid)
+                    if current != expected:
+                        stale.append(pid)
+                if stale:
+                    return json_error(
+                        "carry_photo_ids no longer matches the files the "
+                        "parent import landed (the numeric IDs now point "
+                        "at different photos, likely because the parent's "
+                        f"photos were deleted and re-imported): {stale[:5]}"
+                    )
             # Preserve caller order but deduplicate — the chain does not
             # need repeats and a giant duplicated list wastes work.
             seen_carry = set()
@@ -24630,6 +24738,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "workspace_id": active_ws,
             "created_workspace": created_workspace,
             "carry_photo_ids": carry_photo_ids,
+            # Fingerprint sidecar to carry_photo_ids so a retry-of-retry
+            # can still verify the inherited scope by stable identity
+            # even after the grandparent's job has aged out of history.
+            # Keyed by str(id) for JSON round-tripping; empty for
+            # first-attempt imports or legacy parents with no
+            # fingerprints of their own.
+            "carry_photo_fingerprints": (
+                {
+                    str(pid): parent_allowed_fingerprints[pid]
+                    for pid in (carry_photo_ids or [])
+                    if parent_allowed_fingerprints
+                    and pid in parent_allowed_fingerprints
+                }
+                if parent_allowed_fingerprints
+                else {}
+            ),
         }
         if move_target_snapshot is not None:
             job_config["after_process_move"] = {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24754,6 +24754,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if parent_allowed_fingerprints
                 else {}
             ),
+            # Persist the parent's id so the Jobs page's parallel-retry
+            # gate (``hasActiveRetryFor``) can recognize this retry as
+            # belonging to that parent and suppress a second Retry button
+            # click while this run is still in flight. Without the field
+            # on ``job_config`` the gate reads ``undefined`` on every
+            # active job, so reselecting the failed parent renders a
+            # live Retry button that would race the in-flight retry.
+            "parent_import_job_id": (
+                parent_id_raw.strip() if parent_id_raw else None
+            ),
         }
         if move_target_snapshot is not None:
             job_config["after_process_move"] = {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24593,13 +24593,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # failed files", not "Import whatever's at this path now".
         #
         # Each parent source's ``count`` + ``signature`` (sha256 over
-        # the sorted ``(rel_path, size)`` list) is captured at
-        # parent-completion time in ``import_job._capture_source_snapshots``
-        # and persisted on ``result["source_snapshots"]``. Here we
-        # recompute the current signature for every retry source that
-        # shares a path with a parent source and refuse the retry when
-        # any signature has drifted. Legacy parents from before this
-        # fix have no snapshots and fall through unchanged.
+        # the sorted ``(rel_path, size, mtime_ns)`` list) is captured
+        # at parent DISCOVERY time in
+        # ``import_job._capture_source_snapshots`` and persisted on
+        # ``result["source_snapshots"]``. ``mtime_ns`` is in the tuple
+        # so a same-size in-place replacement doesn't slip past the
+        # size check; discovery-time capture keeps a card ejected
+        # mid-copy from stamping ``-1`` sizes that would refuse a
+        # legitimate reinsert-and-retry recovery. Here we recompute
+        # the current signature for every retry source that shares a
+        # path with a parent source and refuse the retry when any
+        # signature has drifted. Legacy parents from before this fix
+        # have no snapshots and fall through unchanged.
         if parent_source_snapshots:
             from import_job import _capture_source_snapshots
             from ingest import discover_source_files

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -23040,14 +23040,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         }
 
     def _capture_photo_fingerprints_for_ids(db, ids):
-        """Return the current ``{id: "folder_path/filename"}`` for each ID.
+        """Return the current fingerprint string for each ID.
 
-        Same shape as ``import_job._capture_photo_fingerprints`` but at
+        Same shape as ``import_job._capture_photo_fingerprints`` (which
+        owns the string format via ``_fingerprint_for_row``) but at
         request time on caller-supplied IDs, so a recovery retry can
-        detect when SQLite has reused an ID for an unrelated photo since
-        the parent import ran. Missing IDs are simply absent from the
-        result — the caller decides how to treat that.
+        detect when SQLite has reused an ID for an unrelated photo
+        since the parent import ran. The fingerprint now includes
+        ``file_size`` and ``file_hash`` alongside the path, catching
+        the case where a delete-then-import put an unrelated file at
+        the same path — path alone would then match falsely and the
+        retry's after-import chain (and any ``after_process_move``)
+        would sweep up the imposter. Missing IDs are simply absent
+        from the result — the caller decides how to treat that.
         """
+        from import_job import _fingerprint_for_row
+
         cleaned = []
         for pid in ids or []:
             if isinstance(pid, int) and not isinstance(pid, bool) and pid > 0:
@@ -23063,18 +23071,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             rows = db.conn.execute(
                 f"""SELECT p.id AS id,
                            f.path AS folder_path,
-                           p.filename AS filename
+                           p.filename AS filename,
+                           p.file_size AS file_size,
+                           p.file_hash AS file_hash
                     FROM photos p
                     JOIN folders f ON f.id = p.folder_id
                     WHERE p.id IN ({placeholders})""",
                 list(chunk),
             ).fetchall()
             for row in rows:
-                folder_path = row["folder_path"] or ""
-                filename = row["filename"] or ""
-                if not folder_path or not filename:
+                fp = _fingerprint_for_row(row)
+                if fp is None:
                     continue
-                fingerprints[row["id"]] = f"{folder_path}/{filename}"
+                fingerprints[row["id"]] = fp
         return fingerprints
 
     def _validate_parent_import_job(parent_id, active_ws, db):
@@ -23082,15 +23091,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         retry is allowed to inherit.
 
         Returns ``(parent_config, allowed_ids, allowed_fingerprints,
-        None)`` on success or ``(None, None, None, error_response)`` when
-        the parent can't be used. ``parent_config`` is the parent job's
-        persisted config dict; ``allowed_ids`` is the set of photo IDs a
-        retry may include in ``carry_photo_ids`` — the parent's own
-        imported IDs plus any the parent itself inherited from an earlier
-        retry. ``allowed_fingerprints`` maps those IDs to the stable
-        ``folder_path/filename`` recorded at parent-run time, so the
-        retry can refuse a carry ID whose current row belongs to an
-        unrelated photo that happened to reuse the numeric ID.
+        parent_source_snapshots, None)`` on success or ``(None, None,
+        None, None, error_response)`` when the parent can't be used.
+        ``parent_config`` is the parent job's persisted config dict (it
+        also carries ``root_import_job_id`` when the parent is itself
+        a retry, so the caller can persist a single root pointer
+        regardless of how deep the retry chain goes); ``allowed_ids``
+        is the set of photo IDs a retry may include in
+        ``carry_photo_ids`` — the parent's own imported IDs plus any
+        the parent itself inherited from an earlier retry.
+        ``allowed_fingerprints`` maps those IDs to the stable
+        ``folder_path/filename|size|hash`` recorded at parent-run time,
+        so the retry can refuse a carry ID whose current row belongs to
+        an unrelated photo that happened to reuse the numeric ID.
+        ``parent_source_snapshots`` is the parent's
+        ``result["source_snapshots"]`` (``{source_str: {count,
+        signature}}``) so the caller can verify the retry's sources
+        still hold the same contents the parent enumerated — refusing
+        a retry against a different SD card mounted at the same path,
+        or a source whose files were edited between runs.
 
         Cross-workspace parents are refused: photos and folders live
         globally, so a caller who names a parent from another workspace
@@ -23117,7 +23136,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 (parent_id,),
             ).fetchone()
             if row is None:
-                return None, None, None, json_error(
+                return None, None, None, None, json_error(
                     "parent_import_job_id not found — the original import "
                     "may have aged out of history; start a new import",
                     404,
@@ -23133,12 +23152,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except (json.JSONDecodeError, TypeError):
                 parent_result = {}
         if parent_type != "import":
-            return None, None, None, json_error(
+            return None, None, None, None, json_error(
                 "parent_import_job_id must reference an import job "
                 f"(got type {parent_type!r})"
             )
         if parent_workspace != active_ws:
-            return None, None, None, json_error(
+            return None, None, None, None, json_error(
                 "parent_import_job_id belongs to a different workspace "
                 "than the active one; switch workspaces or start a new "
                 "import instead of retrying"
@@ -23181,7 +23200,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if pid <= 0 or not isinstance(value, str) or not value:
                     continue
                 allowed_fingerprints.setdefault(pid, value)
-        return parent_config, allowed_ids, allowed_fingerprints, None
+        parent_source_snapshots = parent_result.get("source_snapshots")
+        if not isinstance(parent_source_snapshots, dict):
+            parent_source_snapshots = None
+        return (
+            parent_config,
+            allowed_ids,
+            allowed_fingerprints,
+            parent_source_snapshots,
+            None,
+        )
 
     def _validate_after_import(value, db, *, allow_missing=False):
         """Return a JSON error response for a bad after_import spec, else None.
@@ -24437,6 +24465,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         parent_config = None
         parent_allowed_ids = None
         parent_allowed_fingerprints = None
+        parent_source_snapshots = None
         if parent_id_raw is not None:
             if not isinstance(parent_id_raw, str) or not parent_id_raw.strip():
                 return json_error(
@@ -24446,6 +24475,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 parent_config,
                 parent_allowed_ids,
                 parent_allowed_fingerprints,
+                parent_source_snapshots,
                 parent_err,
             ) = _validate_parent_import_job(
                 parent_id_raw.strip(), db._active_workspace_id, db,
@@ -24552,6 +24582,63 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     continue
                 seen_carry.add(pid)
                 carry_photo_ids.append(pid)
+
+        # A recovery retry must not silently import files the parent
+        # never saw. Without this guard a retry against a source whose
+        # contents changed since the failed run — a different SD card
+        # mounted at the same path, or new photos added to the same
+        # card — would silently enumerate every current file and copy
+        # the newly-appeared ones, then flow their IDs into the
+        # carried processing / NAS-move scope. The button says "Retry
+        # failed files", not "Import whatever's at this path now".
+        #
+        # Each parent source's ``count`` + ``signature`` (sha256 over
+        # the sorted ``(rel_path, size)`` list) is captured at
+        # parent-completion time in ``import_job._capture_source_snapshots``
+        # and persisted on ``result["source_snapshots"]``. Here we
+        # recompute the current signature for every retry source that
+        # shares a path with a parent source and refuse the retry when
+        # any signature has drifted. Legacy parents from before this
+        # fix have no snapshots and fall through unchanged.
+        if parent_source_snapshots:
+            from import_job import _capture_source_snapshots
+            from ingest import discover_source_files
+
+            drifted_sources = []
+            for src in sources:
+                parent_snap = parent_source_snapshots.get(src)
+                if not isinstance(parent_snap, dict) or not parent_snap:
+                    continue
+                # Reuse the same discovery + snapshot helpers the parent
+                # ran through so a mismatch here reflects a genuine
+                # source change, not a difference in enumeration logic.
+                try:
+                    current_files = discover_source_files(
+                        src, file_types, recursive=recursive,
+                    )
+                except Exception:
+                    log.exception(
+                        "Failed to re-enumerate source for retry snapshot "
+                        "check: %s", src,
+                    )
+                    drifted_sources.append(src)
+                    continue
+                current_snap = _capture_source_snapshots(
+                    current_files, [src],
+                ).get(src) or {}
+                if current_snap.get("signature") != parent_snap.get(
+                    "signature",
+                ):
+                    drifted_sources.append(src)
+            if drifted_sources:
+                return json_error(
+                    "The source contents have changed since the original "
+                    "import (a different SD card at the same path, or new "
+                    "or missing files). Retrying would import files the "
+                    "original run never saw. Verify the source, then "
+                    "start a new import instead of retrying: "
+                    f"{drifted_sources[:3]}"
+                )
 
         # A retry that keeps the same remote target must land on the
         # same host/root/mount as the failed run — otherwise the retry
@@ -24763,6 +24850,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # live Retry button that would race the in-flight retry.
             "parent_import_job_id": (
                 parent_id_raw.strip() if parent_id_raw else None
+            ),
+            # Root of the retry chain: the original failed import that
+            # every retry (and retry-of-retry) descends from. Persisted
+            # separately from ``parent_import_job_id`` so the Jobs page
+            # can gate parallel launches on the original selection even
+            # when the active job's direct parent is another retry.
+            # Without this a retry-of-retry's ``parent_import_job_id``
+            # points at the first retry, so reselecting the original
+            # failed import still renders a live Retry button that would
+            # race the in-flight retry. Inherits the parent's root when
+            # the parent already carries one; otherwise the parent IS
+            # the root of this chain.
+            "root_import_job_id": (
+                (parent_config.get("root_import_job_id")
+                 or parent_id_raw.strip())
+                if parent_config is not None and parent_id_raw
+                else None
             ),
         }
         if move_target_snapshot is not None:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17842,47 +17842,107 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # probe.
         from move import _tracked_destination_ancestor
         db = _get_db()
-        tracked = _tracked_destination_ancestor(db, -1, destination)
-        # The destination itself may sit above every tracked archive while the
-        # folder template still maps generated files into one — e.g.
-        # destination /Photography with a tracked root /Photography/2026 and
-        # template 2026/%Y-%m-%d lands every file inside the managed
-        # /Photography/2026 archive. Checking only the destination's ancestors
-        # leaves managed_archive None even though the import IS a merge into
-        # a tracked archive. Fall back to the concrete full_path values from
-        # preview_destination() so we catch that case, while still avoiding
-        # the sibling-folder false positive the destination-only guard was
-        # written to prevent (a broad mount whose tracked archive is a
-        # sibling of the generated folders never becomes an ancestor of any
-        # full_path).
-        if tracked is None:
-            for entry in result.get("folders") or []:
-                full_path = entry.get("full_path")
-                if not full_path:
-                    continue
-                candidate = _tracked_destination_ancestor(db, -1, full_path)
-                if candidate is not None:
-                    tracked = candidate
-                    break
-        result["managed_archive"] = None
-        if tracked:
-            from db import _subtree_prefix
-            prefix = _subtree_prefix(tracked["path"])
+        from db import _subtree_prefix
+
+        def _archive_photo_count(archive_path):
+            prefix = _subtree_prefix(archive_path)
             # Count only ok/partial folders — the same set ingest treats as
-            # "the archive" — so the callout's "N photos" matches what the merge
-            # actually considers present. Pure catalog read; no on-disk check.
-            count = db.conn.execute(
+            # "the archive" — so the callout's "N photos" matches what the
+            # merge actually considers present. Pure catalog read; no on-disk
+            # check.
+            return db.conn.execute(
                 """SELECT COUNT(*) AS c
                      FROM photos p JOIN folders f ON f.id = p.folder_id
                     WHERE (f.path = ?
                            OR substr(REPLACE(f.path, '\\', '/'), 1, ?) = ?)
                       AND f.status IN ('ok', 'partial')""",
-                (tracked["path"], len(prefix), prefix),
+                (archive_path, len(prefix), prefix),
             ).fetchone()["c"]
-            result["managed_archive"] = {
-                "path": tracked["path"],
-                "photo_count": count,
+
+        managed_archives = []
+        managed_archive = None
+
+        dest_tracked = _tracked_destination_ancestor(db, -1, destination)
+        if dest_tracked is not None:
+            # The destination itself is (or sits inside) a tracked archive, so
+            # every generated folder lands inside it — full coverage.
+            managed_archive = {
+                "path": dest_tracked["path"],
+                "photo_count": _archive_photo_count(dest_tracked["path"]),
             }
+            managed_archives = [dict(managed_archive, coverage="full")]
+        else:
+            # The destination itself may sit above every tracked archive while
+            # the folder template still maps generated files into one — e.g.
+            # destination /Photography with a tracked root /Photography/2026
+            # and template 2026/%Y-%m-%d lands every file inside the managed
+            # /Photography/2026 archive. Checking only the destination's
+            # ancestors leaves managed_archive None even though the import IS
+            # a merge into a tracked archive. Walk the concrete full_path
+            # values from preview_destination() so we catch that case, while
+            # still avoiding the sibling-folder false positive the
+            # destination-only guard was written to prevent (a broad mount
+            # whose tracked archive is a sibling of the generated folders
+            # never becomes an ancestor of any full_path).
+            #
+            # Do NOT collapse mixed coverage to a single archive. A source
+            # spanning multiple date-templated folders can split so that some
+            # generated folders land inside a tracked archive and others land
+            # outside it, or land in DIFFERENT tracked archives — for example
+            # files from 2025 and 2026 with destination /Photography, template
+            # %Y/%Y-%m-%d, and only /Photography/2026 tracked (2025 files land
+            # outside the archive), or the same source but with both
+            # /Photography/2025 and /Photography/2026 tracked (each subset
+            # lands in a different archive). Breaking at the first match and
+            # asserting "this import lands inside archive X" for the whole
+            # preview lies about the other subsets. Aggregate the matches and
+            # expose partial/multiple overlaps distinctly.
+            folder_entries = result.get("folders") or []
+            per_archive = {}  # archive_path -> matched_folder_count
+            unmatched = 0
+            considered = 0
+            for entry in folder_entries:
+                full_path = entry.get("full_path")
+                if not full_path:
+                    continue
+                considered += 1
+                candidate = _tracked_destination_ancestor(db, -1, full_path)
+                if candidate is None:
+                    unmatched += 1
+                else:
+                    key = candidate["path"]
+                    per_archive[key] = per_archive.get(key, 0) + 1
+            for archive_path, matched in per_archive.items():
+                # A single archive covers "all" generated folders only when it
+                # matched every considered entry AND nothing landed outside a
+                # tracked archive AND no other tracked archive claimed any
+                # folder. Anything else is a partial overlap for that archive.
+                full = (
+                    unmatched == 0
+                    and len(per_archive) == 1
+                    and matched == considered
+                    and considered > 0
+                )
+                managed_archives.append({
+                    "path": archive_path,
+                    "photo_count": _archive_photo_count(archive_path),
+                    "coverage": "full" if full else "partial",
+                })
+            if (
+                len(managed_archives) == 1
+                and managed_archives[0]["coverage"] == "full"
+            ):
+                managed_archive = {
+                    "path": managed_archives[0]["path"],
+                    "photo_count": managed_archives[0]["photo_count"],
+                }
+
+        result["managed_archive"] = managed_archive
+        # ``managed_archives`` is the authoritative list — the UI should
+        # prefer it so partial or multi-archive overlaps are described
+        # honestly. ``managed_archive`` stays populated only for the
+        # single-archive full-coverage case so older clients keep working.
+        result["managed_archives"] = managed_archives
         return jsonify(result)
 
     @app.route("/api/import/folder-preview/thumbnail")
@@ -23056,13 +23116,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     allowed_ids.add(pid)
         return parent_config, allowed_ids, None
 
-    def _validate_after_import(value, db):
+    def _validate_after_import(value, db, *, allow_missing=False):
         """Return a JSON error response for a bad after_import spec, else None.
 
         Shared by both import endpoints: null means import-only; a non-null
         value must be a saved-process id that exists, so chained processing
         can't fail hours later on a dangling id the enqueue step could have
-        caught.
+        caught. ``allow_missing`` waives the existence check — used by the
+        recovery-retry path when the parent import already captured a
+        frozen ``after_import_snapshot`` for this exact id, so a Settings
+        delete between the failed run and the retry no longer strands the
+        retry outright.
         """
         if value is None:
             return None
@@ -23071,7 +23135,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "after_import must be a process id or null, got "
                 f"{type(value).__name__}"
             )
-        if db.get_saved_process(value) is None:
+        if not allow_missing and db.get_saved_process(value) is None:
             return json_error(f"unknown process id: {value}")
         return None
 
@@ -24277,23 +24341,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             after_import = (
                 effective_cfg.get("pipeline", {}).get("default_process_id")
             )
-        err = _validate_after_import(after_import, db)
-        if err is not None:
-            return err
-
-        file_types = body.get("file_types", "both")
-        skip_duplicates = bool(body.get("skip_duplicates", True))
-        verify_by_hash = bool(body.get("verify_by_hash", False))
-        trust_likely_duplicates = bool(
-            body.get("trust_likely_duplicates", False)
-        ) and not verify_by_hash
-        recursive = bool(body.get("recursive", True))
-        import_tags, location_from_gps, tag_options_err = (
-            _validate_import_tag_options(body)
-        )
-        if tag_options_err is not None:
-            return tag_options_err
-
         # Recovery-retry imports carry forward the photo IDs a previous
         # attempt already landed, so the after-import chain covers the
         # complete original scope even though those files are skipped as
@@ -24312,6 +24359,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # decides which folders the NAS transfer sweeps up, potentially
         # moving folders outside the active workspace. Refuse the
         # request rather than silently permit it.
+        #
+        # Resolved BEFORE ``_validate_after_import`` so a retry whose saved
+        # process was deleted between the failed run and this retry can
+        # still start: the parent's frozen ``after_import_snapshot`` is a
+        # legitimate substitute for the deleted process's stage flags, and
+        # rejecting the retry with "unknown process id" here would strand
+        # every deleted-process retry outright.
         parent_id_raw = body.get("parent_import_job_id")
         parent_config = None
         parent_allowed_ids = None
@@ -24327,6 +24381,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             if parent_err is not None:
                 return parent_err
+
+        # Skip the "process still exists" check ONLY when the parent has a
+        # frozen snapshot for THIS exact process id — that snapshot will
+        # substitute for db.resolve_process() below. A retry that changed
+        # the process id must still go through normal existence validation.
+        parent_has_snapshot_for_after_import = (
+            parent_config is not None
+            and parent_config.get("after_import") == after_import
+            and parent_config.get("after_import_snapshot") is not None
+        )
+        err = _validate_after_import(
+            after_import, db,
+            allow_missing=parent_has_snapshot_for_after_import,
+        )
+        if err is not None:
+            return err
+
+        file_types = body.get("file_types", "both")
+        skip_duplicates = bool(body.get("skip_duplicates", True))
+        verify_by_hash = bool(body.get("verify_by_hash", False))
+        trust_likely_duplicates = bool(
+            body.get("trust_likely_duplicates", False)
+        ) and not verify_by_hash
+        recursive = bool(body.get("recursive", True))
+        import_tags, location_from_gps, tag_options_err = (
+            _validate_import_tag_options(body)
+        )
+        if tag_options_err is not None:
+            return tag_options_err
 
         carry_raw = body.get("carry_photo_ids")
         if carry_raw is None:
@@ -24411,12 +24494,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # chain hook fires the pipeline_job's actual toggles are still up
         # for grabs — resolving here freezes them (mirrors the remote-
         # transport snapshot below).
+        #
+        # A recovery retry must inherit the parent's frozen snapshot when
+        # the retry still points at the same process id: the original
+        # enqueue already froze the stages the user accepted, and
+        # resolving again would silently pick up any Settings edit made
+        # after the failure (or fail outright if the process was
+        # deleted). Re-resolve only when the retry deliberately switches
+        # to a different process id — then the user is asking for
+        # whatever that process currently is.
         after_import_snapshot = None
         if after_import is not None:
-            try:
-                after_import_snapshot = db.resolve_process(after_import)
-            except ValueError as e:
-                return json_error(str(e), 404)
+            reused_parent_snapshot = None
+            if parent_config is not None:
+                parent_after_import = parent_config.get("after_import")
+                parent_snapshot_process = (
+                    parent_config.get("after_import_snapshot")
+                )
+                if (
+                    parent_snapshot_process is not None
+                    and parent_after_import == after_import
+                ):
+                    reused_parent_snapshot = parent_snapshot_process
+            if reused_parent_snapshot is not None:
+                after_import_snapshot = reused_parent_snapshot
+            else:
+                try:
+                    after_import_snapshot = db.resolve_process(after_import)
+                except ValueError as e:
+                    return json_error(str(e), 404)
 
         # Validate the optional NAS move that chains after processing
         # completes. Requires after_import (the move fires from the process
@@ -24504,6 +24610,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "trust_likely_duplicates": trust_likely_duplicates,
             "recursive": recursive,
             "after_import": after_import,
+            # Persist the enqueue-time snapshot alongside the process id so a
+            # recovery retry can reuse the exact stages the user accepted.
+            # Without this a retry silently re-resolves the current process
+            # (an edit or delete between the failed run and the retry would
+            # otherwise change or void what runs); see the reuse block above
+            # and the corresponding remote-target snapshot handling.
+            "after_import_snapshot": after_import_snapshot,
             "tags": import_tags,
             "location_from_gps": location_from_gps,
             "allow_missing_exiftool": bool(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17732,12 +17732,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Transparency: if the destination is (or sits inside) a folder Vireo
         # already manages, surface it as an existing archive so the UI can
-        # frame the import as a merge rather than a fresh copy. Pure catalog
-        # read — no file I/O beyond the tracked-folder probe.
-        from move import _tracked_destination_ancestor, _tracked_destination_overlap
+        # frame the import as a merge rather than a fresh copy. Do NOT accept
+        # the inverse relationship (a tracked folder somewhere below the
+        # selected destination): selecting a broad mount such as
+        # /Volumes/Photography while a managed archive lives at
+        # /Volumes/Photography/Raw Files/USA does not mean a new import into
+        # /Volumes/Photography/2026 will merge into that nested archive.
+        # Calling the overlap helper here produced exactly that contradictory
+        # preview. Pure catalog read — no file I/O beyond the tracked-folder
+        # probe.
+        from move import _tracked_destination_ancestor
         db = _get_db()
-        tracked = (_tracked_destination_overlap(db, -1, destination)
-                   or _tracked_destination_ancestor(db, -1, destination))
+        tracked = _tracked_destination_ancestor(db, -1, destination)
         result["managed_archive"] = None
         if tracked:
             from db import _subtree_prefix

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -23105,10 +23105,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     # match the parent's stored value.
                     pass
                 if current_size is not None:
-                    try:
-                        current_hash = compute_file_hash(file_path)
-                    except OSError:
+                    # Match the scanner's empty-file convention: a zero-byte
+                    # file's stored ``file_hash`` is NULL (rendered as
+                    # ``h=`` in ``_fingerprint_for_row``), not the SHA-256
+                    # of empty content. Hashing it here would produce a
+                    # different fingerprint from the parent's and stall
+                    # an otherwise-valid retry of an import that had
+                    # successfully landed a zero-byte image. See PR #1387
+                    # Codex review; scanner.py resets ``file_hash`` on
+                    # ``size == 0 and hash == EMPTY_FILE_SHA256``.
+                    if current_size == 0:
                         current_hash = ""
+                    else:
+                        try:
+                            current_hash = compute_file_hash(file_path)
+                        except OSError:
+                            current_hash = ""
                 fp = _fingerprint_for_row({
                     "folder_path": folder_path,
                     "filename": filename,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24685,19 +24685,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             requested_sources = set(sources)
             unknown_sources = sorted(requested_sources - parent_sources)
             if unknown_sources:
+                unknown_source_text = ", ".join(unknown_sources[:3])
                 return json_error(
                     "Retry submitted source paths the original import "
                     "never enumerated (a different card mounted at the "
                     "same path, or a new source added): "
-                    f"{unknown_sources[:3]}. Start a new import instead "
+                    f"{unknown_source_text}. Start a new import instead "
                     "of retrying."
                 )
             missing_sources = sorted(parent_sources - requested_sources)
             if missing_sources:
+                missing_source_text = ", ".join(missing_sources[:3])
                 return json_error(
                     "A recovery retry must include every source from the "
                     "original import. These sources are missing: "
-                    f"{missing_sources[:3]}. Reconnect all original "
+                    f"{missing_source_text}. Reconnect all original "
                     "sources, or start a new import instead of retrying."
                 )
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -22596,6 +22596,105 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except Exception as e:
             return None, None, json_error(str(e))
 
+    def _remote_target_snapshot(remote_archive_config):
+        """Freeze the parts of a resolved remote target that decide where
+        files land, for retry-time comparison against the parent job.
+
+        Returns None when the current request is not a remote-archive
+        import — a retry that swapped from remote to local (or vice
+        versa) will already fail the exact-equal comparison against a
+        parent snapshot of the opposite shape. See
+        ``api_job_import_photos``'s parent_import_job_id check.
+        """
+        if remote_archive_config is None:
+            return None
+        target = remote_archive_config["target"]
+        return {
+            "host": target.get("host", ""),
+            "user": target.get("user", ""),
+            "port": int(target.get("port") or 22),
+            "remote_path": target.get("remote_path", ""),
+            "mount_path": target.get("mount_path", ""),
+            "subpath": remote_archive_config.get("subpath", ""),
+        }
+
+    def _validate_parent_import_job(parent_id, active_ws, db):
+        """Resolve a retry's parent_import_job_id into the scope this
+        retry is allowed to inherit.
+
+        Returns ``(parent_config, allowed_ids, None)`` on success or
+        ``(None, None, error_response)`` when the parent can't be used.
+        ``parent_config`` is the parent job's persisted config dict;
+        ``allowed_ids`` is the set of photo IDs a retry may include in
+        ``carry_photo_ids`` — the parent's own imported IDs plus any
+        the parent itself inherited from an earlier retry.
+
+        Cross-workspace parents are refused: photos and folders live
+        globally, so a caller who names a parent from another workspace
+        would smuggle that workspace's photos into this workspace's
+        after-import chain and (with after_process_move) its NAS
+        transfer scope. Falls through to job_history when the runner
+        has already pruned the finished job.
+        """
+        runner = app._job_runner
+        parent = runner.get(parent_id)
+        parent_config = None
+        parent_result = None
+        parent_workspace = None
+        parent_type = None
+        if parent is not None:
+            parent_config = parent.get("config") or {}
+            parent_result = parent.get("result") or {}
+            parent_workspace = parent.get("workspace_id")
+            parent_type = parent.get("type")
+        else:
+            row = db.conn.execute(
+                "SELECT type, workspace_id, config, result "
+                "FROM job_history WHERE id = ?",
+                (parent_id,),
+            ).fetchone()
+            if row is None:
+                return None, None, json_error(
+                    "parent_import_job_id not found — the original import "
+                    "may have aged out of history; start a new import",
+                    404,
+                )
+            parent_type = row["type"]
+            parent_workspace = row["workspace_id"]
+            try:
+                parent_config = json.loads(row["config"] or "{}") or {}
+            except (json.JSONDecodeError, TypeError):
+                parent_config = {}
+            try:
+                parent_result = json.loads(row["result"] or "{}") or {}
+            except (json.JSONDecodeError, TypeError):
+                parent_result = {}
+        if parent_type != "import":
+            return None, None, json_error(
+                "parent_import_job_id must reference an import job "
+                f"(got type {parent_type!r})"
+            )
+        if parent_workspace != active_ws:
+            return None, None, json_error(
+                "parent_import_job_id belongs to a different workspace "
+                "than the active one; switch workspaces or start a new "
+                "import instead of retrying"
+            )
+        allowed_ids = set()
+        for source in (
+            parent_result.get("photo_ids") or [],
+            parent_result.get("carried_photo_ids") or [],
+            parent_config.get("carry_photo_ids") or [],
+        ):
+            for pid in source:
+                if (
+                    isinstance(pid, int)
+                    and not isinstance(pid, bool)
+                    and pid > 0
+                ):
+                    allowed_ids.add(pid)
+        return parent_config, allowed_ids, None
+
     def _validate_after_import(value, db):
         """Return a JSON error response for a bad after_import spec, else None.
 
@@ -23839,6 +23938,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # complete original scope even though those files are skipped as
         # duplicates in this run. Validated at request time so a
         # malformed retry body is rejected before a job is created.
+        #
+        # ``parent_import_job_id`` binds this retry to the failed run
+        # whose scope it inherits: the server verifies the parent is an
+        # import job in the same workspace, then constrains
+        # ``carry_photo_ids`` to IDs the parent actually imported (or
+        # itself inherited from an earlier retry). Without this binding
+        # an API caller could inject arbitrary positive integers into
+        # the after-import chain scope — those IDs would then flow into
+        # ``_record_import_collection``'s scope and, with an
+        # ``after_process_move`` chain, into the folder lookup that
+        # decides which folders the NAS transfer sweeps up, potentially
+        # moving folders outside the active workspace. Refuse the
+        # request rather than silently permit it.
+        parent_id_raw = body.get("parent_import_job_id")
+        parent_config = None
+        parent_allowed_ids = None
+        if parent_id_raw is not None:
+            if not isinstance(parent_id_raw, str) or not parent_id_raw.strip():
+                return json_error(
+                    "parent_import_job_id must be a non-empty string"
+                )
+            parent_config, parent_allowed_ids, parent_err = (
+                _validate_parent_import_job(
+                    parent_id_raw.strip(), db._active_workspace_id, db,
+                )
+            )
+            if parent_err is not None:
+                return parent_err
+
         carry_raw = body.get("carry_photo_ids")
         if carry_raw is None:
             carry_photo_ids = None
@@ -23850,6 +23978,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error(
                     "carry_photo_ids must be a list of positive integers"
                 )
+            # A caller-supplied carry list must be bound to a real
+            # parent import job. See parent_import_job_id above.
+            if parent_allowed_ids is None:
+                return json_error(
+                    "carry_photo_ids requires parent_import_job_id "
+                    "(the failed import this retry inherits scope from)"
+                )
+            invalid = [pid for pid in carry_raw if pid not in parent_allowed_ids]
+            if invalid:
+                return json_error(
+                    "carry_photo_ids contains IDs the parent import did "
+                    f"not land or inherit: {invalid[:5]}"
+                )
             # Preserve caller order but deduplicate — the chain does not
             # need repeats and a giant duplicated list wastes work.
             seen_carry = set()
@@ -23859,6 +24000,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     continue
                 seen_carry.add(pid)
                 carry_photo_ids.append(pid)
+
+        # A retry that keeps the same remote target must land on the
+        # same host/root/mount as the failed run — otherwise the retry
+        # would copy the remaining files to a different NAS, or (if
+        # only the mount changed) skip prior successes based on the
+        # old catalog view while transferring failures to a new
+        # location. When the parent recorded a remote_target_snapshot,
+        # verify that the current resolution matches; refuse the retry
+        # if the target has been edited since. The Import-page and
+        # Jobs-page retry helpers both send parent_import_job_id, so
+        # both go through this check.
+        if parent_config is not None:
+            parent_snapshot = parent_config.get("remote_target_snapshot")
+            if parent_snapshot is not None:
+                current_snapshot = _remote_target_snapshot(
+                    remote_archive_config,
+                )
+                if current_snapshot != parent_snapshot:
+                    return json_error(
+                        "The remote target for the original import has "
+                        "changed (host, path, mount, or subpath differs). "
+                        "Verify Settings → Remote targets and start a new "
+                        "import instead of retrying."
+                    )
 
         # Snapshot the chosen saved process's stage flags at enqueue time
         # so a mid-import edit or delete can't silently change (or void)
@@ -23933,6 +24098,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ),
             "remote_target_id": remote_target_id or None,
             "remote_subpath": remote_subpath or None,
+            "remote_target_snapshot": _remote_target_snapshot(
+                remote_archive_config,
+            ),
             "workspace_id": active_ws,
             "created_workspace": created_workspace,
             "carry_photo_ids": carry_photo_ids,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -23046,15 +23046,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         owns the string format via ``_fingerprint_for_row``) but at
         request time on caller-supplied IDs, so a recovery retry can
         detect when SQLite has reused an ID for an unrelated photo
-        since the parent import ran. The fingerprint now includes
+        since the parent import ran. The fingerprint includes
         ``file_size`` and ``file_hash`` alongside the path, catching
         the case where a delete-then-import put an unrelated file at
         the same path — path alone would then match falsely and the
         retry's after-import chain (and any ``after_process_move``)
-        would sweep up the imposter. Missing IDs are simply absent
-        from the result — the caller decides how to treat that.
+        would sweep up the imposter.
+
+        Size and hash come from **the file on disk right now**, not the
+        catalog. When a destination file is overwritten at the same
+        path between the parent run and this retry without a rescan,
+        ``photos.file_size`` / ``photos.file_hash`` still carry the
+        parent's values — comparing two copies of the same cached row
+        would then admit the changed bytes into the retry's chain and
+        NAS-move scope. Reading the file forces a byte-identity check
+        that catches a stealth overwrite; a missing or unreadable file
+        yields empty size/hash so the fingerprint won't match the
+        parent's and the retry fails-closed. Missing IDs are simply
+        absent from the result — the caller decides how to treat that.
         """
         from import_job import _fingerprint_for_row
+        from scanner import compute_file_hash
 
         cleaned = []
         for pid in ids or []:
@@ -23071,16 +23083,38 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             rows = db.conn.execute(
                 f"""SELECT p.id AS id,
                            f.path AS folder_path,
-                           p.filename AS filename,
-                           p.file_size AS file_size,
-                           p.file_hash AS file_hash
+                           p.filename AS filename
                     FROM photos p
                     JOIN folders f ON f.id = p.folder_id
                     WHERE p.id IN ({placeholders})""",
                 list(chunk),
             ).fetchall()
             for row in rows:
-                fp = _fingerprint_for_row(row)
+                folder_path = row["folder_path"] or ""
+                filename = row["filename"] or ""
+                if not folder_path or not filename:
+                    continue
+                file_path = os.path.join(folder_path, filename)
+                current_size = None
+                current_hash = ""
+                try:
+                    current_size = os.path.getsize(file_path)
+                except OSError:
+                    # Missing / unreadable file falls through with
+                    # empty size + hash so the fingerprint won't
+                    # match the parent's stored value.
+                    pass
+                if current_size is not None:
+                    try:
+                        current_hash = compute_file_hash(file_path)
+                    except OSError:
+                        current_hash = ""
+                fp = _fingerprint_for_row({
+                    "folder_path": folder_path,
+                    "filename": filename,
+                    "file_size": current_size,
+                    "file_hash": current_hash,
+                })
                 if fp is None:
                     continue
                 fingerprints[row["id"]] = fp
@@ -24609,11 +24643,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             from import_job import _capture_source_snapshots
             from ingest import discover_source_files
 
+            # Fail-closed on retry sources the parent never enumerated:
+            # skipping validation for unknown paths would let a retry
+            # import every file at that path (no prior catalog entry
+            # gates them via ``skip_duplicates``) and stream those IDs
+            # into the after-import chain / NAS-move scope, even though
+            # the "Retry failed files" button only ever promised the
+            # parent's failed files. See PR #1387 Codex review.
+            unknown_sources = [
+                src for src in sources
+                if not isinstance(parent_source_snapshots.get(src), dict)
+                or not parent_source_snapshots.get(src)
+            ]
+            if unknown_sources:
+                return json_error(
+                    "Retry submitted source paths the original import "
+                    "never enumerated (a different card mounted at the "
+                    "same path, or a new source added): "
+                    f"{unknown_sources[:3]}. Start a new import instead "
+                    "of retrying."
+                )
+
             drifted_sources = []
             for src in sources:
                 parent_snap = parent_source_snapshots.get(src)
-                if not isinstance(parent_snap, dict) or not parent_snap:
-                    continue
                 # Reuse the same discovery + snapshot helpers the parent
                 # ran through so a mismatch here reflects a genuine
                 # source change, not a difference in enumeration logic.
@@ -25085,6 +25138,46 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     log.exception(
                         "Failed to invalidate missing-originals cache "
                         "after import-photos job",
+                    )
+
+        # Server-side retry-exclusivity gate: refuse a retry whose
+        # root ancestor already has an active retry in flight, even
+        # when the Jobs-page UI gate was bypassed (two tabs, a stale
+        # UI that didn't observe the sibling retry yet, or a direct
+        # API caller). Without this an overlapping retry can enqueue
+        # a second import against the same source and destination and
+        # race the chained after-import / NAS move against the first
+        # one. Runs after all snapshot validation so a rejected
+        # request costs no worker thread. Best-effort against
+        # exact-simultaneous starts — ``list_jobs`` releases the
+        # runner lock before ``start`` takes it — which is acceptable
+        # for the double-click / two-tab case this fix targets; the
+        # follow-up work is to fold both under one runner-side call.
+        # See PR #1387 Codex review.
+        retry_root = job_config.get("root_import_job_id")
+        if retry_root:
+            for other in runner.list_jobs():
+                if other.get("type") != "import":
+                    continue
+                if other.get("status") not in ("queued", "running", "paused"):
+                    continue
+                other_cfg = other.get("config") or {}
+                other_root = (
+                    other_cfg.get("root_import_job_id")
+                    or other_cfg.get("parent_import_job_id")
+                )
+                # Only reject a competing RETRY — one whose own
+                # ancestry root matches ours. The failed parent itself
+                # (still in ``_jobs`` briefly after finishing) has no
+                # ancestry field so it never matches here, letting the
+                # first retry through. The parent's own liveness is
+                # gated separately by ``_validate_parent_import_job``.
+                if other_root and other_root == retry_root:
+                    return json_error(
+                        "Another retry for the same failed import is "
+                        "already in flight; wait for it to finish "
+                        "before starting a new one.",
+                        409,
                     )
 
         job_id = runner.start(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17744,6 +17744,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from move import _tracked_destination_ancestor
         db = _get_db()
         tracked = _tracked_destination_ancestor(db, -1, destination)
+        # The destination itself may sit above every tracked archive while the
+        # folder template still maps generated files into one — e.g.
+        # destination /Photography with a tracked root /Photography/2026 and
+        # template 2026/%Y-%m-%d lands every file inside the managed
+        # /Photography/2026 archive. Checking only the destination's ancestors
+        # leaves managed_archive None even though the import IS a merge into
+        # a tracked archive. Fall back to the concrete full_path values from
+        # preview_destination() so we catch that case, while still avoiding
+        # the sibling-folder false positive the destination-only guard was
+        # written to prevent (a broad mount whose tracked archive is a
+        # sibling of the generated folders never becomes an ancestor of any
+        # full_path).
+        if tracked is None:
+            for entry in result.get("folders") or []:
+                full_path = entry.get("full_path")
+                if not full_path:
+                    continue
+                candidate = _tracked_destination_ancestor(db, -1, full_path)
+                if candidate is not None:
+                    tracked = candidate
+                    break
         result["managed_archive"] = None
         if tracked:
             from db import _subtree_prefix

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -23170,14 +23170,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         parent_result = None
         parent_workspace = None
         parent_type = None
+        parent_status = None
         if parent is not None:
             parent_config = parent.get("config") or {}
             parent_result = parent.get("result") or {}
             parent_workspace = parent.get("workspace_id")
             parent_type = parent.get("type")
+            parent_status = parent.get("status")
         else:
             row = db.conn.execute(
-                "SELECT type, workspace_id, config, result "
+                "SELECT type, status, workspace_id, config, result "
                 "FROM job_history WHERE id = ?",
                 (parent_id,),
             ).fetchone()
@@ -23188,6 +23190,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     404,
                 )
             parent_type = row["type"]
+            parent_status = row["status"]
             parent_workspace = row["workspace_id"]
             try:
                 parent_config = json.loads(row["config"] or "{}") or {}
@@ -23201,6 +23204,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return None, None, None, None, json_error(
                 "parent_import_job_id must reference an import job "
                 f"(got type {parent_type!r})"
+            )
+        if parent_status not in {"completed", "failed", "cancelled"}:
+            return None, None, None, None, json_error(
+                "parent_import_job_id is still active "
+                f"(status {parent_status!r}); wait for the original import "
+                "to finish before retrying",
+                409,
             )
         if parent_workspace != active_ws:
             return None, None, None, None, json_error(
@@ -24517,6 +24527,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error(
                     "parent_import_job_id must be a non-empty string"
                 )
+            if "new_workspace_name" in body:
+                return json_error(
+                    "A recovery retry cannot create a new workspace; "
+                    "retry in the original import's workspace or start "
+                    "a new import instead."
+                )
             (
                 parent_config,
                 parent_allowed_ids,
@@ -24662,11 +24678,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # into the after-import chain / NAS-move scope, even though
             # the "Retry failed files" button only ever promised the
             # parent's failed files. See PR #1387 Codex review.
-            unknown_sources = [
-                src for src in sources
-                if not isinstance(parent_source_snapshots.get(src), dict)
-                or not parent_source_snapshots.get(src)
-            ]
+            parent_sources = {
+                src for src, snapshot in parent_source_snapshots.items()
+                if isinstance(snapshot, dict) and snapshot
+            }
+            requested_sources = set(sources)
+            unknown_sources = sorted(requested_sources - parent_sources)
             if unknown_sources:
                 return json_error(
                     "Retry submitted source paths the original import "
@@ -24674,6 +24691,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "same path, or a new source added): "
                     f"{unknown_sources[:3]}. Start a new import instead "
                     "of retrying."
+                )
+            missing_sources = sorted(parent_sources - requested_sources)
+            if missing_sources:
+                return json_error(
+                    "A recovery retry must include every source from the "
+                    "original import. These sources are missing: "
+                    f"{missing_sources[:3]}. Reconnect all original "
+                    "sources, or start a new import instead of retrying."
                 )
 
             drifted_sources = []

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -25196,7 +25196,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             for other in runner.list_jobs():
                 if other.get("type") != "import":
                     continue
-                if other.get("status") not in ("queued", "running", "paused"):
+                # ``pausing`` is a live status: ``pause_job`` publishes
+                # it immediately, but the worker keeps running until it
+                # reaches ``is_cancelled`` and only then flips to
+                # ``paused``. Treating ``pausing`` as inactive would let a
+                # second retry slip in during that window and race the
+                # first one's chained processing / NAS move.
+                if other.get("status") not in (
+                    "queued", "running", "pausing", "paused",
+                ):
                     continue
                 other_cfg = other.get("config") or {}
                 other_root = (

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -22956,6 +22956,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "subpath": remote_archive_config.get("subpath", ""),
         }
 
+    def _move_target_snapshot(target):
+        """Freeze the parts of a chained after_process_move target that
+        decide where files land, for retry-time comparison.
+
+        ``local_archive_root`` and ``mount_path`` set the local staging
+        →NAS boundary the move sweeps across; ``host``/``user``/
+        ``port``/``remote_path`` set where the NAS transfer actually
+        lands. All are captured so any Settings edit that would
+        redirect the chained move triggers a decline on retry. Returns
+        None when no chained-move target is present.
+        """
+        if target is None:
+            return None
+        return {
+            "id": target.get("id", ""),
+            "host": target.get("host", ""),
+            "user": target.get("user", ""),
+            "port": int(target.get("port") or 22),
+            "remote_path": target.get("remote_path", ""),
+            "mount_path": target.get("mount_path", ""),
+            "local_archive_root": target.get("local_archive_root", ""),
+        }
+
     def _validate_parent_import_job(parent_id, active_ws, db):
         """Resolve a retry's parent_import_job_id into the scope this
         retry is allowed to inherit.
@@ -24351,6 +24374,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # both go through this check.
         if parent_config is not None:
             parent_snapshot = parent_config.get("remote_target_snapshot")
+            parent_remote_target_id = parent_config.get("remote_target_id")
             if parent_snapshot is not None:
                 current_snapshot = _remote_target_snapshot(
                     remote_archive_config,
@@ -24362,6 +24386,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "Verify Settings → Remote targets and start a new "
                         "import instead of retrying."
                     )
+            elif parent_remote_target_id:
+                # Parent job was a remote import from before the
+                # snapshot check landed, so its persisted config
+                # records only the target ID. Both retry helpers
+                # reconstruct the request from that ID, and
+                # ``_resolve_remote_archive_target`` then walks the
+                # CURRENT Settings entry — a Settings edit since the
+                # original run would silently redirect the transfer
+                # to a different host/root/mount. Refuse the retry
+                # instead of trusting the current resolution.
+                return json_error(
+                    "The original remote import predates the recovery-"
+                    "retry safety check (no remote-target snapshot was "
+                    "recorded). Verify Settings → Remote targets still "
+                    "point at the intended host, then start a new "
+                    "import instead of retrying."
+                )
 
         # Snapshot the chosen saved process's stage flags at enqueue time
         # so a mid-import edit or delete can't silently change (or void)
@@ -24388,6 +24429,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         if move_err is not None:
             return move_err
+
+        # A retry with a chained NAS move must land on the same
+        # host/root/mount as the parent. When the parent recorded a
+        # ``target_snapshot`` for the chained target, verify the
+        # currently-resolved target matches — a Settings edit since
+        # enqueue-time could otherwise silently redirect the chained
+        # transfer even though the primary snapshot check above
+        # accepted the request. When the parent had a chained move but
+        # no snapshot (predates this check), refuse rather than trust
+        # the current resolution — same reasoning as the primary
+        # remote-target legacy check.
+        if parent_config is not None:
+            parent_move_cfg = parent_config.get("after_process_move") or {}
+            parent_move_snapshot = parent_move_cfg.get("target_snapshot")
+            parent_move_target_id = parent_move_cfg.get("remote_target_id")
+            if parent_move_snapshot is not None:
+                current_move_snapshot = _move_target_snapshot(
+                    move_target_snapshot,
+                )
+                if current_move_snapshot != parent_move_snapshot:
+                    return json_error(
+                        "The chained NAS-move target for the original "
+                        "import has changed (host, path, mount, or archive "
+                        "root differs). Verify Settings → Remote targets "
+                        "and start a new import instead of retrying."
+                    )
+            elif parent_move_target_id:
+                return json_error(
+                    "The original import's chained NAS-move target "
+                    "predates the recovery-retry safety check (no target "
+                    "snapshot was recorded). Verify Settings → Remote "
+                    "targets still point at the intended host, then start "
+                    "a new import instead of retrying."
+                )
 
         active_ws, created_workspace, workspace_err = (
             _prepare_import_workspace(db, body)
@@ -24447,6 +24522,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             job_config["after_process_move"] = {
                 "remote_target_id": move_target_snapshot["id"],
                 "target_name": move_target_snapshot["name"],
+                # Persisted alongside the id so a recovery retry can
+                # detect a Settings edit that would redirect the
+                # chained transfer to a different host or root.
+                # Parallels ``remote_target_snapshot`` for the primary
+                # remote destination. See the parent-verification
+                # block above.
+                "target_snapshot": _move_target_snapshot(
+                    move_target_snapshot,
+                ),
             }
 
         def _chain_after_import(job, result):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -22925,16 +22925,41 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return collection_id, collection_name
 
-    def _record_import_collection(result, workspace_id):
-        """Attach a collection to a complete, successful import result."""
-        photo_ids = result.get("photo_ids") or []
-        if not result.get("ok") or result.get("cancelled") or not photo_ids:
+    def _record_import_collection(result, workspace_id, chain_photo_ids=None):
+        """Attach a collection to a complete, successful import result.
+
+        ``chain_photo_ids`` optionally extends the collection scope beyond
+        the files newly imported by this run. Recovery-retry imports pass
+        the photo IDs earlier attempts already landed so the after-import
+        chain processes the complete original scope instead of only the
+        newly-recovered files. The carry list is recorded on the result as
+        ``carried_photo_ids`` for transparency; ``result["photo_ids"]``
+        keeps meaning "files this run imported", so downstream counters
+        and retry helpers don't double-count on repeated retries.
+        """
+        photo_ids = list(result.get("photo_ids") or [])
+        seen = set(photo_ids)
+        carried = []
+        if chain_photo_ids:
+            for pid in chain_photo_ids:
+                if pid in seen:
+                    continue
+                seen.add(pid)
+                carried.append(pid)
+        if carried:
+            result["carried_photo_ids"] = carried
+        collection_ids = photo_ids + carried
+        if (
+            not result.get("ok")
+            or result.get("cancelled")
+            or not collection_ids
+        ):
             return None, None
         try:
             thread_db = Database(db_path)
             thread_db.set_active_workspace(workspace_id)
             collection_id, collection_name = _create_import_collection(
-                thread_db, photo_ids,
+                thread_db, collection_ids,
             )
             result["collection_id"] = collection_id
             result["collection_name"] = collection_name
@@ -23141,7 +23166,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
                 return
 
-            thread_db, col_id = _record_import_collection(result, active_ws)
+            carry_photo_ids = list(
+                (job.get("config") or {}).get("carry_photo_ids") or []
+            )
+            thread_db, col_id = _record_import_collection(
+                result, active_ws, chain_photo_ids=carry_photo_ids,
+            )
+            chain_scope = photo_ids + list(
+                result.get("carried_photo_ids") or []
+            )
 
             if after_import is None:
                 result["after_import_skipped"] = "import-only"
@@ -23152,7 +23185,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if result.get("cancelled"):
                 result["after_import_skipped"] = "import cancelled"
                 return
-            if not photo_ids:
+            if not chain_scope:
                 result["after_import_skipped"] = "no photos"
                 return
             if col_id is None:
@@ -23801,6 +23834,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if tag_options_err is not None:
             return tag_options_err
 
+        # Recovery-retry imports carry forward the photo IDs a previous
+        # attempt already landed, so the after-import chain covers the
+        # complete original scope even though those files are skipped as
+        # duplicates in this run. Validated at request time so a
+        # malformed retry body is rejected before a job is created.
+        carry_raw = body.get("carry_photo_ids")
+        if carry_raw is None:
+            carry_photo_ids = None
+        else:
+            if not isinstance(carry_raw, list) or not all(
+                isinstance(x, int) and not isinstance(x, bool) and x > 0
+                for x in carry_raw
+            ):
+                return json_error(
+                    "carry_photo_ids must be a list of positive integers"
+                )
+            # Preserve caller order but deduplicate — the chain does not
+            # need repeats and a giant duplicated list wastes work.
+            seen_carry = set()
+            carry_photo_ids = []
+            for pid in carry_raw:
+                if pid in seen_carry:
+                    continue
+                seen_carry.add(pid)
+                carry_photo_ids.append(pid)
+
         # Snapshot the chosen saved process's stage flags at enqueue time
         # so a mid-import edit or delete can't silently change (or void)
         # the after-import run the user already accepted. An archive-copy
@@ -23876,6 +23935,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "remote_subpath": remote_subpath or None,
             "workspace_id": active_ws,
             "created_workspace": created_workspace,
+            "carry_photo_ids": carry_photo_ids,
         }
         if move_target_snapshot is not None:
             job_config["after_process_move"] = {
@@ -23892,7 +23952,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             photos gets one, including the import-only choice.
             """
             photo_ids = result.get("photo_ids") or []
-            thread_db, col_id = _record_import_collection(result, active_ws)
+            carry_photo_ids = list(
+                (job.get("config") or {}).get("carry_photo_ids") or []
+            )
+            thread_db, col_id = _record_import_collection(
+                result, active_ws, chain_photo_ids=carry_photo_ids,
+            )
+            # Recovery-retry imports may carry forward files earlier
+            # attempts landed. The original failed run skipped its
+            # after-import chain because ``ok`` was False, so those files
+            # were never processed. Roll them into the chain scope now so
+            # the collection AND the folder-based after-move both cover
+            # the complete original import, not just the newly-recovered
+            # files. ``carried_photo_ids`` on the result is the validated
+            # subset actually included, so a stale ID never leaks into
+            # this scope.
+            chain_scope = photo_ids + list(
+                result.get("carried_photo_ids") or []
+            )
 
             if after_import is None:
                 result["after_import_skipped"] = "import-only"
@@ -23903,7 +23980,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if result.get("cancelled"):
                 result["after_import_skipped"] = "import cancelled"
                 return
-            if not photo_ids:
+            if not chain_scope:
                 result["after_import_skipped"] = "no new photos"
                 return
             if col_id is None:
@@ -23918,13 +23995,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # non-nested set: moving an ancestor also moves its
                 # descendants. The target itself is the enqueue-time
                 # snapshot, so a Settings edit mid-chain can't redirect the
-                # move.
+                # move. Uses ``chain_scope`` so a recovery retry moves the
+                # folders holding the original run's successful files too.
                 after_move = None
                 if move_target_snapshot is not None:
                     from import_chain import minimal_move_set
                     folder_rows = []
-                    for i in range(0, len(photo_ids), 500):
-                        chunk = photo_ids[i:i + 500]
+                    for i in range(0, len(chain_scope), 500):
+                        chunk = chain_scope[i:i + 500]
                         ph = ",".join("?" * len(chunk))
                         folder_rows.extend(thread_db.conn.execute(
                             "SELECT DISTINCT f.id, f.path FROM photos p "

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -130,12 +130,25 @@ def _capture_source_snapshots(files, sources):
     files the user's original import never saw.
 
     Signature is a sha256 over the sorted ``(relative_posix_path,
-    size)`` list of files under each source root; a healthy file
-    reports its ``st_size`` byte count, an unreadable file renders as
-    ``-1`` so a stat failure produces a distinct signature from a
-    successful stat at the same path. Files not under a source root
-    (empty in practice — discovery only yields paths under the source)
-    are skipped.
+    size, mtime_ns)`` list of files under each source root; a healthy
+    file reports its ``st_size`` and ``st_mtime_ns``, an unreadable
+    file renders both as ``-1`` so a stat failure produces a distinct
+    signature from a successful stat at the same path. ``st_mtime_ns``
+    is included alongside size so a same-size in-place replacement
+    (edit that preserves byte count, or a rewritten SD-card file at
+    the identical path and length) is caught by the drift check —
+    ``size`` alone would treat it as unchanged and let the retry copy
+    the new bytes as if they were the parent's failed files. Files
+    not under a source root (empty in practice — discovery only yields
+    paths under the source) are skipped.
+
+    Called from the import job at DISCOVERY time, before any copy work
+    starts, so the persisted snapshot reflects the source as the
+    parent first observed it. Snapshotting at completion time instead
+    would let a card ejected or momentarily unreadable mid-copy record
+    ``-1`` for successfully-discovered files, then refuse the natural
+    "reinsert the card and retry" recovery even though the source is
+    unchanged.
     """
     if not sources:
         return {}
@@ -150,10 +163,13 @@ def _capture_source_snapshots(files, sources):
             except ValueError:
                 continue
             try:
-                size = f.stat().st_size
+                st = f.stat()
+                size = st.st_size
+                mtime_ns = st.st_mtime_ns
             except OSError:
                 size = -1
-            entries.append((rel.as_posix(), size))
+                mtime_ns = -1
+            entries.append((rel.as_posix(), size, mtime_ns))
         entries.sort()
         payload = json.dumps(entries, separators=(",", ":"))
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
@@ -790,6 +806,14 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             onerror=_discovery_onerror,
         ))
     discovered = len(files)
+
+    # Snapshot the discovered source metadata NOW — before any copy work
+    # or duplicate hashing — so a card ejected or momentarily unreadable
+    # mid-run doesn't backfill ``-1`` sizes for files we successfully
+    # enumerated. Reinserting the card and retrying is a common recovery
+    # workflow, and the retry-side signature check must have a snapshot
+    # taken from the source as-observed at run start to accept it.
+    source_snapshots = _capture_source_snapshots(files, params.sources)
 
     checker = None
     if params.skip_duplicates:
@@ -2126,10 +2150,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # recovery retry can detect a source whose contents changed
         # between the failed run and the retry — e.g. a different SD
         # card mounted at the same path, or new photos added to the
-        # same card. See ``_capture_source_snapshots`` for the format.
-        "source_snapshots": _capture_source_snapshots(
-            files, params.sources,
-        ),
+        # same card. Captured at DISCOVERY time (see the ``source_snapshots``
+        # assignment above the copy loop); recording it here instead
+        # would let a mid-copy card ejection stamp ``-1`` sizes and
+        # refuse a legitimate reinsert-and-retry recovery.
+        "source_snapshots": source_snapshots,
         "skipped_duplicate": skipped_duplicate,
         "unverified_duplicate": unverified_duplicate,
         "unverified_duplicates_only": unverified_duplicates_only,
@@ -2293,6 +2318,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             onerror=_discovery_onerror,
         ))
     discovered = len(files)
+
+    # Snapshot the discovered source metadata NOW — before any copy work
+    # or duplicate hashing — so a card ejected or momentarily unreadable
+    # mid-run doesn't backfill ``-1`` sizes for files we successfully
+    # enumerated. Reinserting the card and retrying is a common recovery
+    # workflow, and the retry-side signature check must have a snapshot
+    # taken from the source as-observed at run start to accept it.
+    source_snapshots = _capture_source_snapshots(files, params.sources)
 
     checker = None
     if params.skip_duplicates:
@@ -3544,10 +3577,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # recovery retry can detect a source whose contents changed
         # between the failed run and the retry — e.g. a different SD
         # card mounted at the same path, or new photos added to the
-        # same card. See ``_capture_source_snapshots`` for the format.
-        "source_snapshots": _capture_source_snapshots(
-            files, params.sources,
-        ),
+        # same card. Captured at DISCOVERY time (see the ``source_snapshots``
+        # assignment above the copy loop); recording it here instead
+        # would let a mid-copy card ejection stamp ``-1`` sizes and
+        # refuse a legitimate reinsert-and-retry recovery.
+        "source_snapshots": source_snapshots,
         "skipped_duplicate": skipped_duplicate,
         "unverified_duplicate": unverified_duplicate,
         "unverified_duplicates_only": unverified_duplicates_only,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -113,6 +113,57 @@ def _invalidate_new_images(db, root):
 IMPORT_BATCH_SIZE = 200
 
 
+def _capture_photo_fingerprints(db, photo_ids):
+    """Capture ``{id: "folder_path/filename"}`` for each landed photo.
+
+    Persisted in the import result so a retry can verify each carried ID
+    is still the same file. ``photos.id`` is an ``INTEGER PRIMARY KEY``
+    without ``AUTOINCREMENT``, so a delete-then-import cycle can reuse
+    an ID for an unrelated photo; without a stable-identity check the
+    retry's after-import chain (and any ``after_process_move``) would
+    silently pick up that unrelated row. Full path is the fingerprint
+    because photos share a ``UNIQUE(folder_id, filename)`` constraint
+    and ``folders.path`` is itself ``UNIQUE`` — two files cannot share
+    a full path in the catalog. Keys are stringified for JSON storage.
+    """
+    if not photo_ids:
+        return {}
+    fingerprints = {}
+    for chunk in _chunks(sorted(int(pid) for pid in photo_ids)):
+        placeholders = ",".join("?" for _ in chunk)
+        rows = db.conn.execute(
+            f"""SELECT p.id AS id, f.path AS folder_path, p.filename AS filename
+                FROM photos p
+                JOIN folders f ON f.id = p.folder_id
+                WHERE p.id IN ({placeholders})""",
+            list(chunk),
+        ).fetchall()
+        for row in rows:
+            folder_path = row["folder_path"] or ""
+            filename = row["filename"] or ""
+            if not folder_path or not filename:
+                continue
+            fingerprints[str(row["id"])] = f"{folder_path}/{filename}"
+    return fingerprints
+
+
+def _chunks(items, size=500):
+    """Yield ``items`` split into lists of up to ``size`` elements.
+
+    Kept module-private so callers here don't reach into ``db._chunks``.
+    500 keeps well under SQLite's default 999 bound-parameter cap while
+    holding fingerprint round-trips to one per few hundred photos.
+    """
+    buf = []
+    for item in items:
+        buf.append(item)
+        if len(buf) >= size:
+            yield buf
+            buf = []
+    if buf:
+        yield buf
+
+
 # Case-folded matching is unconditional on darwin/win32 (the OS enforces
 # case-insensitive filesystems). On Linux we probe each source's actual
 # filesystem: a FAT/exFAT/NTFS-mounted SD card is case-insensitive even
@@ -1986,6 +2037,15 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # the local path. Without this the remote import always missed
         # after-import processing. See PR #1113 review.
         "photo_ids": sorted(imported_photo_ids),
+        # Stable-identity map so a recovery retry can verify each carried
+        # ID still points at the same file. Without this the retry
+        # authorizes any current photo row that happens to share an ID
+        # with something the parent landed — an especially real risk
+        # after users delete recent imports (SQLite reuses the freed
+        # IDs on the next insert).
+        "photo_fingerprints": _capture_photo_fingerprints(
+            db, imported_photo_ids,
+        ),
         "skipped_duplicate": skipped_duplicate,
         "unverified_duplicate": unverified_duplicate,
         "unverified_duplicates_only": unverified_duplicates_only,
@@ -3387,6 +3447,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         "copied": copied,
         "verified": verified,
         "photo_ids": sorted(imported_photo_ids),
+        # Stable-identity map so a recovery retry can verify each carried
+        # ID still points at the same file. Without this the retry
+        # authorizes any current photo row that happens to share an ID
+        # with something the parent landed — an especially real risk
+        # after users delete recent imports (SQLite reuses the freed
+        # IDs on the next insert).
+        "photo_fingerprints": _capture_photo_fingerprints(
+            db, imported_photo_ids,
+        ),
         "skipped_duplicate": skipped_duplicate,
         "unverified_duplicate": unverified_duplicate,
         "unverified_duplicates_only": unverified_duplicates_only,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -156,11 +156,24 @@ def _capture_source_snapshots(files, sources):
     for src in sources:
         src_path = Path(src)
         src_str = str(src)
-        entries = []
+        # Deduplicate by relative path so overlapping sources (a case the
+        # Import page explicitly supports — e.g. selecting both ``/card``
+        # and ``/card/DCIM``) don't double-count nested files. The combined
+        # ``files`` list contains each nested file twice (once from each
+        # enumeration), so a plain append would put two identical entries
+        # in this source's snapshot; the retry re-enumerates each source
+        # alone and produces one entry per file, so the parent's doubled
+        # snapshot would refuse an unchanged card. Keying by ``rel.as_posix()``
+        # collapses the twin discoveries into the single-source view retry
+        # validation reconstructs. See PR #1387 Codex review.
+        entries_by_rel = {}
         for f in files:
             try:
                 rel = f.relative_to(src_path)
             except ValueError:
+                continue
+            rel_str = rel.as_posix()
+            if rel_str in entries_by_rel:
                 continue
             try:
                 st = f.stat()
@@ -169,8 +182,8 @@ def _capture_source_snapshots(files, sources):
             except OSError:
                 size = -1
                 mtime_ns = -1
-            entries.append((rel.as_posix(), size, mtime_ns))
-        entries.sort()
+            entries_by_rel[rel_str] = (rel_str, size, mtime_ns)
+        entries = sorted(entries_by_rel.values())
         payload = json.dumps(entries, separators=(",", ":"))
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         snapshots[src_str] = {"count": len(entries), "signature": digest}

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -52,6 +52,8 @@ Reconnaissance notes (Task 2.0, verified 2026-07-04):
 
 import contextlib
 import errno
+import hashlib
+import json
 import logging
 import os
 import posixpath
@@ -59,6 +61,7 @@ import shutil
 import sys
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 
 # POSIX advisory lock used by the hardlinkless-FS promote fallback (see
 # copy_and_hash_verify below). Unavailable on Windows; Vireo targets
@@ -113,18 +116,88 @@ def _invalidate_new_images(db, root):
 IMPORT_BATCH_SIZE = 200
 
 
+def _capture_source_snapshots(files, sources):
+    """Return ``{source_str: {"count": N, "signature": HEX}}`` per source.
+
+    Persisted in the import result so a recovery retry can verify each
+    source's file set still matches what the parent ran against. Without
+    this check, retrying against ``/mnt/card`` after the card was
+    ejected and a different one mounted at the same path would silently
+    import every file on the new card (they have no prior catalog
+    entry, so ``skip_duplicates`` doesn't gate them). Files added to
+    the same card between the failed run and the retry produce the
+    same mismatch — the "Retry failed files" button should not import
+    files the user's original import never saw.
+
+    Signature is a sha256 over the sorted ``(relative_posix_path,
+    size)`` list of files under each source root; a healthy file
+    reports its ``st_size`` byte count, an unreadable file renders as
+    ``-1`` so a stat failure produces a distinct signature from a
+    successful stat at the same path. Files not under a source root
+    (empty in practice — discovery only yields paths under the source)
+    are skipped.
+    """
+    if not sources:
+        return {}
+    snapshots = {}
+    for src in sources:
+        src_path = Path(src)
+        src_str = str(src)
+        entries = []
+        for f in files:
+            try:
+                rel = f.relative_to(src_path)
+            except ValueError:
+                continue
+            try:
+                size = f.stat().st_size
+            except OSError:
+                size = -1
+            entries.append((rel.as_posix(), size))
+        entries.sort()
+        payload = json.dumps(entries, separators=(",", ":"))
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        snapshots[src_str] = {"count": len(entries), "signature": digest}
+    return snapshots
+
+
+def _fingerprint_for_row(row):
+    """Format one photo row into a stable identity string.
+
+    Format: ``folder_path/filename|s=SIZE|h=HASH``. Path alone is not
+    enough: SQLite is free to reuse a freed ``photos.id`` on the next
+    insert, so a delete-then-import cycle can put an unrelated file at
+    the same path under the same numeric ID. ``file_size`` (always
+    populated by the copy pass) and ``file_hash`` (populated by
+    ``scanner.scan`` after the copy verifies) together identify the
+    file's bytes; a genuine retry sees identical values, a same-path
+    imposter almost never does. Missing hash/size render as empty
+    segments so the format stays comparable between parent-capture time
+    and retry-verify time even when the scanner hasn't stamped a hash
+    (both sides observe the same NULL and match). Returns ``None`` when
+    the row is missing the path fields the retry needs to compare
+    against.
+    """
+    folder_path = row["folder_path"] or ""
+    filename = row["filename"] or ""
+    if not folder_path or not filename:
+        return None
+    size = row["file_size"]
+    file_hash = row["file_hash"] or ""
+    size_str = "" if size is None else str(size)
+    return f"{folder_path}/{filename}|s={size_str}|h={file_hash}"
+
+
 def _capture_photo_fingerprints(db, photo_ids):
-    """Capture ``{id: "folder_path/filename"}`` for each landed photo.
+    """Capture ``{id: fingerprint_string}`` for each landed photo.
 
     Persisted in the import result so a retry can verify each carried ID
     is still the same file. ``photos.id`` is an ``INTEGER PRIMARY KEY``
     without ``AUTOINCREMENT``, so a delete-then-import cycle can reuse
     an ID for an unrelated photo; without a stable-identity check the
     retry's after-import chain (and any ``after_process_move``) would
-    silently pick up that unrelated row. Full path is the fingerprint
-    because photos share a ``UNIQUE(folder_id, filename)`` constraint
-    and ``folders.path`` is itself ``UNIQUE`` — two files cannot share
-    a full path in the catalog. Keys are stringified for JSON storage.
+    silently pick up that unrelated row. See ``_fingerprint_for_row``
+    for the string format. Keys are stringified for JSON storage.
     """
     if not photo_ids:
         return {}
@@ -132,18 +205,21 @@ def _capture_photo_fingerprints(db, photo_ids):
     for chunk in _chunks(sorted(int(pid) for pid in photo_ids)):
         placeholders = ",".join("?" for _ in chunk)
         rows = db.conn.execute(
-            f"""SELECT p.id AS id, f.path AS folder_path, p.filename AS filename
+            f"""SELECT p.id AS id,
+                       f.path AS folder_path,
+                       p.filename AS filename,
+                       p.file_size AS file_size,
+                       p.file_hash AS file_hash
                 FROM photos p
                 JOIN folders f ON f.id = p.folder_id
                 WHERE p.id IN ({placeholders})""",
             list(chunk),
         ).fetchall()
         for row in rows:
-            folder_path = row["folder_path"] or ""
-            filename = row["filename"] or ""
-            if not folder_path or not filename:
+            fp = _fingerprint_for_row(row)
+            if fp is None:
                 continue
-            fingerprints[str(row["id"])] = f"{folder_path}/{filename}"
+            fingerprints[str(row["id"])] = fp
     return fingerprints
 
 
@@ -2046,6 +2122,14 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         "photo_fingerprints": _capture_photo_fingerprints(
             db, imported_photo_ids,
         ),
+        # Per-source signature over the discovered file set so a
+        # recovery retry can detect a source whose contents changed
+        # between the failed run and the retry — e.g. a different SD
+        # card mounted at the same path, or new photos added to the
+        # same card. See ``_capture_source_snapshots`` for the format.
+        "source_snapshots": _capture_source_snapshots(
+            files, params.sources,
+        ),
         "skipped_duplicate": skipped_duplicate,
         "unverified_duplicate": unverified_duplicate,
         "unverified_duplicates_only": unverified_duplicates_only,
@@ -3455,6 +3539,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # IDs on the next insert).
         "photo_fingerprints": _capture_photo_fingerprints(
             db, imported_photo_ids,
+        ),
+        # Per-source signature over the discovered file set so a
+        # recovery retry can detect a source whose contents changed
+        # between the failed run and the retry — e.g. a different SD
+        # card mounted at the same path, or new photos added to the
+        # same card. See ``_capture_source_snapshots`` for the format.
+        "source_snapshots": _capture_source_snapshots(
+            files, params.sources,
         ),
         "skipped_duplicate": skipped_duplicate,
         "unverified_duplicate": unverified_duplicate,

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -3042,6 +3042,19 @@ async function retryFailedImport() {
   button.disabled = true;
   button.textContent = 'Starting retry…';
   hint.textContent = 'Already imported files will be skipped.';
+  // Flip the in-flight flag BEFORE the retry request goes out — not after
+  // its response arrives. Retry validation synchronously re-enumerates
+  // sources and hashes every carried destination file to guard against
+  // stealth overwrites, which pushes the fetch to a materially non-trivial
+  // wall-clock. If the main Start button remains enabled during that
+  // window, a click launches an ordinary import (no ``parent_import_job_id``
+  // in its body) that the server-side retry exclusivity gate can't catch,
+  // and the two runs race over the same card and destination. Mirror what
+  // startImport() does: flag first, updateStartAvailability(), then fetch;
+  // clear the flag on failure so the button re-enables. See PR #1387
+  // Codex review.
+  importStartInFlight = true;
+  updateStartAvailability();
   try {
     const resp = await fetch('/api/jobs/import-photos', {
       method: 'POST',
@@ -3051,14 +3064,6 @@ async function retryFailedImport() {
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) throw new Error(data.error || 'retry failed to start');
     activeJobId = data.job_id;
-    importStartInFlight = true;
-    // finishJob() re-enables the main Start button after the failed
-    // copy import ends. Without refreshing availability here the
-    // original Start would stay enabled while the recovery retry is
-    // running, letting the user launch a second import of the same
-    // card into the same destination concurrently. Mirror what
-    // startImport() does after flipping the flag.
-    updateStartAvailability();
     document.getElementById('progressCard').style.display = '';
     document.getElementById('resultCard').style.display = 'none';
     document.getElementById('progressCard').scrollIntoView({
@@ -3066,6 +3071,8 @@ async function retryFailedImport() {
     });
     watchJob(activeJobId);
   } catch (e) {
+    importStartInFlight = false;
+    updateStartAvailability();
     button.disabled = false;
     button.textContent = 'Retry failed files';
     hint.textContent = String(e.message || e);

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2405,8 +2405,16 @@ async function renderDestStructure(excludePaths) {
   if (data.managed_archive) {
     const callout = document.createElement('div');
     callout.className = 'managed-archive-callout';
+    // Phrase this in terms of where the generated folders land, not the
+    // selected destination. The backend flags this callout whenever the
+    // resulting folders sit inside a tracked archive — which happens both
+    // when the destination itself is under that archive AND when the
+    // destination is above the archive but the folder template maps
+    // generated folders back into it (destination /Photography,
+    // tracked /Photography/2026, template 2026/%Y-%m-%d). Saying "this
+    // destination is inside" is inaccurate for the second case.
     const label = document.createElement('span');
-    label.textContent = 'This destination is inside the managed archive rooted at ';
+    label.textContent = 'Files imported here land inside the managed archive rooted at ';
     const path = document.createElement('span');
     path.style.fontFamily = 'monospace';
     path.textContent = data.managed_archive.path;
@@ -2792,6 +2800,27 @@ function retryBodyFromFinishedJob(job) {
     location_from_gps: !!cfg.location_from_gps,
     allow_missing_exiftool: !!cfg.allow_missing_exiftool,
   };
+  // Carry forward the complete original import scope so the after-import
+  // process runs on ALL files the user meant to import, not only the
+  // ones this retry newly landed. The parent's failed run skipped
+  // chaining entirely (its result.ok was false), so those photos are
+  // still unprocessed even though they're on disk. On a retry-of-retry
+  // the parent's own carry list must persist too, otherwise the second
+  // retry would forget everything the first retry inherited from the
+  // original attempt.
+  const parentCarry = Array.isArray(cfg.carry_photo_ids)
+    ? cfg.carry_photo_ids : [];
+  const parentImported = Array.isArray(job.result && job.result.photo_ids)
+    ? job.result.photo_ids : [];
+  const carry = [];
+  const carrySeen = new Set();
+  parentCarry.concat(parentImported).forEach((pid) => {
+    if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return;
+    if (carrySeen.has(pid)) return;
+    carrySeen.add(pid);
+    carry.push(pid);
+  });
+  if (carry.length) body.carry_photo_ids = carry;
   if (cfg.remote_target_id) {
     delete body.destination;
     body.remote_target_id = cfg.remote_target_id;

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2950,16 +2950,31 @@ function retryBodyFromFinishedJob(job) {
   // resolution still matches the parent's snapshot. Skip when the
   // parent has no id (defensive; production always has one).
   if (!job.id) return null;
+  // Preserve `""` when the parent's config explicitly stored an empty
+  // folder_template — that means "copy directly into the archive root",
+  // and `||` here would silently redirect the retry to a date-tree the
+  // user didn't ask for. Fall back to the default only when the key is
+  // truly absent/nullish. Same treatment on the Jobs page.
+  const folderTemplate = cfg.folder_template != null
+    ? cfg.folder_template : '%Y/%Y-%m-%d';
+  // Preserve the parent's duplicate-skip semantics. Forcing skip_duplicates
+  // on for every retry means a failed file that happens to match some
+  // existing catalog entry — including from an unrelated card — is
+  // silently skipped again instead of getting the copy the user asked
+  // for; that hits imports the user deliberately configured with
+  // duplicate skipping OFF particularly hard. The copy layer treats
+  // byte-identical prior successes already sitting at the destination
+  // path as adoptable skips regardless of this flag, so preserving the
+  // parent value still avoids re-copying files that landed successfully.
+  const parentSkipDuplicates = cfg.skip_duplicates != null
+    ? !!cfg.skip_duplicates : true;
   const body = {
     sources: cfg.sources.slice(),
     destination: cfg.destination,
     recursive: cfg.recursive !== false,
-    folder_template: cfg.folder_template || '%Y/%Y-%m-%d',
+    folder_template: folderTemplate,
     file_types: cfg.file_types || 'both',
-    // A recovery run must preserve already-landed files. Even if the
-    // original import intentionally allowed duplicates, the retry's job is
-    // to fill the failed gaps, not copy every successful file again.
-    skip_duplicates: true,
+    skip_duplicates: parentSkipDuplicates,
     verify_by_hash: !!cfg.verify_by_hash,
     trust_likely_duplicates: !!cfg.trust_likely_duplicates,
     after_import: cfg.after_import == null ? null : cfg.after_import,

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2532,7 +2532,16 @@ async function renderDestStructure(excludePaths) {
   // when there is no folder table to draw.
   applyFolderTemplateSamples(data.template_samples);
   const folders = data.folders || [];
-  if (!folders.length && !data.managed_archive) return data;
+  const archives = Array.isArray(data.managed_archives)
+    ? data.managed_archives
+    : (data.managed_archive
+        ? [{
+            path: data.managed_archive.path,
+            photo_count: data.managed_archive.photo_count,
+            coverage: 'full',
+          }]
+        : []);
+  if (!folders.length && !archives.length) return data;
 
   const headline = document.createElement('div');
   headline.className = 'structure-headline';
@@ -2542,29 +2551,34 @@ async function renderDestStructure(excludePaths) {
     ' (' + data.new_folders + ' new, ' + data.existing_folders + ' existing)';
   el.appendChild(headline);
 
-  if (data.managed_archive) {
+  // Phrase each callout in terms of where the generated folders land,
+  // not the selected destination — the backend flags an archive whenever
+  // *some* generated folders sit inside it (including when the
+  // destination is above the archive but the template maps files back
+  // into it). Coverage 'full' means every generated folder lands inside
+  // this archive; 'partial' means only some do — either because part of
+  // the source lands outside every tracked archive, or because multiple
+  // archives split the generated folders between them. Say so, so the
+  // caller does not read "lands inside X" as "all of it lands inside X".
+  const multipleArchives = archives.length > 1;
+  archives.forEach((arch) => {
     const callout = document.createElement('div');
     callout.className = 'managed-archive-callout';
-    // Phrase this in terms of where the generated folders land, not the
-    // selected destination. The backend flags this callout whenever the
-    // resulting folders sit inside a tracked archive — which happens both
-    // when the destination itself is under that archive AND when the
-    // destination is above the archive but the folder template maps
-    // generated folders back into it (destination /Photography,
-    // tracked /Photography/2026, template 2026/%Y-%m-%d). Saying "this
-    // destination is inside" is inaccurate for the second case.
     const label = document.createElement('span');
-    label.textContent = 'Files imported here land inside the managed archive rooted at ';
+    const partial = arch.coverage === 'partial' || multipleArchives;
+    label.textContent = partial
+      ? 'Some files imported here will land inside the managed archive rooted at '
+      : 'Files imported here land inside the managed archive rooted at ';
     const path = document.createElement('span');
     path.style.fontFamily = 'monospace';
-    path.textContent = data.managed_archive.path;
+    path.textContent = arch.path;
     const tail = document.createElement('span');
-    tail.textContent = ' — ' + data.managed_archive.photo_count +
-      ' photo' + (data.managed_archive.photo_count === 1 ? '' : 's') +
+    tail.textContent = ' — ' + arch.photo_count +
+      ' photo' + (arch.photo_count === 1 ? '' : 's') +
       ' already cataloged there.';
     callout.append(label, path, tail);
     el.appendChild(callout);
-  }
+  });
 
   const table = document.createElement('table');
   table.className = 'structure-table';

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2767,6 +2767,13 @@ async function finishJob(jobId) {
 
 function retryBodyFromFinishedJob(job) {
   const cfg = (job && job.config) || {};
+  // Recovery retry always POSTs to /api/jobs/import-photos, which rejects
+  // requests without a destination. An in-place import finishes with a
+  // non-empty sources list but cfg.destination === null / cfg.mode ===
+  // "in_place", so exposing the retry action there would offer a run that
+  // cannot start. Gate on the persisted job type/mode the same way the
+  // Jobs page does.
+  if (!job || job.type !== 'import' || cfg.mode === 'in_place') return null;
   if (!Array.isArray(cfg.sources) || !cfg.sources.length) return null;
   const body = {
     sources: cfg.sources.slice(),
@@ -2819,6 +2826,13 @@ async function retryFailedImport() {
     if (!resp.ok) throw new Error(data.error || 'retry failed to start');
     activeJobId = data.job_id;
     importStartInFlight = true;
+    // finishJob() re-enables the main Start button after the failed
+    // copy import ends. Without refreshing availability here the
+    // original Start would stay enabled while the recovery retry is
+    // running, letting the user launch a second import of the same
+    // card into the same destination concurrently. Mirror what
+    // startImport() does after flipping the flag.
+    updateStartAvailability();
     document.getElementById('progressCard').style.display = '';
     document.getElementById('resultCard').style.display = 'none';
     document.getElementById('progressCard').scrollIntoView({

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2256,10 +2256,14 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
     collapsed.textContent = duplicateCount.toLocaleString() +
       ' duplicate' + (duplicateCount === 1 ? '' : 's') +
       ' hidden — ' + (duplicateCount === 1 ? 'it will' : 'they will') +
-      ' be skipped. ' + pendingFiles.length.toLocaleString() +
-      ' file' + (pendingFiles.length === 1 ? '' : 's') +
-      ' to import ' + (pendingFiles.length === 1 ? 'is' : 'are') +
-      ' shown below.';
+      ' be skipped. ' + (
+        pendingFiles.length
+          ? pendingFiles.length.toLocaleString() +
+            ' file' + (pendingFiles.length === 1 ? '' : 's') +
+            ' to import ' + (pendingFiles.length === 1 ? 'is' : 'are') +
+            ' shown below.'
+          : 'Nothing else will be imported from this selection.'
+      );
     grid.appendChild(collapsed);
   }
 

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2783,6 +2783,11 @@ function retryBodyFromFinishedJob(job) {
   // Jobs page does.
   if (!job || job.type !== 'import' || cfg.mode === 'in_place') return null;
   if (!Array.isArray(cfg.sources) || !cfg.sources.length) return null;
+  // The server binds the retry's carry list to this parent (below) and
+  // — when the parent used a remote target — verifies the current
+  // resolution still matches the parent's snapshot. Skip when the
+  // parent has no id (defensive; production always has one).
+  if (!job.id) return null;
   const body = {
     sources: cfg.sources.slice(),
     destination: cfg.destination,
@@ -2799,6 +2804,7 @@ function retryBodyFromFinishedJob(job) {
     tags: Array.isArray(cfg.tags) ? cfg.tags.slice() : [],
     location_from_gps: !!cfg.location_from_gps,
     allow_missing_exiftool: !!cfg.allow_missing_exiftool,
+    parent_import_job_id: job.id,
   };
   // Carry forward the complete original import scope so the after-import
   // process runs on ALL files the user meant to import, not only the

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -44,6 +44,17 @@ body { display: flex; flex-direction: column; height: 100vh; }
   font-size: 11px; color: var(--text-secondary); overflow-wrap: anywhere;
   margin-top: 4px; width: 100%;
 }
+.field-required { color: var(--danger); font-size: 10px; font-weight: 600; }
+.field-error {
+  display: none; width: 100%; margin: -2px 0 8px; padding-left: 2px;
+  color: var(--danger); font-size: 12px; font-weight: 600;
+}
+.field-error.visible { display: block; }
+.input-invalid { border-color: var(--danger) !important; }
+.destination-mode-hint {
+  font-size: 11px; color: var(--text-secondary); margin: -2px 0 10px;
+  overflow-wrap: anywhere;
+}
 .recent-destinations { margin: -2px 0 8px 0; }
 .recent-destinations-label { font-size: 11px; color: var(--text-secondary); margin-bottom: 4px; }
 .recent-destination-list { display: flex; flex-wrap: wrap; gap: 4px; }
@@ -51,6 +62,11 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .input-fixed { max-width: 240px; flex: 0 1 240px; }
 .preview-summary { font-size: 12px; color: var(--text-secondary); margin-top: 6px; }
 .import-preview-grid { display: flex; flex-direction: column; gap: 12px; margin-top: 12px; max-height: 520px; overflow-y: auto; }
+.import-preview-collapsed {
+  padding: 9px 11px; border-radius: 6px; color: var(--text-secondary);
+  background: var(--bg-tertiary); border: 1px solid var(--border-primary);
+  font-size: 12px;
+}
 .import-preview-folder { display: flex; flex-direction: column; gap: 6px; }
 .import-preview-folder-header { font-size: 12px; font-weight: 600; color: var(--text-secondary); overflow-wrap: anywhere; }
 .import-preview-thumbs { display: grid; grid-template-columns: repeat(auto-fill, minmax(104px, 1fr)); gap: 8px; }
@@ -114,7 +130,13 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .pill-warn { background: color-mix(in srgb, var(--warning, #bf8700) 18%, transparent); color: var(--warning, #9a6700); }
 .unsafe-list { margin: 6px 0 0 0; padding-left: 18px; font-size: 12px; color: var(--text-secondary); }
 .result-links a { color: var(--accent); font-size: 12px; }
-#importError { color: var(--danger); font-size: 12px; margin-top: 6px; display: none; }
+#importError {
+  color: var(--danger); font-size: 13px; font-weight: 600;
+  margin: 0 0 10px; padding: 9px 11px; display: none;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
+}
 .warn { font-size: 12px; color: var(--warning, #bf8700); margin-top: 6px; }
 .staging-items { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
 .staging-item { border: 1px solid var(--border-primary); border-radius: 6px; padding: 10px; background: var(--bg-tertiary); }
@@ -322,8 +344,11 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div class="row">
         <label>Archive destination</label>
         <select id="destMode" class="input-fixed" onchange="onImportDestModeChange()">
-          <option value="local" selected>Local path</option>
+          <option value="local" selected>Local or mounted path</option>
         </select>
+      </div>
+      <div class="destination-mode-hint" id="destModeHint">
+        Use this for folders on this Mac and NAS volumes mounted in Finder.
       </div>
       <div id="destLocalRows">
       <div class="row">
@@ -341,9 +366,13 @@ body { display: flex; flex-direction: column; height: 100vh; }
       </div>
       <div id="destRemoteRows" style="display:none;">
         <div class="row">
-          <label>Remote subpath</label>
-          <input type="text" id="remoteSubpath" class="input-fixed" placeholder="2026/trip" oninput="updateRemoteDestPreview()">
+          <label for="remoteSubpath">Folder inside NAS <span class="field-required">Required</span></label>
+          <input type="text" id="remoteSubpath" class="input-fixed"
+                 placeholder="Raw Files/USA" aria-required="true"
+                 aria-describedby="remoteSubpathError remoteDestPreview"
+                 oninput="updateRemoteDestPreview()">
         </div>
+        <div class="field-error" id="remoteSubpathError" role="alert"></div>
         <div class="remote-preview" id="remoteDestPreview"></div>
       </div>
       <div class="row">
@@ -396,12 +425,13 @@ body { display: flex; flex-direction: column; height: 100vh; }
 
     <div class="card">
       <div class="row">
-        <button class="btn" id="btnPreview" onclick="previewImport()">Preview import</button>
-        <button class="btn btn-primary" id="btnStart" onclick="startImport()">Start import</button>
+        <button class="btn" type="button" id="btnPreview" onclick="previewImport()">Preview import</button>
+        <button class="btn btn-primary" type="button" id="btnStart"
+                aria-describedby="importError" onclick="startImport()">Start import</button>
       </div>
+      <div id="importError" role="alert" aria-live="assertive"></div>
       <div class="preview-summary" id="previewSummary"></div>
       <div id="importPreviewGrid" class="import-preview-grid" style="display:none;"></div>
-      <div id="importError"></div>
     </div>
 
     <div class="card" id="progressCard" style="display:none;">
@@ -422,6 +452,11 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div id="chainInfo" class="hint" style="margin-top:8px;"></div>
       <div id="taggingInfo" class="hint" style="margin-top:8px;"></div>
       <div id="modelWarning" class="warn" style="display:none;"></div>
+      <div class="row" id="retryImportRow" style="display:none;margin-top:10px;">
+        <button class="btn btn-primary" type="button" id="btnRetryImport"
+                onclick="retryFailedImport()">Retry failed files</button>
+        <span class="hint" id="retryImportHint"></span>
+      </div>
       <div class="result-links" style="margin-top:8px;">
         <a href="/browse">Open Browse</a> &nbsp;·&nbsp; <a href="/jobs">Open Jobs</a>
       </div>
@@ -488,6 +523,8 @@ let importTags = [];
 let newImagesSnapshotId = null;
 let importExiftoolReady = null;
 let importExiftoolRequired = true;
+let importStartInFlight = false;
+let lastFinishedImportJob = null;
 
 async function loadImportReadiness() {
   const status = document.getElementById('importExiftoolStatus');
@@ -527,6 +564,7 @@ async function loadImportReadiness() {
     advanced.style.display = 'none';
     repairSection.style.display = 'none';
   }
+  updateStartAvailability();
 }
 
 async function installImportExiftool() {
@@ -637,6 +675,7 @@ function updateImportMode() {
   refreshSourceCounts();
   scheduleImportPreview();
   updateAfterMoveUI();
+  updateStartAvailability();
 }
 
 function selectedFileTypes() {
@@ -732,7 +771,8 @@ function wireDestStructureInvalidation() {
   [
     'chkRecursive', 'fileTypePreset', 'destMode', 'remoteSubpath',
     'chkSkipDuplicates', 'chkTrustLikelyDuplicates', 'chkVerifyByHash', 'destInput',
-    'folderTemplatePreset', 'folderTemplate',
+    'folderTemplatePreset', 'folderTemplate', 'newWorkspaceName',
+    'chkAllowMissingExiftool',
   ].forEach((id) => {
     const el = document.getElementById(id);
     if (!el) return;
@@ -740,6 +780,10 @@ function wireDestStructureInvalidation() {
       hideDestStructure();
       scheduleImportPreview();
       updateAfterMoveUI();
+      if (id === 'destInput' || id === 'destMode') {
+        updateDestinationModeHint();
+      }
+      updateStartAvailability();
     };
     el.addEventListener('change', onPreviewOptionChange);
     el.addEventListener('input', onPreviewOptionChange);
@@ -748,6 +792,7 @@ function wireDestStructureInvalidation() {
     el.addEventListener('change', () => {
       hideDestStructure();
       scheduleImportPreview();
+      updateStartAvailability();
     });
   });
 }
@@ -763,6 +808,7 @@ function updateWorkspaceMode() {
   // ...and the resync can change whether a process chains at all, which
   // gates the "Then move to NAS" row.
   updateAfterMoveUI();
+  updateStartAvailability();
 }
 
 function importRemoteTargetId() {
@@ -814,25 +860,50 @@ function updateRemoteDestPreview() {
   const el = document.getElementById('remoteDestPreview');
   if (!el) return;
   el.textContent = '';
+  const input = document.getElementById('remoteSubpath');
+  const errorEl = document.getElementById('remoteSubpathError');
   const t = importRemoteTarget();
-  if (!t) return;
-  const subResult = normalizeRemoteSubpath(document.getElementById('remoteSubpath').value);
+  if (!t) {
+    if (errorEl) {
+      errorEl.textContent = 'Choose a configured NAS target.';
+      errorEl.classList.add('visible');
+    }
+    if (input) input.classList.add('input-invalid');
+    updateStartAvailability();
+    return;
+  }
+  const subResult = normalizeRemoteSubpath(input.value);
+  let fieldError = '';
   if (subResult.error) {
-    el.appendChild(remotePreviewWarn('Warning: ' + subResult.error));
+    fieldError = subResult.error + ' Enter a folder such as Raw Files/USA.';
   } else if (!subResult.value) {
-    const hint = document.createElement('div');
-    hint.textContent = 'Name the archive folder under ' + t.remote_path + ', e.g. 2026/kenya-trip.';
-    el.appendChild(hint);
+    fieldError = 'Enter the folder inside ' + t.remote_path +
+      ', for example Raw Files/USA.';
   } else {
     const line = document.createElement('div');
-    line.textContent = 'Archive over SSH to: ';
+    line.textContent = 'Vireo will send files directly over SSH to: ';
     const span = document.createElement('span');
     span.style.fontFamily = 'monospace';
     span.textContent = rsyncDestSpec(
       t.user, t.host, t.remote_path.replace(/\/+$/, '') + '/' + subResult.value);
     line.appendChild(span);
     el.appendChild(line);
+    if (t.mount_path) {
+      const catalogLine = document.createElement('div');
+      catalogLine.textContent = 'The same folder is cataloged at: ';
+      const catalogPath = document.createElement('span');
+      catalogPath.style.fontFamily = 'monospace';
+      catalogPath.textContent =
+        t.mount_path.replace(/\/+$/, '') + '/' + subResult.value;
+      catalogLine.appendChild(catalogPath);
+      el.appendChild(catalogLine);
+    }
   }
+  if (errorEl) {
+    errorEl.textContent = fieldError;
+    errorEl.classList.toggle('visible', !!fieldError);
+  }
+  if (input) input.classList.toggle('input-invalid', !!fieldError);
   if (!importRsyncAvailable) {
     el.appendChild(remotePreviewWarn('Warning: no GNU rsync found. Install GNU rsync or set its path under Settings > Paths.'));
   }
@@ -841,6 +912,7 @@ function updateRemoteDestPreview() {
   } else if (!importIsAbsolutePath(t.mount_path)) {
     el.appendChild(remotePreviewWarn('Warning: this target local mount path must be absolute.'));
   }
+  updateStartAvailability();
 }
 
 function remoteArchiveSelectionReady() {
@@ -851,14 +923,39 @@ function remoteArchiveSelectionReady() {
   return !subResult.error && !!subResult.value;
 }
 
+function updateDestinationModeHint() {
+  const hint = document.getElementById('destModeHint');
+  if (!hint) return;
+  const target = importRemoteTarget();
+  if (target) {
+    hint.textContent = 'Direct SSH transfer to ' + target.remote_path +
+      '. The folder inside that root is required below.';
+    return;
+  }
+  const destination =
+    (document.getElementById('destInput')?.value || '').trim();
+  const mountedTarget = importRemoteTargets.find((item) => {
+    const mount = String(item.mount_path || '').replace(/\/+$/, '');
+    return mount && (
+      destination === mount || destination.indexOf(mount + '/') === 0
+    );
+  });
+  hint.textContent = mountedTarget
+    ? 'Using ' + mountedTarget.name + ' through its Finder-mounted path ' +
+      mountedTarget.mount_path + '. Files are copied through the mounted volume.'
+    : 'Use this for folders on this Mac and NAS volumes mounted in Finder.';
+}
+
 function onImportDestModeChange() {
   const remoteId = importRemoteTargetId();
   const localRows = document.getElementById('destLocalRows');
   const remoteRows = document.getElementById('destRemoteRows');
   if (localRows) localRows.style.display = remoteId ? 'none' : '';
   if (remoteRows) remoteRows.style.display = remoteId ? '' : 'none';
+  updateDestinationModeHint();
   updateRemoteDestPreview();
   updateAfterMoveUI();
+  updateStartAvailability();
 }
 
 async function loadImportRemoteTargets() {
@@ -880,7 +977,7 @@ async function loadImportRemoteTargets() {
   importRemoteTargets.forEach((t) => {
     const opt = document.createElement('option');
     opt.value = 'remote:' + t.id;
-    opt.textContent = t.name + ' - ' + t.user + '@' + t.host + ' (SSH)';
+    opt.textContent = t.name + ' — direct transfer over SSH';
     sel.appendChild(opt);
   });
   onImportDestModeChange();
@@ -931,6 +1028,7 @@ function renderSources() {
     div.appendChild(btn);
     list.appendChild(div);
   });
+  updateStartAvailability();
 }
 
 function selectedSourceCountOptions() {
@@ -1670,10 +1768,107 @@ let _globalDefaultProcessId = null;
 // default rather than sticking on whatever placeholder was showing.
 let _workspaceDefaultProcessId = null;
 
-function showError(msg) {
+function importFormProblem() {
+  if (!sources.length && newImagesSnapshotId === null) {
+    return {
+      message: 'Add at least one source folder.',
+      target: document.getElementById('sourceCard'),
+    };
+  }
+  const allowMissingExiftool =
+    !!document.getElementById('chkAllowMissingExiftool')?.checked;
+  if (
+    importExiftoolRequired && importExiftoolReady === false
+    && !allowMissingExiftool
+  ) {
+    return {
+      message: 'Repair ExifTool before importing, or use Advanced → Import without metadata.',
+      target: document.getElementById('exiftoolCard'),
+    };
+  }
+  if (document.getElementById('workspaceNew')?.checked) {
+    const name =
+      (document.getElementById('newWorkspaceName')?.value || '').trim();
+    if (!name) {
+      return {
+        message: 'Enter a name for the new workspace.',
+        target: document.getElementById('newWorkspaceName'),
+      };
+    }
+  }
+  const copyMode =
+    newImagesSnapshotId === null && selectedImportMode() === 'copy';
+  if (!copyMode) return null;
+  const fileTypes = selectedFileTypes();
+  if (Array.isArray(fileTypes) && !fileTypes.length) {
+    return {
+      message: 'Choose at least one file extension.',
+      target: document.getElementById('fileTypePreset'),
+    };
+  }
+  const remoteId = importRemoteTargetId();
+  if (remoteId) {
+    const target = importRemoteTarget();
+    const subResult = normalizeRemoteSubpath(
+      document.getElementById('remoteSubpath').value);
+    if (!target) {
+      return {
+        message: 'Choose a configured NAS target.',
+        target: document.getElementById('destMode'),
+      };
+    }
+    if (!importRsyncAvailable) {
+      return {
+        message: 'Direct NAS transfer needs GNU rsync. Repair its path in Settings, or use the mounted Local path.',
+        target: document.getElementById('destMode'),
+      };
+    }
+    if (!target.mount_path || !importIsAbsolutePath(target.mount_path)) {
+      return {
+        message: 'This NAS target needs an absolute mounted path in Settings before Vireo can catalog imported files.',
+        target: document.getElementById('destMode'),
+      };
+    }
+    if (subResult.error || !subResult.value) {
+      return {
+        message: subResult.error
+          ? subResult.error + ' Enter a folder such as Raw Files/USA.'
+          : 'Enter the folder inside ' + target.remote_path +
+            ', for example Raw Files/USA.',
+        target: document.getElementById('remoteSubpath'),
+      };
+    }
+  } else {
+    const destination =
+      (document.getElementById('destInput').value || '').trim();
+    if (!destination) {
+      return {
+        message: 'Choose a destination folder.',
+        target: document.getElementById('destInput'),
+      };
+    }
+  }
+  return null;
+}
+
+function updateStartAvailability() {
+  const button = document.getElementById('btnStart');
+  if (!button) return;
+  const problem = importFormProblem();
+  button.disabled = importStartInFlight || !!problem;
+  button.title = problem ? problem.message : '';
+  button.setAttribute('aria-disabled', button.disabled ? 'true' : 'false');
+}
+
+function showError(msg, target) {
   const el = document.getElementById('importError');
   el.textContent = msg;
   el.style.display = msg ? 'block' : 'none';
+  if (msg && target) {
+    const focusTarget = target.focus ? target : null;
+    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    if (focusTarget) focusTarget.focus({ preventScroll: true });
+  }
 }
 
 function formatBytes(n) {
@@ -1939,12 +2134,34 @@ function renderImportPreviewGrid(files, duplicatePaths, destinationFiles) {
     return;
   }
 
+  // Duplicate-heavy retries should foreground the work Vireo will actually
+  // perform. Rendering hundreds of skipped cards obscures the one failed
+  // file and schedules a thumbnail request for every duplicate. Keep those
+  // files collapsed into one summary and render only pending/unavailable
+  // items. Before duplicate detection runs `duplicatePaths` is empty, so
+  // callers that need the full in-place preview retain the existing view.
+  const pendingFiles = files.filter((f) => !dupes.has(f.path));
+  const duplicateCount = files.length - pendingFiles.length;
   const groups = {};
-  files.forEach((f) => {
+  pendingFiles.forEach((f) => {
     const key = f.subfolder || 'Source';
     if (!groups[key]) groups[key] = [];
     groups[key].push(f);
   });
+
+  if (duplicateCount) {
+    const collapsed = document.createElement('div');
+    collapsed.className = 'import-preview-collapsed';
+    collapsed.setAttribute('data-testid', 'collapsed-duplicate-preview');
+    collapsed.textContent = duplicateCount.toLocaleString() +
+      ' duplicate' + (duplicateCount === 1 ? '' : 's') +
+      ' hidden — ' + (duplicateCount === 1 ? 'it will' : 'they will') +
+      ' be skipped. ' + pendingFiles.length.toLocaleString() +
+      ' file' + (pendingFiles.length === 1 ? '' : 's') +
+      ' to import ' + (pendingFiles.length === 1 ? 'is' : 'are') +
+      ' shown below.';
+    grid.appendChild(collapsed);
+  }
 
   Object.keys(groups).sort().forEach((subfolder) => {
     const groupEl = document.createElement('div');
@@ -2076,9 +2293,14 @@ function resolvedCopyDestination() {
     const t = importRemoteTarget();
     if (!t || !t.mount_path || !importIsAbsolutePath(t.mount_path)) return '';
     const sub = normalizeRemoteSubpath(document.getElementById('remoteSubpath').value);
-    if (sub.error) return '';
+    // The mount root by itself is not a valid remote selection: the SSH
+    // importer requires a folder below the configured remote root. Rendering
+    // a destination preview for the bare mount made an invalid form look
+    // complete and could surface an unrelated managed archive nested below
+    // that mount.
+    if (sub.error || !sub.value) return '';
     const base = t.mount_path.replace(/\/+$/, '');
-    return sub.value ? base + '/' + sub.value : base;
+    return base + '/' + sub.value;
   }
   const local = (document.getElementById('destInput').value || '').trim();
   return importIsAbsolutePath(local) ? local : '';
@@ -2184,7 +2406,7 @@ async function renderDestStructure(excludePaths) {
     const callout = document.createElement('div');
     callout.className = 'managed-archive-callout';
     const label = document.createElement('span');
-    label.textContent = 'Merging into a managed archive at ';
+    label.textContent = 'This destination is inside the managed archive rooted at ';
     const path = document.createElement('span');
     path.style.fontFamily = 'monospace';
     path.textContent = data.managed_archive.path;
@@ -2287,8 +2509,8 @@ async function previewImport(opts) {
       clearImportPreviewGrid();
       return;
     }
-    renderImportPreviewGrid(files, [], null);
     if (snapshotMode) {
+      renderImportPreviewGrid(files, [], null);
       const unavailable = Number(data.unavailable_count || 0);
       summary.textContent = Number(data.total_count || files.length).toLocaleString() +
         ' captured file' + (Number(data.total_count || files.length) === 1 ? '' : 's') +
@@ -2297,10 +2519,12 @@ async function previewImport(opts) {
       return;
     }
     if (!copyMode) {
+      renderImportPreviewGrid(files, [], null);
       summary.textContent = files.length + ' files found · originals will stay in place';
       return;
     }
     if (!document.getElementById('chkSkipDuplicates').checked) {
+      renderImportPreviewGrid(files, [], null);
       summary.textContent = files.length + ' files found · duplicates will be copied';
       // No dedup gate, so every discovered file lands — pass no exclusions
       // so the folder-structure counts match the full copy set.
@@ -2401,16 +2625,13 @@ function renderFolderTable(el, folders) {
 async function startImport() {
   showError('');
   addImportTagFromInput();
-  if (!sources.length && newImagesSnapshotId === null) {
-    showError('Add at least one source folder.');
+  const problem = importFormProblem();
+  if (problem) {
+    showError(problem.message, problem.target);
+    updateStartAvailability();
     return;
   }
   const allowMissingExiftool = !!document.getElementById('chkAllowMissingExiftool')?.checked;
-  if (importExiftoolRequired && importExiftoolReady === false && !allowMissingExiftool) {
-    showError('Repair ExifTool before importing, or use Advanced → Import without metadata.');
-    document.getElementById('exiftoolCard')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    return;
-  }
   const copyMode = newImagesSnapshotId === null && selectedImportMode() === 'copy';
   const body = newImagesSnapshotId !== null ? {
     source_snapshot_id: newImagesSnapshotId,
@@ -2474,7 +2695,8 @@ async function startImport() {
   // archive copy + chained process + eligible target) — a hidden row means
   // a stale checkbox must not send anything.
   body.after_process_move = afterMoveRequest();
-  document.getElementById('btnStart').disabled = true;
+  importStartInFlight = true;
+  updateStartAvailability();
   try {
     const resp = await fetch(copyMode ? '/api/jobs/import-photos' : '/api/jobs/import-in-place', {
       method: 'POST',
@@ -2492,8 +2714,9 @@ async function startImport() {
     document.getElementById('resultCard').style.display = 'none';
     watchJob(activeJobId);
   } catch (e) {
-    showError(String(e.message || e));
-    document.getElementById('btnStart').disabled = false;
+    importStartInFlight = false;
+    showError(String(e.message || e), document.getElementById('btnStart'));
+    updateStartAvailability();
   }
 }
 
@@ -2532,16 +2755,91 @@ async function finishJob(jobId) {
     }
     await new Promise(r => setTimeout(r, 1000));
   }
-  document.getElementById('btnStart').disabled = false;
+  importStartInFlight = false;
+  updateStartAvailability();
   if (!job || !job.result) {
     showError('Import ended but its result could not be loaded — check the Jobs page.');
     return;
   }
+  lastFinishedImportJob = job;
   renderResult(job.result, job.status);
+}
+
+function retryBodyFromFinishedJob(job) {
+  const cfg = (job && job.config) || {};
+  if (!Array.isArray(cfg.sources) || !cfg.sources.length) return null;
+  const body = {
+    sources: cfg.sources.slice(),
+    destination: cfg.destination,
+    recursive: cfg.recursive !== false,
+    folder_template: cfg.folder_template || '%Y/%Y-%m-%d',
+    file_types: cfg.file_types || 'both',
+    // A recovery run must preserve already-landed files. Even if the
+    // original import intentionally allowed duplicates, the retry's job is
+    // to fill the failed gaps, not copy every successful file again.
+    skip_duplicates: true,
+    verify_by_hash: !!cfg.verify_by_hash,
+    trust_likely_duplicates: !!cfg.trust_likely_duplicates,
+    after_import: cfg.after_import == null ? null : cfg.after_import,
+    tags: Array.isArray(cfg.tags) ? cfg.tags.slice() : [],
+    location_from_gps: !!cfg.location_from_gps,
+    allow_missing_exiftool: !!cfg.allow_missing_exiftool,
+  };
+  if (cfg.remote_target_id) {
+    delete body.destination;
+    body.remote_target_id = cfg.remote_target_id;
+    body.remote_subpath = cfg.remote_subpath;
+  }
+  if (cfg.after_process_move && cfg.after_process_move.remote_target_id) {
+    body.after_process_move = {
+      remote_target_id: cfg.after_process_move.remote_target_id,
+    };
+  }
+  return body;
+}
+
+async function retryFailedImport() {
+  const button = document.getElementById('btnRetryImport');
+  const hint = document.getElementById('retryImportHint');
+  const body = retryBodyFromFinishedJob(lastFinishedImportJob);
+  if (!body) {
+    hint.textContent = 'The original import settings are no longer available. Start a new import from the source card.';
+    return;
+  }
+  button.disabled = true;
+  button.textContent = 'Starting retry…';
+  hint.textContent = 'Already imported files will be skipped.';
+  try {
+    const resp = await fetch('/api/jobs/import-photos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) throw new Error(data.error || 'retry failed to start');
+    activeJobId = data.job_id;
+    importStartInFlight = true;
+    document.getElementById('progressCard').style.display = '';
+    document.getElementById('resultCard').style.display = 'none';
+    document.getElementById('progressCard').scrollIntoView({
+      behavior: 'smooth', block: 'center',
+    });
+    watchJob(activeJobId);
+  } catch (e) {
+    button.disabled = false;
+    button.textContent = 'Retry failed files';
+    hint.textContent = String(e.message || e);
+  }
 }
 
 function renderResult(res, status) {
   document.getElementById('resultCard').style.display = '';
+  const retryRow = document.getElementById('retryImportRow');
+  const retryButton = document.getElementById('btnRetryImport');
+  const retryHint = document.getElementById('retryImportHint');
+  retryRow.style.display = 'none';
+  retryHint.textContent = '';
+  retryButton.disabled = false;
   const pill = document.getElementById('safeToFormatPill');
   const unsafe = document.getElementById('unsafeList');
   unsafe.innerHTML = '';
@@ -2650,6 +2948,15 @@ function renderResult(res, status) {
     res.skipped_duplicate + ' duplicates skipped · ' + res.failed + ' failed' +
     (status && status !== 'completed' ? ' · job ' + status : '');
   renderFolderTable(document.getElementById('resultFolders'), res.folders || {});
+
+  const failedCount = Number(res.failed || 0);
+  if (failedCount > 0 && retryBodyFromFinishedJob(lastFinishedImportJob)) {
+    retryRow.style.display = '';
+    retryButton.textContent = 'Retry ' + failedCount + ' failed file' +
+      (failedCount === 1 ? '' : 's');
+    retryHint.textContent =
+      'Uses the same source and destination; successful files are skipped.';
+  }
 
   renderChainInfo(res);
   renderTaggingInfo(res);

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -382,6 +382,12 @@
     var cfg = jobConfig(job);
     if (!job || job.type !== 'import' || cfg.mode === 'in_place' ||
         !Array.isArray(cfg.sources) || !cfg.sources.length) return null;
+    // parent_import_job_id lets the server bind carry_photo_ids to this
+    // parent's imported scope and, when the parent used a remote
+    // target, verify the target still resolves to the enqueue-time
+    // host/root/mount. Without a parent id the server rejects the
+    // carry list, so the retry couldn't chain properly.
+    if (!job.id) return null;
     var body = {
       sources: cfg.sources.slice(),
       destination: cfg.destination,
@@ -395,6 +401,7 @@
       tags: Array.isArray(cfg.tags) ? cfg.tags.slice() : [],
       location_from_gps: !!cfg.location_from_gps,
       allow_missing_exiftool: !!cfg.allow_missing_exiftool,
+      parent_import_job_id: job.id,
     };
     // Recover the complete original scope. See import.html for the full
     // rationale; the summary: the parent's failed run skipped chaining

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -379,12 +379,16 @@
   }
 
   // A retry job carries its parent's id in ``config.parent_import_job_id``
+  // and the original failed import's id in ``config.root_import_job_id``
   // (see api_job_import_photos). Suppresses the Retry button on the
-  // parent while any active-or-recently-launched retry from that parent
-  // is still in flight — a second click would otherwise enqueue a
-  // parallel import of the same source and destination, letting the
-  // after-import chains and any ``after_process_move`` race with the
-  // first retry's move (which may already have relocated the folders).
+  // original failed import while any active-or-recently-launched retry
+  // in that chain is still in flight — a second click would otherwise
+  // enqueue a parallel import of the same source and destination,
+  // letting the after-import chains and any ``after_process_move`` race
+  // with the first retry's move (which may already have relocated the
+  // folders). Matches either field so a retry-of-retry — whose direct
+  // ``parent_import_job_id`` points at the first retry, not the
+  // original failed import — still blocks the original's Retry button.
   function hasActiveRetryFor(parentId) {
     if (!parentId) return false;
     return activeJobs.some(function(candidate) {
@@ -393,7 +397,9 @@
       if (status === 'completed' || status === 'failed' ||
           status === 'cancelled') return false;
       var cfg = jobConfig(candidate);
-      return cfg && cfg.parent_import_job_id === parentId;
+      if (!cfg) return false;
+      return cfg.parent_import_job_id === parentId ||
+             cfg.root_import_job_id === parentId;
     });
   }
 

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -378,6 +378,25 @@
     return job && job.config && typeof job.config === 'object' ? job.config : {};
   }
 
+  // A retry job carries its parent's id in ``config.parent_import_job_id``
+  // (see api_job_import_photos). Suppresses the Retry button on the
+  // parent while any active-or-recently-launched retry from that parent
+  // is still in flight — a second click would otherwise enqueue a
+  // parallel import of the same source and destination, letting the
+  // after-import chains and any ``after_process_move`` race with the
+  // first retry's move (which may already have relocated the folders).
+  function hasActiveRetryFor(parentId) {
+    if (!parentId) return false;
+    return activeJobs.some(function(candidate) {
+      if (!candidate || candidate.type !== 'import') return false;
+      var status = candidate.status;
+      if (status === 'completed' || status === 'failed' ||
+          status === 'cancelled') return false;
+      var cfg = jobConfig(candidate);
+      return cfg && cfg.parent_import_job_id === parentId;
+    });
+  }
+
   function importRetryBody(job) {
     var cfg = jobConfig(job);
     if (!job || job.type !== 'import' || cfg.mode === 'in_place' ||
@@ -511,11 +530,24 @@
 
     var failedImportCount = job.result && Number(job.result.failed || 0);
     if (!isLive && failedImportCount > 0 && importRetryBody(job)) {
+      var retryInFlight = hasActiveRetryFor(job.id);
       html += '<div style="padding:10px 0 2px;font-size:12px;color:var(--text-muted);">';
-      html += '<button class="btn-retry" data-retry-import-job="' +
-        escapeAttr(job.id) + '">Retry ' + failedImportCount + ' failed file' +
-        (failedImportCount === 1 ? '' : 's') + '</button>';
-      html += '<span style="margin-left:8px;">Same source and destination; successful files are skipped.</span>';
+      if (retryInFlight) {
+        // Same failed job, retry already running. A second Start would
+        // race the first — same source, same destination, same carry
+        // scope — so surface the in-flight status instead of a live
+        // button. Re-enables automatically when the retry finishes and
+        // ``activeJobs`` no longer contains it.
+        html += '<button class="btn-retry" disabled aria-disabled="true" ' +
+          'title="A retry for this import is already running">' +
+          'Retry in progress…</button>';
+        html += '<span style="margin-left:8px;">Retry already launched for this job; wait for it to finish before starting another.</span>';
+      } else {
+        html += '<button class="btn-retry" data-retry-import-job="' +
+          escapeAttr(job.id) + '">Retry ' + failedImportCount + ' failed file' +
+          (failedImportCount === 1 ? '' : 's') + '</button>';
+        html += '<span style="margin-left:8px;">Same source and destination; successful files are skipped.</span>';
+      }
       html += '</div>';
     }
 
@@ -980,6 +1012,24 @@
         }
         return;
       }
+      // Backstop the render-time gate: a click landing between poll
+      // ticks could otherwise fire a second retry for the same parent
+      // while the first is still active. Same rationale as the disabled
+      // button above; keeps the parallel-launch race closed even when
+      // ``activeJobs`` refreshed just after render.
+      if (hasActiveRetryFor(retryJobId)) {
+        if (typeof showToast === 'function') {
+          showToast(
+            'A retry for this import is already running; wait for it to finish.',
+            'info',
+          );
+        }
+        return;
+      }
+      // Preserve the original count-specific label so the error path
+      // below can restore it exactly — dropping to a generic "Retry
+      // failed files" would silently hide the real failed-file count.
+      var retryOriginalLabel = retryImportBtn.textContent;
       retryImportBtn.disabled = true;
       retryImportBtn.textContent = 'Starting retry…';
       fetch('/api/jobs/import-photos', {
@@ -1003,7 +1053,7 @@
         fetchJobs();
       }).catch(function(error) {
         retryImportBtn.disabled = false;
-        retryImportBtn.textContent = 'Retry failed files';
+        retryImportBtn.textContent = retryOriginalLabel;
         if (typeof showToast === 'function') showToast(error.message, 'error');
       });
       return;

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -388,13 +388,23 @@
     // host/root/mount. Without a parent id the server rejects the
     // carry list, so the retry couldn't chain properly.
     if (!job.id) return null;
+    // See import.html retryBodyFromFinishedJob for the full rationale:
+    // an empty custom folder_template means "copy into the archive
+    // root" and must not be overwritten by the default; the parent's
+    // skip_duplicates setting must not be forced on, or a failed file
+    // that matches some other catalog entry gets skipped again instead
+    // of copied.
+    var folderTemplate = cfg.folder_template != null
+      ? cfg.folder_template : '%Y/%Y-%m-%d';
+    var parentSkipDuplicates = cfg.skip_duplicates != null
+      ? !!cfg.skip_duplicates : true;
     var body = {
       sources: cfg.sources.slice(),
       destination: cfg.destination,
       recursive: cfg.recursive !== false,
-      folder_template: cfg.folder_template || '%Y/%Y-%m-%d',
+      folder_template: folderTemplate,
       file_types: cfg.file_types || 'both',
-      skip_duplicates: true,
+      skip_duplicates: parentSkipDuplicates,
       verify_by_hash: !!cfg.verify_by_hash,
       trust_likely_duplicates: !!cfg.trust_likely_duplicates,
       after_import: cfg.after_import == null ? null : cfg.after_import,

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -380,7 +380,7 @@
 
   function importRetryBody(job) {
     var cfg = jobConfig(job);
-    if (!job || job.type !== 'import' ||
+    if (!job || job.type !== 'import' || cfg.mode === 'in_place' ||
         !Array.isArray(cfg.sources) || !cfg.sources.length) return null;
     var body = {
       sources: cfg.sources.slice(),
@@ -396,6 +396,24 @@
       location_from_gps: !!cfg.location_from_gps,
       allow_missing_exiftool: !!cfg.allow_missing_exiftool,
     };
+    // Recover the complete original scope. See import.html for the full
+    // rationale; the summary: the parent's failed run skipped chaining
+    // entirely, so previously-landed files still need processing, and
+    // on repeated retries the accumulated carry list has to keep
+    // growing rather than reset to only the last retry's landed files.
+    var parentCarry = Array.isArray(cfg.carry_photo_ids)
+      ? cfg.carry_photo_ids : [];
+    var parentImported = Array.isArray(job.result && job.result.photo_ids)
+      ? job.result.photo_ids : [];
+    var carry = [];
+    var carrySeen = {};
+    parentCarry.concat(parentImported).forEach(function(pid) {
+      if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) return;
+      if (carrySeen[pid]) return;
+      carrySeen[pid] = true;
+      carry.push(pid);
+    });
+    if (carry.length) body.carry_photo_ids = carry;
     if (cfg.remote_target_id) {
       delete body.destination;
       body.remote_target_id = cfg.remote_target_id;

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -378,6 +378,37 @@
     return job && job.config && typeof job.config === 'object' ? job.config : {};
   }
 
+  function importRetryBody(job) {
+    var cfg = jobConfig(job);
+    if (!job || job.type !== 'import' ||
+        !Array.isArray(cfg.sources) || !cfg.sources.length) return null;
+    var body = {
+      sources: cfg.sources.slice(),
+      destination: cfg.destination,
+      recursive: cfg.recursive !== false,
+      folder_template: cfg.folder_template || '%Y/%Y-%m-%d',
+      file_types: cfg.file_types || 'both',
+      skip_duplicates: true,
+      verify_by_hash: !!cfg.verify_by_hash,
+      trust_likely_duplicates: !!cfg.trust_likely_duplicates,
+      after_import: cfg.after_import == null ? null : cfg.after_import,
+      tags: Array.isArray(cfg.tags) ? cfg.tags.slice() : [],
+      location_from_gps: !!cfg.location_from_gps,
+      allow_missing_exiftool: !!cfg.allow_missing_exiftool,
+    };
+    if (cfg.remote_target_id) {
+      delete body.destination;
+      body.remote_target_id = cfg.remote_target_id;
+      body.remote_subpath = cfg.remote_subpath;
+    }
+    if (cfg.after_process_move && cfg.after_process_move.remote_target_id) {
+      body.after_process_move = {
+        remote_target_id: cfg.after_process_move.remote_target_id,
+      };
+    }
+    return body;
+  }
+
   function jobCollectionText(job) {
     var cfg = jobConfig(job);
     if (cfg.collection_name) return 'Collection: ' + cfg.collection_name;
@@ -442,6 +473,16 @@
       html += '<span>' + esc(visibleProgress.label) + ': ' + progressPct(visibleProgress) + '%</span>';
     }
     html += '</div>';
+
+    var failedImportCount = job.result && Number(job.result.failed || 0);
+    if (!isLive && failedImportCount > 0 && importRetryBody(job)) {
+      html += '<div style="padding:10px 0 2px;font-size:12px;color:var(--text-muted);">';
+      html += '<button class="btn-retry" data-retry-import-job="' +
+        escapeAttr(job.id) + '">Retry ' + failedImportCount + ' failed file' +
+        (failedImportCount === 1 ? '' : 's') + '</button>';
+      html += '<span style="margin-left:8px;">Same source and destination; successful files are skipped.</span>';
+      html += '</div>';
+    }
 
     // Steps
     var steps = job.steps || job.tree || [];
@@ -891,6 +932,47 @@
 
   // Event delegation for detail pane clicks (step toggle, pause/resume, cancel)
   document.getElementById('jobDetailPane').addEventListener('click', function(e) {
+    var retryImportBtn = e.target.closest('[data-retry-import-job]');
+    if (retryImportBtn) {
+      var retryJobId = retryImportBtn.getAttribute('data-retry-import-job');
+      var retryJob = activeJobs.concat(historyJobs).find(function(job) {
+        return job.id === retryJobId;
+      });
+      var retryBody = importRetryBody(retryJob);
+      if (!retryBody) {
+        if (typeof showToast === 'function') {
+          showToast('The original import settings are no longer available.', 'error');
+        }
+        return;
+      }
+      retryImportBtn.disabled = true;
+      retryImportBtn.textContent = 'Starting retry…';
+      fetch('/api/jobs/import-photos', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(retryBody),
+      }).then(function(response) {
+        return response.json().catch(function() { return {}; }).then(function(data) {
+          if (!response.ok) {
+            throw new Error(data.error || 'Retry failed to start');
+          }
+          return data;
+        });
+      }).then(function(data) {
+        if (typeof showToast === 'function') {
+          showToast('Import retry started. Successful files will be skipped.', 'info');
+        }
+        selectedJobId = data.job_id;
+        selectedSource = 'active';
+        currentView = data.job_id;
+        fetchJobs();
+      }).catch(function(error) {
+        retryImportBtn.disabled = false;
+        retryImportBtn.textContent = 'Retry failed files';
+        if (typeof showToast === 'function') showToast(error.message, 'error');
+      });
+      return;
+    }
     var stepHeader = e.target.closest('[data-toggle-step]');
     if (stepHeader) {
       toggleStep(stepHeader.getAttribute('data-toggle-step'));

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -13870,6 +13870,44 @@ def test_import_page_returns_200(app_and_db):
     assert "/api/jobs/import-photos" in html
 
 
+def test_import_page_surfaces_destination_errors_and_recovery_actions(
+    app_and_db,
+):
+    """Import validation belongs beside the field and before the preview,
+    while failed copy runs offer a preconfigured recovery action."""
+    app, _ = app_and_db
+    html = app.test_client().get("/import").data.decode()
+
+    assert 'id="remoteSubpathError"' in html
+    assert 'aria-required="true"' in html
+    assert "Folder inside NAS" in html
+    assert "Local or mounted path" in html
+    assert "updateStartAvailability" in html
+    assert "importFormProblem" in html
+    assert html.index('id="importError"') < html.index('id="importPreviewGrid"')
+    assert 'id="retryImportRow"' in html
+    assert "retryFailedImport" in html
+    assert "Already imported files will be skipped" in html
+
+
+def test_import_page_collapses_duplicate_thumbnails(app_and_db):
+    """A one-file retry must not render or fetch thumbnails for every
+    catalogued duplicate on the card."""
+    app, _ = app_and_db
+    html = app.test_client().get("/import").data.decode()
+
+    assert "collapsed-duplicate-preview" in html
+    assert "duplicateCount.toLocaleString()" in html
+    assert "const pendingFiles = files.filter" in html
+    # Copy-with-dedup waits for the duplicate stream before rendering the
+    # grid; in-place and no-dedup branches still render immediately.
+    marker = "if (snapshotMode) {"
+    preview_prefix = html[
+        html.index("async function previewImport"):html.index(marker)
+    ]
+    assert "renderImportPreviewGrid(files, [], null)" not in preview_prefix
+
+
 def test_import_page_resolves_default_process_client_side(app_and_db):
     """Templates are Jinja-free by convention, so the after-import menu's
     default resolves in page JS from the workspace's config_overrides

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -6308,6 +6308,59 @@ def test_import_photos_new_workspace_ignores_old_default_process(
     assert config["after_import"] is None
 
 
+def test_import_photos_carry_photo_ids_persisted(app_and_db, tmp_path):
+    """A recovery retry passes ``carry_photo_ids`` so the after-import chain
+    covers the complete original scope, not only the newly-recovered files.
+    The endpoint validates, deduplicates while preserving order, and stores
+    the list on the job config where ``_chain_after_import`` can read it.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        "carry_photo_ids": [7, 3, 7, 42],
+    })
+    assert resp.status_code == 200, resp.get_json()
+    config = _job_config(client, resp.get_json()["job_id"])
+    assert config["carry_photo_ids"] == [7, 3, 42]
+
+
+def test_import_photos_carry_photo_ids_defaults_to_none(app_and_db, tmp_path):
+    """A first-attempt import (no carry list) leaves the field null so
+    ``_chain_after_import`` reads an empty list, not a non-list sentinel."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    config = _job_config(client, resp.get_json()["job_id"])
+    assert config["carry_photo_ids"] is None
+
+
+def test_import_photos_carry_photo_ids_validation_400s(app_and_db, tmp_path):
+    """Malformed carry lists fail at enqueue rather than crashing the
+    chain hook mid-run. Rejects: non-list, non-int entries, booleans (which
+    isinstance-int as True/False), zero, and negative IDs."""
+    app, _ = app_and_db
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    dest = str(tmp_path / "archive")
+    for bad in ("not-a-list", [1, "two"], [1, True], [0], [-3], [1.5]):
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": dest,
+            "after_import": None,
+            "carry_photo_ids": bad,
+        })
+        assert resp.status_code == 400, (bad, resp.get_json())
+        assert "carry_photo_ids" in resp.get_json()["error"]
+
+
 def test_import_in_place_new_workspace_ignores_old_default_process(
         app_and_db, tmp_path):
     """Same regression as above, exercised through the in-place endpoint —
@@ -6668,6 +6721,69 @@ def test_import_chains_process_job(app_and_db, tmp_path):
         assert res["collection_name"].startswith("Import ")
         photos = db.get_collection_photos(col_id, per_page=999999)
         assert sorted(p["id"] for p in photos) == sorted(res["photo_ids"])
+
+
+def test_import_retry_chains_carried_photo_ids(app_and_db, tmp_path):
+    """A recovery-retry import carries forward the original run's successful
+    photo IDs so the chained process runs on the complete original scope,
+    not only the files this retry newly landed.
+
+    Reproduction of the P1 bug: the original run had 1 file failed, so its
+    ``_chain_after_import`` returned early on ``not ok`` — nothing was
+    processed. On retry, ``skip_duplicates`` is forced True, so the
+    previously-successful files are excluded from ``photo_ids`` (they are
+    now duplicates). Without ``carry_photo_ids`` the retry's collection
+    holds only the newly-recovered files and the previously-successful
+    ones stay unprocessed forever.
+    """
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    quick_look_id = next(
+        pr["id"] for pr in db.get_saved_processes()
+        if pr["name"] == "Quick look")
+    card = _chain_card(tmp_path)
+    with app.test_client() as client:
+        # Land the seed files successfully. In production this would be
+        # the "984 succeeded" from a partially-failed run; here we
+        # simulate the "previously-imported" set by running a complete
+        # import first, then use those IDs as the carry list for the
+        # follow-up retry.
+        first = _post_import(client, card, tmp_path / "arch", None)
+        first_result = wait_for_job_via_client(client, first)["result"]
+        seed_ids = list(first_result["photo_ids"])
+        assert seed_ids, first_result
+
+        # Re-import the same card with skip_duplicates=True and a
+        # non-empty carry list. Every card file dedupes (skipped_duplicate),
+        # photo_ids is empty, but carry_photo_ids reintroduces the seed
+        # scope for the chain — the recovery-retry codepath.
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [str(card)],
+            "destination": str(tmp_path / "arch"),
+            "after_import": quick_look_id,
+            "skip_duplicates": True,
+            "carry_photo_ids": seed_ids,
+        })
+        assert resp.status_code == 200, resp.get_json()
+        retry_id = resp.get_json()["job_id"]
+        retry_job = wait_for_job_via_client(client, retry_id)
+        retry_result = retry_job["result"]
+
+        # The retry itself imported nothing (all files dedupe), but the
+        # chain must fire because carry_photo_ids brought the original
+        # scope back in.
+        assert retry_result.get("photo_ids") == []
+        assert sorted(retry_result.get("carried_photo_ids") or []) == \
+            sorted(seed_ids)
+        assert retry_result.get("process_job_id"), retry_result
+        assert retry_result.get("after_import_skipped") is None
+        assert retry_result.get("collection_id")
+        col_id = retry_result["collection_id"]
+        photos = db.get_collection_photos(col_id, per_page=999999)
+        # The collection must cover the original scope so quick-look runs
+        # against every photo the user intended to import.
+        assert sorted(p["id"] for p in photos) == sorted(seed_ids)
 
 
 def test_import_pauses_chained_classification_when_labels_are_missing(

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -6741,11 +6741,8 @@ def test_import_photos_retry_refuses_same_size_replacement(
         # pad the replacement to preserve the size so the test still
         # exercises the "same-size-different-bytes" invariant.
         original = Path(card) / "DSC_0001.jpg"
-        original_size = original.stat().st_size
-        # A no-op mtime bump would race the filesystem's timestamp
-        # resolution on retry; sleep past the resolution boundary
-        # before rewriting so mtime_ns strictly advances.
-        time.sleep(0.02)
+        original_stat = original.stat()
+        original_size = original_stat.st_size
         Image.new("RGB", (16, 16), "green").save(str(original))
         replacement_size = original.stat().st_size
         if replacement_size != original_size:
@@ -6760,10 +6757,19 @@ def test_import_photos_retry_refuses_same_size_replacement(
                     fh.write(b"\x00" * needed)
                 elif needed < 0:
                     fh.truncate(original_size)
-            # File writes update mtime again; no extra sleep needed
-            # since we're only asserting mtime != parent's, not
-            # ordering of two rewrites.
             assert original.stat().st_size == original_size
+        # Force an mtime change beyond coarse one-second filesystem
+        # granularity instead of relying on a short wall-clock sleep.
+        rewritten_stat = original.stat()
+        bumped_mtime_ns = max(
+            original_stat.st_mtime_ns,
+            rewritten_stat.st_mtime_ns,
+        ) + 2_000_000_000
+        os.utime(
+            original,
+            ns=(rewritten_stat.st_atime_ns, bumped_mtime_ns),
+        )
+        assert original.stat().st_mtime_ns != original_stat.st_mtime_ns
 
         resp = client.post("/api/jobs/import-photos", json={
             "sources": [card],
@@ -6882,6 +6888,68 @@ def test_import_photos_parent_job_wrong_workspace_rejected(
         })
     assert resp.status_code == 400
     assert "different workspace" in resp.get_json()["error"]
+
+
+@pytest.mark.parametrize("status", [
+    "queued", "running", "pausing", "paused",
+])
+def test_import_photos_parent_job_must_be_terminal(
+        app_and_db, tmp_path, status):
+    """A retry cannot use an import that is still active as its parent.
+    Active parents have incomplete results and snapshots, so accepting one
+    can enqueue two imports against the same source and destination."""
+    app, db = app_and_db
+    runner = app._job_runner
+    parent_id = f"import-active-{status}"
+    with runner._lock:
+        runner._jobs[parent_id] = {
+            "id": parent_id,
+            "type": "import",
+            "status": status,
+            "workspace_id": db._active_workspace_id,
+            "config": {},
+            "result": {},
+        }
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+
+    assert resp.status_code == 409, resp.get_json()
+    assert "still active" in resp.get_json()["error"]
+
+
+def test_import_photos_retry_cannot_create_new_workspace(
+        app_and_db, tmp_path):
+    """A parent is bound to its original workspace; creating and switching
+    to another workspace after validating that parent would leak carried
+    photo scope across workspaces."""
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    original_workspace = db._active_workspace_id
+    with app.test_client() as client:
+        card = _import_card(tmp_path)
+        parent_id = _post_import(
+            client, card, tmp_path / "archive", None,
+        )
+        wait_for_job_via_client(client, parent_id)
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+            "new_workspace_name": "Unsafe Retry Workspace",
+        })
+
+    assert resp.status_code == 400, resp.get_json()
+    assert "cannot create a new workspace" in resp.get_json()["error"]
+    assert db._active_workspace_id == original_workspace
 
 
 def test_import_photos_parent_job_missing_404(app_and_db, tmp_path):
@@ -7155,6 +7223,8 @@ def test_import_photos_remote_target_edit_blocks_retry(
     Otherwise the retry would copy the remaining files to a different
     NAS, or (if the mount changed) skip prior successes based on the
     old catalog view while transferring failures to a new location."""
+    from wait import wait_for_job_via_client
+
     app, _ = app_and_db
     _save_remote_target(monkeypatch, tmp_path)
     with app.test_client() as client:
@@ -7163,6 +7233,7 @@ def test_import_photos_remote_target_edit_blocks_retry(
             "/api/jobs/import-photos", json=_remote_import_body(card))
         assert first.status_code == 200, first.get_json()
         parent_id = first.get_json()["job_id"]
+        wait_for_job_via_client(client, parent_id)
 
         # Simulate the operator editing the target — new host, new
         # remote_path, new mount — after the failed run finished.
@@ -7191,6 +7262,8 @@ def test_import_photos_remote_target_unchanged_retry_ok(
     """When the target hasn't changed, a retry with parent_import_job_id
     is accepted — same host/root/mount/subpath resolves to the same
     snapshot."""
+    from wait import wait_for_job_via_client
+
     app, _ = app_and_db
     _save_remote_target(monkeypatch, tmp_path)
     with app.test_client() as client:
@@ -7199,6 +7272,7 @@ def test_import_photos_remote_target_unchanged_retry_ok(
             "/api/jobs/import-photos", json=_remote_import_body(card))
         assert first.status_code == 200, first.get_json()
         parent_id = first.get_json()["job_id"]
+        wait_for_job_via_client(client, parent_id)
 
         retry = client.post(
             "/api/jobs/import-photos", json=_remote_import_body(
@@ -7236,6 +7310,44 @@ def test_import_photos_retry_rejects_unknown_source(
         })
         assert resp.status_code == 400, resp.get_json()
         assert "never enumerated" in resp.get_json()["error"]
+
+
+def test_import_photos_retry_requires_every_parent_source(
+        app_and_db, tmp_path):
+    """A retry cannot omit one of a multi-source parent's sources.
+    Otherwise it can finish and run carried processing even though failures
+    from the omitted source were never retried."""
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    card_a = tmp_path / "card-a"
+    card_b = tmp_path / "card-b"
+    card_a.mkdir()
+    card_b.mkdir()
+    Image.new("RGB", (16, 16), "red").save(card_a / "A.jpg")
+    Image.new("RGB", (16, 16), "blue").save(card_b / "B.jpg")
+
+    with app.test_client() as client:
+        parent = client.post("/api/jobs/import-photos", json={
+            "sources": [str(card_a), str(card_b)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+        })
+        assert parent.status_code == 200, parent.get_json()
+        parent_id = parent.get_json()["job_id"]
+        wait_for_job_via_client(client, parent_id)
+
+        retry = client.post("/api/jobs/import-photos", json={
+            "sources": [str(card_a)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+
+    assert retry.status_code == 400, retry.get_json()
+    error = retry.get_json()["error"]
+    assert "every source" in error
+    assert str(card_b) in error
 
 
 def test_import_photos_retry_rejects_second_concurrent_retry(

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -7163,6 +7163,92 @@ def test_import_photos_remote_target_unchanged_retry_ok(
         assert retry.status_code == 200, retry.get_json()
 
 
+def test_import_photos_retry_rejects_unknown_source(
+        app_and_db, tmp_path):
+    """A retry that lists a source path the parent never enumerated is
+    refused: skipping validation for unknown paths would let the retry
+    import every file at that path and stream them into the after-
+    import / NAS-move scope, even though the button only promises the
+    parent's failed files. See PR #1387 Codex review."""
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        parent_card = _import_card(tmp_path)
+        parent_id = _post_import(
+            client, parent_card, tmp_path / "archive", None,
+        )
+        wait_for_job_via_client(client, parent_id)
+
+        # Retry lists a *different* card path the parent never saw.
+        (tmp_path / "rogue").mkdir()
+        rogue_card = _import_card(tmp_path / "rogue")
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [rogue_card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert resp.status_code == 400, resp.get_json()
+        assert "never enumerated" in resp.get_json()["error"]
+
+
+def test_import_photos_retry_rejects_second_concurrent_retry(
+        app_and_db, tmp_path, monkeypatch):
+    """Once one retry for a failed import is in flight, a second
+    submission with the same parent (or its root ancestor) is rejected
+    409 rather than racing another import + after-import chain against
+    the first one. See PR #1387 Codex review."""
+    import import_job
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    card = _import_card(tmp_path)
+    with app.test_client() as client:
+        parent_id = _post_import(
+            client, card, tmp_path / "archive", None,
+        )
+        wait_for_job_via_client(client, parent_id)
+
+        # Block the first retry inside run_import_job so it stays
+        # active while we submit the second one. The parent already
+        # finished above, so it doesn't hit this hook.
+        release_first_retry = threading.Event()
+
+        def blocking_result(job, runner, db_path, workspace_id, params):
+            assert release_first_retry.wait(timeout=5)
+            return {
+                "ok": True, "cancelled": False, "photo_ids": [],
+                "discovered": 0, "copied": 0, "verified": 0,
+                "skipped_duplicate": 0, "failed": 0,
+                "safe_to_format": True, "unsafe_files": [],
+                "folders": {}, "errors": [],
+            }
+
+        monkeypatch.setattr(import_job, "run_import_job", blocking_result)
+
+        first_retry = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert first_retry.status_code == 200, first_retry.get_json()
+
+        # Second retry with the same parent should be rejected 409.
+        second_retry = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert second_retry.status_code == 409, second_retry.get_json()
+        assert "already in flight" in second_retry.get_json()["error"]
+
+        release_first_retry.set()
+        wait_for_job_via_client(client, first_retry.get_json()["job_id"])
+
+
 def test_import_photos_remote_and_destination_mutually_exclusive(
         app_and_db, tmp_path, monkeypatch):
     app, _ = app_and_db

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -6347,6 +6347,101 @@ def test_import_photos_carry_photo_ids_persisted(app_and_db, tmp_path):
         assert config["carry_photo_ids"] == expected
 
 
+def test_import_photos_persists_after_import_snapshot(app_and_db, tmp_path):
+    """An import with a chained process freezes the process's stage flags in
+    the persisted job config, so a recovery retry can reuse the exact stages
+    the user originally accepted rather than re-resolving (and picking up a
+    mid-recovery Settings edit or 404ing on a deleted process)."""
+    app, db = app_and_db
+    client = app.test_client()
+    quick_look_id = next(
+        pr["id"] for pr in db.get_saved_processes() if pr["name"] == "Quick look")
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": quick_look_id,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    config = _job_config(client, resp.get_json()["job_id"])
+    snap = config["after_import_snapshot"]
+    assert snap is not None
+    # Snapshot mirrors db.resolve_process — a dict of the stage flags at
+    # enqueue time. The important invariant is that it's persisted and
+    # matches the current resolution, so the retry validator has a frozen
+    # record to fall back on.
+    assert snap == db.resolve_process(quick_look_id)
+
+
+def test_import_photos_retry_reuses_parent_after_import_snapshot(
+        app_and_db, tmp_path):
+    """When a retry keeps the same ``after_import`` id, the endpoint uses the
+    parent's frozen snapshot instead of re-resolving. This is what protects
+    the retry from a mid-recovery edit to the saved process (or a delete
+    that would otherwise 404 the retry outright)."""
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    with app.test_client() as client:
+        quick_look_id = next(
+            pr["id"] for pr in db.get_saved_processes()
+            if pr["name"] == "Quick look")
+        parent_id = _post_import(client, _import_card(tmp_path),
+                                 tmp_path / "archive", quick_look_id)
+        wait_for_job_via_client(client, parent_id)
+        parent_config = _job_config(client, parent_id)
+        parent_snapshot = parent_config["after_import_snapshot"]
+        assert parent_snapshot is not None
+
+        # Flip a stage AFTER the parent has run — a Settings edit the retry
+        # must not silently pick up. ``skip_classify`` starts True on the
+        # Quick look seed, so flipping to False produces a different
+        # resolution the frozen snapshot must not equal.
+        db.update_saved_process(quick_look_id, skip_classify=False)
+        current = db.resolve_process(quick_look_id)
+        assert current != parent_snapshot
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": quick_look_id,
+            "parent_import_job_id": parent_id,
+        })
+        assert resp.status_code == 200, resp.get_json()
+        retry_config = _job_config(client, resp.get_json()["job_id"])
+        assert retry_config["after_import_snapshot"] == parent_snapshot
+
+
+def test_import_photos_retry_survives_deleted_process(app_and_db, tmp_path):
+    """When the saved process is deleted after a failed run, a retry that
+    still points at that id must still start — reusing the parent's frozen
+    snapshot instead of 404ing on ``db.resolve_process``."""
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    with app.test_client() as client:
+        quick_look_id = next(
+            pr["id"] for pr in db.get_saved_processes()
+            if pr["name"] == "Quick look")
+        parent_id = _post_import(client, _import_card(tmp_path),
+                                 tmp_path / "archive", quick_look_id)
+        wait_for_job_via_client(client, parent_id)
+        parent_snapshot = _job_config(client, parent_id)[
+            "after_import_snapshot"]
+        assert parent_snapshot is not None
+
+        db.delete_saved_process(quick_look_id)
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": quick_look_id,
+            "parent_import_job_id": parent_id,
+        })
+        assert resp.status_code == 200, resp.get_json()
+        retry_config = _job_config(client, resp.get_json()["job_id"])
+        assert retry_config["after_import_snapshot"] == parent_snapshot
+
+
 def test_import_photos_carry_photo_ids_defaults_to_none(app_and_db, tmp_path):
     """A first-attempt import (no carry list) leaves the field null so
     ``_chain_after_import`` reads an empty list, not a non-list sentinel."""

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -6313,18 +6313,38 @@ def test_import_photos_carry_photo_ids_persisted(app_and_db, tmp_path):
     covers the complete original scope, not only the newly-recovered files.
     The endpoint validates, deduplicates while preserving order, and stores
     the list on the job config where ``_chain_after_import`` can read it.
+
+    The carry list must be bound to a real parent import job (see
+    parent_import_job_id validation) so a caller can't inject arbitrary
+    photo IDs into the chain scope.
     """
+    from wait import wait_for_job_via_client
+
     app, _ = app_and_db
-    client = app.test_client()
-    resp = client.post("/api/jobs/import-photos", json={
-        "sources": [_import_card(tmp_path)],
-        "destination": str(tmp_path / "archive"),
-        "after_import": None,
-        "carry_photo_ids": [7, 3, 7, 42],
-    })
-    assert resp.status_code == 200, resp.get_json()
-    config = _job_config(client, resp.get_json()["job_id"])
-    assert config["carry_photo_ids"] == [7, 3, 42]
+    with app.test_client() as client:
+        parent_id = _post_import(client, _import_card(tmp_path),
+                                 tmp_path / "archive", None)
+        parent_result = wait_for_job_via_client(client, parent_id)["result"]
+        parent_photo_ids = list(parent_result["photo_ids"])
+        assert parent_photo_ids, parent_result
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+            # Duplicate + reorder to prove dedup preserves caller order.
+            "carry_photo_ids": (
+                [parent_photo_ids[0]] * 2 + list(reversed(parent_photo_ids))
+            ),
+        })
+        assert resp.status_code == 200, resp.get_json()
+        config = _job_config(client, resp.get_json()["job_id"])
+        expected = [parent_photo_ids[0]] + [
+            pid for pid in reversed(parent_photo_ids)
+            if pid != parent_photo_ids[0]
+        ]
+        assert config["carry_photo_ids"] == expected
 
 
 def test_import_photos_carry_photo_ids_defaults_to_none(app_and_db, tmp_path):
@@ -6345,7 +6365,9 @@ def test_import_photos_carry_photo_ids_defaults_to_none(app_and_db, tmp_path):
 def test_import_photos_carry_photo_ids_validation_400s(app_and_db, tmp_path):
     """Malformed carry lists fail at enqueue rather than crashing the
     chain hook mid-run. Rejects: non-list, non-int entries, booleans (which
-    isinstance-int as True/False), zero, and negative IDs."""
+    isinstance-int as True/False), zero, and negative IDs. The shape check
+    runs BEFORE the parent-import binding, so a real parent isn't needed
+    to fail these."""
     app, _ = app_and_db
     client = app.test_client()
     card = _import_card(tmp_path)
@@ -6359,6 +6381,137 @@ def test_import_photos_carry_photo_ids_validation_400s(app_and_db, tmp_path):
         })
         assert resp.status_code == 400, (bad, resp.get_json())
         assert "carry_photo_ids" in resp.get_json()["error"]
+
+
+def test_import_photos_carry_photo_ids_requires_parent(app_and_db, tmp_path):
+    """A carry list without ``parent_import_job_id`` is refused: without a
+    parent binding an API caller could inject arbitrary positive IDs into
+    the after-import chain scope (and, with after_process_move, into the
+    NAS transfer's folder lookup)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        "carry_photo_ids": [1, 2, 3],
+    })
+    assert resp.status_code == 400
+    error = resp.get_json()["error"]
+    assert "parent_import_job_id" in error
+
+
+def test_import_photos_carry_photo_ids_rejects_unlisted_ids(
+        app_and_db, tmp_path):
+    """Carry IDs must all come from the parent's imported or previously-
+    inherited scope. A caller who names a real parent but supplies
+    unrelated IDs is refused before the job is enqueued."""
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        parent_id = _post_import(client, _import_card(tmp_path),
+                                 tmp_path / "archive", None)
+        parent_result = wait_for_job_via_client(client, parent_id)["result"]
+        parent_photo_ids = list(parent_result["photo_ids"])
+        assert parent_photo_ids
+
+        stray = max(parent_photo_ids) + 999
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+            "carry_photo_ids": parent_photo_ids + [stray],
+        })
+        assert resp.status_code == 400
+        error = resp.get_json()["error"]
+        assert "parent import did not land" in error
+        assert str(stray) in error
+
+
+def test_import_photos_parent_job_wrong_workspace_rejected(
+        app_and_db, tmp_path):
+    """A parent import from another workspace is refused — photos and
+    folders are global, so accepting a cross-workspace parent would let a
+    caller smuggle another workspace's photos into this workspace's
+    after-import chain and (with after_process_move) into its NAS
+    transfer's folder lookup."""
+    from datetime import datetime, timedelta
+
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    original_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+
+    # Flask-per-request Database picks the workspace with the newest
+    # last_opened_at; nudge each in turn to switch what /api/jobs/*
+    # sees as active.
+    now = datetime.now()
+    db.update_workspace(
+        other_ws, last_opened_at=(now + timedelta(seconds=10)).isoformat())
+    with app.test_client() as client:
+        parent_id = _post_import(client, _import_card(tmp_path),
+                                 tmp_path / "archive-other", None)
+        parent_result = wait_for_job_via_client(client, parent_id)["result"]
+        parent_photo_ids = list(parent_result["photo_ids"])
+        assert parent_photo_ids
+    db.update_workspace(
+        original_ws, last_opened_at=(now + timedelta(seconds=20)).isoformat())
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive-active"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+            "carry_photo_ids": parent_photo_ids,
+        })
+    assert resp.status_code == 400
+    assert "different workspace" in resp.get_json()["error"]
+
+
+def test_import_photos_parent_job_missing_404(app_and_db, tmp_path):
+    """A parent id the runner has no record of (and no history row for)
+    is refused with a clear 404 rather than a silent accept."""
+    app, _ = app_and_db
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": "not-a-real-job-id",
+            "carry_photo_ids": [1],
+        })
+    assert resp.status_code == 404
+    assert "parent_import_job_id not found" in resp.get_json()["error"]
+
+
+def test_import_photos_parent_job_wrong_type_rejected(app_and_db, tmp_path):
+    """A parent id that names a non-import job (e.g. a thumbnail
+    generation run) can't seed an import retry — refuse with the actual
+    type in the message so the caller can diagnose."""
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        # Need a completed non-import job with a history row.
+        # /api/jobs/thumbnails is a convenient no-op when there are no
+        # photos yet — it still finishes and persists a job_history row.
+        resp = client.post("/api/jobs/thumbnails", json={})
+        assert resp.status_code == 200, resp.get_json()
+        non_import_id = resp.get_json()["job_id"]
+        wait_for_job_via_client(client, non_import_id)
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": non_import_id,
+            "carry_photo_ids": [1],
+        })
+    assert resp.status_code == 400
+    assert "must reference an import job" in resp.get_json()["error"]
 
 
 def test_import_in_place_new_workspace_ignores_old_default_process(
@@ -6552,6 +6705,94 @@ def test_import_photos_remote_happy_path(app_and_db, tmp_path, monkeypatch):
     # Destination recorded as the resolved local mount path.
     expected_dest = os.path.join(str(tmp_path / "mount"), "2026", "trip")
     assert config["destination"] == expected_dest
+    # Snapshot the parts of the target that decide where files land so a
+    # later retry can detect a Settings edit and refuse rather than
+    # silently transferring to a different NAS.
+    assert config["remote_target_snapshot"] == {
+        "host": "nas",
+        "user": "me",
+        "port": 22,
+        "remote_path": "/volume1/Photography",
+        "mount_path": str(tmp_path / "mount"),
+        "subpath": "2026/trip",
+    }
+
+
+def test_import_photos_local_has_no_remote_target_snapshot(
+        app_and_db, tmp_path):
+    """A local-destination import records ``remote_target_snapshot`` as
+    None so a later retry (which is also local) compares None==None and
+    doesn't spuriously reject."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    config = _job_config(client, resp.get_json()["job_id"])
+    assert config["remote_target_snapshot"] is None
+
+
+def test_import_photos_remote_target_edit_blocks_retry(
+        app_and_db, tmp_path, monkeypatch):
+    """When the saved remote target has been edited since the parent run
+    (host, remote_path, mount_path, port, or user), refuse the retry.
+    Otherwise the retry would copy the remaining files to a different
+    NAS, or (if the mount changed) skip prior successes based on the
+    old catalog view while transferring failures to a new location."""
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    with app.test_client() as client:
+        card = _import_card(tmp_path)
+        first = client.post(
+            "/api/jobs/import-photos", json=_remote_import_body(card))
+        assert first.status_code == 200, first.get_json()
+        parent_id = first.get_json()["job_id"]
+
+        # Simulate the operator editing the target — new host, new
+        # remote_path, new mount — after the failed run finished.
+        _save_remote_target(
+            monkeypatch,
+            tmp_path,
+            host="different-nas",
+            remote_path="/volume2/Elsewhere",
+            mount_path=str(tmp_path / "mount2"),
+        )
+
+        # Retry with parent_import_job_id should be refused because the
+        # resolved current snapshot no longer matches the parent's.
+        retry = client.post(
+            "/api/jobs/import-photos", json=_remote_import_body(
+                card, parent_import_job_id=parent_id,
+            ),
+        )
+        assert retry.status_code == 400, retry.get_json()
+        assert "remote target" in retry.get_json()["error"].lower()
+        assert "changed" in retry.get_json()["error"].lower()
+
+
+def test_import_photos_remote_target_unchanged_retry_ok(
+        app_and_db, tmp_path, monkeypatch):
+    """When the target hasn't changed, a retry with parent_import_job_id
+    is accepted — same host/root/mount/subpath resolves to the same
+    snapshot."""
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    with app.test_client() as client:
+        card = _import_card(tmp_path)
+        first = client.post(
+            "/api/jobs/import-photos", json=_remote_import_body(card))
+        assert first.status_code == 200, first.get_json()
+        parent_id = first.get_json()["job_id"]
+
+        retry = client.post(
+            "/api/jobs/import-photos", json=_remote_import_body(
+                card, parent_import_job_id=parent_id,
+            ),
+        )
+        assert retry.status_code == 200, retry.get_json()
 
 
 def test_import_photos_remote_and_destination_mutually_exclusive(
@@ -6758,11 +6999,16 @@ def test_import_retry_chains_carried_photo_ids(app_and_db, tmp_path):
         # non-empty carry list. Every card file dedupes (skipped_duplicate),
         # photo_ids is empty, but carry_photo_ids reintroduces the seed
         # scope for the chain — the recovery-retry codepath.
+        # parent_import_job_id binds the carry list to the first run so
+        # the server can validate that every carry ID actually came from
+        # a real parent import (the security check that prevents
+        # arbitrary-ID injection).
         resp = client.post("/api/jobs/import-photos", json={
             "sources": [str(card)],
             "destination": str(tmp_path / "arch"),
             "after_import": quick_look_id,
             "skip_duplicates": True,
+            "parent_import_job_id": first,
             "carry_photo_ids": seed_ids,
         })
         assert resp.status_code == 200, resp.get_json()

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3582,7 +3582,15 @@ def _import_card(tmp_path, names=("DSC_0001.jpg",)):
     card = tmp_path / "import-card"
     card.mkdir(exist_ok=True)
     for name in names:
-        Image.new("RGB", (16, 16), "red").save(str(card / name))
+        target = card / name
+        # Idempotent: don't rewrite an existing file. Callers that pass
+        # ``_import_card(tmp_path)`` to both the parent import and the
+        # retry request rely on the card looking unchanged between the
+        # two calls, which now includes ``st_mtime_ns`` (part of the
+        # source-drift signature) — rewriting the file would bump mtime
+        # and trip the drift check.
+        if not target.exists():
+            Image.new("RGB", (16, 16), "red").save(str(target))
     return str(card)
 
 
@@ -6591,6 +6599,135 @@ def test_import_photos_retry_accepts_unchanged_source(
             "parent_import_job_id": parent_id,
         })
         assert resp.status_code == 200, resp.get_json()
+
+
+def test_import_photos_source_snapshot_records_discovery_time_size(
+        app_and_db, tmp_path):
+    """The parent's ``source_snapshots`` must be captured at DISCOVERY
+    time, not at completion time. Without this, a card ejected or
+    momentarily unreadable mid-run would backfill ``-1`` sizes for
+    successfully-discovered files; the retry-side signature check
+    would then refuse the natural "reinsert the card and retry"
+    recovery even though the source hasn't actually changed.
+
+    Regression guard: the persisted snapshot must match a fresh
+    discovery-time capture of the same source, and must NOT match the
+    signature a completion-time capture would have produced if the
+    card had become unreadable between discovery and completion."""
+    from pathlib import Path
+
+    from import_job import _capture_source_snapshots
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        card = _import_card(tmp_path)
+        parent_id = _post_import(client, card,
+                                 tmp_path / "archive", None)
+        parent = wait_for_job_via_client(client, parent_id)
+
+        snapshots = parent["result"]["source_snapshots"]
+        card_snap = snapshots.get(card) or next(iter(snapshots.values()))
+        assert card_snap["count"] == 1
+        assert card_snap["signature"]
+
+        # A discovery-time capture repeated against the (still
+        # readable) source must reproduce the parent's signature. If
+        # it doesn't, the parent recorded something other than what a
+        # normal discovery-time capture would produce.
+        real_path = Path(card) / "DSC_0001.jpg"
+        rediscovered = _capture_source_snapshots([real_path], [card])
+        assert (
+            rediscovered[card]["signature"] == card_snap["signature"]
+        ), (
+            "persisted snapshot signature does not match a fresh "
+            "discovery-time capture of the same file"
+        )
+
+        # A completion-time capture with the file unreadable (the
+        # ejected-card mid-run scenario) would stamp ``-1`` and yield
+        # a different signature. Prove the parent's signature is NOT
+        # that one — the snapshot was captured while the source was
+        # readable, not backfilled after ejection.
+        import unittest.mock as _mock
+        original_stat = Path.stat
+
+        def _fail_stat(self, *args, **kwargs):
+            if str(self) == str(real_path):
+                raise OSError("simulated ejected card")
+            return original_stat(self, *args, **kwargs)
+
+        with _mock.patch.object(Path, "stat", _fail_stat):
+            ejected_snapshot = _capture_source_snapshots(
+                [real_path], [card],
+            )
+        assert (
+            ejected_snapshot[card]["signature"]
+            != card_snap["signature"]
+        ), (
+            "parent snapshot signature matches an ejected-card capture, "
+            "so the snapshot must have been recorded at completion time "
+            "instead of at discovery"
+        )
+
+
+def test_import_photos_retry_refuses_same_size_replacement(
+        app_and_db, tmp_path):
+    """A file replaced with different bytes at the same path and same
+    byte size still counts as a source change: without ``mtime_ns`` in
+    the snapshot tuple the ``(rel_path, size)`` signature would match
+    and the retry would silently copy the new bytes as if they were
+    the parent's failed files. Guard against that by asserting the
+    drift check refuses the retry when only the mtime differs."""
+    from pathlib import Path
+
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        card = _import_card(tmp_path)
+        parent_id = _post_import(client, card,
+                                 tmp_path / "archive", None)
+        wait_for_job_via_client(client, parent_id)
+
+        # Replace the single card file with a different-color image of
+        # identical dimensions. Two 16x16 solid-color JPEGs typically
+        # encode to identical byte counts; if PIL happens to differ,
+        # pad the replacement to preserve the size so the test still
+        # exercises the "same-size-different-bytes" invariant.
+        original = Path(card) / "DSC_0001.jpg"
+        original_size = original.stat().st_size
+        # A no-op mtime bump would race the filesystem's timestamp
+        # resolution on retry; sleep past the resolution boundary
+        # before rewriting so mtime_ns strictly advances.
+        time.sleep(0.02)
+        Image.new("RGB", (16, 16), "green").save(str(original))
+        replacement_size = original.stat().st_size
+        if replacement_size != original_size:
+            # PIL's encoder produced a slightly different byte count.
+            # Pad or truncate to the original size to keep this a
+            # same-size replacement test. (Ext4/APFS both accept
+            # arbitrary bytes appended to a JPEG; the drift check
+            # doesn't validate JPEG structure.)
+            with open(original, "ab") as fh:
+                needed = original_size - replacement_size
+                if needed > 0:
+                    fh.write(b"\x00" * needed)
+                elif needed < 0:
+                    fh.truncate(original_size)
+            # File writes update mtime again; no extra sleep needed
+            # since we're only asserting mtime != parent's, not
+            # ordering of two rewrites.
+            assert original.stat().st_size == original_size
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert resp.status_code == 400, resp.get_json()
+        assert "source contents have changed" in resp.get_json()["error"]
 
 
 def test_import_photos_carry_photo_ids_validation_400s(app_and_db, tmp_path):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -6671,6 +6671,51 @@ def test_import_photos_source_snapshot_records_discovery_time_size(
         )
 
 
+def test_import_photos_source_snapshot_dedupes_overlapping_sources(
+        tmp_path):
+    """When the Import page selects overlapping sources such as
+    ``/card`` and ``/card/DCIM``, ``discover_source_files`` runs once
+    per source and yields each nested file twice in the combined list.
+    Without dedup, ``_capture_source_snapshots`` records each occurrence
+    in every applicable source's signature — parent snapshot for
+    ``/card/DCIM`` would list ``IMG.jpg`` twice, but retry validation
+    re-enumerates each source alone (one occurrence per file) and
+    computes a different signature, refusing a card whose contents did
+    not change. Assert both parent-side snapshots collapse to what a
+    single-source retry-time capture would produce."""
+    from import_job import _capture_source_snapshots
+
+    card = tmp_path / "card"
+    dcim = card / "DCIM"
+    dcim.mkdir(parents=True)
+    img = dcim / "IMG_0001.jpg"
+    img.write_bytes(b"payload")
+
+    # Simulate the discovery loop for overlapping sources: each source's
+    # enumeration runs independently and both surface the nested file.
+    combined_files = [img, img]
+    snapshots = _capture_source_snapshots(
+        combined_files, [str(card), str(dcim)],
+    )
+
+    # Retry re-enumerates each source alone, so the per-source signature
+    # captured from ``[img]`` is what the drift check will compare
+    # against; those must match the deduped parent snapshot.
+    single_card = _capture_source_snapshots([img], [str(card)])
+    single_dcim = _capture_source_snapshots([img], [str(dcim)])
+
+    assert snapshots[str(card)]["count"] == 1
+    assert snapshots[str(dcim)]["count"] == 1
+    assert (
+        snapshots[str(card)]["signature"]
+        == single_card[str(card)]["signature"]
+    )
+    assert (
+        snapshots[str(dcim)]["signature"]
+        == single_dcim[str(dcim)]["signature"]
+    )
+
+
 def test_import_photos_retry_refuses_same_size_replacement(
         app_and_db, tmp_path):
     """A file replaced with different bytes at the same path and same

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -6455,6 +6455,37 @@ def test_import_photos_carry_photo_ids_defaults_to_none(app_and_db, tmp_path):
     assert resp.status_code == 200, resp.get_json()
     config = _job_config(client, resp.get_json()["job_id"])
     assert config["carry_photo_ids"] is None
+    # First-attempt imports have no parent, so the persisted config
+    # advertises that to the Jobs page's parallel-retry gate.
+    assert config["parent_import_job_id"] is None
+
+
+def test_import_photos_retry_persists_parent_import_job_id(
+        app_and_db, tmp_path):
+    """A recovery retry stores its parent's id on ``job_config`` so the
+    Jobs page's ``hasActiveRetryFor`` gate can suppress a second Retry
+    button click on the same failed parent while this retry is running.
+    Without persistence the client-side check reads ``undefined`` on
+    every active job and the gate never fires."""
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        parent_id = _post_import(client, _import_card(tmp_path),
+                                 tmp_path / "archive", None)
+        wait_for_job_via_client(client, parent_id)
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert resp.status_code == 200, resp.get_json()
+        retry_id = resp.get_json()["job_id"]
+        wait_for_job_via_client(client, retry_id)
+        retry_config = _job_config(client, retry_id)
+        assert retry_config["parent_import_job_id"] == parent_id
 
 
 def test_import_photos_carry_photo_ids_validation_400s(app_and_db, tmp_path):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -7406,6 +7406,73 @@ def test_import_photos_retry_rejects_second_concurrent_retry(
         wait_for_job_via_client(client, first_retry.get_json()["job_id"])
 
 
+def test_import_photos_retry_rejects_second_retry_while_first_is_pausing(
+        app_and_db, tmp_path, monkeypatch):
+    """``pause_job`` publishes ``pausing`` immediately, but the worker
+    keeps running until it reaches a checkpoint — so the first retry is
+    still actively copying/writing while its public status is
+    ``pausing``. Treating that state as inactive would let a second
+    retry slip in and race the chained after-import / NAS move against
+    the still-running first one. See PR #1387 Codex review."""
+    import import_job
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    card = _import_card(tmp_path)
+    with app.test_client() as client:
+        parent_id = _post_import(
+            client, card, tmp_path / "archive", None,
+        )
+        wait_for_job_via_client(client, parent_id)
+
+        # Signal from inside the worker so we know its public status
+        # has advanced from ``queued`` to ``running`` before we try to
+        # pause it — ``pause_job`` requires ``running``.
+        first_retry_running = threading.Event()
+        release_first_retry = threading.Event()
+
+        def blocking_result(job, runner, db_path, workspace_id, params):
+            first_retry_running.set()
+            assert release_first_retry.wait(timeout=5)
+            return {
+                "ok": True, "cancelled": False, "photo_ids": [],
+                "discovered": 0, "copied": 0, "verified": 0,
+                "skipped_duplicate": 0, "failed": 0,
+                "safe_to_format": True, "unsafe_files": [],
+                "folders": {}, "errors": [],
+            }
+
+        monkeypatch.setattr(import_job, "run_import_job", blocking_result)
+
+        first_retry = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert first_retry.status_code == 200, first_retry.get_json()
+        first_retry_id = first_retry.get_json()["job_id"]
+
+        # Wait until the worker is running, then request a pause. The
+        # worker is still blocked in ``blocking_result``, so the job
+        # sits in ``pausing`` (never advances to ``paused``).
+        assert first_retry_running.wait(timeout=5)
+        assert app._job_runner.pause_job(first_retry_id) is True
+        assert app._job_runner.get(first_retry_id)["status"] == "pausing"
+
+        second_retry = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert second_retry.status_code == 409, second_retry.get_json()
+        assert "already in flight" in second_retry.get_json()["error"]
+
+        release_first_retry.set()
+        wait_for_job_via_client(client, first_retry_id)
+
+
 def test_import_photos_remote_and_destination_mutually_exclusive(
         app_and_db, tmp_path, monkeypatch):
     app, _ = app_and_db

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -6458,6 +6458,7 @@ def test_import_photos_carry_photo_ids_defaults_to_none(app_and_db, tmp_path):
     # First-attempt imports have no parent, so the persisted config
     # advertises that to the Jobs page's parallel-retry gate.
     assert config["parent_import_job_id"] is None
+    assert config["root_import_job_id"] is None
 
 
 def test_import_photos_retry_persists_parent_import_job_id(
@@ -6466,7 +6467,9 @@ def test_import_photos_retry_persists_parent_import_job_id(
     Jobs page's ``hasActiveRetryFor`` gate can suppress a second Retry
     button click on the same failed parent while this retry is running.
     Without persistence the client-side check reads ``undefined`` on
-    every active job and the gate never fires."""
+    every active job and the gate never fires. On a first-level retry
+    ``root_import_job_id`` equals ``parent_import_job_id`` — the parent
+    is itself the root of the chain."""
     from wait import wait_for_job_via_client
 
     app, _ = app_and_db
@@ -6486,6 +6489,108 @@ def test_import_photos_retry_persists_parent_import_job_id(
         wait_for_job_via_client(client, retry_id)
         retry_config = _job_config(client, retry_id)
         assert retry_config["parent_import_job_id"] == parent_id
+        assert retry_config["root_import_job_id"] == parent_id
+
+
+def test_import_photos_retry_of_retry_inherits_root_import_job_id(
+        app_and_db, tmp_path):
+    """A retry-of-retry's ``root_import_job_id`` names the ORIGINAL
+    failed import, not its direct parent. Without this the Jobs page's
+    ``hasActiveRetryFor`` gate — keyed on the original failed job's id
+    — cannot recognize a deep retry as belonging to the chain, and a
+    second Retry click on the original would enqueue a parallel import
+    while the retry is still in flight."""
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        original_id = _post_import(client, _import_card(tmp_path),
+                                   tmp_path / "archive", None)
+        wait_for_job_via_client(client, original_id)
+
+        first_retry_resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": original_id,
+        })
+        assert first_retry_resp.status_code == 200, first_retry_resp.get_json()
+        first_retry_id = first_retry_resp.get_json()["job_id"]
+        wait_for_job_via_client(client, first_retry_id)
+
+        second_retry_resp = client.post("/api/jobs/import-photos", json={
+            "sources": [_import_card(tmp_path)],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": first_retry_id,
+        })
+        assert second_retry_resp.status_code == 200, (
+            second_retry_resp.get_json())
+        second_retry_id = second_retry_resp.get_json()["job_id"]
+        wait_for_job_via_client(client, second_retry_id)
+        second_retry_config = _job_config(client, second_retry_id)
+        # Direct parent is the first retry; root points back at the
+        # original failed import so the gate matches either link.
+        assert second_retry_config["parent_import_job_id"] == first_retry_id
+        assert second_retry_config["root_import_job_id"] == original_id
+
+
+def test_import_photos_retry_refuses_source_content_change(
+        app_and_db, tmp_path):
+    """A recovery retry against a source whose file set changed since
+    the failed run is refused. Without this guard a "Retry failed
+    files" click against ``/mnt/card`` after a different card was
+    mounted there — or after new photos were shot on the same card —
+    would silently enumerate the current contents and import files the
+    original run never saw."""
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        card = _import_card(tmp_path)
+        parent_id = _post_import(client, card,
+                                 tmp_path / "archive", None)
+        wait_for_job_via_client(client, parent_id)
+
+        # Simulate a source-content change between runs (an
+        # unexpectedly-added file on the same card, or a different card
+        # entirely mounted at the same path).
+        Image.new("RGB", (16, 16), "blue").save(
+            os.path.join(card, "IMG_NEW.jpg"),
+        )
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert resp.status_code == 400, resp.get_json()
+        error = resp.get_json()["error"]
+        assert "source contents have changed" in error
+
+
+def test_import_photos_retry_accepts_unchanged_source(
+        app_and_db, tmp_path):
+    """The complement to the drift check: a retry against an unchanged
+    source succeeds. Documents that the check only refuses genuine
+    content changes and doesn't silently break every retry."""
+    from wait import wait_for_job_via_client
+
+    app, _ = app_and_db
+    with app.test_client() as client:
+        card = _import_card(tmp_path)
+        parent_id = _post_import(client, card,
+                                 tmp_path / "archive", None)
+        wait_for_job_via_client(client, parent_id)
+
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [card],
+            "destination": str(tmp_path / "archive"),
+            "after_import": None,
+            "parent_import_job_id": parent_id,
+        })
+        assert resp.status_code == 200, resp.get_json()
 
 
 def test_import_photos_carry_photo_ids_validation_400s(app_and_db, tmp_path):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -545,6 +545,8 @@ def test_jobs_page_returns_200(app_and_db):
     assert b'Jobs' in resp.data
     assert b'data-pause-job' in resp.data
     assert b'data-resume-job' in resp.data
+    assert b'data-retry-import-job' in resp.data
+    assert b'importRetryBody' in resp.data
 
 
 def test_navbar_has_jobs_link(app_and_db):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -2693,6 +2693,64 @@ def test_destination_preview_above_managed_archive_does_not_claim_merge(
         )
 
 
+def test_destination_preview_generated_folder_inside_managed_archive_flags_merge(
+    setup, tmp_path,
+):
+    """When the selected destination sits ABOVE a tracked archive but the
+    folder template maps generated files INTO that archive, the preview must
+    surface the archive as a merge (not stay silent because the destination
+    itself isn't inside a tracked folder).
+
+    Example: destination /Photography with tracked root /Photography/2026 and
+    template 2026/%Y-%m-%d — the generated folder /Photography/2026/2026-07-28
+    is inside the tracked archive even though the destination isn't.
+    """
+    app, db_path = setup
+    root = tmp_path / "Photography"
+    managed = root / "2026"
+    existing = managed / "2026-01-01"
+    existing.mkdir(parents=True)
+    old = existing / "old.jpg"
+    Image.new("RGB", (16, 16), "green").save(old)
+
+    from db import Database
+    seed = Database(db_path)
+    managed_id = seed.add_folder(str(managed))
+    existing_id = seed.add_folder(
+        str(existing), parent_id=managed_id, workspace_root=False,
+    )
+    seed.add_photo(
+        existing_id, old.name, ".jpg",
+        old.stat().st_size, old.stat().st_mtime,
+    )
+    seed.close()
+
+    src = tmp_path / "card"
+    src.mkdir()
+    new = src / "new.jpg"
+    Image.new("RGB", (16, 16), "blue").save(new)
+    mtime = datetime(2026, 7, 28, 9, 30, 0).timestamp()
+    os.utime(str(new), (mtime, mtime))
+
+    with app.test_client() as c:
+        resp = c.post("/api/import/destination-preview", json={
+            "sources": [str(src)],
+            # Destination is /Photography (ABOVE the tracked /Photography/2026),
+            # but the template pushes generated files into 2026/... — i.e.
+            # inside the tracked archive.
+            "destination": str(root),
+            "folder_template": "2026/%Y-%m-%d",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["managed_archive"] is not None
+        assert data["managed_archive"]["path"] == str(managed)
+        assert data["managed_archive"]["photo_count"] == 1
+        assert data["folders"][0]["full_path"] == str(
+            managed / "2026-07-28"
+        )
+
+
 def _wait_for_job(client, job_id, timeout=30.0):
     """Poll the job-status endpoint until the job completes or fails."""
     deadline = time.time() + timeout

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -2642,6 +2642,57 @@ def test_destination_preview_inside_managed_archive_flags_ancestor(setup, tmp_pa
         assert data["managed_archive"]["photo_count"] == 1
 
 
+def test_destination_preview_above_managed_archive_does_not_claim_merge(
+    setup, tmp_path,
+):
+    """A broad destination root must not claim it will merge into a managed
+    archive nested somewhere below it.
+
+    The import page can target a mounted NAS root while an existing library
+    lives several segments below that root. The resulting folder may be a
+    sibling of the library, so treating descendant overlap as a merge makes
+    the callout contradict the exact-folder table.
+    """
+    app, db_path = setup
+    mount_root = tmp_path / "Photography"
+    managed = mount_root / "Raw Files" / "USA" / "2026"
+    shoot = managed / "2026-07-26"
+    shoot.mkdir(parents=True)
+    old = shoot / "old.jpg"
+    Image.new("RGB", (16, 16), "green").save(old)
+
+    from db import Database
+    seed = Database(db_path)
+    managed_id = seed.add_folder(str(managed))
+    shoot_id = seed.add_folder(
+        str(shoot), parent_id=managed_id, workspace_root=False,
+    )
+    seed.add_photo(
+        shoot_id, old.name, ".jpg", old.stat().st_size, old.stat().st_mtime,
+    )
+    seed.close()
+
+    src = tmp_path / "card"
+    src.mkdir()
+    new = src / "new.jpg"
+    Image.new("RGB", (16, 16), "blue").save(new)
+    mtime = datetime(2026, 7, 27, 9, 30, 0).timestamp()
+    os.utime(str(new), (mtime, mtime))
+
+    with app.test_client() as c:
+        resp = c.post("/api/import/destination-preview", json={
+            "sources": [str(src)],
+            "destination": str(mount_root),
+            "folder_template": "%Y/%Y-%m-%d",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["managed_archive"] is None
+        assert data["folders"][0]["full_path"] == str(
+            mount_root / "2026" / "2026-07-27"
+        )
+
+
 def _wait_for_job(client, job_id, timeout=30.0):
     """Poll the job-status endpoint until the job completes or fails."""
     deadline = time.time() + timeout

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -2751,6 +2751,130 @@ def test_destination_preview_generated_folder_inside_managed_archive_flags_merge
         )
 
 
+def test_destination_preview_partial_managed_archive_overlap(setup, tmp_path):
+    """When only some generated folders land inside a tracked archive, the
+    preview must NOT claim the whole import merges into it — the callout
+    lies about the files landing outside the archive.
+
+    Example: destination /Photography, template %Y/%Y-%m-%d, only
+    /Photography/2026 tracked. Files from 2025 land in /Photography/2025/...
+    (outside the archive) while files from 2026 land in /Photography/2026/...
+    (inside it). ``managed_archives`` must record 2026 as coverage='partial'
+    and ``managed_archive`` (the legacy single-archive field) must be None.
+    """
+    app, db_path = setup
+    root = tmp_path / "Photography"
+    managed = root / "2026"
+    existing = managed / "2026-01-01"
+    existing.mkdir(parents=True)
+    old = existing / "old.jpg"
+    Image.new("RGB", (16, 16), "green").save(old)
+
+    from db import Database
+    seed = Database(db_path)
+    managed_id = seed.add_folder(str(managed))
+    existing_id = seed.add_folder(
+        str(existing), parent_id=managed_id, workspace_root=False,
+    )
+    seed.add_photo(
+        existing_id, old.name, ".jpg",
+        old.stat().st_size, old.stat().st_mtime,
+    )
+    seed.close()
+
+    src = tmp_path / "card"
+    src.mkdir()
+    inside = src / "in-2026.jpg"
+    outside = src / "in-2025.jpg"
+    Image.new("RGB", (16, 16), "blue").save(inside)
+    Image.new("RGB", (16, 16), "red").save(outside)
+    inside_mtime = datetime(2026, 7, 28, 9, 30, 0).timestamp()
+    outside_mtime = datetime(2025, 6, 30, 9, 30, 0).timestamp()
+    os.utime(str(inside), (inside_mtime, inside_mtime))
+    os.utime(str(outside), (outside_mtime, outside_mtime))
+
+    with app.test_client() as c:
+        resp = c.post("/api/import/destination-preview", json={
+            "sources": [str(src)],
+            "destination": str(root),
+            "folder_template": "%Y/%Y-%m-%d",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Legacy single-archive field stays None — the merge does NOT cover
+        # every generated folder.
+        assert data["managed_archive"] is None
+        archives = data.get("managed_archives") or []
+        assert len(archives) == 1
+        assert archives[0]["path"] == str(managed)
+        assert archives[0]["photo_count"] == 1
+        assert archives[0]["coverage"] == "partial"
+
+
+def test_destination_preview_multiple_managed_archives(setup, tmp_path):
+    """When generated folders split across MULTIPLE tracked archives, each is
+    reported so the UI does not silently pin the whole import to one of them.
+    """
+    app, db_path = setup
+    root = tmp_path / "Photography"
+    managed_2025 = root / "2025"
+    managed_2026 = root / "2026"
+    prior_25 = managed_2025 / "2025-01-01"
+    prior_26 = managed_2026 / "2026-01-01"
+    prior_25.mkdir(parents=True)
+    prior_26.mkdir(parents=True)
+    old_25 = prior_25 / "old-25.jpg"
+    old_26 = prior_26 / "old-26.jpg"
+    Image.new("RGB", (16, 16), "green").save(old_25)
+    Image.new("RGB", (16, 16), "olive").save(old_26)
+
+    from db import Database
+    seed = Database(db_path)
+    m25 = seed.add_folder(str(managed_2025))
+    m26 = seed.add_folder(str(managed_2026))
+    d25 = seed.add_folder(str(prior_25), parent_id=m25, workspace_root=False)
+    d26 = seed.add_folder(str(prior_26), parent_id=m26, workspace_root=False)
+    seed.add_photo(
+        d25, old_25.name, ".jpg",
+        old_25.stat().st_size, old_25.stat().st_mtime,
+    )
+    seed.add_photo(
+        d26, old_26.name, ".jpg",
+        old_26.stat().st_size, old_26.stat().st_mtime,
+    )
+    seed.close()
+
+    src = tmp_path / "card"
+    src.mkdir()
+    in25 = src / "in-2025.jpg"
+    in26 = src / "in-2026.jpg"
+    Image.new("RGB", (16, 16), "blue").save(in25)
+    Image.new("RGB", (16, 16), "red").save(in26)
+    os.utime(
+        str(in25),
+        (datetime(2025, 6, 30, 9, 30, 0).timestamp(),) * 2,
+    )
+    os.utime(
+        str(in26),
+        (datetime(2026, 7, 28, 9, 30, 0).timestamp(),) * 2,
+    )
+
+    with app.test_client() as c:
+        resp = c.post("/api/import/destination-preview", json={
+            "sources": [str(src)],
+            "destination": str(root),
+            "folder_template": "%Y/%Y-%m-%d",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # No single archive covers every generated folder.
+        assert data["managed_archive"] is None
+        archives = data.get("managed_archives") or []
+        paths = sorted(a["path"] for a in archives)
+        assert paths == sorted([str(managed_2025), str(managed_2026)])
+        assert all(a["coverage"] == "partial" for a in archives)
+
+
 def _wait_for_job(client, job_id, timeout=30.0):
     """Poll the job-status endpoint until the job completes or fails."""
     deadline = time.time() + timeout


### PR DESCRIPTION
## Summary

Clarifies mounted-path versus direct-SSH destinations, validates required NAS subpaths inline, and prevents misleading managed-archive previews.
Collapses duplicate-heavy previews around the files that will actually import and avoids unnecessary thumbnail work.
Adds safe, preconfigured failed-file retries from Import results and Jobs history.
Validated with 32 Import-page browser tests, focused backend and page tests, JavaScript syntax checks, Ruff, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recovery retry UI for failed import jobs, reconstructing sources/destination/options and continuing chained processing with carry-forward photos.
  * Destination-preview improvements for managed archives: supports partial and multi-archive coverage with updated callouts.
  * Import page now supports collapsed duplicate previews (“duplicates hidden”) and preserves the banner when nothing remains.
* **Bug Fixes**
  * Prevented invalid/edited retry targets via stronger remote-destination and snapshot validation; added retry-in-progress collision protection.
* **Tests**
  * Expanded e2e and API regression coverage for duplicate collapsing, remote-copy validation, managed-archive coverage, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->