### PR TITLE
Stop classify from reporting a dropped share as failed photos

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -64,8 +64,21 @@ _SENTINEL = object()  # unique end-of-stream marker
 _MAX_SOURCE_OFFLINE_PAUSES = 3
 
 
-def _missing_archive_mount_root(path: str) -> str | None:
-    """Return a likely missing mount root that must not be auto-created."""
+def _archive_mount_root_candidates(path: str) -> list[str]:
+    """Return the plausible mount-root prefix(es) for ``path``, if any.
+
+    Extracts the mount-root component under the OS's mount conventions —
+    the first entry under ``/Volumes/`` or ``/mnt/`` (SMB/NFS style), or
+    the first user/name pair under ``/media/<user>/``. These conventions
+    strongly imply the user intended the location as a mount point; the
+    caller decides what state to require of it (missing entirely vs.
+    present but not actually mounted).
+
+    Both the raw expanded path and the normalized absolute form are
+    checked so relative or ``~``-prefixed paths still match. Duplicates
+    are collapsed, and paths not shaped like a mount root return no
+    candidates.
+    """
     def _candidate(posix_path: str) -> str | None:
         parts = posix_path.split("/")
         if len(parts) >= 3 and parts[0] == "" and parts[1] in {"Volumes", "mnt"}:
@@ -78,10 +91,56 @@ def _missing_archive_mount_root(path: str) -> str | None:
     normalized = os.path.normpath(os.path.abspath(os.path.expanduser(path)))
     normalized_posix = normalized.replace("\\", "/")
 
-    for mount_root in (_candidate(raw_posix), _candidate(normalized_posix)):
-        if mount_root and not os.path.lexists(mount_root):
+    seen: list[str] = []
+    for cand in (_candidate(raw_posix), _candidate(normalized_posix)):
+        if cand and cand not in seen:
+            seen.append(cand)
+    return seen
+
+
+def _missing_archive_mount_root(path: str) -> str | None:
+    """Return a likely missing mount root that must not be auto-created.
+
+    "Missing" here means the mount-root directory itself doesn't exist —
+    which is what the archive-parent preflight needs, so ``makedirs``
+    doesn't silently create a stub directory and write onto the local
+    disk when the intended NAS wasn't mounted. A mount point that
+    persists after unmount (Linux ``/mnt/<name>``) is NOT flagged by
+    this helper — see ``_source_offline_reason`` for the mid-run outage
+    check that also treats a directory-still-there-but-not-mounted case
+    as offline.
+    """
+    for mount_root in _archive_mount_root_candidates(path):
+        if not os.path.lexists(mount_root):
             return mount_root
     return None
+
+
+def _mount_root_offline(mount_root: str) -> bool:
+    """Whether ``mount_root`` appears to not have a filesystem mounted at it.
+
+    Two shapes count as offline, because callers only get here when a
+    subtree read has already failed:
+
+    * The directory is entirely gone — macOS removes ``/Volumes/<share>``
+      on eject, so ``lexists`` alone is enough.
+    * The directory exists but ``os.path.ismount`` reports nothing is
+      mounted at it — the Linux common case, where the mount point
+      (``/mnt/<share>``, ``/media/<user>/<name>``) persists after
+      ``umount`` or after a network drop. Codex #1388 P1 r3663493889:
+      without this branch, the pipeline would treat every descendant as
+      an isolated folder outage instead of pausing for reconnection.
+
+    A stale mount whose device is dead can raise EIO from stat probes;
+    treat that as offline too — we're in the "reads are already failing"
+    path so the mount can't be considered healthy.
+    """
+    if not os.path.lexists(mount_root):
+        return True
+    try:
+        return not os.path.ismount(mount_root)
+    except OSError:
+        return True
 
 
 def _source_offline_reason(
@@ -103,32 +162,35 @@ def _source_offline_reason(
     * ``"mount"`` — the shared volume is gone. Every remaining photo on it
       will fail the same way; classify should pause the whole run so the
       user can reconnect.
-    * ``"folder"`` — the mount root is still present but this one folder no
-      longer resolves. Other folders in the collection may be healthy, so
-      the caller should skip photos in this folder as unreachable and keep
-      processing rather than stopping cold. This covers a single deleted
-      or renamed local folder — the incident-fix's original global-stop
-      behavior would have stranded later healthy folders (and, on
-      ``reclassify=True``, cleared their existing predictions during
-      finalization with no replacement).
+    * ``"folder"`` — the mount root is still present and mounted but this
+      one folder no longer resolves. Other folders in the collection may
+      be healthy, so the caller should skip photos in this folder as
+      unreachable and keep processing rather than stopping cold. This
+      covers a single deleted or renamed local folder — the incident
+      fix's original global-stop behavior would have stranded later
+      healthy folders (and, on ``reclassify=True``, cleared their
+      existing predictions during finalization with no replacement).
 
-    Deliberately conservative. Both probes require evidence that a tree —
-    the mount or the folder itself — is gone, so no single unreadable file
-    can ever trip them, and a collection on a local disk with all its
-    folders intact always returns ``None`` and keeps today's per-photo
-    behavior.
+    Deliberately conservative — a healthy containing folder always
+    returns ``None`` regardless of the image path, so a single unreadable
+    file inside a working tree stays a per-photo failure and can never
+    trip the mount-root check by itself.
     """
-    mount_root = _missing_archive_mount_root(image_path)
-    if mount_root:
-        return "mount", f"volume {mount_root} is not mounted"
-    # A stale mount can keep the mount root in place while the subtree turns
-    # unreadable, so fall back to asking whether the containing folder still
-    # resolves. os.path.isdir() swallows the EIO and returns False. Scope
-    # this to the folder rather than the whole source: a single missing
-    # local folder is not evidence the rest of the collection is offline.
-    if folder_path and not os.path.isdir(folder_path):
-        return "folder", f"folder {folder_path} is unreadable"
-    return None
+    # A readable folder means one bad file, not a source outage — this
+    # short-circuit is what protects a local ``/mnt/photos/...`` catalog
+    # (unusual, but legal) from tripping the mount-root check just because
+    # a single file has been deleted.
+    if not folder_path or os.path.isdir(folder_path):
+        return None
+    # The folder itself is gone / unreachable. If that folder lives under
+    # a mount-shaped path and the mount is no longer active, this is a
+    # mount-scoped outage (Codex #1388 P1 r3663493889): pause the whole
+    # run instead of skipping folder-by-folder while the same dead share
+    # rejects every subsequent read.
+    for mount_root in _archive_mount_root_candidates(image_path):
+        if _mount_root_offline(mount_root):
+            return "mount", f"volume {mount_root} is not mounted"
+    return "folder", f"folder {folder_path} is unreadable"
 
 
 @dataclass

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -156,15 +156,27 @@ def _mount_root_offline(mount_root: str) -> bool:
 
     * The directory is entirely gone — macOS removes ``/Volumes/<share>``
       on eject, so ``lexists`` alone is enough.
-    * A stale mount whose device is dead raises EIO from stat/listdir
-      probes — we're in the "reads are already failing" path so an
+    * A stale mount whose device is dead raises EIO from ``listdir`` /
+      stat probes — we're in the "reads are already failing" path so an
       errored probe can't be considered healthy.
-    * The directory exists, ``os.path.ismount`` reports nothing is
-      mounted, AND the directory is empty — the Linux common case, where
-      the mount-point stub (``/mnt/<share>``, ``/media/<user>/<name>``)
-      persists after ``umount`` or a network drop. When the mount was
-      active its contents lived on the mounted filesystem, so an
-      unmounted stub is typically empty.
+    * The directory exists, is readable but empty, and
+      ``os.path.ismount`` reports nothing is mounted at it — the Linux
+      common case, where the mount-point stub (``/mnt/<share>``,
+      ``/media/<user>/<name>``) persists after ``umount`` or a network
+      drop. When the mount was active its contents lived on the mounted
+      filesystem, so an unmounted stub is typically empty.
+
+    ``ismount`` is intentionally NOT used as an early "still mounted →
+    healthy" short-circuit. A stale SMB/NFS mount can keep its
+    mount-point metadata after the server disconnects, so
+    ``os.path.ismount`` still returns True while every read against
+    the root raises EIO. Trusting ismount alone would classify the
+    dropped share as folder-scoped and classify would keep reissuing
+    reads across the dead share instead of pausing for reconnection
+    (Codex #1388 P1 r3664211201). Probe with ``listdir`` first;
+    ``ismount`` only comes into play as a positive mount-identity
+    signal when the root is empty (to tell an actual empty mount from
+    an unmounted stub).
 
     An ``ismount``-negative directory that still has siblings is not
     treated as offline — that's proof it's an ordinary local directory
@@ -176,16 +188,31 @@ def _mount_root_offline(mount_root: str) -> bool:
     """
     if not os.path.lexists(mount_root):
         return True
-    try:
-        if os.path.ismount(mount_root):
-            return False
-    except OSError:
-        return True
+    # Probe the root itself before consulting ``ismount``: a dead SMB/NFS
+    # mount that still shows up in ``mount`` will keep ``ismount == True``
+    # but every read raises EIO. Catching that here is what lets classify
+    # scope the outage to the mount and pause, rather than falling
+    # through to the folder-scoped branch and hammering the dead share.
     try:
         entries = os.listdir(mount_root)
     except OSError:
         return True
-    return not entries
+    if entries:
+        # Readable and populated: whether it's a real mount or a plain
+        # local directory, callers should treat it as online. The
+        # folder-scoped branch above will still flag whatever subtree
+        # was individually unreachable.
+        return False
+    # Empty root: distinguish an actual mount that happens to be empty
+    # from a bare mount-point stub. ``ismount`` here is a positive
+    # identity check (still mounted → healthy), not a readability
+    # claim. If the ismount probe itself errors, treat as offline —
+    # we're already on the failed-read path and have no reason to be
+    # generous.
+    try:
+        return not os.path.ismount(mount_root)
+    except OSError:
+        return True
 
 
 def _source_offline_reason(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3923,6 +3923,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # message always produces a valid X-of-N ratio. total_failed sums
                 # per-model failures and can exceed total in multi-model runs.
                 failed_photo_ids: set = set()
+                # Photos we never opened because their containing folder was
+                # unreachable at read time. Kept apart from ``failed`` (those
+                # ARE actual per-photo decode failures) so the rollup can name
+                # unreachable photos honestly, and kept as unique photo IDs so
+                # a folder outage that hits the same photos across every model
+                # in a multi-model run doesn't multiply-count.
+                source_skipped_photo_ids: set = set()
 
                 skipped_model_names: list = []
                 models_succeeded = 0
@@ -4532,6 +4539,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                             # unreachable and let later photos
                                             # in healthy folders keep processing.
                                             source_skipped += 1
+                                            source_skipped_photo_ids.add(
+                                                photo["id"]
+                                            )
                                             continue
                                         if not _handle_source_offline(reason):
                                             break
@@ -4562,6 +4572,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                             # counter still bounds how many
                                             # times we ask.
                                             source_skipped += 1
+                                            source_skipped_photo_ids.add(
+                                                photo["id"]
+                                            )
                                             continue
                                         # Retry succeeded — fall through to
                                         # the normal inference path below.
@@ -4798,6 +4811,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # IDs (not per-model attempt count) so the badge can never
                 # exceed total photos.
                 n_failed_photos = len(failed_photo_ids)
+                n_source_skipped_photos = len(source_skipped_photo_ids)
                 if source_offline["reason"]:
                     # Must carry the "[classify] Fatal:" prefix: the end-of-run
                     # rollup picks the job's headline error by that marker and
@@ -4809,13 +4823,41 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         f"Process again to classify the rest — photos already "
                         f"classified will be skipped."
                     )
-                # A run that gave up on a dead source did NOT classify the
-                # collection, so it must not land on the job tree as a clean
-                # green stage — "completed" here would tell the user their
-                # photos were processed when most were never opened.
+                    # extract_masks_stage / eye_keypoints_stage only gate on
+                    # abort.is_set(); with the source dead there is nothing
+                    # for them to read either, so without this they walk every
+                    # detected photo and reproduce the exact "N failed"
+                    # pattern this PR fixes — just one stage later, before
+                    # the failed-stage rollup at the end of the pipeline gets
+                    # a chance to short-circuit them.
+                    abort.set()
+                elif n_source_skipped_photos > 0:
+                    # Folder-scoped outage: some photos were unreachable but
+                    # the source as a whole is not necessarily gone (other
+                    # folders in the collection may still be healthy). Do NOT
+                    # abort — later stages can still make progress on the
+                    # reachable photos — but the classify pass did not open
+                    # every photo it was asked to, so surface a fatal-prefixed
+                    # error so the end-of-run rollup names the outage instead
+                    # of letting the run finish silent-green.
+                    errors.append(
+                        f"[classify] Fatal: {n_source_skipped_photos} of "
+                        f"{total} photos unreachable (source offline). "
+                        f"Reconnect the missing folder(s) and run Process "
+                        f"again to classify the rest."
+                    )
+                # A run that gave up on a dead source, or that skipped photos
+                # because their folder was unreachable, did NOT classify the
+                # whole collection, so it must not land on the job tree as a
+                # clean green stage — "completed" here would tell the user
+                # their photos were processed when some were never opened.
                 stages["classify"]["status"] = (
                     "failed"
-                    if (total_failed > 0 or source_offline["reason"])
+                    if (
+                        total_failed > 0
+                        or source_offline["reason"]
+                        or n_source_skipped_photos > 0
+                    )
                     else "completed"
                 )
                 if total_failed > 0:
@@ -4829,6 +4871,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     "detected": detect_state["total_detected"],
                     "failed": total_failed,
                     "source_offline": source_offline["reason"],
+                    "source_skipped": n_source_skipped_photos,
                     "already_classified": total_skipped_existing,
                     "full_image_fallbacks": total_full_image_fallbacks,
                     "weak_detection_rescues": len(contextual_weak_ids),

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3962,10 +3962,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         source_offline["reason"] = reason
                         return False
                     source_offline["pauses"] += 1
-                    errors.append(
-                        f"[classify] Source {reason} — paused. Reconnect it "
-                        f"and resume to classify the rest, or cancel the run."
-                    )
+                    # Don't push a pause message into ``errors``: a successful
+                    # reconnect+resume leaves classify completing normally, but
+                    # templates/pipeline.html treats every ``[classify]`` error
+                    # as a failed stage and suppresses the success redirect
+                    # (Codex #1388 P1). ``pause_job`` below already flips the
+                    # job state to ``pausing``/``paused`` (that's what the UI
+                    # renders while parked), and the give-up path below
+                    # appends its own ``[classify] Fatal:`` entry — so a run
+                    # that never comes back still surfaces a real terminal
+                    # error, and a run that does come back does not.
                     log.warning("Classify paused: source offline (%s)", reason)
 
                     pause = getattr(runner, "pause_job", None)
@@ -4173,6 +4179,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # counted once per (photo × spec) — matching ``total``.
                     photos_cached_in_spec: set = set()
                     photos_inferred_in_spec: set = set()
+                    # Per-spec tracking of photos whose per-photo iteration
+                    # was actually entered in THIS spec. Used by the
+                    # reclassify clear below so it never wipes predictions
+                    # for photos this spec never opened — on a mount-scoped
+                    # give-up we break out of the batch loop before reaching
+                    # later photos, and on a folder-scoped outage every photo
+                    # under the missing folder is skipped without ever
+                    # producing a replacement prediction. Without this,
+                    # ``clear_predictions`` on a ``reclassify=True`` run
+                    # would delete the prior predictions for those photos
+                    # even though nothing in this run had a chance to
+                    # rewrite them (Codex #1388 P1).
+                    spec_reached_photo_ids: set = set()
                     # Photos that iterated past the inner abort check IN THIS spec.
                     # Used for the per-spec ``runner.update_step`` progress (which
                     # is bounded by ``total``, not the multi-spec stage total) and
@@ -4280,6 +4299,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             stages["classify"]["seen"] = (
                                 stages["classify"].get("seen", 0) + 1
                             )
+                            # Photo entered THIS spec's per-photo body; scopes
+                            # the reclassify clear below so unreached photos
+                            # keep their prior predictions.
+                            spec_reached_photo_ids.add(photo["id"])
                             # Record this photo as classify-processed for the first
                             # successful model. Used by the stale-detection purge to
                             # restrict deletions to photos actually reclassified.
@@ -4544,6 +4567,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                             )
                                             continue
                                         if not _handle_source_offline(reason):
+                                            # Give-up: image never loaded, so
+                                            # this photo is unreached — same
+                                            # bucket as the folder-scoped
+                                            # skip above. Keeps the
+                                            # reclassify clear below from
+                                            # wiping its prior prediction
+                                            # (Codex #1388 P1).
+                                            source_skipped_photo_ids.add(
+                                                photo["id"]
+                                            )
                                             break
                                         # Resumed. The user reconnected the
                                         # share, so retry the same detection
@@ -4668,13 +4701,30 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # already wrote fresh classifier_runs rows for processed
                     # detections — wiping them here would strand the gate and
                     # force the next non-reclassify pass to re-infer everything.
+                    #
+                    # Scope to photos this spec actually reached AND wasn't
+                    # skipped as source-offline: an unreached photo (mount-
+                    # scoped give-up, or every photo under a vanished folder)
+                    # is one this run had no chance to rewrite, so wiping
+                    # its prior prediction would leave it with nothing at
+                    # all (Codex #1388 P1). Fall back to the collection-
+                    # wide clear when no source outage occurred — that's
+                    # still the desired behavior on a clean reclassify.
                     if params.reclassify:
-                        thread_db.clear_predictions(
-                            model=model_name,
-                            collection_photo_ids=[p["id"] for p in photos],
-                            labels_fingerprint=spec_fp,
-                            clear_run_keys=False,
-                        )
+                        if source_skipped_photo_ids:
+                            clear_ids = list(
+                                spec_reached_photo_ids
+                                - source_skipped_photo_ids
+                            )
+                        else:
+                            clear_ids = [p["id"] for p in photos]
+                        if clear_ids:
+                            thread_db.clear_predictions(
+                                model=model_name,
+                                collection_photo_ids=clear_ids,
+                                labels_fingerprint=spec_fp,
+                                clear_run_keys=False,
+                            )
 
                     group_result = _store_grouped_predictions(
                         raw_results, job["id"], model_name,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -84,8 +84,10 @@ def _missing_archive_mount_root(path: str) -> str | None:
     return None
 
 
-def _source_offline_reason(folder_path: str, image_path: str) -> str | None:
-    """Return why the photo's SOURCE is unreachable, or None if it isn't.
+def _source_offline_reason(
+    folder_path: str, image_path: str,
+) -> tuple[str, str] | None:
+    """Return ``(scope, reason)`` for an unreachable source, or ``None``.
 
     Distinguishes "this one file won't load" (corrupt RAW, bad permissions —
     genuinely that photo's failure) from "the volume holding the collection
@@ -95,19 +97,37 @@ def _source_offline_reason(folder_path: str, image_path: str) -> str | None:
     the collection "failed" — which reads to the user as "your photos are
     broken" rather than "reconnect the share".
 
-    Deliberately conservative. Both probes require evidence that the source
-    *tree* is gone, so no single unreadable file can ever trip them, and a
-    collection on a local disk (no /Volumes-style mount root, folder still
-    present) always returns None and keeps today's per-photo behavior.
+    ``scope`` says how far the outage reaches, so callers can react at the
+    right blast radius:
+
+    * ``"mount"`` — the shared volume is gone. Every remaining photo on it
+      will fail the same way; classify should pause the whole run so the
+      user can reconnect.
+    * ``"folder"`` — the mount root is still present but this one folder no
+      longer resolves. Other folders in the collection may be healthy, so
+      the caller should skip photos in this folder as unreachable and keep
+      processing rather than stopping cold. This covers a single deleted
+      or renamed local folder — the incident-fix's original global-stop
+      behavior would have stranded later healthy folders (and, on
+      ``reclassify=True``, cleared their existing predictions during
+      finalization with no replacement).
+
+    Deliberately conservative. Both probes require evidence that a tree —
+    the mount or the folder itself — is gone, so no single unreadable file
+    can ever trip them, and a collection on a local disk with all its
+    folders intact always returns ``None`` and keeps today's per-photo
+    behavior.
     """
     mount_root = _missing_archive_mount_root(image_path)
     if mount_root:
-        return f"volume {mount_root} is not mounted"
+        return "mount", f"volume {mount_root} is not mounted"
     # A stale mount can keep the mount root in place while the subtree turns
     # unreadable, so fall back to asking whether the containing folder still
-    # resolves. os.path.isdir() swallows the EIO and returns False.
+    # resolves. os.path.isdir() swallows the EIO and returns False. Scope
+    # this to the folder rather than the whole source: a single missing
+    # local folder is not evidence the rest of the collection is offline.
     if folder_path and not os.path.isdir(folder_path):
-        return f"folder {folder_path} is unreadable"
+        return "folder", f"folder {folder_path} is unreadable"
     return None
 
 
@@ -4504,19 +4524,51 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         folder_path, image_path,
                                     )
                                     if offline:
-                                        if not _handle_source_offline(offline):
+                                        scope, reason = offline
+                                        if scope == "folder":
+                                            # A single missing folder is not
+                                            # evidence the whole source is
+                                            # offline; skip this photo as
+                                            # unreachable and let later photos
+                                            # in healthy folders keep processing.
+                                            source_skipped += 1
+                                            continue
+                                        if not _handle_source_offline(reason):
                                             break
-                                        # Resumed. Count this one as
-                                        # unreachable rather than failed: the
-                                        # source tree was gone, so the photo
-                                        # was never actually examined and
-                                        # calling it a failure would repeat
-                                        # the same lie at smaller scale.
-                                        source_skipped += 1
+                                        # Resumed. The user reconnected the
+                                        # share, so retry the same detection
+                                        # before advancing — silently skipping
+                                        # it here would leave the photo
+                                        # unclassified even though the source
+                                        # is back, and on a reclassify run
+                                        # finalization would clear its old
+                                        # prediction with no replacement.
+                                        img, folder_path, image_path = (
+                                            _prepare_image(
+                                                photo, folders,
+                                                None if full_image_fallback
+                                                else detection,
+                                            )
+                                        )
+                                        if img is None:
+                                            # Retry failed too — the remount
+                                            # didn't stick. Count this one as
+                                            # unreachable rather than failed:
+                                            # the source tree was gone, so the
+                                            # photo was never actually
+                                            # examined and calling it a
+                                            # failure would repeat the same
+                                            # lie at smaller scale. The pause
+                                            # counter still bounds how many
+                                            # times we ask.
+                                            source_skipped += 1
+                                            continue
+                                        # Retry succeeded — fall through to
+                                        # the normal inference path below.
+                                    else:
+                                        failed += 1
+                                        failed_photo_ids.add(photo["id"])
                                         continue
-                                    failed += 1
-                                    failed_photo_ids.add(photo["id"])
-                                    continue
                                 inference_batch.append({
                                     "photo": photo,
                                     "detection_id": detection["id"],

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -152,19 +152,13 @@ def _mount_root_offline(mount_root: str) -> bool:
 
     Callers only get here when a subtree read has already failed, so we
     need positive evidence the root was actually a mount before scoping
-    the outage to the whole share. Three shapes count as offline:
+    the outage to the whole share. Two shapes count as offline:
 
     * The directory is entirely gone — macOS removes ``/Volumes/<share>``
       on eject, so ``lexists`` alone is enough.
     * A stale mount whose device is dead raises EIO from ``listdir`` /
       stat probes — we're in the "reads are already failing" path so an
       errored probe can't be considered healthy.
-    * The directory exists, is readable but empty, and
-      ``os.path.ismount`` reports nothing is mounted at it — the Linux
-      common case, where the mount-point stub (``/mnt/<share>``,
-      ``/media/<user>/<name>``) persists after ``umount`` or a network
-      drop. When the mount was active its contents lived on the mounted
-      filesystem, so an unmounted stub is typically empty.
 
     ``ismount`` is intentionally NOT used as an early "still mounted →
     healthy" short-circuit. A stale SMB/NFS mount can keep its
@@ -173,18 +167,20 @@ def _mount_root_offline(mount_root: str) -> bool:
     the root raises EIO. Trusting ismount alone would classify the
     dropped share as folder-scoped and classify would keep reissuing
     reads across the dead share instead of pausing for reconnection
-    (Codex #1388 P1 r3664211201). Probe with ``listdir`` first;
-    ``ismount`` only comes into play as a positive mount-identity
-    signal when the root is empty (to tell an actual empty mount from
-    an unmounted stub).
+    (Codex #1388 P1 r3664211201). Probe with ``listdir`` first.
 
-    An ``ismount``-negative directory that still has siblings is not
-    treated as offline — that's proof it's an ordinary local directory
-    that happens to sit under ``/mnt/`` or ``/media/<user>/``, and one
-    deleted subfolder inside it must stay folder-scoped (Codex #1388 P1
-    r3663642357). Otherwise a user who deletes ``/mnt/photos/trip``
-    from a plain local ``/mnt/photos`` catalog would see the whole run
-    pause and eventually abandon their healthy sibling folders.
+    A root that exists and is readable — populated OR empty — is
+    treated as online. Populated is proof either that the mount is
+    live or that this is an ordinary local directory with siblings
+    to work through; either way any specific missing subtree is a
+    folder-scoped issue (Codex #1388 P1 r3663642357). Empty is
+    ambiguous — it could be an unmounted stub OR an ordinary local
+    ``/mnt/photos`` whose only child (the deleted collection folder)
+    just went away — so err folder-scoped rather than paint every
+    folder-only outage as a whole-mount outage (Codex #1388 P1
+    r3664348752). If the mount truly is dead, the ``listdir`` OSError
+    branch above still fires and catches the case that matters
+    (mount registered but server unreachable).
     """
     if not os.path.lexists(mount_root):
         return True
@@ -194,25 +190,15 @@ def _mount_root_offline(mount_root: str) -> bool:
     # scope the outage to the mount and pause, rather than falling
     # through to the folder-scoped branch and hammering the dead share.
     try:
-        entries = os.listdir(mount_root)
+        os.listdir(mount_root)
     except OSError:
         return True
-    if entries:
-        # Readable and populated: whether it's a real mount or a plain
-        # local directory, callers should treat it as online. The
-        # folder-scoped branch above will still flag whatever subtree
-        # was individually unreachable.
-        return False
-    # Empty root: distinguish an actual mount that happens to be empty
-    # from a bare mount-point stub. ``ismount`` here is a positive
-    # identity check (still mounted → healthy), not a readability
-    # claim. If the ismount probe itself errors, treat as offline —
-    # we're already on the failed-read path and have no reason to be
-    # generous.
-    try:
-        return not os.path.ismount(mount_root)
-    except OSError:
-        return True
+    # Readable root: whether populated (real mount OR local dir with
+    # siblings) or empty (empty mount OR local dir whose only child
+    # was deleted), we can't reliably prove the missing subtree is a
+    # mount-wide outage. Callers should treat it as online and take
+    # the folder-scoped branch.
+    return False
 
 
 def _source_offline_reason(
@@ -263,6 +249,42 @@ def _source_offline_reason(
         if _mount_root_offline(mount_root):
             return "mount", f"volume {mount_root} is not mounted"
     return "folder", f"folder {folder_path} is unreadable"
+
+
+def _still_offline_photo_ids(thread_db, photo_ids) -> set:
+    """Return the subset of ``photo_ids`` whose folder is still unreadable.
+
+    Downstream stages (extract_masks, eye_keypoints) filter photos by
+    the aggregate ``source_offline_state["skipped_photo_ids"]`` set so
+    an offline folder's photos aren't re-opened just to fail again.
+    That set accumulates across every classifier spec, but the folder
+    can recover between specs — or between classify and mask
+    extraction. Without a re-probe the mask/eye-keypoint stages would
+    silently exclude a photo whose folder came back (Codex #1388 P2
+    r3664348758). Anything the DB no longer knows about is dropped
+    from the returned set — a photo that was purged since classify
+    can't be filtered either.
+    """
+    if not photo_ids:
+        return set()
+    ids = [int(pid) for pid in photo_ids]
+    placeholders = ",".join("?" * len(ids))
+    rows = thread_db.conn.execute(
+        f"SELECT p.id, f.path "
+        f"FROM photos p JOIN folders f ON p.folder_id = f.id "
+        f"WHERE p.id IN ({placeholders})",
+        ids,
+    ).fetchall()
+    still_offline: set = set()
+    for row in rows:
+        pid = row["id"] if hasattr(row, "keys") else row[0]
+        path = row["path"] if hasattr(row, "keys") else row[1]
+        # ``isdir`` False covers both a still-missing folder and a
+        # mount-scoped outage (dead mount → isdir False for every
+        # child), so a single probe suffices for either scope.
+        if not path or not os.path.isdir(path):
+            still_offline.add(pid)
+    return still_offline
 
 
 @dataclass
@@ -4821,7 +4843,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         # offline; skip this photo as
                                         # unreachable and let later photos
                                         # in healthy folders keep processing.
-                                        source_skipped += 1
+                                        # Guard the counter with the per-spec
+                                        # skipped-photo set so a multi-subject
+                                        # photo (N qualifying detections)
+                                        # counts once, not N times — the
+                                        # per-spec ``total`` and step summary
+                                        # are photo-scoped, and without this
+                                        # the row could report e.g. ``3
+                                        # unreachable`` out of ``1`` photo
+                                        # (Codex #1388 P2 r3664348763).
+                                        if (
+                                            photo["id"]
+                                            not in spec_source_skipped_photo_ids
+                                        ):
+                                            source_skipped += 1
                                         source_skipped_photo_ids.add(
                                             photo["id"]
                                         )
@@ -5361,8 +5396,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # so healthy folders keep processing here; this filter is
                 # how "healthy folders keep processing" stays true without
                 # dragging the missing folder's photos along.
+                #
+                # Re-probe before filtering: the aggregate skipped set
+                # accumulates across every classifier spec, and a folder
+                # that dropped for spec A can recover before mask
+                # extraction runs. Without the re-probe we'd silently
+                # exclude photos whose folder came back (Codex #1388 P2
+                # r3664348758).
                 source_skipped_photo_ids = source_offline_state.get(
                     "skipped_photo_ids") or set()
+                if source_skipped_photo_ids:
+                    source_skipped_photo_ids = _still_offline_photo_ids(
+                        thread_db, source_skipped_photo_ids,
+                    )
                 if source_skipped_photo_ids:
                     photos = [
                         p for p in photos
@@ -6050,8 +6096,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # photo and record them as eye-detection failures — the
                 # same downstream-hammering pattern the classify pause is
                 # meant to prevent (Codex #1388 P2 r3664058173).
+                #
+                # Re-probe so a folder that recovered between classify
+                # and this stage is not left out (Codex #1388 P2
+                # r3664348758).
                 source_skipped_photo_ids = source_offline_state.get(
                     "skipped_photo_ids") or set()
+                if source_skipped_photo_ids:
+                    source_skipped_photo_ids = _still_offline_photo_ids(
+                        thread_db, source_skipped_photo_ids,
+                    )
                 if source_skipped_photo_ids:
                     photos_for_stage = [
                         p for p in photos_for_stage

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -249,25 +249,34 @@ def _source_offline_reason(
       healthy folders (and, on ``reclassify=True``, cleared their
       existing predictions during finalization with no replacement).
 
-    Deliberately conservative — a healthy containing folder always
-    returns ``None`` regardless of the image path, so a single unreadable
-    file inside a working tree stays a per-photo failure and can never
-    trip the mount-root check by itself.
+    Deliberately conservative — an image path with no mount-shaped
+    prefix under a readable containing folder returns ``None``, so a
+    single unreadable file inside an ordinary local tree stays a
+    per-photo failure. A readable folder under a mount-shaped path is
+    still probed at the mount root, since a stale SMB/NFS mount can
+    keep folder metadata cached (Codex #1388 P1 r3665254569) — a
+    successful root probe there also returns ``None``.
     """
-    # A readable folder means one bad file, not a source outage — this
-    # short-circuit is what protects a local ``/mnt/photos/...`` catalog
-    # (unusual, but legal) from tripping the mount-root check just because
-    # a single file has been deleted.
-    if not folder_path or os.path.isdir(folder_path):
+    if not folder_path:
         return None
-    # The folder itself is gone / unreachable. If that folder lives under
-    # a mount-shaped path and the mount is no longer active, this is a
-    # mount-scoped outage (Codex #1388 P1 r3663493889): pause the whole
-    # run instead of skipping folder-by-folder while the same dead share
-    # rejects every subsequent read.
+    # A dead SMB/NFS mount can keep folder metadata cached: reads
+    # against the folder's files still raise EIO, but
+    # ``os.path.isdir(folder_path)`` returns True from the stale stat.
+    # Probe every mount-shaped root candidate first (Codex #1388 P1
+    # r3665254569) so that case is scoped mount-wide and classify
+    # pauses for reconnection, rather than being misread as "one bad
+    # file" and letting classify keep hammering the dead share. A
+    # successful root probe leaves the caller with the ordinary
+    # "readable folder → per-photo failure" outcome below.
     for mount_root in _archive_mount_root_candidates(image_path):
         if _mount_root_offline(mount_root):
             return "mount", f"volume {mount_root} is not mounted"
+    # No mount-root candidate is offline. A readable folder means the
+    # file is the problem, not the source — protects a local
+    # ``/mnt/photos/...`` catalog (unusual, but legal) from tripping
+    # the folder-scoped branch just because a single file was deleted.
+    if os.path.isdir(folder_path):
+        return None
     return "folder", f"folder {folder_path} is unreadable"
 
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3949,7 +3949,59 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # pause/retry loop.
                 source_offline: dict = {"reason": None, "pauses": 0}
 
-                def _handle_source_offline(reason):
+                def _publish_pause_reason(reason, step_id):
+                    """Surface the offline reason on transient progress/pause state.
+
+                    Codex #1388 P1 r3663383513: the pause itself was only
+                    reported via server-side log; the jobs UI showed a generic
+                    ``paused`` state with no indication of *why* classify
+                    parked, so users could not tell they needed to remount a
+                    named volume and might keep pressing Resume until the
+                    bounded retry budget converted a recoverable outage into a
+                    failed run. Publish the reason via the progress event
+                    (mirrored onto ``job['progress']`` for /api/jobs polls and
+                    the SSE stream alike) and set the classify step's
+                    ``current_file`` so the reason renders directly beneath
+                    the paused pipeline step, right next to the Resume button.
+                    Kept off ``errors`` so a successful resume still finalizes
+                    as ``completed``.
+                    """
+                    message = (
+                        f"Paused: source {reason}. Reconnect it and press "
+                        f"Resume to keep classifying."
+                    )
+                    if step_id is not None:
+                        with contextlib.suppress(Exception):
+                            runner.update_step(
+                                job["id"], step_id, current_file=message,
+                            )
+                    _emit_progress(
+                        runner, job["id"], stages, "classify",
+                        message,
+                        step_id=step_id,
+                        pause_reason=message,
+                    )
+
+                def _clear_pause_reason(step_id):
+                    """Drop the pause banner once the user has resumed.
+
+                    Leaving a stale ``pause_reason`` on ``job['progress']``
+                    after a successful reconnect would keep the "reconnect
+                    and Resume" banner visible while classify happily runs.
+                    """
+                    if step_id is not None:
+                        with contextlib.suppress(Exception):
+                            runner.update_step(
+                                job["id"], step_id, current_file="",
+                            )
+                    _emit_progress(
+                        runner, job["id"], stages, "classify",
+                        "Resumed classification",
+                        step_id=step_id,
+                        pause_reason=None,
+                    )
+
+                def _handle_source_offline(reason, step_id=None):
                     """Park on a dead source; report whether we may continue.
 
                     Returns True when the run was paused and then resumed, so
@@ -3973,6 +4025,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # that never comes back still surfaces a real terminal
                     # error, and a run that does come back does not.
                     log.warning("Classify paused: source offline (%s)", reason)
+                    # Publish BEFORE calling pause_job so the reason is already
+                    # in job['progress'] by the time the UI reacts to the
+                    # ``pausing`` status flip. Otherwise the banner would only
+                    # appear after the next progress event, which for a fully
+                    # blocked read might be minutes away.
+                    _publish_pause_reason(reason, step_id)
 
                     pause = getattr(runner, "pause_job", None)
                     paused = False
@@ -3980,12 +4038,31 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         with contextlib.suppress(Exception):
                             paused = bool(pause(job["id"]))
                     if not paused:
-                        # Nothing to park on (non-pausable job, or a direct
-                        # run_pipeline_job call in a test). Stop rather than
-                        # spin through the rest of the collection collecting
-                        # instant EIOs.
-                        source_offline["reason"] = reason
-                        return False
+                        # ``pause_job`` returns False in two very different
+                        # cases: (a) the job is not pausable at all — a
+                        # non-pausable pipeline or a direct
+                        # ``run_pipeline_job`` call in a test — genuinely
+                        # nothing to park on, and (b) the user already
+                        # pressed Pause while this network read was blocked,
+                        # so the job's public state is already ``pausing``
+                        # and a second pause request is a no-op. Treating (b)
+                        # as "can't pause" would waste the user's Pause
+                        # click by giving up instead of parking (Codex
+                        # #1388 P2 r3663383518); check
+                        # ``pause_requested`` and fall through to the
+                        # checkpoint so the run parks on the user's
+                        # already-in-flight request.
+                        pause_probe = getattr(runner, "pause_requested", None)
+                        already_pausing = False
+                        if pause_probe is not None:
+                            with contextlib.suppress(Exception):
+                                already_pausing = bool(pause_probe(job["id"]))
+                        if not already_pausing:
+                            # Nothing to park on. Stop rather than spin
+                            # through the rest of the collection
+                            # collecting instant EIOs.
+                            source_offline["reason"] = reason
+                            return False
 
                     # Blocks here until the user resumes or cancels. Classify
                     # is a registered pause participant, so this is the same
@@ -3993,6 +4070,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     if _pause_checkpoint():
                         source_offline["reason"] = reason
                         return False
+                    # Successful resume: drop the stale "reconnect and Resume"
+                    # banner before the caller retries the read.
+                    _clear_pause_reason(step_id)
                     return True
 
                 from datetime import datetime as dt
@@ -4596,7 +4676,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     # the same way (and the finalization
                                     # rollup sets abort so downstream stages
                                     # skip the dead source).
-                                    if not _handle_source_offline(reason):
+                                    if not _handle_source_offline(
+                                        reason, step_id=step_id,
+                                    ):
                                         # Give-up: image never loaded, so
                                         # this photo is unreached — same
                                         # bucket as the folder-scoped skip

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -58,6 +58,11 @@ log = logging.getLogger(__name__)
 
 _SENTINEL = object()  # unique end-of-stream marker
 
+# How many times classify will pause for a vanished source volume before it
+# stops asking. Resuming without actually remounting the share would otherwise
+# pause again on the very next photo, forever.
+_MAX_SOURCE_OFFLINE_PAUSES = 3
+
 
 def _missing_archive_mount_root(path: str) -> str | None:
     """Return a likely missing mount root that must not be auto-created."""
@@ -76,6 +81,33 @@ def _missing_archive_mount_root(path: str) -> str | None:
     for mount_root in (_candidate(raw_posix), _candidate(normalized_posix)):
         if mount_root and not os.path.lexists(mount_root):
             return mount_root
+    return None
+
+
+def _source_offline_reason(folder_path: str, image_path: str) -> str | None:
+    """Return why the photo's SOURCE is unreachable, or None if it isn't.
+
+    Distinguishes "this one file won't load" (corrupt RAW, bad permissions —
+    genuinely that photo's failure) from "the volume holding the collection
+    went away" (every remaining read will fail too). Only the second warrants
+    stopping the run: a dropped SMB/NFS share turns each read into an instant
+    EIO, so a stage that keeps going marks the entire untouched remainder of
+    the collection "failed" — which reads to the user as "your photos are
+    broken" rather than "reconnect the share".
+
+    Deliberately conservative. Both probes require evidence that the source
+    *tree* is gone, so no single unreadable file can ever trip them, and a
+    collection on a local disk (no /Volumes-style mount root, folder still
+    present) always returns None and keeps today's per-photo behavior.
+    """
+    mount_root = _missing_archive_mount_root(image_path)
+    if mount_root:
+        return f"volume {mount_root} is not mounted"
+    # A stale mount can keep the mount root in place while the subtree turns
+    # unreadable, so fall back to asking whether the containing folder still
+    # resolves. os.path.isdir() swallows the EIO and returns False.
+    if folder_path and not os.path.isdir(folder_path):
+        return f"folder {folder_path} is unreadable"
     return None
 
 
@@ -3882,6 +3914,54 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 first_model_photo_ids: set = set()
                 fresh_full_image_ids_by_photo: dict = {}
 
+                # ``reason`` latches only when classify is giving up for good,
+                # so the remaining models in a multi-model run skip themselves
+                # instead of re-discovering the same dead share. ``pauses``
+                # bounds the reconnect ping-pong: a user who resumes without
+                # actually fixing the mount gets a few tries, not an infinite
+                # pause/retry loop.
+                source_offline: dict = {"reason": None, "pauses": 0}
+
+                def _handle_source_offline(reason):
+                    """Park on a dead source; report whether we may continue.
+
+                    Returns True when the run was paused and then resumed, so
+                    the caller should keep classifying (the user reconnected
+                    the share). Returns False when classify should stop: the
+                    runner can't park, the job was cancelled, or we've already
+                    paused for this too many times.
+                    """
+                    if source_offline["pauses"] >= _MAX_SOURCE_OFFLINE_PAUSES:
+                        source_offline["reason"] = reason
+                        return False
+                    source_offline["pauses"] += 1
+                    errors.append(
+                        f"[classify] Source {reason} — paused. Reconnect it "
+                        f"and resume to classify the rest, or cancel the run."
+                    )
+                    log.warning("Classify paused: source offline (%s)", reason)
+
+                    pause = getattr(runner, "pause_job", None)
+                    paused = False
+                    if pause is not None:
+                        with contextlib.suppress(Exception):
+                            paused = bool(pause(job["id"]))
+                    if not paused:
+                        # Nothing to park on (non-pausable job, or a direct
+                        # run_pipeline_job call in a test). Stop rather than
+                        # spin through the rest of the collection collecting
+                        # instant EIOs.
+                        source_offline["reason"] = reason
+                        return False
+
+                    # Blocks here until the user resumes or cancels. Classify
+                    # is a registered pause participant, so this is the same
+                    # safe boundary the per-photo cancel check already uses.
+                    if _pause_checkpoint():
+                        source_offline["reason"] = reason
+                        return False
+                    return True
+
                 from datetime import datetime as dt
 
                 for spec_idx, active_spec in enumerate(resolved_specs_local):
@@ -3892,6 +3972,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         runner.update_step(job["id"], step_id,
                                            status="completed",
                                            summary="Skipped (cancelled)")
+                        continue
+                    if source_offline["reason"]:
+                        # The share died during an earlier model. Every read for
+                        # this one would fail the same way, so say so instead of
+                        # running up a second identical failure count (the
+                        # incident's "0 predictions, 865 failed" second model).
+                        runner.update_step(
+                            job["id"], step_id, status="completed",
+                            summary=(
+                                f"Skipped (source {source_offline['reason']})"
+                            ),
+                        )
                         continue
 
                     runner.update_step(job["id"], step_id, status="running")
@@ -4030,6 +4122,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     )
                     raw_results: list = []
                     failed = 0
+                    # Photos we never got to look at because the source volume
+                    # was offline. Kept apart from ``failed`` so the summary
+                    # never reports an unreachable share as broken photos.
+                    source_skipped = 0
                     skipped_existing = 0
                     full_image_fallbacks = 0
                     stages["classify"].setdefault("cached", 0)
@@ -4137,7 +4233,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             )
 
                     for batch_start in range(0, total, batch_size):
-                        if _should_abort(abort):
+                        if _should_abort(abort) or source_offline["reason"]:
                             break
                         batch = photos[batch_start:batch_start + batch_size]
 
@@ -4147,7 +4243,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             # next batch boundary (~32 photos). The outer batch
                             # loop's check at the top of the next iteration will
                             # then break out of the batch loop entirely.
-                            if _should_abort(abort):
+                            # ``source_offline`` rides the same boundary: once
+                            # the share is gone there is nothing left to read,
+                            # so stop pulling photos rather than spending the
+                            # rest of the batch collecting instant EIOs.
+                            if _should_abort(abort) or source_offline["reason"]:
                                 break
                             processed_in_spec += 1
                             stages["classify"]["seen"] = (
@@ -4394,6 +4494,26 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     None if full_image_fallback else detection,
                                 )
                                 if img is None:
+                                    # Before blaming the photo, check whether the
+                                    # source itself vanished. A dropped share
+                                    # fails every remaining read instantly, so
+                                    # counting these as per-photo failures would
+                                    # report the untouched remainder of the
+                                    # collection as broken images.
+                                    offline = _source_offline_reason(
+                                        folder_path, image_path,
+                                    )
+                                    if offline:
+                                        if not _handle_source_offline(offline):
+                                            break
+                                        # Resumed. Count this one as
+                                        # unreachable rather than failed: the
+                                        # source tree was gone, so the photo
+                                        # was never actually examined and
+                                        # calling it a failure would repeat
+                                        # the same lie at smaller scale.
+                                        source_skipped += 1
+                                        continue
                                     failed += 1
                                     failed_photo_ids.add(photo["id"])
                                     continue
@@ -4587,6 +4707,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         )
                     if failed:
                         parts.append(f"{failed} failed")
+                    if source_skipped:
+                        parts.append(
+                            f"{source_skipped} unreachable (source offline)"
+                        )
+                    if source_offline["reason"]:
+                        # Name the photos we never reached rather than folding
+                        # them into a count that reads as "classified".
+                        parts.append(
+                            f"stopped after {processed_in_spec} of {total} — "
+                            f"source {source_offline['reason']}"
+                        )
                     runner.update_step(
                         job["id"], step_id, status="completed",
                         summary=", ".join(parts),
@@ -4615,8 +4746,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # IDs (not per-model attempt count) so the badge can never
                 # exceed total photos.
                 n_failed_photos = len(failed_photo_ids)
+                if source_offline["reason"]:
+                    # Must carry the "[classify] Fatal:" prefix: the end-of-run
+                    # rollup picks the job's headline error by that marker and
+                    # would otherwise fall back to errors[0] — likely an
+                    # unrelated per-photo warning logged much earlier.
+                    errors.append(
+                        f"[classify] Fatal: source "
+                        f"{source_offline['reason']}. Reconnect it and run "
+                        f"Process again to classify the rest — photos already "
+                        f"classified will be skipped."
+                    )
+                # A run that gave up on a dead source did NOT classify the
+                # collection, so it must not land on the job tree as a clean
+                # green stage — "completed" here would tell the user their
+                # photos were processed when most were never opened.
                 stages["classify"]["status"] = (
-                    "failed" if total_failed > 0 else "completed"
+                    "failed"
+                    if (total_failed > 0 or source_offline["reason"])
+                    else "completed"
                 )
                 if total_failed > 0:
                     errors.append(
@@ -4628,6 +4776,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     "predictions_stored": total_predictions_stored,
                     "detected": detect_state["total_detected"],
                     "failed": total_failed,
+                    "source_offline": source_offline["reason"],
                     "already_classified": total_skipped_existing,
                     "full_image_fallbacks": total_full_image_fallbacks,
                     "weak_detection_rescues": len(contextual_weak_ids),

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -67,12 +67,20 @@ _MAX_SOURCE_OFFLINE_PAUSES = 3
 def _archive_mount_root_candidates(path: str) -> list[str]:
     """Return the plausible mount-root prefix(es) for ``path``, if any.
 
-    Extracts the mount-root component under the OS's mount conventions —
-    the first entry under ``/Volumes/`` or ``/mnt/`` (SMB/NFS style), or
-    the first user/name pair under ``/media/<user>/``. These conventions
-    strongly imply the user intended the location as a mount point; the
-    caller decides what state to require of it (missing entirely vs.
-    present but not actually mounted).
+    Extracts the mount-root component under each OS's mount conventions —
+    the first entry under ``/Volumes/`` or ``/mnt/`` (SMB/NFS style), the
+    first user/name pair under ``/media/<user>/``, a Windows drive letter
+    (``Z:/...`` — mapped SMB drives use this), or a UNC share
+    (``//server/share/...``). These shapes strongly imply the user
+    intended the location as a mount point; the caller decides what state
+    to require of it (missing entirely vs. present but not actually
+    mounted).
+
+    Windows mapped drives and UNC paths (Codex #1388 P2 r3663816324) are
+    documented storage layouts in ``docs/WINDOWS_SUPPORT.md``; without
+    detecting them, a disconnected SMB share on Windows would fall
+    through to folder-scoped skips and classify would keep reissuing
+    reads across the dead share instead of pausing for reconnection.
 
     Both the raw expanded path and the normalized absolute form are
     checked so relative or ``~``-prefixed paths still match. Duplicates
@@ -85,6 +93,29 @@ def _archive_mount_root_candidates(path: str) -> list[str]:
             return f"/{parts[1]}/{parts[2]}"
         if len(parts) >= 4 and parts[0] == "" and parts[1] == "media":
             return f"/media/{parts[2]}/{parts[3]}"
+        # UNC share: ``\\server\share\...`` after backslash-normalization
+        # becomes ``//server/share/...``, so ``parts`` starts with two
+        # empty strings.
+        if (
+            len(parts) >= 4
+            and parts[0] == ""
+            and parts[1] == ""
+            and parts[2]
+            and parts[3]
+        ):
+            return f"//{parts[2]}/{parts[3]}"
+        # Windows drive letter: ``Z:\...`` after normalization becomes
+        # ``Z:/...``. ``os.path.ismount("Z:")`` (no separator) returns
+        # False even for a real mounted drive because Windows treats
+        # ``Z:`` as a relative path on drive Z, so return with a trailing
+        # separator that ismount accepts.
+        if (
+            parts
+            and len(parts[0]) == 2
+            and parts[0][1] == ":"
+            and parts[0][0].isalpha()
+        ):
+            return f"{parts[0].upper()}/"
         return None
 
     raw_posix = os.path.expanduser(path).replace("\\", "/")
@@ -4804,6 +4835,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                             else detection,
                                         )
                                     )
+                                    if img is not None:
+                                        # Successful recovery: refund the
+                                        # pause budget so an unrelated
+                                        # outage later in the run — a
+                                        # second share that drops, or the
+                                        # same share dropping again hours
+                                        # later — still gets its own
+                                        # bounded retry window. Without
+                                        # this, three separately-recovered
+                                        # outages exhaust the budget and
+                                        # the fourth outage immediately
+                                        # takes the give-up branch without
+                                        # ever offering Resume (Codex
+                                        # #1388 P2 r3663816327). The
+                                        # ``pauses`` bound is meant to
+                                        # protect against a user who
+                                        # resumes WITHOUT actually
+                                        # remounting the share — a
+                                        # successful read is proof the
+                                        # share IS back, so the counter
+                                        # can honestly reset.
+                                        source_offline["pauses"] = 0
                                 if gave_up_on_source:
                                     break
                                 if img is None:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -121,9 +121,29 @@ def _archive_mount_root_candidates(path: str) -> list[str]:
     raw_posix = os.path.expanduser(path).replace("\\", "/")
     normalized = os.path.normpath(os.path.abspath(os.path.expanduser(path)))
     normalized_posix = normalized.replace("\\", "/")
+    # Also probe the symlink-resolved form so a catalog alias like
+    # ``/photos`` pointing into ``/Volumes/NAS/photos`` retains its
+    # mount-shaped prefix (Codex #1388 P2 r3664891998). Without this,
+    # neither the raw alias nor its ``abspath`` normalization has a
+    # ``/Volumes``/``/mnt``/``/media``/drive-letter/UNC prefix, so
+    # ``_source_offline_reason`` would classify a disconnected share
+    # reached via the alias as folder-scoped and classify would skip
+    # its photos instead of pausing for reconnection. ``realpath``
+    # only resolves symlinks (readlink), so it does not stat the
+    # target and stays safe even when the underlying mount is dead.
+    try:
+        resolved = os.path.realpath(os.path.expanduser(path))
+    except OSError:
+        resolved = None
+    resolved_posix = (
+        resolved.replace("\\", "/") if resolved else None
+    )
 
     seen: list[str] = []
-    for cand in (_candidate(raw_posix), _candidate(normalized_posix)):
+    for source in (raw_posix, normalized_posix, resolved_posix):
+        if source is None:
+            continue
+        cand = _candidate(source)
         if cand and cand not in seen:
             seen.append(cand)
     return seen
@@ -249,6 +269,54 @@ def _source_offline_reason(
         if _mount_root_offline(mount_root):
             return "mount", f"volume {mount_root} is not mounted"
     return "folder", f"folder {folder_path} is unreadable"
+
+
+def _still_offline_folder_ids_of(thread_db, folder_ids) -> set:
+    """Return the folder IDs whose stored ``folders.path`` is unreachable.
+
+    Twin of ``_still_offline_folder_ids`` that takes folder IDs directly
+    instead of a photo-seed set. Downstream stages use this to catch a
+    dead source that classify never observed — a fully-cached classify
+    (every detection + classifier result already stored) makes no image
+    opens, so ``source_offline_state["skipped_photo_ids"]`` stays empty
+    even if every remaining file lives on a disconnected share. Without
+    an always-probe pass over the downstream worklist, ``extract_masks``
+    / ``eye_keypoints`` would then reopen the dead source, hammering it
+    photo-by-photo — the exact pattern the classify pause is meant to
+    prevent (Codex #1388 P1 r3664891993).
+
+    Each unique folder path is probed once (``isdir`` returns False for
+    every child of a dead mount, so a single probe covers folder- and
+    mount-scoped outages alike). Folders the DB no longer knows about
+    are silently dropped, and the lookup is chunked under SQLite's
+    bind-variable limit so large worklists don't raise ``too many SQL
+    variables`` before the filter can run (see ``db.py``'s
+    ``_SQLITE_PARAM_CHUNK_SIZE``).
+    """
+    if not folder_ids:
+        return set()
+    ids = [int(fid) for fid in folder_ids]
+    _CHUNK = 900
+    probe_cache: dict = {}
+    still_offline: set = set()
+    for i in range(0, len(ids), _CHUNK):
+        chunk = ids[i:i + _CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        rows = thread_db.conn.execute(
+            f"SELECT id, path FROM folders WHERE id IN ({placeholders})",
+            chunk,
+        ).fetchall()
+        for row in rows:
+            fid = row["id"] if hasattr(row, "keys") else row[0]
+            path = row["path"] if hasattr(row, "keys") else row[1]
+            if not path:
+                still_offline.add(fid)
+                continue
+            if path not in probe_cache:
+                probe_cache[path] = os.path.isdir(path)
+            if not probe_cache[path]:
+                still_offline.add(fid)
+    return still_offline
 
 
 def _still_offline_folder_ids(thread_db, seed_photo_ids) -> set:
@@ -5407,16 +5475,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
                 photos = _filter_excluded(thread_db.get_collection_photos(collection_id, per_page=999999))
 
-                # Drop photos classify couldn't reach because their folder
-                # was offline. Without this we'd render_proxy every one of
-                # them, they'd all skip with proxy=None, and the stage
-                # summary would land as "N skipped" — obscuring the real
-                # cause (missing folder) with a mask-extraction failure
-                # count (Codex #1388 P2 r3664058173). The folder-scoped
-                # branch in classify deliberately leaves ``abort`` clear
-                # so healthy folders keep processing here; this filter is
-                # how "healthy folders keep processing" stays true without
-                # dragging the missing folder's photos along.
+                # Drop photos whose folder is offline. Without this we'd
+                # render_proxy every one of them, they'd all skip with
+                # proxy=None, and the stage summary would land as "N
+                # skipped" — obscuring the real cause (missing folder)
+                # with a mask-extraction failure count (Codex #1388 P2
+                # r3664058173). The folder-scoped branch in classify
+                # deliberately leaves ``abort`` clear so healthy folders
+                # keep processing here; this filter is how "healthy
+                # folders keep processing" stays true without dragging
+                # the missing folder's photos along.
+                #
+                # Always probe the worklist's folders — do NOT gate on
+                # ``source_skipped_photo_ids`` (Codex #1388 P1
+                # r3664891993). A fully-cached classify (every detection
+                # + classifier result already stored, only masks missing
+                # — e.g. after a SAM variant change) makes no image
+                # opens, so the seed set stays empty even though every
+                # remaining file is on an unreachable share. Without the
+                # unconditional probe, extract_masks would then reopen
+                # the dead source photo-by-photo, count each failed
+                # render_proxy as merely skipped, and the pipeline
+                # could finish "successfully" with no masks made.
                 #
                 # Filter by FOLDER, not by photo id: the classify seed
                 # only accumulates photos that reached ``_prepare_image``,
@@ -5431,17 +5511,70 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # for spec A comes back before mask extraction runs, so
                 # its photos aren't silently excluded (Codex #1388 P2
                 # r3664348758).
-                source_skipped_photo_ids = source_offline_state.get(
-                    "skipped_photo_ids") or set()
-                if source_skipped_photo_ids:
-                    still_offline_folder_ids = _still_offline_folder_ids(
-                        thread_db, source_skipped_photo_ids,
+                def _row_folder_id(row):
+                    # sqlite.Row raises IndexError on missing columns; a
+                    # test-shape dict raises KeyError. Both mean "no
+                    # folder to probe" for this row — leave it in place
+                    # rather than treating it as offline.
+                    try:
+                        fid = row["folder_id"]
+                    except (KeyError, IndexError):
+                        return None
+                    return fid
+
+                worklist_folder_ids = {
+                    fid for fid in (_row_folder_id(p) for p in photos)
+                    if fid is not None
+                }
+                still_offline_folder_ids = _still_offline_folder_ids_of(
+                    thread_db, worklist_folder_ids,
+                )
+                if still_offline_folder_ids:
+                    kept, dropped = [], []
+                    for p in photos:
+                        if _row_folder_id(p) in still_offline_folder_ids:
+                            dropped.append(p)
+                        else:
+                            kept.append(p)
+                    total_before = len(photos)
+                    photos = kept
+                    dropped_ids = {p["id"] for p in dropped}
+                    # Publish so eye_keypoints (later downstream) sees
+                    # the same offline set without having to re-probe
+                    # every folder from scratch.
+                    prior_skipped = (
+                        source_offline_state.get("skipped_photo_ids")
+                        or set()
                     )
-                    if still_offline_folder_ids:
-                        photos = [
-                            p for p in photos
-                            if p["folder_id"] not in still_offline_folder_ids
-                        ]
+                    source_offline_state["skipped_photo_ids"] = (
+                        set(prior_skipped) | dropped_ids
+                    )
+                    already_flagged_classify = any(
+                        e.startswith("[classify] Fatal:") for e in errors
+                    )
+                    if not already_flagged_classify:
+                        # Classify didn't already own this outage
+                        # (e.g. fully-cached run where classify made no
+                        # image reads). Surface the source-offline
+                        # failure at this stage instead — a fatal-
+                        # prefixed error keeps the end-of-run rollup
+                        # from picking an unrelated warning as the
+                        # headline error, and marking the stage
+                        # ``failed`` prevents the pipeline from
+                        # finishing "successfully" with no masks made.
+                        errors.append(
+                            f"[extract_masks] Fatal: "
+                            f"{len(dropped_ids)} of {total_before} "
+                            f"photos unreachable (source offline). "
+                            f"Reconnect the missing folder(s) and run "
+                            f"Process again to extract the rest."
+                        )
+                        stages["extract_masks"]["status"] = "failed"
+                    log.warning(
+                        "Extract-masks: dropped %d photo(s) from %d "
+                        "offline folder(s); source not reachable.",
+                        len(dropped_ids), len(still_offline_folder_ids),
+                    )
 
                 # Build a map of photo_id -> primary detection (highest confidence)
                 # from the detections table. Only photos with detections and without
@@ -6117,13 +6250,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         if p["id"] not in params.exclude_photo_ids
                     ]
 
-                # Drop photos classify couldn't reach because their folder
-                # was offline. eye_keypoints also opens the source image
-                # (via the pipeline detect_eye_keypoints_stage → keypoint
-                # runners), so without this it would walk every unreachable
-                # photo and record them as eye-detection failures — the
-                # same downstream-hammering pattern the classify pause is
+                # Drop photos whose folder is offline. eye_keypoints also
+                # opens the source image (via the pipeline
+                # detect_eye_keypoints_stage → keypoint runners), so
+                # without this it would walk every unreachable photo and
+                # record them as eye-detection failures — the same
+                # downstream-hammering pattern the classify pause is
                 # meant to prevent (Codex #1388 P2 r3664058173).
+                #
+                # Always probe the worklist's folders — not just when
+                # classify populated ``source_skipped_photo_ids`` (Codex
+                # #1388 P1 r3664891993). A fully-cached-classify /
+                # eye-only rerun makes no image reads in classify, so
+                # the seed set can stay empty even when every remaining
+                # file is on an unreachable share.
                 #
                 # Filter by FOLDER, not by photo id — cached photos
                 # never populate the classify seed set, so an ID-only
@@ -6131,17 +6271,65 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # P2 r3664694179). Re-probing per folder also lets a
                 # folder that recovered between classify and this stage
                 # rejoin (Codex #1388 P2 r3664348758).
-                source_skipped_photo_ids = source_offline_state.get(
-                    "skipped_photo_ids") or set()
-                if source_skipped_photo_ids:
-                    still_offline_folder_ids = _still_offline_folder_ids(
-                        thread_db, source_skipped_photo_ids,
+                def _row_folder_id(row):
+                    # sqlite.Row raises IndexError on missing columns; a
+                    # test-shape dict raises KeyError. Both mean "no
+                    # folder to probe" for this row.
+                    try:
+                        fid = row["folder_id"]
+                    except (KeyError, IndexError):
+                        return None
+                    return fid
+
+                worklist_folder_ids = {
+                    fid for fid in (
+                        _row_folder_id(p) for p in photos_for_stage
+                    ) if fid is not None
+                }
+                still_offline_folder_ids = _still_offline_folder_ids_of(
+                    thread_db, worklist_folder_ids,
+                )
+                if still_offline_folder_ids:
+                    dropped_ids = {
+                        p["id"] for p in photos_for_stage
+                        if _row_folder_id(p) in still_offline_folder_ids
+                    }
+                    photos_for_stage = [
+                        p for p in photos_for_stage
+                        if _row_folder_id(p) not in still_offline_folder_ids
+                    ]
+                    # The stage-level call at the bottom re-resolves
+                    # photos from ``collection_id`` and filters via
+                    # ``exclude_photo_ids`` — the local filter above
+                    # only drives the weight-download planner and
+                    # ``total``. Merge the offline IDs into the stage's
+                    # exclusion set so the actual keypoint runners
+                    # don't reopen the dead source (CodeRabbit
+                    # r3664548813).
+                    existing_exclude = (
+                        set(params.exclude_photo_ids)
+                        if params.exclude_photo_ids else set()
                     )
-                    if still_offline_folder_ids:
-                        photos_for_stage = [
-                            p for p in photos_for_stage
-                            if p["folder_id"] not in still_offline_folder_ids
-                        ]
+                    params.exclude_photo_ids = (
+                        existing_exclude | dropped_ids
+                    )
+                    # Publish for anyone downstream that may probe
+                    # ``source_offline_state`` later.
+                    prior_skipped = (
+                        source_offline_state.get("skipped_photo_ids")
+                        or set()
+                    )
+                    source_offline_state["skipped_photo_ids"] = (
+                        set(prior_skipped) | dropped_ids
+                    )
+                    if dropped_ids:
+                        log.warning(
+                            "Eye-keypoints: dropped %d photo(s) from "
+                            "%d offline folder(s); source not "
+                            "reachable.",
+                            len(dropped_ids),
+                            len(still_offline_folder_ids),
+                        )
                 total = len(photos_for_stage)
                 start_time = time.time()
                 processed = {"count": 0}

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -251,51 +251,61 @@ def _source_offline_reason(
     return "folder", f"folder {folder_path} is unreadable"
 
 
-def _still_offline_photo_ids(thread_db, photo_ids) -> set:
-    """Return the subset of ``photo_ids`` whose folder is still unreadable.
+def _still_offline_folder_ids(thread_db, seed_photo_ids) -> set:
+    """Return the folder IDs whose ``folders.path`` is still unreadable.
 
-    Downstream stages (extract_masks, eye_keypoints) filter photos by
-    the aggregate ``source_offline_state["skipped_photo_ids"]`` set so
-    an offline folder's photos aren't re-opened just to fail again.
-    That set accumulates across every classifier spec, but the folder
-    can recover between specs — or between classify and mask
-    extraction. Without a re-probe the mask/eye-keypoint stages would
-    silently exclude a photo whose folder came back (Codex #1388 P2
-    r3664348758). Anything the DB no longer knows about is dropped
-    from the returned set — a photo that was purged since classify
-    can't be filtered either.
+    Downstream stages (extract_masks, eye_keypoints) use this to expand
+    the classify-observed ``source_offline_state["skipped_photo_ids"]``
+    set from photo-ID-scoped exclusion to folder-scoped exclusion.
+    Classify only ever adds a photo to that set after calling
+    ``_prepare_image``; the non-reclassify cache branch short-circuits
+    before that call, so cached photos in the same offline folder
+    never enter the seed set (Codex #1388 P2 r3664694179). Filtering
+    by folder catches them too — otherwise they slip through and force
+    mask/eye-keypoint stages to reopen the dead source, the exact
+    downstream-hammering pattern the classify pause is meant to
+    prevent.
 
-    The IN-clause lookup is chunked under SQLite's bind-variable limit
+    Each unique folder path is probed once (dead mount → ``isdir``
+    False for every child, so a single probe suffices for either
+    mount- or folder-scoped outages). Anything the DB no longer knows
+    about is silently dropped — a photo that was purged since
+    classify can't be filtered by folder either.
+
+    The seed lookup is chunked under SQLite's bind-variable limit
     (999 on legacy builds this repo explicitly accommodates — see
-    ``db.py``'s ``_SQLITE_PARAM_CHUNK_SIZE``). Without chunking a large
-    offline folder would raise ``OperationalError: too many SQL
-    variables`` before the mask/eye-keypoint stages could get past this
-    filter and continue with photos from healthy folders (Codex #1388
-    P2 r3664525158).
+    ``db.py``'s ``_SQLITE_PARAM_CHUNK_SIZE``). Without chunking a
+    large offline folder would raise ``OperationalError: too many
+    SQL variables`` before the mask/eye-keypoint stages could get
+    past this filter and continue with photos from healthy folders
+    (Codex #1388 P2 r3664525158).
     """
-    if not photo_ids:
+    if not seed_photo_ids:
         return set()
-    ids = [int(pid) for pid in photo_ids]
+    ids = [int(pid) for pid in seed_photo_ids]
     _CHUNK = 900
-    still_offline: set = set()
+    probe_cache: dict = {}
+    still_offline_folder_ids: set = set()
     for i in range(0, len(ids), _CHUNK):
         chunk = ids[i:i + _CHUNK]
         placeholders = ",".join("?" * len(chunk))
         rows = thread_db.conn.execute(
-            f"SELECT p.id, f.path "
+            f"SELECT DISTINCT p.folder_id, f.path "
             f"FROM photos p JOIN folders f ON p.folder_id = f.id "
             f"WHERE p.id IN ({placeholders})",
             chunk,
         ).fetchall()
         for row in rows:
-            pid = row["id"] if hasattr(row, "keys") else row[0]
+            fid = row["folder_id"] if hasattr(row, "keys") else row[0]
             path = row["path"] if hasattr(row, "keys") else row[1]
-            # ``isdir`` False covers both a still-missing folder and a
-            # mount-scoped outage (dead mount → isdir False for every
-            # child), so a single probe suffices for either scope.
-            if not path or not os.path.isdir(path):
-                still_offline.add(pid)
-    return still_offline
+            if not path:
+                still_offline_folder_ids.add(fid)
+                continue
+            if path not in probe_cache:
+                probe_cache[path] = os.path.isdir(path)
+            if not probe_cache[path]:
+                still_offline_folder_ids.add(fid)
+    return still_offline_folder_ids
 
 
 @dataclass
@@ -5408,23 +5418,30 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # how "healthy folders keep processing" stays true without
                 # dragging the missing folder's photos along.
                 #
-                # Re-probe before filtering: the aggregate skipped set
-                # accumulates across every classifier spec, and a folder
-                # that dropped for spec A can recover before mask
-                # extraction runs. Without the re-probe we'd silently
-                # exclude photos whose folder came back (Codex #1388 P2
+                # Filter by FOLDER, not by photo id: the classify seed
+                # only accumulates photos that reached ``_prepare_image``,
+                # so the non-reclassify cache branch — which appends the
+                # cached prediction to raw_results and ``continue``s
+                # without any disk touch — never contributes its photos
+                # to the seed set. An ID-only filter would leave those
+                # cached photos in place, and mask/eye-keypoint stages
+                # would reopen the same dead source (Codex #1388 P2
+                # r3664694179). Re-probing per folder also handles the
+                # multi-spec recovery case where a folder that dropped
+                # for spec A comes back before mask extraction runs, so
+                # its photos aren't silently excluded (Codex #1388 P2
                 # r3664348758).
                 source_skipped_photo_ids = source_offline_state.get(
                     "skipped_photo_ids") or set()
                 if source_skipped_photo_ids:
-                    source_skipped_photo_ids = _still_offline_photo_ids(
+                    still_offline_folder_ids = _still_offline_folder_ids(
                         thread_db, source_skipped_photo_ids,
                     )
-                if source_skipped_photo_ids:
-                    photos = [
-                        p for p in photos
-                        if p["id"] not in source_skipped_photo_ids
-                    ]
+                    if still_offline_folder_ids:
+                        photos = [
+                            p for p in photos
+                            if p["folder_id"] not in still_offline_folder_ids
+                        ]
 
                 # Build a map of photo_id -> primary detection (highest confidence)
                 # from the detections table. Only photos with detections and without
@@ -6108,20 +6125,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # same downstream-hammering pattern the classify pause is
                 # meant to prevent (Codex #1388 P2 r3664058173).
                 #
-                # Re-probe so a folder that recovered between classify
-                # and this stage is not left out (Codex #1388 P2
-                # r3664348758).
+                # Filter by FOLDER, not by photo id — cached photos
+                # never populate the classify seed set, so an ID-only
+                # filter would leave them in the worklist (Codex #1388
+                # P2 r3664694179). Re-probing per folder also lets a
+                # folder that recovered between classify and this stage
+                # rejoin (Codex #1388 P2 r3664348758).
                 source_skipped_photo_ids = source_offline_state.get(
                     "skipped_photo_ids") or set()
                 if source_skipped_photo_ids:
-                    source_skipped_photo_ids = _still_offline_photo_ids(
+                    still_offline_folder_ids = _still_offline_folder_ids(
                         thread_db, source_skipped_photo_ids,
                     )
-                if source_skipped_photo_ids:
-                    photos_for_stage = [
-                        p for p in photos_for_stage
-                        if p["id"] not in source_skipped_photo_ids
-                    ]
+                    if still_offline_folder_ids:
+                        photos_for_stage = [
+                            p for p in photos_for_stage
+                            if p["folder_id"] not in still_offline_folder_ids
+                        ]
                 total = len(photos_for_stage)
                 start_time = time.time()
                 processed = {"count": 0}

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1153,6 +1153,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             "archive": {"status": "pending", "count": 0, "label": "Archiving photos"},
         }
 
+        # Photos classify skipped because their folder went offline mid-run
+        # (folder-scoped outage; abort stays clear so healthy folders keep
+        # processing). Downstream source-reading stages (extract_masks,
+        # eye_keypoints) filter these out so they don't walk back into the
+        # missing folder and re-record the same photos as mask/keypoint
+        # failures, obscuring the intended source-offline diagnosis
+        # (Codex #1388 P2 r3664058173). Held on a dict rather than
+        # ``stages["classify"]`` because ``_update_stages`` pushes stage
+        # dicts as JSON to SSE consumers, and a raw ``set`` isn't
+        # JSON-serialisable.
+        source_offline_state: dict = {"skipped_photo_ids": set()}
+
         # Normalize model_ids: prefer the explicit list, fall back to the legacy
         # single `model_id`, and finally to `[]` which means "use the active model
         # from config." This is the knob the multi-model fix hangs off of.
@@ -4991,7 +5003,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     total_failed += failed
                     total_skipped_existing += skipped_existing
                     models_succeeded += 1
-                    completed_step_ids.add(step_id)
+                    # A per-model row is "completed" only when it actually
+                    # finished classifying every photo it was asked to. If
+                    # the mount died (source_offline["reason"] latched) or
+                    # a folder outage left photos unread
+                    # (spec_source_skipped_photo_ids), the row should be
+                    # ``failed`` — the Jobs page reads ``step.status``
+                    # directly and auto-collapses ``completed`` rows without
+                    # warnings, so leaving this ``completed`` would show a
+                    # failed job with a green, collapsed classifier row
+                    # (Codex #1388 P2 r3664058179). The later stage-status
+                    # rollup at the end of the function isn't mapped back
+                    # to the ``classify:<model>`` step, so the fix has to
+                    # land here.
+                    spec_gave_up = bool(source_offline["reason"])
+                    spec_had_skips = bool(spec_source_skipped_photo_ids)
+                    spec_step_status = (
+                        "failed" if (spec_gave_up or spec_had_skips)
+                        else "completed"
+                    )
+                    if spec_step_status == "failed":
+                        failed_step_ids.add(step_id)
+                    else:
+                        completed_step_ids.add(step_id)
 
                     # Reclassify stale-row purge: only fires after the FIRST
                     # successful model has written fresh predictions, so a run
@@ -5100,9 +5134,27 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             f"stopped after {processed_in_spec} of {total} — "
                             f"source {source_offline['reason']}"
                         )
+                    # Attach the outage as ``error=`` on the failed row so the
+                    # Jobs page shows a human-readable reason next to the
+                    # collapsed step, matching the shape of the
+                    # model-load-failure branch above (line 4271).
+                    step_error = None
+                    if spec_step_status == "failed":
+                        if spec_gave_up:
+                            step_error = (
+                                f"Stopped after {processed_in_spec} of "
+                                f"{total} — source {source_offline['reason']}"
+                            )
+                        else:
+                            step_error = (
+                                f"{len(spec_source_skipped_photo_ids)} of "
+                                f"{total} photos unreachable "
+                                "(source offline)"
+                            )
                     runner.update_step(
-                        job["id"], step_id, status="completed",
+                        job["id"], step_id, status=spec_step_status,
                         summary=", ".join(parts),
+                        error=step_error,
                     )
 
                 # Cancellation takes precedence over the all-models-failed-to-load
@@ -5129,6 +5181,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # exceed total photos.
                 n_failed_photos = len(failed_photo_ids)
                 n_source_skipped_photos = len(source_skipped_photo_ids)
+                # Publish the source-skipped set to downstream stages BEFORE
+                # deciding to set ``abort``. extract_masks and eye_keypoints
+                # need this even on the folder-scoped path (abort deliberately
+                # stays clear so healthy folders keep processing) — otherwise
+                # they still walk every detected photo in the missing folder
+                # and re-issue reads against the offline share (Codex #1388
+                # P2 r3664058173).
+                source_offline_state["skipped_photo_ids"] = (
+                    set(source_skipped_photo_ids)
+                )
                 if source_offline["reason"]:
                     # Must carry the "[classify] Fatal:" prefix: the end-of-run
                     # rollup picks the job's headline error by that marker and
@@ -5261,6 +5323,24 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 os.makedirs(masks_dir, exist_ok=True)
 
                 photos = _filter_excluded(thread_db.get_collection_photos(collection_id, per_page=999999))
+
+                # Drop photos classify couldn't reach because their folder
+                # was offline. Without this we'd render_proxy every one of
+                # them, they'd all skip with proxy=None, and the stage
+                # summary would land as "N skipped" — obscuring the real
+                # cause (missing folder) with a mask-extraction failure
+                # count (Codex #1388 P2 r3664058173). The folder-scoped
+                # branch in classify deliberately leaves ``abort`` clear
+                # so healthy folders keep processing here; this filter is
+                # how "healthy folders keep processing" stays true without
+                # dragging the missing folder's photos along.
+                source_skipped_photo_ids = source_offline_state.get(
+                    "skipped_photo_ids") or set()
+                if source_skipped_photo_ids:
+                    photos = [
+                        p for p in photos
+                        if p["id"] not in source_skipped_photo_ids
+                    ]
 
                 # Build a map of photo_id -> primary detection (highest confidence)
                 # from the detections table. Only photos with detections and without
@@ -5934,6 +6014,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     photos_for_stage = [
                         p for p in photos_for_stage
                         if p["id"] not in params.exclude_photo_ids
+                    ]
+
+                # Drop photos classify couldn't reach because their folder
+                # was offline. eye_keypoints also opens the source image
+                # (via the pipeline detect_eye_keypoints_stage → keypoint
+                # runners), so without this it would walk every unreachable
+                # photo and record them as eye-detection failures — the
+                # same downstream-hammering pattern the classify pause is
+                # meant to prevent (Codex #1388 P2 r3664058173).
+                source_skipped_photo_ids = source_offline_state.get(
+                    "skipped_photo_ids") or set()
+                if source_skipped_photo_ids:
+                    photos_for_stage = [
+                        p for p in photos_for_stage
+                        if p["id"] not in source_skipped_photo_ids
                     ]
                 total = len(photos_for_stage)
                 start_time = time.time()

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -5012,9 +5012,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         # delete rows for photos the classifier never reached.
                         # The intersection guarantees there's a replacement
                         # detection AND that the classifier considered it.
+                        #
+                        # Also subtract source-skipped photos: ``first_model_
+                        # photo_ids`` is added to at the TOP of the per-photo
+                        # body (before the image read), so a photo whose read
+                        # later failed with the source offline is still in
+                        # that set. Without this subtraction, the purge below
+                        # would delete any pre-run detection ids whose boxes
+                        # differ from the fresh boxes even for photos we
+                        # never classified — cascading through their prior
+                        # predictions despite the ``clear_predictions``
+                        # exclusion that already spares them (Codex #1388
+                        # P1 r3663922709).
                         purge_ids = (
-                            first_model_photo_ids
-                            & detect_state["processed_ids"]
+                            (first_model_photo_ids
+                             & detect_state["processed_ids"])
+                            - source_skipped_photo_ids
                         )
                         # Delete only pre-run ids the current run did NOT
                         # re-produce. Detection ids are content-addressed

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -119,28 +119,42 @@ def _missing_archive_mount_root(path: str) -> str | None:
 def _mount_root_offline(mount_root: str) -> bool:
     """Whether ``mount_root`` appears to not have a filesystem mounted at it.
 
-    Two shapes count as offline, because callers only get here when a
-    subtree read has already failed:
+    Callers only get here when a subtree read has already failed, so we
+    need positive evidence the root was actually a mount before scoping
+    the outage to the whole share. Three shapes count as offline:
 
     * The directory is entirely gone — macOS removes ``/Volumes/<share>``
       on eject, so ``lexists`` alone is enough.
-    * The directory exists but ``os.path.ismount`` reports nothing is
-      mounted at it — the Linux common case, where the mount point
-      (``/mnt/<share>``, ``/media/<user>/<name>``) persists after
-      ``umount`` or after a network drop. Codex #1388 P1 r3663493889:
-      without this branch, the pipeline would treat every descendant as
-      an isolated folder outage instead of pausing for reconnection.
+    * A stale mount whose device is dead raises EIO from stat/listdir
+      probes — we're in the "reads are already failing" path so an
+      errored probe can't be considered healthy.
+    * The directory exists, ``os.path.ismount`` reports nothing is
+      mounted, AND the directory is empty — the Linux common case, where
+      the mount-point stub (``/mnt/<share>``, ``/media/<user>/<name>``)
+      persists after ``umount`` or a network drop. When the mount was
+      active its contents lived on the mounted filesystem, so an
+      unmounted stub is typically empty.
 
-    A stale mount whose device is dead can raise EIO from stat probes;
-    treat that as offline too — we're in the "reads are already failing"
-    path so the mount can't be considered healthy.
+    An ``ismount``-negative directory that still has siblings is not
+    treated as offline — that's proof it's an ordinary local directory
+    that happens to sit under ``/mnt/`` or ``/media/<user>/``, and one
+    deleted subfolder inside it must stay folder-scoped (Codex #1388 P1
+    r3663642357). Otherwise a user who deletes ``/mnt/photos/trip``
+    from a plain local ``/mnt/photos`` catalog would see the whole run
+    pause and eventually abandon their healthy sibling folders.
     """
     if not os.path.lexists(mount_root):
         return True
     try:
-        return not os.path.ismount(mount_root)
+        if os.path.ismount(mount_root):
+            return False
     except OSError:
         return True
+    try:
+        entries = os.listdir(mount_root)
+    except OSError:
+        return True
+    return not entries
 
 
 def _source_offline_reason(
@@ -4334,6 +4348,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # even though nothing in this run had a chance to
                     # rewrite them (Codex #1388 P1).
                     spec_reached_photo_ids: set = set()
+                    # Per-spec source skips, scoped to just THIS spec's
+                    # reads. Codex #1388 P2 (r3663642360): if the folder
+                    # was unreachable for model A but returned before
+                    # model B, the aggregate ``source_skipped_photo_ids``
+                    # would still exclude that photo from model B's
+                    # reclassify clear — leaving model B's stale
+                    # prediction in place. Because ``add_prediction``
+                    # uses ``INSERT OR IGNORE``, that stale row can win
+                    # over the fresh result and retain the wrong
+                    # species/confidence. Track skips per spec for the
+                    # clear; the aggregate set below still drives the
+                    # outage rollup at end-of-run.
+                    spec_source_skipped_photo_ids: set = set()
                     # Photos that iterated past the inner abort check IN THIS spec.
                     # Used for the per-spec ``runner.update_step`` progress (which
                     # is bounded by ``total``, not the multi-spec stage total) and
@@ -4728,6 +4755,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         source_skipped_photo_ids.add(
                                             photo["id"]
                                         )
+                                        spec_source_skipped_photo_ids.add(
+                                            photo["id"]
+                                        )
                                         break
                                     # Mount-scoped: park and wait for the
                                     # user to reconnect. On give-up,
@@ -4749,6 +4779,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         # prediction (Codex #1388 P1
                                         # r3663159360).
                                         source_skipped_photo_ids.add(
+                                            photo["id"]
+                                        )
+                                        spec_source_skipped_photo_ids.add(
                                             photo["id"]
                                         )
                                         gave_up_on_source = True
@@ -4867,14 +4900,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # scoped give-up, or every photo under a vanished folder)
                     # is one this run had no chance to rewrite, so wiping
                     # its prior prediction would leave it with nothing at
-                    # all (Codex #1388 P1). Fall back to the collection-
-                    # wide clear when no source outage occurred — that's
-                    # still the desired behavior on a clean reclassify.
+                    # all (Codex #1388 P1). Use the per-spec skipped set
+                    # rather than the aggregate one so a photo skipped for
+                    # an earlier spec but successfully reached this spec
+                    # still has its stale prior prediction cleared before
+                    # ``_store_grouped_predictions`` writes the fresh row —
+                    # ``add_prediction`` is ``INSERT OR IGNORE`` and would
+                    # otherwise keep the stale species/confidence (Codex
+                    # #1388 P2 r3663642360). Fall back to the collection-
+                    # wide clear when no source outage hit this spec —
+                    # that's still the desired behavior on a clean
+                    # reclassify.
                     if params.reclassify:
-                        if source_skipped_photo_ids:
+                        if spec_source_skipped_photo_ids:
                             clear_ids = list(
                                 spec_reached_photo_ids
-                                - source_skipped_photo_ids
+                                - spec_source_skipped_photo_ids
                             )
                         else:
                             clear_ids = [p["id"] for p in photos]

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4543,78 +4543,94 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     photo, folders,
                                     None if full_image_fallback else detection,
                                 )
-                                if img is None:
-                                    # Before blaming the photo, check whether the
-                                    # source itself vanished. A dropped share
-                                    # fails every remaining read instantly, so
-                                    # counting these as per-photo failures would
-                                    # report the untouched remainder of the
-                                    # collection as broken images.
+                                # Before blaming the photo, check whether the
+                                # source itself vanished. A dropped share
+                                # fails every remaining read instantly, so
+                                # counting these as per-photo failures would
+                                # report the untouched remainder of the
+                                # collection as broken images.
+                                #
+                                # Loop rather than one-shot pause+retry so a
+                                # mount that stays dead across a resume also
+                                # gets latched when this happens to be the
+                                # last photo (or last detection) needing an
+                                # image read: silently continuing on the
+                                # failed retry would leave source_offline
+                                # ["reason"] unset, abort clear, and
+                                # extract_masks / eye_keypoints would still
+                                # walk every detected photo reissuing reads
+                                # against the dead share (Codex #1388 P1
+                                # r3663278142). _handle_source_offline
+                                # bounds the total pause/retry cycles via
+                                # _MAX_SOURCE_OFFLINE_PAUSES, so this
+                                # can't loop forever.
+                                gave_up_on_source = False
+                                while img is None:
                                     offline = _source_offline_reason(
                                         folder_path, image_path,
                                     )
-                                    if offline:
-                                        scope, reason = offline
-                                        if scope == "folder":
-                                            # A single missing folder is not
-                                            # evidence the whole source is
-                                            # offline; skip this photo as
-                                            # unreachable and let later photos
-                                            # in healthy folders keep processing.
-                                            source_skipped += 1
-                                            source_skipped_photo_ids.add(
-                                                photo["id"]
-                                            )
-                                            continue
-                                        if not _handle_source_offline(reason):
-                                            # Give-up: image never loaded, so
-                                            # this photo is unreached — same
-                                            # bucket as the folder-scoped
-                                            # skip above. Keeps the
-                                            # reclassify clear below from
-                                            # wiping its prior prediction
-                                            # (Codex #1388 P1).
-                                            source_skipped_photo_ids.add(
-                                                photo["id"]
-                                            )
-                                            break
-                                        # Resumed. The user reconnected the
-                                        # share, so retry the same detection
-                                        # before advancing — silently skipping
-                                        # it here would leave the photo
-                                        # unclassified even though the source
-                                        # is back, and on a reclassify run
-                                        # finalization would clear its old
-                                        # prediction with no replacement.
-                                        img, folder_path, image_path = (
-                                            _prepare_image(
-                                                photo, folders,
-                                                None if full_image_fallback
-                                                else detection,
-                                            )
-                                        )
-                                        if img is None:
-                                            # Retry failed too — the remount
-                                            # didn't stick. Count this one as
-                                            # unreachable rather than failed:
-                                            # the source tree was gone, so the
-                                            # photo was never actually
-                                            # examined and calling it a
-                                            # failure would repeat the same
-                                            # lie at smaller scale. The pause
-                                            # counter still bounds how many
-                                            # times we ask.
-                                            source_skipped += 1
-                                            source_skipped_photo_ids.add(
-                                                photo["id"]
-                                            )
-                                            continue
-                                        # Retry succeeded — fall through to
-                                        # the normal inference path below.
-                                    else:
+                                    if offline is None:
+                                        # The source is reachable; this one
+                                        # file is genuinely broken.
                                         failed += 1
                                         failed_photo_ids.add(photo["id"])
-                                        continue
+                                        break
+                                    scope, reason = offline
+                                    if scope == "folder":
+                                        # A single missing folder is not
+                                        # evidence the whole source is
+                                        # offline; skip this photo as
+                                        # unreachable and let later photos
+                                        # in healthy folders keep processing.
+                                        source_skipped += 1
+                                        source_skipped_photo_ids.add(
+                                            photo["id"]
+                                        )
+                                        break
+                                    # Mount-scoped: park and wait for the
+                                    # user to reconnect. On give-up,
+                                    # _handle_source_offline latches
+                                    # source_offline["reason"] and returns
+                                    # False — we then break the per-photo
+                                    # loop so remaining photos short-circuit
+                                    # the same way (and the finalization
+                                    # rollup sets abort so downstream stages
+                                    # skip the dead source).
+                                    if not _handle_source_offline(reason):
+                                        # Give-up: image never loaded, so
+                                        # this photo is unreached — same
+                                        # bucket as the folder-scoped skip
+                                        # above. Keeps the reclassify clear
+                                        # below from wiping its prior
+                                        # prediction (Codex #1388 P1
+                                        # r3663159360).
+                                        source_skipped_photo_ids.add(
+                                            photo["id"]
+                                        )
+                                        gave_up_on_source = True
+                                        break
+                                    # Resumed. Retry the same read before
+                                    # advancing — silently skipping the
+                                    # paused-during photo would leave it
+                                    # unclassified even though the source
+                                    # came back, and on a reclassify run
+                                    # finalization would clear its old
+                                    # prediction with no replacement
+                                    # (Codex #1388 P2). If the retry also
+                                    # fails, the loop re-probes and either
+                                    # pauses again (bounded), degrades to
+                                    # folder-scope, or gives up.
+                                    img, folder_path, image_path = (
+                                        _prepare_image(
+                                            photo, folders,
+                                            None if full_image_fallback
+                                            else detection,
+                                        )
+                                    )
+                                if gave_up_on_source:
+                                    break
+                                if img is None:
+                                    continue
                                 inference_batch.append({
                                     "photo": photo,
                                     "detection_id": detection["id"],

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -264,26 +264,37 @@ def _still_offline_photo_ids(thread_db, photo_ids) -> set:
     r3664348758). Anything the DB no longer knows about is dropped
     from the returned set — a photo that was purged since classify
     can't be filtered either.
+
+    The IN-clause lookup is chunked under SQLite's bind-variable limit
+    (999 on legacy builds this repo explicitly accommodates — see
+    ``db.py``'s ``_SQLITE_PARAM_CHUNK_SIZE``). Without chunking a large
+    offline folder would raise ``OperationalError: too many SQL
+    variables`` before the mask/eye-keypoint stages could get past this
+    filter and continue with photos from healthy folders (Codex #1388
+    P2 r3664525158).
     """
     if not photo_ids:
         return set()
     ids = [int(pid) for pid in photo_ids]
-    placeholders = ",".join("?" * len(ids))
-    rows = thread_db.conn.execute(
-        f"SELECT p.id, f.path "
-        f"FROM photos p JOIN folders f ON p.folder_id = f.id "
-        f"WHERE p.id IN ({placeholders})",
-        ids,
-    ).fetchall()
+    _CHUNK = 900
     still_offline: set = set()
-    for row in rows:
-        pid = row["id"] if hasattr(row, "keys") else row[0]
-        path = row["path"] if hasattr(row, "keys") else row[1]
-        # ``isdir`` False covers both a still-missing folder and a
-        # mount-scoped outage (dead mount → isdir False for every
-        # child), so a single probe suffices for either scope.
-        if not path or not os.path.isdir(path):
-            still_offline.add(pid)
+    for i in range(0, len(ids), _CHUNK):
+        chunk = ids[i:i + _CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        rows = thread_db.conn.execute(
+            f"SELECT p.id, f.path "
+            f"FROM photos p JOIN folders f ON p.folder_id = f.id "
+            f"WHERE p.id IN ({placeholders})",
+            chunk,
+        ).fetchall()
+        for row in rows:
+            pid = row["id"] if hasattr(row, "keys") else row[0]
+            path = row["path"] if hasattr(row, "keys") else row[1]
+            # ``isdir`` False covers both a still-missing folder and a
+            # mount-scoped outage (dead mount → isdir False for every
+            # child), so a single probe suffices for either scope.
+            if not path or not os.path.isdir(path):
+                still_offline.add(pid)
     return still_offline
 
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -5449,6 +5449,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             runner.update_step(job["id"], "extract_masks", status="running")
             _update_stages(runner, job["id"], stages)
 
+            # Latched by the source-offline branch when the mask stage owns
+            # the outage (fully-cached classify + offline masks folder). The
+            # finalizer below preserves ``failed`` when this is set: without
+            # it, ``em_failed`` is zero (offline photos are pre-filtered from
+            # the worklist), and the finalizer flips the stage back to
+            # ``completed`` — silently masking the outage. The end-of-run
+            # rollup at ~L7005 reads only stage ``status`` values, so the job
+            # would complete "successfully" with the missing masks folded
+            # away in ``errors`` (Codex #1388 P1 r3665130244).
+            em_offline_latched = False
+
             try:
                 import config as cfg
                 from dino_embed import embed, embed_batch, embedding_to_blob
@@ -5570,6 +5581,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             f"Process again to extract the rest."
                         )
                         stages["extract_masks"]["status"] = "failed"
+                        # Survive the em_failed==0 finalizer at the bottom
+                        # of this stage — the offline photos were removed
+                        # from the worklist above, so the per-photo failure
+                        # counter would otherwise flip the stage back to
+                        # ``completed`` (Codex #1388 P1 r3665130244).
+                        em_offline_latched = True
                     log.warning(
                         "Extract-masks: dropped %d photo(s) from %d "
                         "offline folder(s); source not reachable.",
@@ -6124,7 +6141,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         "total": total, "cancelled": True,
                     }
                 else:
-                    final_status = "failed" if em_failed > 0 else "completed"
+                    final_status = (
+                        "failed"
+                        if em_failed > 0 or em_offline_latched
+                        else "completed"
+                    )
                     stages["extract_masks"]["status"] = final_status
                     em_rollup = (
                         f"[extract_masks] {em_failed} of {total} photos failed mask extraction"

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -122,6 +122,13 @@
   font-size: 12px; color: var(--text-muted); display: flex; gap: 16px;
   flex-wrap: wrap; padding: 8px 24px; border-bottom: 1px solid var(--border-subtle);
 }
+.job-pause-banner {
+  font-size: 13px; padding: 8px 12px; margin: 8px 0;
+  background: color-mix(in srgb, var(--warning, #d99a24) 12%, transparent);
+  border-left: 3px solid var(--warning, #d99a24);
+  color: var(--text-primary);
+  border-radius: 3px;
+}
 .btn-cancel {
   font-size: 12px; padding: 4px 12px; border-radius: 4px; cursor: pointer;
   background: var(--danger); color: #fff; border: none;
@@ -442,6 +449,16 @@
       html += '<span>' + esc(visibleProgress.label) + ': ' + progressPct(visibleProgress) + '%</span>';
     }
     html += '</div>';
+
+    // Pause reason banner: when classify (or any pipeline stage) parks the
+    // job on an outage it can't recover from on its own — a dropped share,
+    // missing volume — it publishes ``pause_reason`` on job.progress. Without
+    // this banner the user only sees a generic "paused" pill and can't tell
+    // what to fix before pressing Resume.
+    var pauseReason = job.progress && job.progress.pause_reason;
+    if (pauseReason && (job.status === 'pausing' || job.status === 'paused')) {
+      html += '<div class="job-pause-banner">' + esc(pauseReason) + '</div>';
+    }
 
     // Steps
     var steps = job.steps || job.tree || [];

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -13091,7 +13091,12 @@ def test_pipeline_classify_missing_folder_does_not_stop_healthy_folders(
     runner = NoPauseRunner()
     job = _make_job()
 
-    run_pipeline_job(job, runner, db_path, ws_id, params)
+    # The run finishes failed — some photos never got opened — but only AFTER
+    # the healthy folder has been fully processed. Codex #1388 P1 (second
+    # round): a folder-scoped outage must not report as a clean green job,
+    # but that must not come at the cost of stranding the reachable folders.
+    with pytest.raises(RuntimeError) as excinfo:
+        run_pipeline_job(job, runner, db_path, ws_id, params)
 
     # The healthy folder's photos must be classified even though the other
     # folder went away. Without the P1 fix, the gone folder trips a global
@@ -13129,3 +13134,314 @@ def test_pipeline_classify_missing_folder_does_not_stop_healthy_folders(
         f"Missing-folder photos must not be counted as failures; "
         f"got {summaries!r}"
     )
+
+    # The headline error must name the outage honestly. Without the fatal
+    # entry, the end-of-run rollup falls back to errors[0] (an unrelated
+    # per-photo warning logged much earlier) and the user sees a mystery
+    # failure instead of "reconnect the missing folder".
+    msg = str(excinfo.value)
+    assert "unreachable" in msg, (
+        f"A folder-scoped outage must produce a headline error naming the "
+        f"unreachable photos; got {msg!r}"
+    )
+    assert "failed to classify" not in msg, (
+        f"Unreachable photos must not be reported as classification "
+        f"failures in the headline; got {msg!r}"
+    )
+
+
+def test_pipeline_classify_folder_outage_is_not_a_clean_success(
+    tmp_path, monkeypatch,
+):
+    """Folder-scoped outages must not land on the job tree as green.
+
+    Codex #1388 P1 (second round): the folder-scope branch increments
+    ``source_skipped`` and continues without latching
+    ``source_offline["reason"]``. A collection whose only folder disappeared
+    reaches finalization with ``total_failed == 0`` and — pre-fix — landed
+    with ``stages["classify"]["status"] == "completed"`` and no headline
+    error. The user's photos were never opened; the job must say so.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # Point every photo at a folder that never existed on disk — trips the
+    # folder-scoped branch (mount root is still there, the folder itself is
+    # not) for every photo in the collection.
+    fake_missing_folder = str(tmp_path / "vanished_folder")
+
+    def folder_missing_prepare_image(photo, folders, detection, vireo_dir=None):
+        return None, fake_missing_folder, os.path.join(
+            fake_missing_folder, photo["filename"],
+        )
+
+    monkeypatch.setattr(
+        classify_job, "_prepare_image", folder_missing_prepare_image,
+    )
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    msg = str(excinfo.value)
+    assert "[classify] Fatal:" in msg, (
+        f"A folder-scoped outage must produce a fatal [classify]-prefixed "
+        f"error so the end-of-run rollup picks it as the headline instead "
+        f"of an unrelated warning; got {msg!r}"
+    )
+    assert "unreachable" in msg, (
+        f"The fatal error must name the outage as unreachable photos; "
+        f"got {msg!r}"
+    )
+    assert "failed to classify" not in msg, (
+        f"Photos we never opened are not classification failures; the "
+        f"headline must not describe them as such. Got {msg!r}"
+    )
+
+    # The structured result must reflect the outage count so downstream
+    # consumers (jobs API, pipeline card) can render it accurately. The
+    # raise itself proves stages["classify"]["status"] was set to 'failed'
+    # — the only path that reaches the run_pipeline_job failed-stage
+    # rollup — so re-asserting status here would double-cover the same
+    # signal.
+    result_stages = job["result"]["stages"]
+    assert result_stages["classify"].get("source_skipped") == len(photo_ids), (
+        f"Expected {len(photo_ids)} photos flagged as source_skipped; "
+        f"got {result_stages['classify']!r}"
+    )
+
+
+def test_pipeline_classify_give_up_skips_downstream_stages(
+    tmp_path, monkeypatch,
+):
+    """After classify gives up on an offline source, downstream stages skip.
+
+    CodeRabbit #1388: ``extract_masks_stage`` and ``eye_keypoints_stage``
+    gate purely on ``abort.is_set()``. Pre-fix, classify latched
+    ``source_offline["reason"]`` but never set ``abort``, so both stages
+    walked every detected photo and re-opened the same dead share —
+    reproducing the exact "N failed" pattern this PR is meant to fix, one
+    stage later. Set ``abort`` on the give-up path so extract_masks (and
+    eye_keypoints) can't hammer the dead source.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # The share is gone: every load fails.
+    gone_folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+
+    def offline_prepare_image(photo, folders, detection, vireo_dir=None):
+        return None, gone_folder, os.path.join(gone_folder, photo["filename"])
+
+    monkeypatch.setattr(classify_job, "_prepare_image", offline_prepare_image)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    # Spy on the exact function extract_masks_stage would call to re-open
+    # source images (masking.render_proxy). If classify's give-up path
+    # forgets to set abort, extract_masks runs its body and this spy fires;
+    # with the fix it never runs because the stage short-circuits on abort.
+    #
+    # Patched by attribute — extract_masks_stage does `from masking import
+    # (..., render_proxy, ...)` at call time, so setting the attribute on
+    # the module before the pipeline runs is what the imported binding
+    # sees. The patch is a defensive belt-and-suspenders around the
+    # status-Skipped assertion below.
+    render_proxy_calls: list = []
+
+    def spy_render_proxy(*args, **kwargs):
+        render_proxy_calls.append(args)
+        return None
+
+    with contextlib.suppress(Exception):
+        import masking as masking_mod
+        monkeypatch.setattr(masking_mod, "render_proxy", spy_render_proxy)
+
+    # A plain FakeRunner has no pause support, so classify gives up at once —
+    # the same path a non-pausable job takes when the source is offline.
+    # Crucially, do NOT set skip_extract_masks — the whole point of this test
+    # is that extract_masks would otherwise still run.
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Every downstream stage step must have reached a terminal Skipped state
+    # so the jobs tree doesn't leave rows dangling as pending, AND the stage
+    # must have short-circuited (not fallen through to the "running" summary
+    # that its real body writes after entering the try block).
+    extract_masks_updates = [
+        kwargs for (_jid, sid, kwargs) in runner.step_updates
+        if sid == "extract_masks"
+    ]
+    assert any(
+        kwargs.get("summary") == "Skipped"
+        for kwargs in extract_masks_updates
+    ), (
+        f"extract_masks must mark itself Skipped after classify gives up on "
+        f"a dead source; without the fix, abort stays clear and this stage "
+        f"walks every detected photo re-opening the offline share. "
+        f"Got updates {extract_masks_updates!r}"
+    )
+    eye_keypoints_updates = [
+        kwargs for (_jid, sid, kwargs) in runner.step_updates
+        if sid == "eye_keypoints"
+    ]
+    assert any(
+        kwargs.get("summary") == "Skipped"
+        for kwargs in eye_keypoints_updates
+    ), (
+        f"eye_keypoints must mark itself Skipped after classify gives up; "
+        f"got updates {eye_keypoints_updates!r}"
+    )
+
+    # Belt-and-suspenders: extract_masks reaching its inner loop would call
+    # masking.render_proxy on every detected photo. If any calls landed,
+    # the abort-on-give-up path regressed and downstream stages are once
+    # again hammering the dead share.
+    assert not render_proxy_calls, (
+        f"masking.render_proxy fired {len(render_proxy_calls)} time(s) "
+        f"after classify gave up on the offline source — extract_masks "
+        f"walked its per-photo loop instead of short-circuiting on abort."
+    )
+
+    # Sanity check the constant that gates the give-up path exists so a
+    # future rename doesn't silently defeat the test.
+    assert hasattr(pj, "_MAX_SOURCE_OFFLINE_PAUSES")

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12902,6 +12902,46 @@ def test_still_offline_photo_ids_prunes_recovered_folders(tmp_path):
     assert _still_offline_photo_ids(db, []) == set()
 
 
+def test_still_offline_photo_ids_chunks_large_id_sets(tmp_path):
+    """Query in bounded chunks so SQLite's bind-variable limit can't 500 us.
+
+    Codex #1388 P2 (r3664525158): an offline folder can hold more photos
+    than SQLite's ``SQLITE_MAX_VARIABLE_NUMBER`` (999 on legacy builds
+    this repo explicitly accommodates elsewhere), so a single
+    ``id IN (?,?,…)`` here would raise ``OperationalError: too many SQL
+    variables`` before mask/eye-keypoint stages could get past the
+    downstream filter and continue with photos from healthy folders.
+    Exercise well over 999 IDs and pin that the caller still gets a
+    correct still-offline set — no exception, and every photo whose
+    folder is missing is returned.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline_job import _still_offline_photo_ids
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    db = Database(str(tmp_path / "test.db"))
+
+    gone_folder = tmp_path / "vanished"
+    gone_folder.mkdir()
+    gone_folder_id = db.add_folder(str(gone_folder))
+
+    # 2500 > the 999-variable ceiling AND > the 900 chunk size, so the
+    # query has to run in at least three chunks to succeed.
+    photo_ids = [
+        db.add_photo(gone_folder_id, f"p{i:04d}.jpg", ".jpg", 1000, float(i))
+        for i in range(2500)
+    ]
+
+    os.rmdir(gone_folder)
+
+    still_offline = _still_offline_photo_ids(db, photo_ids)
+    assert still_offline == set(photo_ids), (
+        f"Chunked lookup must still return every photo whose folder is "
+        f"unreadable; got {len(still_offline)} of {len(photo_ids)}."
+    )
+
+
 def test_pipeline_classify_pauses_when_source_volume_disappears(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -14257,9 +14257,12 @@ def test_pipeline_classify_give_up_skips_downstream_stages(
         render_proxy_calls.append(args)
         return None
 
-    with contextlib.suppress(Exception):
-        import masking as masking_mod
-        monkeypatch.setattr(masking_mod, "render_proxy", spy_render_proxy)
+    # Patch unconditionally — a suppressed patch would leave
+    # ``render_proxy_calls`` permanently empty, letting the ``assert not
+    # render_proxy_calls`` guard below pass vacuously if extract_masks
+    # regressed (CodeRabbit nit #1388).
+    import masking as masking_mod
+    monkeypatch.setattr(masking_mod, "render_proxy", spy_render_proxy)
 
     # A plain FakeRunner has no pause support, so classify gives up at once —
     # the same path a non-pausable job takes when the source is offline.
@@ -14758,6 +14761,241 @@ def test_pipeline_classify_multimodel_reclassify_per_spec_source_skips(
     )
 
 
+def test_pipeline_classify_stale_purge_preserves_source_skipped_photos(
+    tmp_path, monkeypatch,
+):
+    """The reclassify stale-detection purge must not touch source-skipped photos.
+
+    Codex #1388 P1 (r3663922709): on a reclassify run where detection
+    succeeded but the source disappeared before classification, a photo
+    ends up in ``source_skipped_photo_ids`` AND — because
+    ``first_model_photo_ids`` is added to at the top of the per-photo
+    body, before the image read — remains in ``first_model_photo_ids``
+    too. The purge at ``pipeline_job.py`` lines 5015-5066 therefore
+    included that photo, and if the fresh detect returned different boxes
+    than the pre-run snapshot the pre-run detection ids for the skipped
+    photo were deleted — cascading through their prior predictions
+    despite the new ``clear_predictions`` exclusion that already spared
+    them.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    gone_folder_path = str(tmp_path / "vanishes_at_classify")
+    healthy_folder_path = str(tmp_path / "always_here")
+    os.makedirs(gone_folder_path, exist_ok=True)
+    os.makedirs(healthy_folder_path, exist_ok=True)
+
+    gone_folder_id = db.add_folder(gone_folder_path)
+    healthy_folder_id = db.add_folder(healthy_folder_path)
+
+    # Pre-existing detection: THIS is the row (and its cascaded
+    # prediction) the fix must preserve. Its box is deliberately
+    # different from what fake_detect_batch will return below so that
+    # the pre-run id is NOT re-produced by the fresh detect — the
+    # exact precondition that triggers the purge.
+    gone_photo_id = db.add_photo(
+        gone_folder_id, "gone.jpg", ".jpg", 4000, 4_000_000.0,
+    )
+    _drop_jpeg(gone_folder_path, "gone.jpg")
+    old_gone_det_id = db.save_detections(
+        gone_photo_id,
+        [{"box": {"x": 0.05, "y": 0.05, "w": 0.30, "h": 0.30},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )[0]
+    OLD_SPECIES = "PreservedPriorSpecies"
+    db.add_prediction(
+        detection_id=old_gone_det_id,
+        species=OLD_SPECIES,
+        confidence=0.42,
+        model="BioCLIP-2",
+        labels_fingerprint="fp",
+    )
+
+    # Healthy photo is here to drive ``models_succeeded == 1`` so the
+    # purge fires. Its pre-run boxes are the same as fresh, so it does
+    # not exercise the purge itself.
+    healthy_photo_id = db.add_photo(
+        healthy_folder_id, "healthy.jpg", ".jpg", 5000, 5_000_000.0,
+    )
+    _drop_jpeg(healthy_folder_path, "healthy.jpg")
+    db.save_detections(
+        healthy_photo_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids",
+                     "value": [gone_photo_id, healthy_photo_id]}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    # Fresh detect returns a DIFFERENT box for the gone photo so its
+    # content-addressed id (vireo/detection_id.py) does NOT match the
+    # pre-run id. The pre-run id therefore lands in the purge's
+    # stale-id list — unless the fix excludes source-skipped photos
+    # from the purge scope, which is what this test pins.
+    from detection_id import detection_id as compute_det_id
+    NEW_BOX = (0.75, 0.75, 0.20, 0.20)
+    new_gone_det_id = compute_det_id(
+        gone_photo_id, "megadetector-v6", NEW_BOX, "animal",
+    )
+    assert new_gone_det_id != old_gone_det_id, (
+        "Test setup precondition: fresh box must produce a different "
+        "detection id than the pre-run box, otherwise the purge would "
+        "have nothing to consider stale for this photo."
+    )
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            if p["id"] == gone_photo_id:
+                det_map[p["id"]] = [{
+                    "id": new_gone_det_id,
+                    "box_x": NEW_BOX[0], "box_y": NEW_BOX[1],
+                    "box_w": NEW_BOX[2], "box_h": NEW_BOX[3],
+                    "confidence": 0.9, "category": "animal",
+                }]
+            else:
+                det_map[p["id"]] = [{
+                    "id": d["id"],
+                    "box_x": d["box_x"], "box_y": d["box_y"],
+                    "box_w": d["box_w"], "box_h": d["box_h"],
+                    "confidence": d["detector_confidence"],
+                    "category": d["category"],
+                } for d in db_.get_detections(p["id"])
+                    if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    def selective_prepare_image(photo, folders, detection, vireo_dir=None):
+        # The gone photo's folder vanished between detect and classify.
+        if photo["id"] == gone_photo_id:
+            image_path = os.path.join(
+                str(tmp_path / "vanished_at_classify_time"),
+                photo["filename"],
+            )
+            return None, str(tmp_path / "vanished_at_classify_time"), image_path
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", selective_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "FreshSpecies",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    # NoPauseRunner keeps the gone photo on the folder-scoped path so
+    # the healthy photo still gets classified (``models_succeeded == 1``
+    # is required for the purge to fire).
+    class NoPauseRunner(FakeRunner):
+        def pause_job(self, job_id):
+            return False
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = NoPauseRunner()
+    job = _make_job()
+
+    # A folder-scoped skip on a partial run raises a fatal source-offline
+    # error at the end of the run (Codex #1388 P1) — accept the raise so
+    # the classify body ran the purge.
+    with contextlib.suppress(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The heart of the fix: the pre-run detection row for the
+    # source-skipped photo must still exist. Pre-fix, ``first_model_
+    # photo_ids`` still contained gone_photo_id (added at the top of the
+    # per-photo body before the image read), so the purge treated the
+    # pre-run id as stale and deleted it — cascading through the
+    # prediction below.
+    surviving_det_ids = {
+        row[0] for row in db.conn.execute(
+            "SELECT id FROM detections WHERE photo_id = ?",
+            (gone_photo_id,),
+        ).fetchall()
+    }
+    assert old_gone_det_id in surviving_det_ids, (
+        f"The pre-run detection row for a source-skipped photo must "
+        f"survive the reclassify stale-detection purge. Got surviving "
+        f"ids {surviving_det_ids!r}; expected {old_gone_det_id} to be "
+        f"present."
+    )
+
+    # And its cascaded prediction must survive too — cascading through
+    # the FK delete is exactly what the pre-fix code did.
+    surviving_species = sorted(
+        row[0] for row in db.conn.execute(
+            "SELECT species FROM predictions WHERE detection_id = ?",
+            (old_gone_det_id,),
+        ).fetchall()
+    )
+    assert OLD_SPECIES in surviving_species, (
+        f"The prior prediction for a source-skipped photo must not be "
+        f"cascade-deleted by the stale-detection purge. Got species "
+        f"{surviving_species!r}."
+    )
+
+
 def test_pipeline_classify_recovered_pause_leaves_no_terminal_classify_error(
     tmp_path, monkeypatch,
 ):
@@ -15055,9 +15293,12 @@ def test_pipeline_classify_failed_retry_on_last_photo_latches_source_offline(
         render_proxy_calls.append(args)
         return None
 
-    with contextlib.suppress(Exception):
-        import masking as masking_mod
-        monkeypatch.setattr(masking_mod, "render_proxy", spy_render_proxy)
+    # Patch unconditionally — a suppressed patch would leave
+    # ``render_proxy_calls`` permanently empty, letting the ``assert not
+    # render_proxy_calls`` guard below pass vacuously if the
+    # last-photo retry-fail path regressed (CodeRabbit nit #1388).
+    import masking as masking_mod
+    monkeypatch.setattr(masking_mod, "render_proxy", spy_render_proxy)
 
     class ResumingRunner(FakeRunner):
         """User keeps hitting Resume without actually remounting the share."""

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12851,20 +12851,21 @@ def test_mount_root_offline_false_for_empty_ordinary_local_dir(tmp_path):
     )
 
 
-def test_still_offline_photo_ids_prunes_recovered_folders(tmp_path):
-    """Photos whose folder is now readable must drop out of the skip set.
+def test_still_offline_folder_ids_prunes_recovered_folders(tmp_path):
+    """Folders that recovered must drop out of the still-offline set.
 
     Codex #1388 P2 (r3664348758): the aggregate
     ``source_offline_state["skipped_photo_ids"]`` accumulates across every
     classifier spec, and a folder that dropped for spec A can recover
     before mask extraction runs. Without a re-probe, the downstream
-    filter would silently exclude the now-readable photo and it would
-    never get its masks. Pin that ``_still_offline_photo_ids`` returns
-    only photos whose folder is still missing at re-probe time.
+    filter would silently exclude photos in the now-readable folder and
+    they would never get their masks. Pin that
+    ``_still_offline_folder_ids`` returns only folders that are still
+    missing at re-probe time.
     """
     import config as cfg
     from db import Database
-    from pipeline_job import _still_offline_photo_ids
+    from pipeline_job import _still_offline_folder_ids
 
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
     db = Database(str(tmp_path / "test.db"))
@@ -12887,22 +12888,82 @@ def test_still_offline_photo_ids_prunes_recovered_folders(tmp_path):
     # Now delete the "gone" folder — folder A recovered, folder B is
     # still missing. This is the multi-model recovery shape: both
     # photo IDs entered the aggregate skipped set for an earlier
-    # classifier spec, but only one of them is still unreachable now.
+    # classifier spec, but only one of the two folders is still
+    # unreachable now.
     os.rmdir(gone_folder)
 
-    still_offline = _still_offline_photo_ids(db, {healthy_id, gone_id})
-    assert still_offline == {gone_id}, (
-        f"A recovered folder must drop its photo from the still-offline "
-        f"set so downstream stages can process it; only the folder that "
-        f"remains missing should stay in the set. Got {still_offline!r}."
+    still_offline = _still_offline_folder_ids(db, {healthy_id, gone_id})
+    assert still_offline == {gone_folder_id}, (
+        f"A recovered folder must drop out of the still-offline set so "
+        f"downstream stages can process its photos; only the folder that "
+        f"remains missing should stay. Got {still_offline!r} (expected "
+        f"{{gone_folder_id={gone_folder_id}}})."
     )
 
     # And the empty-input path is a no-op — no DB query needed.
-    assert _still_offline_photo_ids(db, set()) == set()
-    assert _still_offline_photo_ids(db, []) == set()
+    assert _still_offline_folder_ids(db, set()) == set()
+    assert _still_offline_folder_ids(db, []) == set()
 
 
-def test_still_offline_photo_ids_chunks_large_id_sets(tmp_path):
+def test_still_offline_folder_ids_expands_beyond_seed_photos(tmp_path):
+    """A seed photo's folder scopes filtering for ALL photos in that folder.
+
+    Codex #1388 P2 (r3664694179): in a non-reclassify run, photos with
+    cached classifier results take the cache branch without calling
+    ``_prepare_image``, so their IDs never enter
+    ``source_offline_state["skipped_photo_ids"]``. If another photo in
+    the same folder reveals the folder is unavailable, an ID-only filter
+    still leaves those cached photos in the downstream mask/eye-keypoint
+    worklists, and the stages reopen the missing source. Pin that the
+    helper returns the whole *folder* — not just the seed photos — so
+    the caller can filter by ``folder_id`` and catch cached siblings.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline_job import _still_offline_folder_ids
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    db = Database(str(tmp_path / "test.db"))
+
+    gone_folder = tmp_path / "vanished"
+    gone_folder.mkdir()
+    gone_folder_id = db.add_folder(str(gone_folder))
+
+    # ``seed`` is the photo classify observed as unreachable via
+    # ``_prepare_image``. ``cached_sibling`` is a photo in the SAME
+    # folder that took the cache branch and never touched disk, so it
+    # never entered the seed set.
+    seed = db.add_photo(gone_folder_id, "seed.jpg", ".jpg", 1000, 100.0)
+    cached_sibling = db.add_photo(
+        gone_folder_id, "cached.jpg", ".jpg", 1000, 101.0,
+    )
+
+    os.rmdir(gone_folder)
+
+    still_offline = _still_offline_folder_ids(db, {seed})
+    assert still_offline == {gone_folder_id}, (
+        f"Seeding with the reached photo alone must still surface the "
+        f"whole folder as offline so cached siblings can be filtered by "
+        f"folder_id. Got {still_offline!r}."
+    )
+    # And the returned set is what a downstream filter uses to exclude
+    # the cached sibling — assert the filter shape callers apply.
+    photos_for_stage = [
+        {"id": seed, "folder_id": gone_folder_id},
+        {"id": cached_sibling, "folder_id": gone_folder_id},
+    ]
+    filtered = [
+        p for p in photos_for_stage
+        if p["folder_id"] not in still_offline
+    ]
+    assert filtered == [], (
+        f"Cached siblings in an offline folder must be dropped by the "
+        f"folder-scoped filter — otherwise the mask/eye-keypoint stages "
+        f"would reopen the dead source. Got {filtered!r}."
+    )
+
+
+def test_still_offline_folder_ids_chunks_large_id_sets(tmp_path):
     """Query in bounded chunks so SQLite's bind-variable limit can't 500 us.
 
     Codex #1388 P2 (r3664525158): an offline folder can hold more photos
@@ -12911,13 +12972,12 @@ def test_still_offline_photo_ids_chunks_large_id_sets(tmp_path):
     ``id IN (?,?,…)`` here would raise ``OperationalError: too many SQL
     variables`` before mask/eye-keypoint stages could get past the
     downstream filter and continue with photos from healthy folders.
-    Exercise well over 999 IDs and pin that the caller still gets a
-    correct still-offline set — no exception, and every photo whose
-    folder is missing is returned.
+    Exercise well over 999 IDs and pin that the caller still gets the
+    offline folder back — no exception.
     """
     import config as cfg
     from db import Database
-    from pipeline_job import _still_offline_photo_ids
+    from pipeline_job import _still_offline_folder_ids
 
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
     db = Database(str(tmp_path / "test.db"))
@@ -12935,10 +12995,10 @@ def test_still_offline_photo_ids_chunks_large_id_sets(tmp_path):
 
     os.rmdir(gone_folder)
 
-    still_offline = _still_offline_photo_ids(db, photo_ids)
-    assert still_offline == set(photo_ids), (
-        f"Chunked lookup must still return every photo whose folder is "
-        f"unreadable; got {len(still_offline)} of {len(photo_ids)}."
+    still_offline = _still_offline_folder_ids(db, photo_ids)
+    assert still_offline == {gone_folder_id}, (
+        f"Chunked lookup must still surface the unreachable folder; got "
+        f"{still_offline!r}."
     )
 
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12605,7 +12605,16 @@ def test_pipeline_classify_pauses_when_source_volume_disappears(
         f"Photos skipped because the volume vanished must not be reported "
         f"as classification failures; got summary {summaries!r}"
     )
-    assert "unreachable (source offline)" in summaries, (
+    # After Codex #1388 P1 r3663278142, the pause+retry loop runs against
+    # the SAME photo until the pause budget is spent (rather than one
+    # pause per photo advancing through the collection). Photos never
+    # attempted don't count as "unreachable"; the "stopped after N of Y"
+    # line names the outage and accounts for the untouched remainder.
+    # Accept either phrasing so the assertion stays about "did we account
+    # for what got skipped" and not the specific accounting shape.
+    assert (
+        "unreachable" in summaries or "stopped after" in summaries
+    ), (
         f"The summary must still account for the photos it skipped rather "
         f"than silently dropping them; got {summaries!r}"
     )
@@ -13844,4 +13853,203 @@ def test_pipeline_classify_recovered_pause_leaves_no_terminal_classify_error(
         f"terminal errors list — pipeline.html would surface it as a "
         f"failed stage even though classify finished successfully. Got "
         f"{classify_errors!r}"
+    )
+
+
+def test_pipeline_classify_failed_retry_on_last_photo_latches_source_offline(
+    tmp_path, monkeypatch,
+):
+    """A failed resume-retry on the last photo must still latch the outage.
+
+    Codex #1388 P1 (r3663278142): when the source stays offline through the
+    pause/resume cycle AND this is the final photo/detection that needs an
+    image read, the pre-fix retry-failed branch fell through with a silent
+    ``source_skipped += 1; continue`` — the classify loop then exited
+    normally with ``source_offline["reason"]`` unset and ``abort`` still
+    clear. The finalization rollup only sets ``abort`` when
+    ``source_offline["reason"]`` is truthy, so ``extract_masks_stage`` and
+    ``eye_keypoints_stage`` walked every detected photo and reissued reads
+    against the dead share — reproducing the exact "N failed" pattern this
+    PR is meant to fix, one stage later.
+
+    Reproduce by giving the run a SINGLE photo (so no subsequent photo can
+    re-trigger ``_handle_source_offline``) with a mount that stays dead
+    through the resume. The while-loop fix keeps invoking
+    ``_handle_source_offline`` on retry failure until the pause budget is
+    spent, at which point it latches ``source_offline["reason"]`` and
+    downstream stages short-circuit.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    name = "photo0.jpg"
+    pid = db.add_photo(folder_id, name, ".jpg", 4000, 4_000_000.0)
+    _drop_jpeg(folder_path, name)
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    photo_ids = [pid]
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # The mount is dead and the user's premature resumes don't fix it, so
+    # every read — initial AND every retry — fails.
+    gone_folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+    prepare_calls: list = []
+
+    def offline_prepare_image(photo, folders, detection, vireo_dir=None):
+        prepare_calls.append(photo["id"])
+        return None, gone_folder, os.path.join(gone_folder, photo["filename"])
+
+    monkeypatch.setattr(classify_job, "_prepare_image", offline_prepare_image)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    # Spy on masking.render_proxy — the exact call extract_masks_stage
+    # makes to re-open source images. If the fix regresses, abort stays
+    # clear on the last-photo path and extract_masks walks its per-photo
+    # loop hitting this spy.
+    render_proxy_calls: list = []
+
+    def spy_render_proxy(*args, **kwargs):
+        render_proxy_calls.append(args)
+        return None
+
+    with contextlib.suppress(Exception):
+        import masking as masking_mod
+        monkeypatch.setattr(masking_mod, "render_proxy", spy_render_proxy)
+
+    class ResumingRunner(FakeRunner):
+        """User keeps hitting Resume without actually remounting the share."""
+
+        def __init__(self):
+            super().__init__()
+            self.pause_calls = []
+            self._paused = False
+
+        def pause_job(self, job_id):
+            self.pause_calls.append(job_id)
+            self._paused = True
+            return True
+
+        def pause_requested(self, job_id):
+            return self._paused
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            self._paused = False  # premature resume
+            return False
+
+    # Don't set skip_extract_masks — the whole point is that extract_masks
+    # would otherwise re-open the same dead share.
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_regroup=True,
+    )
+
+    runner = ResumingRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The bounded pause loop must have fired — otherwise this test would
+    # be testing the initial-failure path, not the resume-retry path we
+    # care about.
+    assert runner.pause_calls, (
+        "Classify must have paused at least once for the resume-retry "
+        "path to be under test at all; if pause never fired the setup "
+        "regressed, not the code."
+    )
+    assert len(runner.pause_calls) <= pj._MAX_SOURCE_OFFLINE_PAUSES, (
+        f"Classify paused {len(runner.pause_calls)} times for the same "
+        f"dead volume on a single photo; the bounded loop must give up "
+        f"after {pj._MAX_SOURCE_OFFLINE_PAUSES}."
+    )
+
+    # The headline error must name the outage — pre-fix, source_offline
+    # ["reason"] stayed unset on this path so the end-of-run rollup fell
+    # back to an unrelated error.
+    msg = str(excinfo.value)
+    assert "/Volumes/DefinitelyNotMounted12345" in msg, (
+        f"The job's headline error must name the offline volume; "
+        f"got {msg!r}"
+    )
+    assert "failed to classify" not in msg, (
+        f"A dead share must not be reported as photos failing to "
+        f"classify; got {msg!r}"
+    )
+
+    # The core assertion: extract_masks must have skipped. Pre-fix, the
+    # last-photo retry-fail left abort clear, and this stage walked its
+    # per-photo loop reissuing reads against the dead mount.
+    extract_masks_updates = [
+        kwargs for (_jid, sid, kwargs) in runner.step_updates
+        if sid == "extract_masks"
+    ]
+    assert any(
+        kwargs.get("summary") == "Skipped"
+        for kwargs in extract_masks_updates
+    ), (
+        f"extract_masks must mark itself Skipped after classify gives up "
+        f"on the last-photo retry-fail path; without the fix, abort "
+        f"stays clear and this stage walks every detected photo "
+        f"re-opening the offline share. Got updates {extract_masks_updates!r}"
+    )
+    assert not render_proxy_calls, (
+        f"masking.render_proxy fired {len(render_proxy_calls)} time(s) "
+        f"after classify's last-photo retry-fail — extract_masks walked "
+        f"its per-photo loop against the dead share instead of "
+        f"short-circuiting on abort (Codex #1388 P1 r3663278142)."
     )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -13445,3 +13445,403 @@ def test_pipeline_classify_give_up_skips_downstream_stages(
     # Sanity check the constant that gates the give-up path exists so a
     # future rename doesn't silently defeat the test.
     assert hasattr(pj, "_MAX_SOURCE_OFFLINE_PAUSES")
+
+
+def test_pipeline_classify_reclassify_preserves_predictions_for_unreachable_photos(
+    tmp_path, monkeypatch,
+):
+    """Reclassify must not wipe predictions for photos the run never opened.
+
+    Codex #1388 P1 (r3663159360): with ``reclassify=True``, the folder-scoped
+    branch increments ``source_skipped`` and continues without setting
+    ``abort``. Finalization then reaches the collection-wide
+    ``clear_predictions(collection_photo_ids=[p["id"] for p in photos])`` and
+    deletes the existing predictions for photos in the missing folder — even
+    though the run had no chance to write a replacement. The user loses
+    their prior labels for photos we didn't even open.
+
+    Scope the clear to photos this spec actually reached AND wasn't source-
+    skipped, so an unreached photo keeps its prior prediction.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    gone_folder_path = str(tmp_path / "vanished")
+    healthy_folder_path = str(tmp_path / "still_here")
+    os.makedirs(gone_folder_path, exist_ok=True)
+    os.makedirs(healthy_folder_path, exist_ok=True)
+
+    gone_folder_id = db.add_folder(gone_folder_path)
+    healthy_folder_id = db.add_folder(healthy_folder_path)
+
+    photo_ids = []
+    gone_photo_ids: set = set()
+    healthy_photo_ids = []
+    gone_detection_ids = []
+    for i in range(3):
+        name = f"gone{i}.jpg"
+        pid = db.add_photo(
+            gone_folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i,
+        )
+        _drop_jpeg(gone_folder_path, name)
+        det_ids = db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+        gone_photo_ids.add(pid)
+        gone_detection_ids.append(det_ids[0])
+    for i in range(3):
+        name = f"healthy{i}.jpg"
+        pid = db.add_photo(
+            healthy_folder_id, name, ".jpg", 5000 + i, 5_000_000.0 + i,
+        )
+        _drop_jpeg(healthy_folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+        healthy_photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    # Seed a prior prediction for every photo in the unreachable folder under
+    # the same (model, labels_fingerprint) the reclassify run will target.
+    # These are exactly the rows the buggy clear used to wipe out even
+    # though the run couldn't rewrite them.
+    prior_species = "PriorSpecies"
+    for det_id in gone_detection_ids:
+        db.add_prediction(
+            detection_id=det_id,
+            species=prior_species,
+            confidence=0.42,
+            model="clip",
+            labels_fingerprint="fp",
+        )
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    fake_missing_root = str(tmp_path / "vanished_at_classify_time")
+
+    def selective_prepare_image(photo, folders, detection, vireo_dir=None):
+        if photo["id"] in gone_photo_ids:
+            image_path = os.path.join(fake_missing_root, photo["filename"])
+            return None, fake_missing_root, image_path
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", selective_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "FreshSpecies",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    class NoPauseRunner(FakeRunner):
+        def pause_job(self, job_id):
+            return False
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+        reclassify=True,
+    )
+
+    runner = NoPauseRunner()
+    job = _make_job()
+
+    # The run finishes failed (the gone folder was never opened), but the
+    # unreachable photos' prior predictions must still be there afterwards.
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    surviving = db.conn.execute(
+        f"SELECT COUNT(*) FROM predictions p "
+        f"JOIN detections d ON d.id = p.detection_id "
+        f"WHERE d.photo_id IN "
+        f"({','.join('?' * len(gone_photo_ids))}) "
+        f"AND p.species = ?",
+        list(gone_photo_ids) + [prior_species],
+    ).fetchone()[0]
+    assert surviving == len(gone_detection_ids), (
+        f"reclassify with a folder-scoped outage must leave the prior "
+        f"predictions for unreachable photos in place — the run had no "
+        f"chance to rewrite them. Expected {len(gone_detection_ids)} "
+        f"surviving {prior_species!r} rows, got {surviving}."
+    )
+
+    # And the healthy folder's photos should have been (re)classified with
+    # the fresh prediction — the fix must not regress the happy path.
+    fresh_stored = db.conn.execute(
+        f"SELECT COUNT(DISTINCT d.photo_id) FROM predictions p "
+        f"JOIN detections d ON d.id = p.detection_id "
+        f"WHERE d.photo_id IN "
+        f"({','.join('?' * len(healthy_photo_ids))}) "
+        f"AND p.species = 'FreshSpecies'",
+        list(healthy_photo_ids),
+    ).fetchone()[0]
+    assert fresh_stored == len(healthy_photo_ids), (
+        f"Healthy folder must still be classified after the fix; "
+        f"expected {len(healthy_photo_ids)} FreshSpecies rows, "
+        f"got {fresh_stored}."
+    )
+
+
+def test_pipeline_classify_recovered_pause_leaves_no_terminal_classify_error(
+    tmp_path, monkeypatch,
+):
+    """A successful pause+resume must not leave the run looking failed.
+
+    Codex #1388 P1 (r3663159367): the pause path used to append a
+    ``[classify] Source X — paused. Reconnect...`` entry to ``job["errors"]``
+    every time it parked. When the user reconnected and the retry
+    succeeded, that entry stayed in ``job["errors"]`` even though classify
+    completed normally. templates/pipeline.html treats every ``[classify]``
+    error as a failed stage — banner shown, success redirect suppressed —
+    so the newly supported reconnect-and-resume flow still looked failed to
+    the user. After the fix, a run that recovers must not carry a
+    ``[classify]`` entry in its terminal errors.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(6):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    gone_folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+    state = {"mounted": True, "seen": 0}
+
+    def flaky_prepare_image(photo, folders, detection, vireo_dir=None):
+        state["seen"] += 1
+        if state["seen"] == 2:
+            state["mounted"] = False
+        if not state["mounted"]:
+            return None, gone_folder, os.path.join(
+                gone_folder, photo["filename"],
+            )
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", flaky_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    class ReconnectingRunner(FakeRunner):
+        def __init__(self):
+            super().__init__()
+            self.pause_calls = []
+            self._paused = False
+
+        def pause_job(self, job_id):
+            self.pause_calls.append(job_id)
+            self._paused = True
+            return True
+
+        def pause_requested(self, job_id):
+            return self._paused
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            state["mounted"] = True   # user reconnects the volume
+            self._paused = False      # ...and hits Resume
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = ReconnectingRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The share dropped and came back — we must have paused at least once so
+    # this test is exercising the recovery path, not a happy-path run.
+    assert runner.pause_calls, (
+        "The share dropped mid-run; classify must have paused for the "
+        "recovery path to be under test at all. If pause never fired the "
+        "test setup regressed, not the code."
+    )
+
+    # And the recovery must have actually worked — every photo classified.
+    stored = db.conn.execute(
+        "SELECT COUNT(DISTINCT d.photo_id) FROM predictions p "
+        "JOIN detections d ON d.id = p.detection_id",
+    ).fetchone()[0]
+    assert stored == 6, (
+        f"Setup sanity: reconnect+resume must classify every photo for the "
+        f"pause-error assertion below to be meaningful; only {stored} were "
+        f"classified."
+    )
+
+    # The heart of the fix: nothing about the transient pause may survive
+    # into the terminal errors list. Any ``[classify]`` entry here trips
+    # pipeline.html's failure banner and blocks the success redirect,
+    # making the recovered run look failed to the user.
+    classify_errors = [
+        e for e in (job.get("errors") or [])
+        if isinstance(e, str) and e.startswith("[classify]")
+    ]
+    assert not classify_errors, (
+        f"A recovered pause must not leave a [classify] entry in the "
+        f"terminal errors list — pipeline.html would surface it as a "
+        f"failed stage even though classify finished successfully. Got "
+        f"{classify_errors!r}"
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12610,6 +12610,84 @@ def test_source_offline_reason_keeps_populated_local_mnt_dir_folder_scoped(
     )
 
 
+def test_source_offline_reason_flags_stale_mount_still_reporting_ismount_true(
+    monkeypatch,
+):
+    """A dead SMB/NFS mount can keep ``ismount == True``; probe reads too.
+
+    Codex #1388 P1 (r3664211201): ``os.path.ismount`` only inspects
+    mount-point metadata, so a share whose server disconnected can keep
+    ``ismount`` returning True even though every read against the root
+    raises EIO. Pre-fix, ``_mount_root_offline`` short-circuited on
+    ``ismount == True`` and returned "not offline", which routed the
+    dropped share through the folder-scoped branch — classify would then
+    keep reissuing reads across the dead share instead of pausing for
+    reconnection. Pin that the helper probes the root with ``listdir``
+    even when ``ismount`` is True, so a stale-but-registered mount is
+    correctly scoped mount-offline.
+    """
+    import pipeline_job
+
+    folder = "/mnt/photos/2026-07-27"
+    image = os.path.join(folder, "DSC_0001.NEF")
+
+    real_lexists = pipeline_job.os.path.lexists
+    real_isdir = pipeline_job.os.path.isdir
+    real_ismount = pipeline_job.os.path.ismount
+    real_listdir = pipeline_job.os.listdir
+
+    def fake_lexists(path):
+        # The mount-point directory is still present — the mount table
+        # entry hasn't been cleaned up.
+        if path == "/mnt/photos":
+            return True
+        return real_lexists(path)
+
+    def fake_isdir(path):
+        # The subtree read fails — this is what triggered the check in
+        # the first place.
+        if path == folder:
+            return False
+        return real_isdir(path)
+
+    def fake_ismount(path):
+        # ``mount`` still lists /mnt/photos, so ``ismount`` says True —
+        # exactly the case Codex flagged.
+        if path == "/mnt/photos":
+            return True
+        return real_ismount(path)
+
+    def fake_listdir(path):
+        # But the underlying filesystem is dead: reading the root
+        # returns Input/output error. Without probing this, the helper
+        # would trust ``ismount`` alone and mislabel the outage.
+        if path == "/mnt/photos":
+            raise OSError("Input/output error")
+        return real_listdir(path)
+
+    monkeypatch.setattr(pipeline_job.os.path, "lexists", fake_lexists)
+    monkeypatch.setattr(pipeline_job.os.path, "isdir", fake_isdir)
+    monkeypatch.setattr(pipeline_job.os.path, "ismount", fake_ismount)
+    monkeypatch.setattr(pipeline_job.os, "listdir", fake_listdir)
+
+    result = pipeline_job._source_offline_reason(folder, image)
+    assert result is not None, (
+        "A stale mount whose ``ismount`` still returns True but whose "
+        "root read raises EIO must register as offline — otherwise "
+        "classify keeps hammering the dead share instead of pausing."
+    )
+    scope, reason = result
+    assert scope == "mount", (
+        f"A dead-but-still-registered mount must scope offline to the "
+        f"mount so the whole run pauses for reconnection; got scope "
+        f"{scope!r}."
+    )
+    assert "/mnt/photos" in reason, (
+        f"Reason must name the mount the user needs to reconnect; got "
+        f"{reason!r}."
+    )
+
+
 def test_source_offline_reason_flags_stale_mount_that_raises_from_stat(
     monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12377,3 +12377,516 @@ def test_collection_rerun_redoes_only_missing_work(tmp_path, monkeypatch):
     assert inference_calls == [], (
         f"rerun invoked the classifier: {inference_calls}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Source-offline detection (dropped network volume mid-run)
+#
+# A disconnected SMB/NFS share makes EVERY subsequent read fail with EIO.
+# Classify used to count each one as a per-photo failure, so a share that
+# dropped 200 photos into a 984-photo run reported "779 failed" — which reads
+# as "779 of your photos are broken" when the truth is "the volume went away
+# and we never looked at them". These tests pin the distinction.
+# ---------------------------------------------------------------------------
+
+def test_source_offline_reason_none_for_healthy_local_folder(tmp_path):
+    """A readable folder is never 'offline' — a load failure there is the
+    individual file's fault (corrupt RAW, bad permissions) and must stay a
+    per-photo failure."""
+    from pipeline_job import _source_offline_reason
+
+    folder = str(tmp_path / "photos")
+    os.makedirs(folder, exist_ok=True)
+    missing_file = os.path.join(folder, "does_not_exist.NEF")
+
+    assert _source_offline_reason(folder, missing_file) is None, (
+        "A missing/corrupt file inside a healthy folder must NOT be treated "
+        "as an offline source, or one bad RAW would pause the whole run."
+    )
+
+
+def test_source_offline_reason_flags_unmounted_volume():
+    """The incident case: /Volumes/<share> is gone entirely."""
+    from pipeline_job import _source_offline_reason
+
+    folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+    image = os.path.join(folder, "DSC_7280.NEF")
+
+    reason = _source_offline_reason(folder, image)
+    assert reason is not None, (
+        "An unmounted /Volumes/... path must be reported as an offline source."
+    )
+    assert "/Volumes/DefinitelyNotMounted12345" in reason, (
+        f"The reason must name the mount root the user has to reconnect; "
+        f"got {reason!r}"
+    )
+
+
+def test_source_offline_reason_flags_vanished_folder(tmp_path):
+    """A stale mount can keep the mount root while the subtree turns
+    unreadable. The folder no longer resolving is enough to stop the run."""
+    from pipeline_job import _source_offline_reason
+
+    folder = str(tmp_path / "was_here")
+    image = os.path.join(folder, "DSC_0001.NEF")
+
+    reason = _source_offline_reason(folder, image)
+    assert reason is not None, (
+        "A folder that no longer resolves as a directory means the source "
+        "went away, not that one photo is corrupt."
+    )
+    assert folder in reason, f"Reason must name the folder; got {reason!r}"
+
+
+def test_pipeline_classify_pauses_when_source_volume_disappears(
+    tmp_path, monkeypatch,
+):
+    """Losing the source volume mid-classify must pause the job, not burn
+    through the remaining photos marking them 'failed'.
+
+    Reproduces the 2026-07-28 incident: the SMB share dropped partway through
+    classify and every remaining read returned EIO instantly, so the run
+    reported 779 failed photos and then marched on to the next model (865
+    failed) instead of stopping so the user could reconnect.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(6):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # The share is gone: every load fails, and _prepare_image hands back the
+    # archive path it could not read (exactly what it does on EIO today).
+    gone_folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+    prepare_calls = []
+
+    def offline_prepare_image(photo, folders, detection, vireo_dir=None):
+        prepare_calls.append(photo["id"])
+        return None, gone_folder, os.path.join(gone_folder, photo["filename"])
+
+    monkeypatch.setattr(classify_job, "_prepare_image", offline_prepare_image)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    class PausingRunner(FakeRunner):
+        def __init__(self):
+            super().__init__()
+            self.pause_calls = []
+            self._paused = False
+
+        def pause_job(self, job_id):
+            self.pause_calls.append(job_id)
+            self._paused = True
+            return True
+
+        def pause_requested(self, job_id):
+            return self._paused
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            # Simulate the user reconnecting and hitting Resume so the test
+            # does not block forever.
+            self._paused = False
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = PausingRunner()
+    job = _make_job()
+
+    # The share never comes back, so the run ends failed rather than putting
+    # a green check on a collection it never opened.
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert runner.pause_calls, (
+        "Losing the source volume must request a pause so the user can "
+        "reconnect and resume. Instead the run continued and marked every "
+        "remaining photo failed."
+    )
+
+    joined = " ".join(job["errors"])
+    assert "/Volumes/DefinitelyNotMounted12345" in joined, (
+        f"The error must name the volume the user has to reconnect; "
+        f"got {job['errors']!r}"
+    )
+
+    # The whole point: photos we never got to look at are not "failures".
+    classify_steps = [
+        kwargs for (_jid, sid, kwargs) in runner.step_updates
+        if sid.startswith("classify:") and "summary" in kwargs
+    ]
+    summaries = " ".join(k["summary"] for k in classify_steps)
+    assert "failed" not in summaries, (
+        f"Photos skipped because the volume vanished must not be reported "
+        f"as classification failures; got summary {summaries!r}"
+    )
+    assert "unreachable (source offline)" in summaries, (
+        f"The summary must still account for the photos it skipped rather "
+        f"than silently dropping them; got {summaries!r}"
+    )
+    assert "is not mounted" in summaries, (
+        f"The summary must say why it stopped; got {summaries!r}"
+    )
+
+    # A user who keeps resuming without remounting must not loop forever.
+    from pipeline_job import _MAX_SOURCE_OFFLINE_PAUSES
+    assert len(runner.pause_calls) <= _MAX_SOURCE_OFFLINE_PAUSES, (
+        f"Classify paused {len(runner.pause_calls)} times for the same dead "
+        f"volume; it must give up after {_MAX_SOURCE_OFFLINE_PAUSES}."
+    )
+
+    # And we must stop pulling photos, not walk the whole collection.
+    assert len(prepare_calls) < 6, (
+        f"Classify kept requesting images after the volume disappeared "
+        f"({len(prepare_calls)} attempts across 6 photos); it should stop "
+        f"once it has given up on the source."
+    )
+
+
+def test_pipeline_classify_resumes_after_source_volume_reconnects(
+    tmp_path, monkeypatch,
+):
+    """Reconnecting the share and hitting Resume must finish the collection.
+
+    The pause is only worth having if resuming actually classifies the rest —
+    otherwise "reconnect and resume" is a false promise and the user has to
+    re-run the whole pipeline.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(6):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    gone_folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+    state = {"mounted": True, "seen": 0}
+
+    def flaky_prepare_image(photo, folders, detection, vireo_dir=None):
+        state["seen"] += 1
+        if state["seen"] == 2:
+            # The share drops on the second photo.
+            state["mounted"] = False
+        if not state["mounted"]:
+            return None, gone_folder, os.path.join(
+                gone_folder, photo["filename"],
+            )
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", flaky_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    class ReconnectingRunner(FakeRunner):
+        """Models the user remounting the share, then pressing Resume."""
+
+        def __init__(self):
+            super().__init__()
+            self.pause_calls = []
+            self._paused = False
+
+        def pause_job(self, job_id):
+            self.pause_calls.append(job_id)
+            self._paused = True
+            return True
+
+        def pause_requested(self, job_id):
+            return self._paused
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            state["mounted"] = True   # user reconnects the volume
+            self._paused = False      # ...and hits Resume
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = ReconnectingRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert len(runner.pause_calls) == 1, (
+        f"Expected exactly one pause (the share dropped once); got "
+        f"{len(runner.pause_calls)}."
+    )
+
+    # Every photo except the one in flight when the share died should have
+    # been classified.
+    stored = db.conn.execute(
+        "SELECT COUNT(DISTINCT d.photo_id) FROM predictions p "
+        "JOIN detections d ON d.id = p.detection_id",
+    ).fetchone()[0]
+    assert stored >= 4, (
+        f"Resuming after the volume came back should have classified the "
+        f"rest of the collection; only {stored} of 6 photos got predictions."
+    )
+
+    classify_steps = [
+        kwargs for (_jid, sid, kwargs) in runner.step_updates
+        if sid.startswith("classify:") and "summary" in kwargs
+    ]
+    summaries = " ".join(k["summary"] for k in classify_steps)
+    assert "stopped after" not in summaries, (
+        f"The run recovered, so the summary must not claim it stopped early; "
+        f"got {summaries!r}"
+    )
+
+
+def test_pipeline_classify_offline_source_is_not_a_clean_success(
+    tmp_path, monkeypatch,
+):
+    """Giving up on a dead source must fail the job with an accurate headline.
+
+    Marking classify 'completed' would put a green check on a run that never
+    opened most of the collection, and the end-of-run rollup picks the job's
+    headline error by the '[classify] Fatal:' prefix — without one it reports
+    whatever unrelated warning happened to land in errors[0].
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    gone_folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+
+    def offline_prepare_image(photo, folders, detection, vireo_dir=None):
+        return None, gone_folder, os.path.join(gone_folder, photo["filename"])
+
+    monkeypatch.setattr(classify_job, "_prepare_image", offline_prepare_image)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    # A plain FakeRunner has no pause support, so classify gives up at once —
+    # the same path a non-pausable job takes.
+    runner = FakeRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    msg = str(excinfo.value)
+    assert "/Volumes/DefinitelyNotMounted12345" in msg, (
+        f"The job's headline error must name the offline volume rather than "
+        f"an unrelated earlier warning; got {msg!r}"
+    )
+    assert "failed to classify" not in msg, (
+        f"An offline share must not be reported as photos failing to "
+        f"classify; got {msg!r}"
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12657,6 +12657,98 @@ def test_source_offline_reason_flags_stale_mount_that_raises_from_stat(
     )
 
 
+def test_archive_mount_root_candidates_recognises_windows_paths():
+    """Windows mapped drives and UNC shares are documented in
+    ``docs/WINDOWS_SUPPORT.md`` as supported storage layouts.
+
+    Codex #1388 P2 (r3663816324): before this fix, ``_candidate`` only
+    matched POSIX ``/Volumes``, ``/mnt``, ``/media`` prefixes. A
+    disconnected SMB share on Windows (mapped drive ``Z:\\photos`` or
+    UNC ``\\\\server\\share\\photos``) would therefore never produce a
+    mount-root candidate, ``_source_offline_reason`` would fall through
+    to the folder-scoped branch, and classify would keep reissuing
+    reads across the dead share instead of pausing the run for
+    reconnection.
+    """
+    from pipeline_job import _archive_mount_root_candidates
+
+    drive_cands = _archive_mount_root_candidates(r"Z:\photos\raw\DSC_0001.NEF")
+    assert "Z:/" in drive_cands, (
+        f"A Windows mapped-drive path must yield ``Z:/`` (trailing separator "
+        f"so ``os.path.ismount`` accepts it) as a mount-root candidate. "
+        f"Got {drive_cands!r}."
+    )
+
+    unc_cands = _archive_mount_root_candidates(
+        r"\\photos-nas\raw\2026\DSC_0001.NEF",
+    )
+    assert "//photos-nas/raw" in unc_cands, (
+        f"A UNC share path must yield ``//<server>/<share>`` as a mount-root "
+        f"candidate — that's the reconnect boundary the user names when the "
+        f"share drops. Got {unc_cands!r}."
+    )
+
+    # A drive letter with only ``Z:`` and no path underneath still names
+    # a mount root — this covers the corner case where an image path was
+    # itself just ``Z:\image.jpg``.
+    bare_drive = _archive_mount_root_candidates(r"C:\photo.jpg")
+    assert "C:/" in bare_drive, (
+        f"A bare drive-letter path must still yield its drive root; got "
+        f"{bare_drive!r}."
+    )
+
+
+def test_source_offline_reason_flags_disconnected_windows_share(monkeypatch):
+    """A disconnected Windows SMB share must scope its outage to the mount.
+
+    Codex #1388 P2 (r3663816324): without recognising ``Z:/`` and
+    ``//server/share`` as mount roots, ``_source_offline_reason`` would
+    fall through to the folder-scoped branch when the share drops, and
+    classify would skip folder-by-folder while every read into the dead
+    share still failed instantly. Pin that the mount-scoped path fires
+    for both Windows storage shapes so classify pauses for reconnection
+    instead.
+    """
+    import pipeline_job
+
+    folder = r"Z:\photos\2026-07-27"
+    image = folder + r"\DSC_0001.NEF"
+
+    real_isdir = pipeline_job.os.path.isdir
+    real_lexists = pipeline_job.os.path.lexists
+
+    def fake_isdir(path):
+        if path == folder:
+            return False
+        return real_isdir(path)
+
+    def fake_lexists(path):
+        # Windows disconnects a mapped drive by removing the drive
+        # letter entirely — the standard ``lexists`` False path in
+        # ``_mount_root_offline`` covers that.
+        if path == "Z:/":
+            return False
+        return real_lexists(path)
+
+    monkeypatch.setattr(pipeline_job.os.path, "isdir", fake_isdir)
+    monkeypatch.setattr(pipeline_job.os.path, "lexists", fake_lexists)
+
+    result = pipeline_job._source_offline_reason(folder, image)
+    assert result is not None, (
+        "A Windows mapped-drive path whose folder no longer resolves and "
+        "whose drive letter is gone must register as an offline source."
+    )
+    scope, reason = result
+    assert scope == "mount", (
+        f"A disconnected Windows share must scope offline to the mount so "
+        f"the whole run pauses for reconnection; got scope {scope!r}."
+    )
+    assert "Z:" in reason, (
+        f"The reason must name the drive the user needs to reconnect; got "
+        f"{reason!r}."
+    )
+
+
 def test_pipeline_classify_pauses_when_source_volume_disappears(
     tmp_path, monkeypatch,
 ):
@@ -13024,6 +13116,216 @@ def test_pipeline_classify_resumes_after_source_volume_reconnects(
     assert "unreachable" not in summaries, (
         f"After a successful resume nothing should still be reported as "
         f"unreachable — the retry classified it; got {summaries!r}"
+    )
+
+
+def test_pipeline_classify_resets_pause_budget_after_successful_recovery(
+    tmp_path, monkeypatch,
+):
+    """A successful reconnect must refund the pause budget for later outages.
+
+    Codex #1388 P2 (r3663816327): ``source_offline["pauses"]`` counts
+    every pause the run takes for a dead source and gives up once the
+    counter reaches ``_MAX_SOURCE_OFFLINE_PAUSES``. The intent is to
+    protect against a user who keeps pressing Resume without actually
+    remounting the share — an infinite pause/retry ping-pong.
+
+    Pre-fix, the counter never reset even when the user genuinely
+    reconnected and the retry succeeded. On a long classification run
+    over a share that drops and recovers several times (or over several
+    volumes that drop separately), the counter would climb across
+    unrelated outages and a later drop would take the give-up branch on
+    the first pause — the user would never be offered Resume for it,
+    even though the earlier drops were all recovered.
+
+    Pin that after ``_MAX_SOURCE_OFFLINE_PAUSES + 2`` separate
+    drop-and-recover cycles every photo still classifies: a
+    successful retry is proof the share IS back, so the counter can
+    honestly reset.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    # Enough photos to trigger MORE separate drops than the pause budget
+    # allows in a single continuous outage — without the reset, the run
+    # would give up partway through even though every drop was recovered.
+    n_photos = pj._MAX_SOURCE_OFFLINE_PAUSES + 3
+    photo_ids = []
+    for i in range(n_photos):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    gone_folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+    # ``mounted`` flips False right before each initial read attempt so
+    # every photo trips a fresh drop; ``wait_if_paused`` flips it back
+    # True to model the user remounting the share for the resume.
+    state = {"mounted": True}
+
+    def flaky_prepare_image(photo, folders, detection, vireo_dir=None):
+        if not state["mounted"]:
+            return None, gone_folder, os.path.join(
+                gone_folder, photo["filename"],
+            )
+        # Flip immediately so the NEXT photo also trips a drop. The
+        # current photo already loaded successfully; the drop will be
+        # discovered on the next photo's first read attempt.
+        state["mounted"] = False
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", flaky_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    class ReconnectingRunner(FakeRunner):
+        """The user genuinely remounts the share on every pause."""
+
+        def __init__(self):
+            super().__init__()
+            self.pause_calls = []
+            self._paused = False
+
+        def pause_job(self, job_id):
+            self.pause_calls.append(job_id)
+            self._paused = True
+            return True
+
+        def pause_requested(self, job_id):
+            return self._paused
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            state["mounted"] = True   # user reconnects the volume
+            self._paused = False
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = ReconnectingRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Setup sanity: we must have paused MORE times than the fixed budget
+    # allows in a single continuous outage — otherwise this test isn't
+    # exercising the reset path at all.
+    assert len(runner.pause_calls) > pj._MAX_SOURCE_OFFLINE_PAUSES, (
+        f"Setup sanity: this test exercises the pause-budget reset by "
+        f"pausing more than the fixed budget of "
+        f"{pj._MAX_SOURCE_OFFLINE_PAUSES} across separate recovered "
+        f"outages; only {len(runner.pause_calls)} pauses fired."
+    )
+
+    # The heart of the fix: every drop was recovered, so every photo
+    # must be classified. Pre-fix the run would give up after the budget
+    # was spent (~3 photos in), leaving the tail unreachable.
+    stored = db.conn.execute(
+        "SELECT COUNT(DISTINCT d.photo_id) FROM predictions p "
+        "JOIN detections d ON d.id = p.detection_id",
+    ).fetchone()[0]
+    assert stored == n_photos, (
+        f"Every drop was recovered by the user, so every one of the "
+        f"{n_photos} photos must be classified. Only {stored} got "
+        f"predictions — the pause budget wasn't refunded after the "
+        f"successful retries, so the run gave up partway through."
+    )
+
+    # And the terminal errors list must stay clean — a run that recovered
+    # every outage is a successful run.
+    classify_errors = [
+        e for e in (job.get("errors") or [])
+        if isinstance(e, str) and e.startswith("[classify]")
+    ]
+    assert not classify_errors, (
+        f"Every outage was recovered, so no [classify] entry should be "
+        f"latched in the terminal errors list. Got {classify_errors!r}."
     )
 
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12747,6 +12747,81 @@ def test_source_offline_reason_flags_stale_mount_that_raises_from_stat(
     )
 
 
+def test_source_offline_reason_flags_dead_mount_with_cached_folder_stat(
+    monkeypatch,
+):
+    """A dead mount whose folder ``isdir`` still returns True is mount-offline.
+
+    Codex #1388 P1 (r3665254569): a disconnected SMB/NFS mount can keep
+    the containing folder's directory metadata cached, so
+    ``os.path.isdir(folder)`` returns True even though every read of the
+    folder's files raises EIO. Pre-fix ``_source_offline_reason``
+    short-circuited on a truthy ``isdir(folder)`` and returned None — the
+    caller then counted the failed read as a per-photo failure and
+    classify kept hammering the dead share for every remaining photo
+    instead of pausing for reconnection. Pin that the mount-root probe
+    still runs when the folder stat looks fine, so a dead mount is
+    scoped mount-wide.
+    """
+    import pipeline_job
+
+    folder = "/mnt/photos/2026-07-27"
+    image = os.path.join(folder, "DSC_0001.NEF")
+
+    real_lexists = pipeline_job.os.path.lexists
+    real_isdir = pipeline_job.os.path.isdir
+    real_listdir = pipeline_job.os.listdir
+
+    def fake_lexists(path):
+        if path == "/mnt/photos":
+            return True
+        return real_lexists(path)
+
+    def fake_isdir(path):
+        # The critical bit: the folder's directory-stat cache is stale
+        # and still reports True, mirroring the real behaviour of a
+        # disconnected SMB/NFS mount where the containing folder's
+        # metadata survives the drop while file reads underneath it
+        # raise EIO.
+        if path == folder:
+            return True
+        # The mount root itself has to look present for
+        # ``_mount_root_offline`` to reach the ``listdir`` probe.
+        if path == "/mnt/photos":
+            return True
+        return real_isdir(path)
+
+    def fake_listdir(path):
+        # The mount is truly dead: reading the root raises EIO. This is
+        # what the fix relies on to detect the outage even when the
+        # folder stat lies about being present.
+        if path == "/mnt/photos":
+            raise OSError("Input/output error")
+        return real_listdir(path)
+
+    monkeypatch.setattr(pipeline_job.os.path, "lexists", fake_lexists)
+    monkeypatch.setattr(pipeline_job.os.path, "isdir", fake_isdir)
+    monkeypatch.setattr(pipeline_job.os, "listdir", fake_listdir)
+
+    result = pipeline_job._source_offline_reason(folder, image)
+    assert result is not None, (
+        "A cached folder stat that lies about a dead mount must not let "
+        "``_source_offline_reason`` return None — the caller would then "
+        "count every remaining read as a per-photo failure instead of "
+        "pausing for reconnection."
+    )
+    scope, reason = result
+    assert scope == "mount", (
+        f"A dead mount discovered via the mount-root probe must scope "
+        f"the outage mount-wide so the whole run pauses; got scope "
+        f"{scope!r}."
+    )
+    assert "/mnt/photos" in reason, (
+        f"Reason must name the mount the user needs to reconnect; got "
+        f"{reason!r}."
+    )
+
+
 def test_archive_mount_root_candidates_recognises_windows_paths():
     """Windows mapped drives and UNC shares are documented in
     ``docs/WINDOWS_SUPPORT.md`` as supported storage layouts.

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12936,6 +12936,370 @@ def test_pipeline_classify_offline_source_is_not_a_clean_success(
     )
 
 
+def test_pipeline_classify_source_offline_publishes_pause_reason(
+    tmp_path, monkeypatch,
+):
+    """A parked classify run must tell the UI *why* it paused, not just that
+    it did.
+
+    Codex #1388 P1 r3663383513: the incident fix parked the job on a dead
+    source but only wrote the reason to ``vireo.log``. The jobs UI showed
+    a generic "paused" pill with no indication of which volume the user
+    needed to reconnect, so pressing Resume without remounting could burn
+    through the bounded retry budget and turn a recoverable outage into a
+    failed run. Publish the reason via transient progress state (mirrored
+    onto ``job['progress']``) and pin the classify step's ``current_file``
+    so the reason renders under the paused step, next to Resume.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    gone_folder = "/Volumes/NamedShareForBanner/Raw Files"
+
+    def offline_prepare_image(photo, folders, detection, vireo_dir=None):
+        return None, gone_folder, os.path.join(gone_folder, photo["filename"])
+
+    monkeypatch.setattr(classify_job, "_prepare_image", offline_prepare_image)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    class PausingRunner(FakeRunner):
+        def __init__(self):
+            super().__init__()
+            self.pause_calls = []
+            self._paused = False
+
+        def pause_job(self, job_id):
+            self.pause_calls.append(job_id)
+            self._paused = True
+            return True
+
+        def pause_requested(self, job_id):
+            return self._paused
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            self._paused = False
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = PausingRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The banner text must name the volume the user has to reconnect —
+    # a generic "paused" is exactly what Codex flagged.
+    pause_progress_events = [
+        data for (_jid, etype, data) in runner.events
+        if etype == "progress" and data.get("pause_reason")
+    ]
+    assert pause_progress_events, (
+        "Classify parked on a dead source but never published pause_reason "
+        "on a progress event; the UI has no way to tell the user *why* "
+        "the job paused."
+    )
+    reasons = [d["pause_reason"] for d in pause_progress_events]
+    joined_reasons = " ".join(reasons)
+    assert "NamedShareForBanner" in joined_reasons, (
+        f"The pause_reason must name the volume so the user knows what to "
+        f"reconnect; got {reasons!r}"
+    )
+    assert "Resume" in joined_reasons, (
+        f"The pause_reason must tell the user what to do after reconnecting "
+        f"(press Resume); got {reasons!r}"
+    )
+
+    # The classify step's current_file must carry the same reason so it
+    # renders directly under the paused step in the job tree, right next
+    # to the Resume button — the header banner alone is easy to miss on
+    # long collections whose stage tree scrolls off-screen.
+    classify_current_file = [
+        kwargs["current_file"]
+        for (_jid, sid, kwargs) in runner.step_updates
+        if sid.startswith("classify:") and "current_file" in kwargs
+        and kwargs["current_file"]
+    ]
+    assert any(
+        "NamedShareForBanner" in cf for cf in classify_current_file
+    ), (
+        f"The classify step should surface the offline reason via "
+        f"current_file so it renders under the paused step; got "
+        f"{classify_current_file!r}"
+    )
+
+
+def test_pipeline_classify_source_offline_honors_prior_user_pause(
+    tmp_path, monkeypatch,
+):
+    """If the user pressed Pause while a network read was blocked, classify
+    must still park on the checkpoint — not treat the second-pause no-op
+    as evidence that pausing is impossible.
+
+    Codex #1388 P2 r3663383518: ``JobRunner.pause_job`` returns ``False``
+    when the job's status is already ``pausing`` (a Pause request landed
+    while classify was blocked on an EIO). The old code interpreted every
+    ``False`` return as "nothing to park on" and gave up, throwing away
+    the user's Pause click and turning a recoverable outage into a failed
+    run. Treat ``pause_requested`` as evidence a pause is genuinely in
+    flight and fall through to the checkpoint so the run parks on the
+    already-in-flight request instead of latching source offline.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+    from PIL import Image as _PILImage
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(4):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    gone_folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+    # Give ``flaky_prepare_image`` a handle to the runner so the "user
+    # pressed Pause while we were blocked" click can be timed to land at
+    # the exact moment the read starts blocking — that's what puts the
+    # job into ``pausing`` state before classify's own pause_job() call.
+    holder = {"runner": None}
+    state = {"mounted": True, "seen": 0}
+
+    def flaky_prepare_image(photo, folders, detection, vireo_dir=None):
+        state["seen"] += 1
+        if state["seen"] == 2:
+            state["mounted"] = False
+            # The Pause click lands here (the read is about to block on
+            # EIO). By the time _handle_source_offline calls pause_job the
+            # job's public state is already ``pausing`` and pause_job
+            # returns False — the exact edge case Codex #1388 P2 flagged.
+            if holder["runner"] is not None:
+                holder["runner"]._paused = True
+        if not state["mounted"]:
+            return None, gone_folder, os.path.join(
+                gone_folder, photo["filename"],
+            )
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", flaky_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    class PriorPauseRunner(FakeRunner):
+        """Models the user pressing Pause while classify was blocked on EIO.
+
+        ``pause_job`` returns ``False`` — the job's public state is already
+        ``pausing`` — but ``pause_requested`` reports ``True`` so classify
+        can still tell there is a live pause in flight and park on it.
+        """
+
+        def __init__(self):
+            super().__init__()
+            self.pause_calls = []
+            self.wait_calls = 0
+            self._paused = False
+
+        def pause_job(self, job_id):
+            self.pause_calls.append(job_id)
+            return False
+
+        def pause_requested(self, job_id):
+            return self._paused
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            self.wait_calls += 1
+            state["mounted"] = True   # user reconnects the volume
+            self._paused = False      # ...then hits Resume
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = PriorPauseRunner()
+    holder["runner"] = runner
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The pre-fix behavior gave up as soon as pause_job returned False,
+    # never entered the checkpoint, and latched source_offline["reason"]
+    # so classify failed with a ``[classify] Fatal:`` error naming the
+    # volume. Now that we honor the already-in-flight pause, the checkpoint
+    # runs, the user's reconnect+resume flow completes normally, and the
+    # collection classifies to green.
+    assert runner.wait_calls >= 1, (
+        "Classify saw an offline read AND a live pause request, but never "
+        "reached the pause checkpoint — the user's Pause click was silently "
+        "discarded (Codex #1388 P2)."
+    )
+    stored = db.conn.execute(
+        "SELECT COUNT(DISTINCT d.photo_id) FROM predictions p "
+        "JOIN detections d ON d.id = p.detection_id",
+    ).fetchone()[0]
+    assert stored == 4, (
+        f"After the checkpoint parks and the user resumes with the mount "
+        f"back, classify should retry and finish the collection — instead "
+        f"only {stored}/4 photos got predictions, which is the pre-fix "
+        f"give-up path."
+    )
+    # And crucially, the run must not have logged a headline failure —
+    # the whole point of parking (instead of giving up on pause_job=False)
+    # is to preserve the recovery path.
+    classify_errors = [e for e in job["errors"] if "[classify] Fatal:" in e]
+    assert not classify_errors, (
+        f"A recovered pause must not surface as a terminal classify error; "
+        f"got {classify_errors!r}"
+    )
+
+
 def test_pipeline_classify_missing_folder_does_not_stop_healthy_folders(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12406,15 +12406,25 @@ def test_source_offline_reason_none_for_healthy_local_folder(tmp_path):
 
 
 def test_source_offline_reason_flags_unmounted_volume():
-    """The incident case: /Volumes/<share> is gone entirely."""
+    """The incident case: /Volumes/<share> is gone entirely.
+
+    Scoped ``"mount"`` because every remaining read of the collection will
+    fail the same way — classify must pause the whole run, not just this
+    folder.
+    """
     from pipeline_job import _source_offline_reason
 
     folder = "/Volumes/DefinitelyNotMounted12345/Raw Files"
     image = os.path.join(folder, "DSC_7280.NEF")
 
-    reason = _source_offline_reason(folder, image)
-    assert reason is not None, (
+    result = _source_offline_reason(folder, image)
+    assert result is not None, (
         "An unmounted /Volumes/... path must be reported as an offline source."
+    )
+    scope, reason = result
+    assert scope == "mount", (
+        f"An unmounted volume must scope offline to the mount so the whole "
+        f"run pauses; got scope {scope!r}."
     )
     assert "/Volumes/DefinitelyNotMounted12345" in reason, (
         f"The reason must name the mount root the user has to reconnect; "
@@ -12423,17 +12433,28 @@ def test_source_offline_reason_flags_unmounted_volume():
 
 
 def test_source_offline_reason_flags_vanished_folder(tmp_path):
-    """A stale mount can keep the mount root while the subtree turns
-    unreadable. The folder no longer resolving is enough to stop the run."""
+    """A single unreadable folder is scoped to that folder alone.
+
+    Codex #1388 P1: with ``reclassify=True`` in a multi-folder collection,
+    stopping the whole run on one deleted local folder would strand later
+    healthy folders (finalization would clear their existing predictions
+    with no replacement). Scope ``"folder"`` lets the run skip the missing
+    folder's photos as unreachable and keep processing the rest.
+    """
     from pipeline_job import _source_offline_reason
 
     folder = str(tmp_path / "was_here")
     image = os.path.join(folder, "DSC_0001.NEF")
 
-    reason = _source_offline_reason(folder, image)
-    assert reason is not None, (
+    result = _source_offline_reason(folder, image)
+    assert result is not None, (
         "A folder that no longer resolves as a directory means the source "
-        "went away, not that one photo is corrupt."
+        "for THIS folder went away, not that one photo is corrupt."
+    )
+    scope, reason = result
+    assert scope == "folder", (
+        f"A single missing folder must not stop the whole run; scope must be "
+        f"'folder' so later healthy folders keep processing. Got {scope!r}."
     )
     assert folder in reason, f"Reason must name the folder; got {reason!r}"
 
@@ -12600,10 +12621,16 @@ def test_pipeline_classify_pauses_when_source_volume_disappears(
     )
 
     # And we must stop pulling photos, not walk the whole collection.
-    assert len(prepare_calls) < 6, (
+    # Each pause is followed by ONE post-resume retry (Codex #1388 P2), so
+    # the upper bound is 2*max + 1 (the initial call that trips the giving-up
+    # branch, no retry). Anything more means classify walked past the pause
+    # budget and kept EIO-ing the rest of the collection.
+    max_prepare_calls = 2 * _MAX_SOURCE_OFFLINE_PAUSES + 1
+    assert len(prepare_calls) <= max_prepare_calls, (
         f"Classify kept requesting images after the volume disappeared "
-        f"({len(prepare_calls)} attempts across 6 photos); it should stop "
-        f"once it has given up on the source."
+        f"({len(prepare_calls)} attempts across 6 photos, cap "
+        f"{max_prepare_calls}); it should stop once it has given up on "
+        f"the source."
     )
 
 
@@ -12763,15 +12790,19 @@ def test_pipeline_classify_resumes_after_source_volume_reconnects(
         f"{len(runner.pause_calls)}."
     )
 
-    # Every photo except the one in flight when the share died should have
-    # been classified.
+    # The photo in flight when the share died must be retried after resume
+    # (Codex #1388 P2), so every photo — including that one — should have
+    # been classified. Silently skipping it would leave the user with a
+    # stranded photo even though the source is back, and on a reclassify
+    # run finalization would clear its old prediction with no replacement.
     stored = db.conn.execute(
         "SELECT COUNT(DISTINCT d.photo_id) FROM predictions p "
         "JOIN detections d ON d.id = p.detection_id",
     ).fetchone()[0]
-    assert stored >= 4, (
-        f"Resuming after the volume came back should have classified the "
-        f"rest of the collection; only {stored} of 6 photos got predictions."
+    assert stored == 6, (
+        f"Reconnect+resume must retry the paused photo so every one of the "
+        f"6 gets classified, not skip it as unreachable; only {stored} got "
+        f"predictions."
     )
 
     classify_steps = [
@@ -12782,6 +12813,10 @@ def test_pipeline_classify_resumes_after_source_volume_reconnects(
     assert "stopped after" not in summaries, (
         f"The run recovered, so the summary must not claim it stopped early; "
         f"got {summaries!r}"
+    )
+    assert "unreachable" not in summaries, (
+        f"After a successful resume nothing should still be reported as "
+        f"unreachable — the retry classified it; got {summaries!r}"
     )
 
 
@@ -12889,4 +12924,208 @@ def test_pipeline_classify_offline_source_is_not_a_clean_success(
     assert "failed to classify" not in msg, (
         f"An offline share must not be reported as photos failing to "
         f"classify; got {msg!r}"
+    )
+
+
+def test_pipeline_classify_missing_folder_does_not_stop_healthy_folders(
+    tmp_path, monkeypatch,
+):
+    """A single deleted local folder must not stop the whole classification.
+
+    Codex #1388 P1: the incident-fix's global-scope offline signal would
+    treat one unreadable folder as evidence the entire collection is
+    offline, so later photos in healthy folders would be skipped without
+    even being tried — and on a ``reclassify=True`` run, finalization
+    would clear their existing predictions with no replacement. Scope
+    ``"folder"`` in ``_source_offline_reason`` keeps the run going past
+    the missing folder so the healthy ones still get classified.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Two local folders whose files stay on disk (previews/thumbnails read
+    # them). The classify-time _prepare_image mock below simulates one
+    # folder going away between preview and classify.
+    gone_folder_path = str(tmp_path / "vanished")
+    healthy_folder_path = str(tmp_path / "still_here")
+    os.makedirs(gone_folder_path, exist_ok=True)
+    os.makedirs(healthy_folder_path, exist_ok=True)
+
+    gone_folder_id = db.add_folder(gone_folder_path)
+    healthy_folder_id = db.add_folder(healthy_folder_path)
+
+    photo_ids = []
+    gone_photo_ids: set = set()
+    healthy_photo_ids = []
+    for i in range(3):
+        name = f"gone{i}.jpg"
+        pid = db.add_photo(
+            gone_folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i,
+        )
+        _drop_jpeg(gone_folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+        gone_photo_ids.add(pid)
+    for i in range(3):
+        name = f"healthy{i}.jpg"
+        pid = db.add_photo(
+            healthy_folder_id, name, ".jpg", 5000 + i, 5_000_000.0 + i,
+        )
+        _drop_jpeg(healthy_folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+        healthy_photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    # The gone folder's classify-time paths point at a subdir that never
+    # exists — that trips _source_offline_reason's folder-scoped branch
+    # without disturbing previews (which see the real files at the paths
+    # stored in the DB).
+    fake_missing_root = str(tmp_path / "vanished_at_classify_time")
+
+    def selective_prepare_image(photo, folders, detection, vireo_dir=None):
+        if photo["id"] in gone_photo_ids:
+            image_path = os.path.join(fake_missing_root, photo["filename"])
+            return None, fake_missing_root, image_path
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", selective_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    # A pausing runner would let the whole run stop; use a plain FakeRunner
+    # so the folder-scoped branch has to keep going on its own rather than
+    # falling back to the pause path.
+    class NoPauseRunner(FakeRunner):
+        def pause_job(self, job_id):
+            return False
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = NoPauseRunner()
+    job = _make_job()
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The healthy folder's photos must be classified even though the other
+    # folder went away. Without the P1 fix, the gone folder trips a global
+    # source_offline["reason"] and the batch/photo loops break before the
+    # healthy folder gets a turn.
+    healthy_stored = db.conn.execute(
+        f"SELECT COUNT(DISTINCT d.photo_id) FROM predictions p "
+        f"JOIN detections d ON d.id = p.detection_id "
+        f"WHERE d.photo_id IN "
+        f"({','.join('?' * len(healthy_photo_ids))})",
+        list(healthy_photo_ids),
+    ).fetchone()[0]
+    assert healthy_stored == len(healthy_photo_ids), (
+        f"A single missing folder must not strand healthy folders; "
+        f"expected {len(healthy_photo_ids)} healthy photos classified but "
+        f"got {healthy_stored}."
+    )
+
+    # The gone folder's photos should surface as unreachable, not as a
+    # global offline that stopped the run.
+    classify_steps = [
+        kwargs for (_jid, sid, kwargs) in runner.step_updates
+        if sid.startswith("classify:") and "summary" in kwargs
+    ]
+    summaries = " ".join(k["summary"] for k in classify_steps)
+    assert "unreachable (source offline)" in summaries, (
+        f"Photos in the missing folder should be reported as unreachable "
+        f"rather than folded into failures; got {summaries!r}"
+    )
+    assert "stopped after" not in summaries, (
+        f"A folder-scoped outage must not report the whole pass as "
+        f"stopped early; got {summaries!r}"
+    )
+    assert "failed" not in summaries, (
+        f"Missing-folder photos must not be counted as failures; "
+        f"got {summaries!r}"
     )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12482,6 +12482,7 @@ def test_source_offline_reason_flags_persistent_mountpoint_after_unmount(
     real_lexists = pipeline_job.os.path.lexists
     real_isdir = pipeline_job.os.path.isdir
     real_ismount = pipeline_job.os.path.ismount
+    real_listdir = pipeline_job.os.listdir
 
     def fake_lexists(path):
         # The persistent mount-point directory is still there.
@@ -12502,9 +12503,20 @@ def test_source_offline_reason_flags_persistent_mountpoint_after_unmount(
             return False
         return real_ismount(path)
 
+    def fake_listdir(path):
+        # An unmounted mount stub is empty — its contents lived on the
+        # mounted filesystem and vanished with the mount. This is the
+        # positive signal ``_mount_root_offline`` uses to distinguish an
+        # actual mount from a plain local directory (Codex #1388 P1
+        # r3663642357).
+        if path == "/mnt/photos":
+            return []
+        return real_listdir(path)
+
     monkeypatch.setattr(pipeline_job.os.path, "lexists", fake_lexists)
     monkeypatch.setattr(pipeline_job.os.path, "isdir", fake_isdir)
     monkeypatch.setattr(pipeline_job.os.path, "ismount", fake_ismount)
+    monkeypatch.setattr(pipeline_job.os, "listdir", fake_listdir)
 
     result = pipeline_job._source_offline_reason(folder, image)
     assert result is not None, (
@@ -12521,6 +12533,80 @@ def test_source_offline_reason_flags_persistent_mountpoint_after_unmount(
     assert "/mnt/photos" in reason, (
         f"Reason must name the mount root the user needs to reconnect; "
         f"got {reason!r}."
+    )
+
+
+def test_source_offline_reason_keeps_populated_local_mnt_dir_folder_scoped(
+    tmp_path,
+):
+    """A plain local dir under ``/mnt/`` isn't a mount just because ismount says so.
+
+    Codex #1388 P1 (r3663642357): the mount-shape check equated
+    ``os.path.ismount == False`` with "mount is offline", but a plain
+    local catalog at ``/mnt/photos`` with several sibling folders is
+    also ``ismount``-negative. Deleting one subfolder (say the trip
+    the user just archived) would then re-classify the whole tree as a
+    mount-wide outage — the run would pause, exhaust its retry budget,
+    and abandon every healthy sibling. Pin that a mount-shaped root
+    with visible sibling entries is treated as an ordinary local dir
+    so the deleted subfolder stays folder-scoped.
+    """
+    import pipeline_job
+
+    mount_root = tmp_path / "mnt_style_local"
+    mount_root.mkdir()
+    # Siblings that survive whatever happened to the missing folder are
+    # the positive proof this is a plain local dir, not an unmounted
+    # share (which would take its whole tree with it).
+    (mount_root / "beach").mkdir()
+    (mount_root / "mountain").mkdir()
+
+    missing_folder = str(mount_root / "trip")
+    image_under_missing = os.path.join(missing_folder, "DSC_0001.NEF")
+
+    # Force the mount-root candidate lookup at the tmp path — the real
+    # helper only recognises /Volumes, /mnt, /media roots, and we need
+    # to exercise the "populated → not offline" branch without touching
+    # the real filesystem's /mnt.
+    real_candidates = pipeline_job._archive_mount_root_candidates
+
+    def fake_candidates(path):
+        if path == image_under_missing:
+            return [str(mount_root)]
+        return real_candidates(path)
+
+    real_ismount = pipeline_job.os.path.ismount
+
+    def fake_ismount(path):
+        # The plain local dir naturally has ``ismount == False`` — mirror
+        # that explicitly so the test doesn't depend on the FS layout of
+        # the CI machine.
+        if path == str(mount_root):
+            return False
+        return real_ismount(path)
+
+    import unittest.mock as mock
+    with (
+        mock.patch.object(
+            pipeline_job, "_archive_mount_root_candidates", fake_candidates,
+        ),
+        mock.patch.object(pipeline_job.os.path, "ismount", fake_ismount),
+    ):
+        result = pipeline_job._source_offline_reason(
+            missing_folder, image_under_missing,
+        )
+
+    assert result is not None, (
+        "The deleted subfolder itself is unreachable, so the helper must "
+        "still report an outage — just scoped to the folder, not the whole "
+        "mount root."
+    )
+    scope, reason = result
+    assert scope == "folder", (
+        f"A mount-shaped root with sibling entries is proof it's a plain "
+        f"local dir; scoping the missing subfolder as a mount outage would "
+        f"pause the whole run and abandon healthy siblings. Got scope "
+        f"{scope!r} reason {reason!r}."
     )
 
 
@@ -14140,6 +14226,233 @@ def test_pipeline_classify_reclassify_preserves_predictions_for_unreachable_phot
         f"Healthy folder must still be classified after the fix; "
         f"expected {len(healthy_photo_ids)} FreshSpecies rows, "
         f"got {fresh_stored}."
+    )
+
+
+def test_pipeline_classify_multimodel_reclassify_per_spec_source_skips(
+    tmp_path, monkeypatch,
+):
+    """Multi-model reclassify must clear per-spec, not per-run, source skips.
+
+    Codex #1388 P2 (r3663642360): ``source_skipped_photo_ids`` used to
+    accumulate across every spec. If a photo was unreachable for model A
+    but the folder was back before model B, model B's reclassify clear
+    still excluded the photo — because the aggregate set said "leave it
+    alone". ``Database.add_prediction`` uses ``INSERT OR IGNORE``, so
+    model B's fresh result then couldn't overwrite the stale prior row,
+    and the photo retained a wrong species/confidence for model B
+    forever. Pin the fix: model B's clear must cover the photo, so its
+    fresh prediction wins.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    gone_folder_path = str(tmp_path / "gone_for_model_a")
+    healthy_folder_path = str(tmp_path / "always_here")
+    os.makedirs(gone_folder_path, exist_ok=True)
+    os.makedirs(healthy_folder_path, exist_ok=True)
+
+    gone_folder_id = db.add_folder(gone_folder_path)
+    healthy_folder_id = db.add_folder(healthy_folder_path)
+
+    gone_photo_id = db.add_photo(
+        gone_folder_id, "gone.jpg", ".jpg", 4000, 4_000_000.0,
+    )
+    _drop_jpeg(gone_folder_path, "gone.jpg")
+    gone_det_id = db.save_detections(
+        gone_photo_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )[0]
+
+    healthy_photo_id = db.add_photo(
+        healthy_folder_id, "healthy.jpg", ".jpg", 5000, 5_000_000.0,
+    )
+    _drop_jpeg(healthy_folder_path, "healthy.jpg")
+    db.save_detections(
+        healthy_photo_id,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids",
+                     "value": [gone_photo_id, healthy_photo_id]}]),
+    )
+
+    model_ids = _setup_two_fake_downloaded_models(tmp_path, monkeypatch)
+    # ``_setup_two_fake_downloaded_models`` only installs the model files;
+    # verify_if_needed still fires for bioclip-2 during
+    # ``_load_model_bundle`` and would try to reach HuggingFace. Stub it
+    # so the second model actually loads under the test's isolated HOME.
+    import model_verify
+    monkeypatch.setattr(
+        model_verify,
+        "verify_if_needed",
+        lambda model_id, model_dir, hf_subdir, optional_files=None: None,
+    )
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    # Pre-seed the stale model-B prediction on the gone photo. This is the
+    # row the pre-fix code left in place because the aggregate skipped set
+    # still contained gone_photo_id when model B's clear ran — the fresh
+    # prediction then couldn't overwrite it via INSERT OR IGNORE, and the
+    # user was stuck with OldModelBSpecies forever.
+    OLD_B = "OldModelBSpecies"
+    db.add_prediction(
+        detection_id=gone_det_id,
+        species=OLD_B,
+        confidence=0.42,
+        model="BioCLIP-2",
+        labels_fingerprint="fp",
+    )
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    # Track which model's classifier was most recently constructed. Model
+    # A (bioclip-vit-b-16) is preloaded by model_loader_stage; model B
+    # (bioclip-2) is constructed by ``_load_model_bundle`` when
+    # classify_stage moves to spec_idx==1. That construction is our
+    # only in-test signal that we've crossed the spec boundary, so we
+    # key the folder-availability behavior off it.
+    current_model = ["A"]
+    fake_missing_root = str(tmp_path / "vanished_at_classify_time")
+
+    def selective_prepare_image(photo, folders, detection, vireo_dir=None):
+        # gone_photo_id is unreachable ONLY during model A. When we're
+        # on model B, its folder is back — matching the P2 scenario where
+        # a transient outage clears before the next spec starts.
+        if (
+            photo["id"] == gone_photo_id
+            and current_model[0] == "A"
+        ):
+            image_path = os.path.join(fake_missing_root, photo["filename"])
+            return None, fake_missing_root, image_path
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", selective_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        # Fresh predictions carry the model in the species string so the
+        # per-model assertions below can pull them apart.
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": f"Fresh_{model_name}",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pretrained = str(kwargs.get("pretrained_str") or "")
+            if model_ids[1] in pretrained:
+                current_model[0] = "B"
+            else:
+                current_model[0] = "A"
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    # NoPauseRunner keeps model A on the folder-scoped path instead of
+    # falling into pause+cancel: an outage that only affects one folder
+    # is exactly the scenario we're pinning.
+    class NoPauseRunner(FakeRunner):
+        def pause_job(self, job_id):
+            return False
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            return False
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_ids=model_ids,
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = NoPauseRunner()
+    job = _make_job()
+
+    # The run does NOT raise here: model B reaches every photo, so
+    # ``models_succeeded`` is 1 and the earlier folder-scoped skip on
+    # model A produces an incomplete rollup but no fatal fatal-source
+    # error — the rollup for a partial multi-model outage returns
+    # normally with a "stopped after" summary rather than raising.
+    with contextlib.suppress(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The heart of the P2 fix: model B's fresh prediction for the
+    # previously-skipped photo must win. Pre-fix, model B's clear
+    # excluded gone_photo_id (still in the aggregate skipped set from
+    # model A) — so INSERT OR IGNORE left the stale OldModelBSpecies in
+    # place, and the fresh row was silently dropped.
+    stored = db.conn.execute(
+        "SELECT species FROM predictions "
+        "WHERE detection_id = ? AND classifier_model = ?",
+        (gone_det_id, "BioCLIP-2"),
+    ).fetchall()
+    species = sorted(row[0] for row in stored)
+    assert "Fresh_BioCLIP-2" in species, (
+        f"Model B's clear must cover a photo model A skipped so the "
+        f"fresh reclassify result can overwrite the stale prior row "
+        f"(add_prediction is INSERT OR IGNORE). Got species {species!r}."
+    )
+    assert OLD_B not in species, (
+        f"The stale model-B prediction for the previously-skipped photo "
+        f"must be cleared before storing the fresh result — otherwise "
+        f"INSERT OR IGNORE leaves the wrong species in place. Got "
+        f"species {species!r}."
     )
 
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -15385,3 +15385,475 @@ def test_pipeline_classify_failed_retry_on_last_photo_latches_source_offline(
         f"its per-photo loop against the dead share instead of "
         f"short-circuiting on abort (Codex #1388 P1 r3663278142)."
     )
+
+
+def test_pipeline_classify_folder_outage_skips_unreachable_photos_in_downstream_stages(
+    tmp_path, monkeypatch,
+):
+    """Folder-scoped outages must exclude unreachable photos from downstream stages.
+
+    Codex #1388 P2 (r3664058173): the folder-scoped branch deliberately
+    leaves ``abort`` clear so healthy folders keep processing — but the
+    unreachable photos still hung off the collection, so
+    ``extract_masks_stage`` (and ``eye_keypoints_stage``) would rebuild
+    ``photos_to_process`` from the whole collection and call
+    ``render_proxy`` against the dead folder for every one of them. Every
+    call returned None, they all landed in the "skipped" bucket, and the
+    stage summary showed a mask-extraction failure count instead of the
+    real diagnosis (missing folder). Filter the classify-time source-
+    skipped set out of extract_masks / eye_keypoints so the missing folder
+    doesn't get walked twice.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    gone_folder_path = str(tmp_path / "vanished")
+    healthy_folder_path = str(tmp_path / "still_here")
+    os.makedirs(gone_folder_path, exist_ok=True)
+    os.makedirs(healthy_folder_path, exist_ok=True)
+
+    gone_folder_id = db.add_folder(gone_folder_path)
+    healthy_folder_id = db.add_folder(healthy_folder_path)
+
+    photo_ids = []
+    gone_photo_ids: set = set()
+    healthy_photo_ids: set = set()
+    for i in range(3):
+        name = f"gone{i}.jpg"
+        pid = db.add_photo(
+            gone_folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i,
+        )
+        _drop_jpeg(gone_folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+        gone_photo_ids.add(pid)
+    for i in range(3):
+        name = f"healthy{i}.jpg"
+        pid = db.add_photo(
+            healthy_folder_id, name, ".jpg", 5000 + i, 5_000_000.0 + i,
+        )
+        _drop_jpeg(healthy_folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+        healthy_photo_ids.add(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    from PIL import Image as _PILImage
+
+    fake_missing_root = str(tmp_path / "vanished_at_classify_time")
+
+    def selective_prepare_image(photo, folders, detection, vireo_dir=None):
+        if photo["id"] in gone_photo_ids:
+            image_path = os.path.join(fake_missing_root, photo["filename"])
+            return None, fake_missing_root, image_path
+        fp = folders.get(photo["folder_id"], "")
+        return (
+            _PILImage.new("RGB", (16, 16), "black"),
+            fp,
+            os.path.join(fp, photo["filename"]),
+        )
+
+    monkeypatch.setattr(classify_job, "_prepare_image", selective_prepare_image)
+
+    def fake_flush_batch(batch, clf, model_type, model_name, db_, raw_results,
+                         top_k=1):
+        for entry in batch:
+            raw_results.append({
+                "photo": entry["photo"],
+                "detection_id": entry.get("detection_id"),
+                "folder_path": entry["folder_path"],
+                "image_path": entry["image_path"],
+                "prediction": "Robin",
+                "confidence": 0.9,
+                "timestamp": None,
+                "filename": entry["photo"]["filename"],
+                "embedding": None,
+                "taxonomy": None,
+            })
+        return 0
+
+    monkeypatch.setattr(classify_job, "_flush_batch", fake_flush_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    # Stub SAM2 / DINOv2 so extract_masks runs end-to-end. Record every
+    # render_proxy image_path so the assertion below can distinguish
+    # "healthy folder was processed" from "gone folder was retried."
+    _stub_extract_masks_heavy_ops(monkeypatch)
+    import masking as masking_mod
+    render_proxy_paths: list = []
+    _original_render_proxy = masking_mod.render_proxy
+
+    def spy_render_proxy(image_path, longest_edge=None):
+        render_proxy_paths.append(image_path)
+        return _original_render_proxy(image_path, longest_edge=longest_edge)
+
+    monkeypatch.setattr(masking_mod, "render_proxy", spy_render_proxy)
+
+    class NoPauseRunner(FakeRunner):
+        def pause_job(self, job_id):
+            return False
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            return False
+
+    # Do NOT skip_extract_masks — this test is that extract_masks runs on
+    # the healthy folder AND skips the gone folder rather than walking it.
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_regroup=True,
+        skip_eye_keypoints=True,
+    )
+
+    runner = NoPauseRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # extract_masks must have opened ONLY the healthy folder's files.
+    # Pre-fix, it also called render_proxy against fake_missing_root for
+    # each unreachable photo and reported them as skips.
+    assert render_proxy_paths, (
+        "extract_masks should have processed the healthy folder — if "
+        "no render_proxy calls fired at all, the stage short-circuited "
+        "and this test doesn't exercise the filter under review."
+    )
+    assert not any(
+        fake_missing_root in path for path in render_proxy_paths
+    ), (
+        f"extract_masks re-opened the missing folder via render_proxy — "
+        f"the classify-time source-skipped set must be filtered out of "
+        f"downstream stages so the folder outage doesn't get walked "
+        f"twice (Codex #1388 P2 r3664058173). Got paths: "
+        f"{render_proxy_paths!r}"
+    )
+    # Belt-and-suspenders: every render_proxy path must live under the
+    # healthy folder root.
+    assert all(
+        healthy_folder_path in path for path in render_proxy_paths
+    ), (
+        f"extract_masks called render_proxy for paths outside the "
+        f"healthy folder — expected only {healthy_folder_path!r}, got "
+        f"{render_proxy_paths!r}"
+    )
+
+
+def test_pipeline_classify_folder_outage_marks_per_model_step_failed(
+    tmp_path, monkeypatch,
+):
+    """The per-model classify step must land as ``failed`` on a folder outage.
+
+    Codex #1388 P2 (r3664058179): the new source-offline summary described
+    the incomplete work in the step's ``summary`` field, but the
+    ``runner.update_step`` call still passed ``status="completed"``. The
+    Jobs page renders status from ``step.status`` directly and auto-
+    collapses ``completed`` rows without warnings, so a failed job would
+    show a green, collapsed classifier row — hiding the reason the stage
+    stopped short. The later stage-status rollup that flips
+    ``stages["classify"]["status"] = "failed"`` isn't mapped back to the
+    per-model step, so this must be fixed inline.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # Every photo lives in a folder that doesn't exist at classify time.
+    fake_missing_folder = str(tmp_path / "vanished_folder")
+
+    def folder_missing_prepare_image(photo, folders, detection, vireo_dir=None):
+        return None, fake_missing_folder, os.path.join(
+            fake_missing_folder, photo["filename"],
+        )
+
+    monkeypatch.setattr(
+        classify_job, "_prepare_image", folder_missing_prepare_image,
+    )
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # Every update_step for the classify:<model> row, in order. The final
+    # terminal one carries the outage status the Jobs page renders.
+    classify_step_updates = [
+        (sid, kwargs) for (_jid, sid, kwargs) in runner.step_updates
+        if sid.startswith("classify:") and "status" in kwargs
+    ]
+    assert classify_step_updates, (
+        "Setup sanity: no classify:<model> step updates fired at all."
+    )
+    terminal = classify_step_updates[-1]
+    sid, kwargs = terminal
+    assert kwargs.get("status") == "failed", (
+        f"On a folder-scoped outage the classify:<model> step must land "
+        f"as 'failed' — leaving it 'completed' shows a green, collapsed "
+        f"row on the Jobs page for a run that never opened the missing "
+        f"folder (Codex #1388 P2 r3664058179). Got status="
+        f"{kwargs.get('status')!r} on step {sid!r} with summary="
+        f"{kwargs.get('summary')!r}."
+    )
+    # The row must also carry a human-readable error so the collapsed row
+    # explains itself.
+    assert kwargs.get("error"), (
+        f"A failed classify:<model> row must carry a non-empty error "
+        f"field naming the outage — that's what the Jobs page shows next "
+        f"to the collapsed row. Got kwargs={kwargs!r}"
+    )
+    assert "unreachable" in kwargs["error"].lower() or (
+        "source" in kwargs["error"].lower()
+    ), (
+        f"The error must name the outage as source-related, not a generic "
+        f"failure; got {kwargs['error']!r}"
+    )
+
+
+def test_pipeline_classify_source_offline_give_up_marks_per_model_step_failed(
+    tmp_path, monkeypatch,
+):
+    """A mount give-up must land the responsible classify:<model> step as failed.
+
+    Codex #1388 P2 (r3664058179), mount-outage variant: the model that
+    was actively reading when the mount died reaches finalization with
+    ``source_offline["reason"]`` latched. Pre-fix, that spec still called
+    ``runner.update_step(..., status="completed", ...)``. The Jobs page
+    would then show a green, collapsed classifier row for the run that
+    gave up — the exact "your photos are fine!" misread this PR fixes.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # Mount-shaped fake path so the outage escalates to mount-scope
+    # (folder scope wouldn't latch source_offline["reason"]).
+    gone_mount = "/Volumes/DefinitelyNotMounted12345/Raw Files"
+
+    def offline_prepare_image(photo, folders, detection, vireo_dir=None):
+        return None, gone_mount, os.path.join(gone_mount, photo["filename"])
+
+    monkeypatch.setattr(classify_job, "_prepare_image", offline_prepare_image)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    # Plain FakeRunner has no pause support, so classify hits the
+    # "can't park → latch source_offline['reason'] and stop" branch.
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The classify:<model> step for the spec that actually gave up must
+    # terminate as ``failed`` — the Jobs page renders status directly and
+    # a ``completed`` row would collapse silent-green.
+    classify_step_updates = [
+        (sid, kwargs) for (_jid, sid, kwargs) in runner.step_updates
+        if sid.startswith("classify:") and "status" in kwargs
+    ]
+    assert classify_step_updates, (
+        "Setup sanity: no classify:<model> step updates fired at all."
+    )
+    terminal = classify_step_updates[-1]
+    sid, kwargs = terminal
+    assert kwargs.get("status") == "failed", (
+        f"On a mount give-up the classify:<model> step must land as "
+        f"'failed' — 'completed' would leave a green, collapsed row on "
+        f"a job that never classified the collection (Codex #1388 P2 "
+        f"r3664058179). Got status={kwargs.get('status')!r} with "
+        f"summary={kwargs.get('summary')!r}."
+    )
+    assert kwargs.get("error"), (
+        f"The failed row must carry an error field naming the mount "
+        f"outage; got kwargs={kwargs!r}"
+    )
+    assert "source" in kwargs["error"].lower(), (
+        f"The error message must name the outage as source-related; "
+        f"got {kwargs['error']!r}"
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12706,7 +12706,7 @@ def test_source_offline_reason_flags_stale_mount_that_raises_from_stat(
 
     real_lexists = pipeline_job.os.path.lexists
     real_isdir = pipeline_job.os.path.isdir
-    real_ismount = pipeline_job.os.path.ismount
+    real_listdir = pipeline_job.os.listdir
 
     def fake_lexists(path):
         if path == "/mnt/photos":
@@ -12718,18 +12718,31 @@ def test_source_offline_reason_flags_stale_mount_that_raises_from_stat(
             return False
         return real_isdir(path)
 
-    def fake_ismount(path):
+    def fake_listdir(path):
+        # ``_mount_root_offline`` probes readability of the mount
+        # root itself via ``os.listdir``; a stale SMB/NFS mount whose
+        # server has disconnected raises ``OSError`` (EIO) from that
+        # call even though ``lexists``/``ismount`` still report the
+        # mount as present. This is the exact behaviour that lets us
+        # scope the outage to the whole mount (pause + resume flow)
+        # rather than silently accepting the dropped share as healthy
+        # and folder-scoping every subsequent read. Without patching
+        # ``os.listdir``, the test would depend on the host machine
+        # not having a real ``/mnt/photos`` — pass on a bare CI image,
+        # fail on WSL/containers/Linux desktops that do — and the
+        # intended branch would never be exercised (CodeRabbit
+        # r3664548822).
         if path == "/mnt/photos":
             raise OSError("Input/output error")
-        return real_ismount(path)
+        return real_listdir(path)
 
     monkeypatch.setattr(pipeline_job.os.path, "lexists", fake_lexists)
     monkeypatch.setattr(pipeline_job.os.path, "isdir", fake_isdir)
-    monkeypatch.setattr(pipeline_job.os.path, "ismount", fake_ismount)
+    monkeypatch.setattr(pipeline_job.os, "listdir", fake_listdir)
 
     result = pipeline_job._source_offline_reason(folder, image)
     assert result is not None and result[0] == "mount", (
-        f"A stale mount whose ismount probe raises must be treated as "
+        f"A stale mount whose listdir probe raises must be treated as "
         f"offline, not silently accepted as healthy. Got {result!r}."
     )
 
@@ -12961,6 +12974,93 @@ def test_still_offline_folder_ids_expands_beyond_seed_photos(tmp_path):
         f"folder-scoped filter — otherwise the mask/eye-keypoint stages "
         f"would reopen the dead source. Got {filtered!r}."
     )
+
+
+def test_archive_mount_root_candidates_resolves_symlink_aliases(tmp_path):
+    """A symlink alias to a mount root must retain mount scope.
+
+    Codex #1388 P2 (r3664891998): a common catalog shape is a stable
+    alias in the user's home (or a top-level ``/photos``) that points
+    into a real mount like ``/Volumes/NAS/photos``. When the underlying
+    share disconnects, neither the raw alias nor its ``abspath``
+    normalization has a ``/Volumes``/``/mnt``/drive-letter/UNC prefix,
+    so pre-fix ``_source_offline_reason`` would classify the dropped
+    share as folder-scoped — skipping its photos silently instead of
+    offering the reconnect-and-resume flow. Pin that ``realpath``
+    resolution surfaces the underlying mount root so the outage scope
+    reaches the whole share.
+    """
+    from pipeline_job import _archive_mount_root_candidates
+
+    # A real symlink whose target is a mount-shaped path. The target
+    # doesn't need to exist — ``realpath`` only resolves symlink chains
+    # (readlink), it doesn't stat the resolved path — but we build a
+    # dead-mount-looking layout on disk to keep the test hermetic.
+    volumes = tmp_path / "Volumes"
+    volumes.mkdir()
+    share_target = volumes / "NAS" / "photos"
+    share_target.mkdir(parents=True)
+
+    alias = tmp_path / "photos_alias"
+    # Point the alias at ``/Volumes/NAS/photos`` verbatim so realpath
+    # yields a canonical mount-shaped absolute path regardless of the
+    # tmp_path prefix.
+    alias.symlink_to("/Volumes/NAS/photos")
+
+    aliased_image = str(alias / "2026-07-28" / "DSC_0001.NEF")
+    cands = _archive_mount_root_candidates(aliased_image)
+    assert "/Volumes/NAS" in cands, (
+        f"A symlink alias into ``/Volumes/NAS`` must yield the "
+        f"underlying mount root via realpath so the outage scope "
+        f"reaches the whole share. Got {cands!r}."
+    )
+
+
+def test_still_offline_folder_ids_of_probes_folder_ids_directly(tmp_path):
+    """The direct-probe helper accepts folder IDs, not a photo seed.
+
+    Codex #1388 P1 (r3664891993): a fully-cached-classify run
+    (every detection and classifier result already stored, only masks
+    missing after a SAM variant change) makes no image opens, so
+    ``source_offline_state["skipped_photo_ids"]`` stays empty even
+    when every remaining file lives on an unreachable share. The
+    seed-based ``_still_offline_folder_ids`` therefore returns an
+    empty set, and downstream stages would reopen the dead source
+    photo-by-photo. Pin that the direct-probe twin handles the
+    fully-cached case by taking folder IDs from the downstream
+    worklist and probing them independently.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline_job import _still_offline_folder_ids_of
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    db = Database(str(tmp_path / "test.db"))
+
+    healthy_folder = tmp_path / "healthy"
+    healthy_folder.mkdir()
+    gone_folder = tmp_path / "vanished"
+    gone_folder.mkdir()
+
+    healthy_folder_id = db.add_folder(str(healthy_folder))
+    gone_folder_id = db.add_folder(str(gone_folder))
+
+    # Delete only the "gone" folder. In the fully-cached scenario the
+    # classify seed set is empty, but the downstream worklist still
+    # references the gone folder via ``folder_id``.
+    os.rmdir(gone_folder)
+
+    still_offline = _still_offline_folder_ids_of(
+        db, {healthy_folder_id, gone_folder_id},
+    )
+    assert still_offline == {gone_folder_id}, (
+        f"Direct-probe helper must return only the folder that is "
+        f"actually unreachable at probe time; got {still_offline!r}."
+    )
+
+    # Empty input is a no-op — no DB query needed.
+    assert _still_offline_folder_ids_of(db, set()) == set()
+    assert _still_offline_folder_ids_of(db, []) == set()
 
 
 def test_still_offline_folder_ids_chunks_large_id_sets(tmp_path):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12976,6 +12976,17 @@ def test_still_offline_folder_ids_expands_beyond_seed_photos(tmp_path):
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "POSIX mount-shape only: on Windows, ``symlink_to('/Volumes/NAS/photos')`` "
+        "treats the target as rooted on the current drive, so ``realpath`` yields "
+        "``C:\\Volumes\\NAS\\photos`` and the drive-letter branch matches instead "
+        "of ``/Volumes/NAS``. The Windows-shape equivalents are exercised by "
+        "``test_archive_mount_root_candidates_recognises_windows_paths`` and "
+        "``test_source_offline_reason_flags_disconnected_windows_share``."
+    ),
+)
 def test_archive_mount_root_candidates_resolves_symlink_aliases(tmp_path):
     """A symlink alias to a mount root must retain mount scope.
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12459,20 +12459,25 @@ def test_source_offline_reason_flags_vanished_folder(tmp_path):
     assert folder in reason, f"Reason must name the folder; got {reason!r}"
 
 
-def test_source_offline_reason_flags_persistent_mountpoint_after_unmount(
+def test_source_offline_reason_keeps_empty_mountshape_root_folder_scoped(
     monkeypatch,
 ):
-    """Linux common case: the mount-point directory outlives the mount.
+    """An empty mount-shaped root with no active mount is folder-scoped.
 
-    Codex #1388 P1 (r3663493889): when a Linux SMB/NFS share mounted on a
-    persistent directory like ``/mnt/photos`` is unmounted (or the network
-    drops), ``lexists("/mnt/photos")`` remains True — only the *contents*
-    become unreachable. Pre-fix, ``_source_offline_reason`` fell through
-    to the folder-scoped branch and classify skipped folder-by-folder
-    instead of pausing, so every descendant of the dead share still
-    reissued a doomed read. Pin that a mount-point-shaped directory
-    without a filesystem mounted at it is treated as a mount-scoped
-    outage regardless of whether the directory itself still exists.
+    Codex #1388 P1 (r3664348752) supersedes the earlier r3663493889
+    behavior: a directory that exists, is readable, is empty, and is
+    not currently a mount point is genuinely ambiguous — it could be
+    an unmounted SMB stub OR an ordinary local ``/mnt/photos`` whose
+    only child (the deleted collection folder) just went away. The
+    two shapes have identical current-state signals, so mount-scoping
+    the outage would pause the whole run for an ordinary local
+    catalog whenever the user archives their last subfolder. Prefer
+    folder-scoped when we can't prove the root was actually a mount;
+    the dead-mount-that-still-shows-up-in-mount case (the far more
+    common failure mode — network drop leaves ``ismount == True``
+    with EIO on every read) is still mount-scoped via the
+    ``listdir`` OSError branch (see the ``…flags_stale_mount…``
+    tests below).
     """
     import pipeline_job
 
@@ -12485,30 +12490,28 @@ def test_source_offline_reason_flags_persistent_mountpoint_after_unmount(
     real_listdir = pipeline_job.os.listdir
 
     def fake_lexists(path):
-        # The persistent mount-point directory is still there.
+        # The mount-point directory (or its plain-local twin) is still
+        # there.
         if path == "/mnt/photos":
             return True
         return real_lexists(path)
 
     def fake_isdir(path):
-        # The subtree is unreachable because the filesystem is gone.
+        # The subtree is unreachable — the collection folder is gone.
         if path == folder:
             return False
         return real_isdir(path)
 
     def fake_ismount(path):
-        # But nothing is actually mounted at /mnt/photos — the whole
-        # share, not just this one folder, is offline.
+        # No filesystem currently mounted at /mnt/photos. Could be a
+        # cleanly-unmounted share OR a plain local dir. We can't tell.
         if path == "/mnt/photos":
             return False
         return real_ismount(path)
 
     def fake_listdir(path):
-        # An unmounted mount stub is empty — its contents lived on the
-        # mounted filesystem and vanished with the mount. This is the
-        # positive signal ``_mount_root_offline`` uses to distinguish an
-        # actual mount from a plain local directory (Codex #1388 P1
-        # r3663642357).
+        # Empty root: either an unmounted stub or a plain local dir
+        # whose only child was the deleted folder. Same signal.
         if path == "/mnt/photos":
             return []
         return real_listdir(path)
@@ -12520,19 +12523,15 @@ def test_source_offline_reason_flags_persistent_mountpoint_after_unmount(
 
     result = pipeline_job._source_offline_reason(folder, image)
     assert result is not None, (
-        "A mount-point-shaped path with no filesystem mounted at it must "
-        "register as an offline source — pre-fix, this fell through to "
-        "the folder-scoped branch and never paused the run."
+        "The deleted subfolder is still unreachable, so the helper must "
+        "report an outage — just scoped to the folder, not the whole mount."
     )
     scope, reason = result
-    assert scope == "mount", (
-        f"Persistent-mountpoint outages must scope to the mount so the "
-        f"whole run pauses for reconnection; scoping to 'folder' would "
-        f"re-hit the dead share once per descendant. Got scope {scope!r}."
-    )
-    assert "/mnt/photos" in reason, (
-        f"Reason must name the mount root the user needs to reconnect; "
-        f"got {reason!r}."
+    assert scope == "folder", (
+        f"An empty mount-shaped root without positive mount-identity "
+        f"evidence is ambiguous; scoping it as a mount outage would pause "
+        f"an ordinary local catalog whenever its last subfolder is "
+        f"archived. Got scope {scope!r} reason {reason!r}."
     )
 
 
@@ -12825,6 +12824,82 @@ def test_source_offline_reason_flags_disconnected_windows_share(monkeypatch):
         f"The reason must name the drive the user needs to reconnect; got "
         f"{reason!r}."
     )
+
+
+def test_mount_root_offline_false_for_empty_ordinary_local_dir(tmp_path):
+    """An empty readable directory that isn't a mount is NOT offline.
+
+    Codex #1388 P1 (r3664348752): an ordinary local ``/mnt/photos``
+    whose only child (the deleted collection folder) just went away is
+    empty + ``ismount=False`` + readable — the same signals as an
+    unmounted stub. Pre-fix the helper returned True for either shape,
+    upgrading the missing subfolder to a mount-wide outage; the whole
+    run would pause and eventually abandon any healthy siblings. Pin
+    that ``_mount_root_offline`` treats a readable directory as online
+    regardless of whether it's populated or empty and whether it's
+    ismount-positive.
+    """
+    from pipeline_job import _mount_root_offline
+
+    empty_root = tmp_path / "empty_mnt_style"
+    empty_root.mkdir()  # readable, empty, not a mount
+
+    assert _mount_root_offline(str(empty_root)) is False, (
+        "An empty readable directory must not be reported as offline just "
+        "because ismount is False — that would pause runs on an ordinary "
+        "local catalog whose last subfolder was archived."
+    )
+
+
+def test_still_offline_photo_ids_prunes_recovered_folders(tmp_path):
+    """Photos whose folder is now readable must drop out of the skip set.
+
+    Codex #1388 P2 (r3664348758): the aggregate
+    ``source_offline_state["skipped_photo_ids"]`` accumulates across every
+    classifier spec, and a folder that dropped for spec A can recover
+    before mask extraction runs. Without a re-probe, the downstream
+    filter would silently exclude the now-readable photo and it would
+    never get its masks. Pin that ``_still_offline_photo_ids`` returns
+    only photos whose folder is still missing at re-probe time.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline_job import _still_offline_photo_ids
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    db = Database(str(tmp_path / "test.db"))
+
+    healthy_folder = tmp_path / "healthy"
+    healthy_folder.mkdir()
+    gone_folder = tmp_path / "vanished"
+    gone_folder.mkdir()
+
+    healthy_folder_id = db.add_folder(str(healthy_folder))
+    gone_folder_id = db.add_folder(str(gone_folder))
+
+    healthy_id = db.add_photo(
+        healthy_folder_id, "a.jpg", ".jpg", 1000, 100.0,
+    )
+    gone_id = db.add_photo(
+        gone_folder_id, "b.jpg", ".jpg", 1000, 101.0,
+    )
+
+    # Now delete the "gone" folder — folder A recovered, folder B is
+    # still missing. This is the multi-model recovery shape: both
+    # photo IDs entered the aggregate skipped set for an earlier
+    # classifier spec, but only one of them is still unreachable now.
+    os.rmdir(gone_folder)
+
+    still_offline = _still_offline_photo_ids(db, {healthy_id, gone_id})
+    assert still_offline == {gone_id}, (
+        f"A recovered folder must drop its photo from the still-offline "
+        f"set so downstream stages can process it; only the folder that "
+        f"remains missing should stay in the set. Got {still_offline!r}."
+    )
+
+    # And the empty-input path is a no-op — no DB query needed.
+    assert _still_offline_photo_ids(db, set()) == set()
+    assert _still_offline_photo_ids(db, []) == set()
 
 
 def test_pipeline_classify_pauses_when_source_volume_disappears(
@@ -14232,6 +14307,141 @@ def test_pipeline_classify_folder_outage_is_not_a_clean_success(
     )
 
 
+def test_pipeline_classify_folder_outage_counts_each_photo_once(
+    tmp_path, monkeypatch,
+):
+    """A multi-subject unreachable photo counts once, not once per detection.
+
+    Codex #1388 P2 (r3664348763): the per-spec ``source_skipped`` counter
+    was incremented inside the per-detection loop. A single photo with N
+    qualifying detections would report ``N unreachable`` even though the
+    per-spec ``total`` (and the ``spec_source_skipped_photo_ids`` set) are
+    photo-scoped, so the step summary could read e.g. ``3 unreachable``
+    out of ``1`` photo. Pin that a single unreachable photo with several
+    detections counts as one skipped photo.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    name = "photo0.jpg"
+    pid = db.add_photo(folder_id, name, ".jpg", 4000, 4_000_000.0)
+    _drop_jpeg(folder_path, name)
+    # Three qualifying animal detections on the same photo — this is what
+    # a multi-subject frame looks like to classify.
+    db.save_detections(
+        pid,
+        [
+            {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+             "confidence": 0.9, "category": "animal"},
+            {"box": {"x": 0.4, "y": 0.4, "w": 0.2, "h": 0.2},
+             "confidence": 0.85, "category": "animal"},
+            {"box": {"x": 0.7, "y": 0.1, "w": 0.2, "h": 0.2},
+             "confidence": 0.8, "category": "animal"},
+        ],
+        detector_model="MegaDetector",
+    )
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    import labels_fingerprint as lfp
+    monkeypatch.setattr(lfp, "compute_fingerprint", lambda *a, **k: "fp")
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            det_map[p["id"]] = [{
+                "id": d["id"],
+                "box_x": d["box_x"], "box_y": d["box_y"],
+                "box_w": d["box_w"], "box_h": d["box_h"],
+                "confidence": d["detector_confidence"],
+                "category": d["category"],
+            } for d in db_.get_detections(p["id"])
+                if d["detector_model"] != "full-image"]
+        return det_map, len(batch), {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    # Point every detection at a folder that never existed on disk — trips
+    # the folder-scoped branch. Because ``_prepare_image`` fails at the
+    # per-detection level, pre-fix the counter fires three times for this
+    # one photo.
+    fake_missing_folder = str(tmp_path / "vanished_folder")
+
+    def folder_missing_prepare_image(photo, folders, detection, vireo_dir=None):
+        return None, fake_missing_folder, os.path.join(
+            fake_missing_folder, photo["filename"],
+        )
+
+    monkeypatch.setattr(
+        classify_job, "_prepare_image", folder_missing_prepare_image,
+    )
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            import numpy as np
+            return np.zeros(512, dtype=np.float32)
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The per-model step summary must say "1 unreachable" for our single
+    # multi-detection photo, not "3 unreachable" (one tick per detection).
+    classify_steps = [
+        kwargs for (_jid, sid, kwargs) in runner.step_updates
+        if sid.startswith("classify:") and "summary" in kwargs
+    ]
+    summaries = " ".join(k["summary"] for k in classify_steps)
+    assert "1 unreachable" in summaries, (
+        f"A single unreachable photo with multiple qualifying detections "
+        f"must count as one skipped photo in the step summary, not once "
+        f"per detection. Got summary {summaries!r}"
+    )
+    assert "3 unreachable" not in summaries, (
+        f"Pre-fix regression: the summary reported N unreachable for a "
+        f"multi-subject photo with N detections. Got {summaries!r}"
+    )
+
+    # And the stage rollup must report the same photo-scoped count.
+    result_stages = job["result"]["stages"]
+    assert result_stages["classify"].get("source_skipped") == 1, (
+        f"Structured source_skipped is a photo-scoped count for downstream "
+        f"consumers; got {result_stages['classify']!r}"
+    )
+
+
 def test_pipeline_classify_give_up_skips_downstream_stages(
     tmp_path, monkeypatch,
 ):
@@ -15533,6 +15743,14 @@ def test_pipeline_classify_folder_outage_skips_unreachable_photos_in_downstream_
         )
         photo_ids.append(pid)
         healthy_photo_ids.add(pid)
+
+    # Drop the DB-recorded folder from disk so downstream stages re-probe
+    # (Codex #1388 P2 r3664348758) still see it as offline. Without this,
+    # the aggregate skip set would be pruned by the re-probe helper and
+    # extract_masks would (correctly) walk the now-reachable folder.
+    for entry in os.listdir(gone_folder_path):
+        os.remove(os.path.join(gone_folder_path, entry))
+    os.rmdir(gone_folder_path)
 
     col_id = db.add_collection(
         "Test",

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -12459,6 +12459,118 @@ def test_source_offline_reason_flags_vanished_folder(tmp_path):
     assert folder in reason, f"Reason must name the folder; got {reason!r}"
 
 
+def test_source_offline_reason_flags_persistent_mountpoint_after_unmount(
+    monkeypatch,
+):
+    """Linux common case: the mount-point directory outlives the mount.
+
+    Codex #1388 P1 (r3663493889): when a Linux SMB/NFS share mounted on a
+    persistent directory like ``/mnt/photos`` is unmounted (or the network
+    drops), ``lexists("/mnt/photos")`` remains True — only the *contents*
+    become unreachable. Pre-fix, ``_source_offline_reason`` fell through
+    to the folder-scoped branch and classify skipped folder-by-folder
+    instead of pausing, so every descendant of the dead share still
+    reissued a doomed read. Pin that a mount-point-shaped directory
+    without a filesystem mounted at it is treated as a mount-scoped
+    outage regardless of whether the directory itself still exists.
+    """
+    import pipeline_job
+
+    folder = "/mnt/photos/2026-07-27"
+    image = os.path.join(folder, "DSC_0001.NEF")
+
+    real_lexists = pipeline_job.os.path.lexists
+    real_isdir = pipeline_job.os.path.isdir
+    real_ismount = pipeline_job.os.path.ismount
+
+    def fake_lexists(path):
+        # The persistent mount-point directory is still there.
+        if path == "/mnt/photos":
+            return True
+        return real_lexists(path)
+
+    def fake_isdir(path):
+        # The subtree is unreachable because the filesystem is gone.
+        if path == folder:
+            return False
+        return real_isdir(path)
+
+    def fake_ismount(path):
+        # But nothing is actually mounted at /mnt/photos — the whole
+        # share, not just this one folder, is offline.
+        if path == "/mnt/photos":
+            return False
+        return real_ismount(path)
+
+    monkeypatch.setattr(pipeline_job.os.path, "lexists", fake_lexists)
+    monkeypatch.setattr(pipeline_job.os.path, "isdir", fake_isdir)
+    monkeypatch.setattr(pipeline_job.os.path, "ismount", fake_ismount)
+
+    result = pipeline_job._source_offline_reason(folder, image)
+    assert result is not None, (
+        "A mount-point-shaped path with no filesystem mounted at it must "
+        "register as an offline source — pre-fix, this fell through to "
+        "the folder-scoped branch and never paused the run."
+    )
+    scope, reason = result
+    assert scope == "mount", (
+        f"Persistent-mountpoint outages must scope to the mount so the "
+        f"whole run pauses for reconnection; scoping to 'folder' would "
+        f"re-hit the dead share once per descendant. Got scope {scope!r}."
+    )
+    assert "/mnt/photos" in reason, (
+        f"Reason must name the mount root the user needs to reconnect; "
+        f"got {reason!r}."
+    )
+
+
+def test_source_offline_reason_flags_stale_mount_that_raises_from_stat(
+    monkeypatch,
+):
+    """A stale mount whose stat probes raise EIO is still offline.
+
+    ``os.path.ismount`` uses stat calls on the path and its parent; a
+    dead NFS/SMB mount can raise ``OSError`` (EIO) from those instead of
+    returning a clean answer. Since we only ask about the mount state
+    once a read has already failed, an errored probe must count as
+    offline — otherwise the same dead share would be treated as healthy
+    and folder-scoped for every subsequent read.
+    """
+    import pipeline_job
+
+    folder = "/mnt/photos/2026-07-27"
+    image = os.path.join(folder, "DSC_0001.NEF")
+
+    real_lexists = pipeline_job.os.path.lexists
+    real_isdir = pipeline_job.os.path.isdir
+    real_ismount = pipeline_job.os.path.ismount
+
+    def fake_lexists(path):
+        if path == "/mnt/photos":
+            return True
+        return real_lexists(path)
+
+    def fake_isdir(path):
+        if path == folder:
+            return False
+        return real_isdir(path)
+
+    def fake_ismount(path):
+        if path == "/mnt/photos":
+            raise OSError("Input/output error")
+        return real_ismount(path)
+
+    monkeypatch.setattr(pipeline_job.os.path, "lexists", fake_lexists)
+    monkeypatch.setattr(pipeline_job.os.path, "isdir", fake_isdir)
+    monkeypatch.setattr(pipeline_job.os.path, "ismount", fake_ismount)
+
+    result = pipeline_job._source_offline_reason(folder, image)
+    assert result is not None and result[0] == "mount", (
+        f"A stale mount whose ismount probe raises must be treated as "
+        f"offline, not silently accepted as healthy. Got {result!r}."
+    )
+
+
 def test_pipeline_classify_pauses_when_source_volume_disappears(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -16353,3 +16353,127 @@ def test_pipeline_classify_source_offline_give_up_marks_per_model_step_failed(
         f"The error message must name the outage as source-related; "
         f"got {kwargs['error']!r}"
     )
+
+
+def test_pipeline_extract_masks_offline_survives_finalizer_override(
+    tmp_path, monkeypatch,
+):
+    """A mask-stage-owned outage must stay ``failed`` through finalization.
+
+    Codex #1388 P1 (r3665130244): when classify is fully cached (or skipped)
+    but masks are still needed from an offline folder, ``extract_masks_stage``
+    latches ``stages["extract_masks"]["status"] = "failed"`` in its
+    source-offline branch. But the finalizer at the bottom of the stage
+    derives ``final_status`` solely from ``em_failed``: because the offline
+    photos were pre-filtered from the worklist, ``em_failed`` is 0, so the
+    finalizer flips the stage back to ``"completed"`` — silently erasing
+    the outage. The end-of-run rollup only reads stage ``status`` values,
+    so the whole job then reports "successfully completed" while the
+    ``[extract_masks] Fatal:`` error sits in the errors list with no
+    corresponding failed stage to surface it.
+
+    Skip classify entirely to reproduce the fully-cached scenario without
+    also having to seed classifier_runs rows: the bug is not about how
+    the mask stage learns about the offline source, only about whether
+    its ``failed`` verdict survives its own finalizer.
+    """
+    import shutil
+
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i in range(3):
+        name = f"photo{i}.jpg"
+        pid = db.add_photo(folder_id, name, ".jpg", 4000 + i, 4_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+
+    col_id = db.add_collection(
+        "Test",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    # Delete the folder from disk AFTER seeding the DB. _still_offline_folder_ids_of
+    # probes the folder's stored path via os.path.isdir — an absent directory
+    # is exactly what a dropped SMB share looks like from userspace.
+    shutil.rmtree(folder_path)
+
+    # Skip classify (and thus model_loader). extract_masks_stage runs
+    # against the collection photos with no ``source_offline_state``
+    # seeded by classify, and must detect the outage on its own via the
+    # folder probe — the exact scenario Codex called out for the
+    # fully-cached path.
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    # The rollup at the bottom of run_pipeline_job derives failure state
+    # ONLY from stage statuses in ``stages`` — it does NOT scan errors
+    # for ``[extract_masks] Fatal:`` entries. So this RuntimeError firing
+    # at all is the load-bearing assertion: the finalizer preserved
+    # ``failed`` rather than overwriting it with ``completed``.
+    assert "extract_masks" in str(excinfo.value).lower(), (
+        f"The job's headline error must name extract_masks as the failed "
+        f"stage; got {excinfo.value!r}"
+    )
+
+    # The user-visible step update must also land as ``failed`` — the Jobs
+    # page reads status from step updates, and a ``completed`` step here
+    # would render a collapsed green row on a run that produced no masks.
+    em_step_updates = [
+        kwargs for (_jid, sid, kwargs) in runner.step_updates
+        if sid == "extract_masks" and "status" in kwargs
+    ]
+    assert em_step_updates, (
+        "Setup sanity: no extract_masks step updates fired at all."
+    )
+    terminal_em = em_step_updates[-1]
+    assert terminal_em.get("status") == "failed", (
+        f"The mask-stage terminal step update must be 'failed' — "
+        f"'completed' would leave a green, collapsed row on a run that "
+        f"never produced masks (Codex #1388 P1 r3665130244). Got "
+        f"status={terminal_em.get('status')!r} summary="
+        f"{terminal_em.get('summary')!r}"
+    )
+
+    # And the Fatal error must be preserved in the job's errors list so
+    # the pipeline UI can render the offline diagnostic under the card.
+    em_fatal = [
+        e for e in (job.get("errors") or [])
+        if isinstance(e, str) and e.startswith("[extract_masks] Fatal:")
+    ]
+    assert em_fatal, (
+        f"A source-offline mask stage must record a [extract_masks] "
+        f"Fatal: entry so the end-of-run rollup can name it as the "
+        f"headline error; got errors={job.get('errors')!r}"
+    )
+    assert "source offline" in em_fatal[0].lower(), (
+        f"The extract_masks Fatal error must name the outage as "
+        f"source-offline; got {em_fatal[0]!r}"
+    )


### PR DESCRIPTION
## The incident

A processing run lost its SMB share (`/Volumes/Photography`, Tailscale-mounted) partway through classify. From `~/.vireo/vireo.log`, ~1,644 reads failed with `Input/output error` inside a **two-minute window** — the instantaneous burst signature of a dead mount, not slow I/O:

```
2026-07-28 05:02:25 WARNING image_loader: Failed to load image:
  /Volumes/Photography/Raw Files/USA/2026/2026-07-26/DSC_7280.NEF — b'Input/output error'
```

What the user saw:

| stage | reported |
|---|---|
| Detect subjects | 946 animals in 984 photos ✅ (finished before the drop) |
| Classify — BioCLIP-2.5 | 86 predictions, **779 failed** |
| Classify — iNat21 | 0 predictions, **865 failed** |

"779 failed" reads as *779 of your photos are broken*. The truth was *the volume went away and we never opened them*. Classify then ran a second model to completion against the same dead mount, producing an identical bogus failure count.

## The fix

`_source_offline_reason()` separates **"this one file won't load"** (corrupt RAW, permissions — genuinely that photo's failure) from **"the source tree is gone"** (every remaining read will fail too). It's deliberately conservative — both probes require evidence the *tree* vanished, so no single unreadable file can trip it, and collections on local disks keep today's behavior exactly.

Classify consults it before blaming a photo:

- **Pauses and parks** on an offline source. Classify is already a registered pause participant (`pipeline_job.py:6085`) and promoted pipeline jobs are `pausable: True` (`jobs.py:287`), so this genuinely suspends the run.
- **Resume actually finishes the collection.** Remount the share, hit Resume, and classify continues — no full re-run. Without this the pause would be a false promise.
- **Bounded at 3 pauses** so resuming without fixing the mount can't ping-pong forever.
- **Skipped photos are reported honestly** as `N unreachable (source offline)` — never folded into `failed`.
- **A run that gives up marks classify `failed`**, not `completed`. Otherwise the job tree would show a green check on a collection it never opened.
- The give-up error carries the `[classify] Fatal:` prefix the end-of-run rollup uses to select the job's headline error, so it names the volume instead of falling back to an unrelated earlier warning.

## Scope notes

- **Detect needs no equivalent change.** `classify_job.py:467` already treats a decode failure as "leave unprocessed, retry next pass" rather than a failure — which is why detect reported cleanly in the incident. Classify was the uniquely broken stage.
- **Classify's image source is unchanged.** A separate option was to point classify at the local working copies (which would have made it immune to the mount dropping), but measurement showed that changes white balance and exposure for 100% of photos (`preserve_highlights` vs rawpy defaults) and half-size Bayer decode for 45MP files. Not worth an unvalidated accuracy risk; deferred pending an A/B.
- The Extract-features failure in the same run (dead Hugging Face client retried 693× at ~247s each) is a **separate bug**, not addressed here.

## Tests

6 new tests, all of which fail without the fix:

- 3 unit cases for `_source_offline_reason` (healthy folder with a missing file → not offline; unmounted volume → offline; vanished folder → offline)
- `..._pauses_when_source_volume_disappears` — reproduces the incident; pins that skipped photos aren't called failures and that the pause count is bounded
- `..._resumes_after_source_volume_reconnects` — pins that Resume finishes the collection
- `..._offline_source_is_not_a_clean_success` — pins the failed status and the accurate headline error

Suite results (all against final code):

- pipeline suites: **501 passed**, 55 skipped
- queue + classify suites: **126 passed**
- jobs: **30 passed**
- CLAUDE.md mandated suite: **1950 passed**, 1 failed
- `ruff check` clean

The single failure is `test_api_exiftool_status_reports_missing`, which is pre-existing on this machine (exiftool isn't installed) and reproduces on a clean tree with the change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mid-run source-offline handling during classification: pauses for reconnection, retries within a bounded budget, then reports unreachable items and skips affected downstream processing without reopening dead sources.
  * Updated reclassification behavior to preserve predictions for items not reached and to clear/limit source-skipping to the affected photos/specs.
  * Downstream mask/keypoint extraction now filters out photos from offline folders.
* **UI**
  * Added a job “pause reason” banner in job details while pausing/paused.
* **Tests**
  * Expanded unit and end-to-end coverage for source-offline detection, pause/retry/recovery, downstream skipping, and reclassification correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->