### PR TITLE
Offer a darktable download from Settings

### DIFF
--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -1057,6 +1057,43 @@ git commit -m "feat: verify downloaded darktable against the API's SHA256 digest
 - Modify: `vireo/darktable_install.py`
 - Test: `vireo/tests/test_darktable_install.py`
 
+### OPEN QUESTION — decide this before writing the Linux path
+
+Task 3's code review surfaced a real performance problem that this task is the
+right place to solve.
+
+**The problem.** Task 3 sets `APPIMAGE_EXTRACT_AND_RUN=1` when invoking an
+AppImage (gated on `_is_appimage`, so only AppImage users pay). But when that
+variable is set, the AppImage type-2 runtime does not probe FUSE first — it
+*unconditionally* unpacks the whole squashfs to a temp dir, runs, and deletes.
+darktable's AppImage is ~178 MB, and the develop job calls `develop_photo` once
+per photo in a plain loop (`app.py`). So a 200-photo develop job on Linux
+extracts and deletes 178 MB **two hundred times**, and that overhead counts
+against the 120 s per-photo timeout.
+
+**The proposed alternative:** run `./X.AppImage --appimage-extract` **once at
+install time** here in Task 7, and point `darktable_bin` at
+`squashfs-root/usr/bin/darktable-cli`. If it works it is strictly better — that
+layout is what darktable's walk-up-from-`argv[0]` resource lookup expects, it
+survives `realpath`, it needs no `argv[1]` prefix, no FUSE at any version, and
+costs nothing per export. The trade is ~500 MB of disk, once.
+
+**Why it is not already decided:** darktable's `AppRun` does real setup before
+exec'ing — it sets `CAMLIBS`, `IOLIBS`, `GIO_EXTRA_MODULES`, and sources
+`apprun-hooks/linuxdeploy-plugin-gtk.sh`. The extracted `darktable-cli` may not
+run correctly without that environment, depending on whether linuxdeploy patched
+RPATH. **This is an empirical question that must be tested on real Linux** — it
+cannot be settled by reading.
+
+**What to do:** test it on Linux before implementing the Linux branch. If the
+extracted binary works, take it and simplify (Task 3's `argv[1]` prefix and env
+var become dead code for our own installs, though keep them for user-configured
+AppImages). If it does not, keep the current approach and note the per-photo cost
+in the plan so it is a known limitation rather than a surprise.
+
+**Do not silently pick one.** If you cannot test on Linux, say so and leave the
+current approach in place with the cost documented.
+
 - [ ] **Step 1: Write the failing tests**
 
 Append to `vireo/tests/test_darktable_install.py`:

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -1349,18 +1349,31 @@ def _clear_release_cache():
 
 Add `import pytest` to the file if it is not already there. Then:
 
+**CONTRACT CHANGE from Task 5's review.** `resolve_release()` returns a **2-tuple
+`(release_or_None, reason_or_None)`**, not a bare value. Bare `None` conflated
+four distinct outcomes — unsupported platform, no matching asset, asset rejected
+as suspicious, and network failure — so this route would have told a user behind
+a proxy or over GitHub's 60/hr rate limit *"No darktable build is published for
+this platform."* That is false, and it is the exact failure `CLAUDE.md` forbids.
+
+`darktable_install` exports the three reason strings as constants
+(`REASON_UNREACHABLE`, `REASON_NO_PLATFORM_BUILD`, `REASON_NO_USABLE_ASSET`) —
+compare against those, do not duplicate the literals. `resolve_release` also
+never raises now, so **the route's `except` clause is not a fallback you can rely
+on** — the reason string is.
+
 ```python
 def test_api_darktable_install_available_shape(app_and_db, monkeypatch):
     """The confirmation needs version, name, size, url and digest."""
     import darktable_install
     app, _ = app_and_db
-    monkeypatch.setattr(darktable_install, "resolve_release", lambda: {
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: ({
         "version": "5.6.0",
         "name": "darktable-5.6.0-arm64.dmg",
         "size": 87094261,
         "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
         "digest": "sha256:" + "a" * 64,
-    })
+    }, None))
 
     data = app.test_client().get('/api/darktable/install/available').get_json()
     assert data['available'] is True
@@ -1369,8 +1382,35 @@ def test_api_darktable_install_available_shape(app_and_db, monkeypatch):
     assert data['digest'].startswith("sha256:")
 
 
-def test_api_darktable_install_available_falls_back_when_api_unreachable(app_and_db, monkeypatch):
-    """Never a dead button: an unreachable API yields a reason, not a 500."""
+def test_api_darktable_install_available_reports_network_failure_honestly(app_and_db, monkeypatch):
+    """A user behind a proxy must not be told their platform is unsupported."""
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (None, darktable_install.REASON_UNREACHABLE))
+
+    resp = app.test_client().get('/api/darktable/install/available')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['available'] is False
+    assert data['reason'] == darktable_install.REASON_UNREACHABLE
+    assert 'platform' not in data['reason'].lower()
+
+
+def test_api_darktable_install_available_handles_unsupported_platform(app_and_db, monkeypatch):
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (None, darktable_install.REASON_NO_PLATFORM_BUILD))
+
+    data = app.test_client().get('/api/darktable/install/available').get_json()
+    assert data['available'] is False
+    assert data['reason'] == darktable_install.REASON_NO_PLATFORM_BUILD
+
+
+def test_api_darktable_install_available_survives_an_unexpected_raise(app_and_db, monkeypatch):
+    """Belt and braces: resolve_release should never raise, but if it does the
+    route must still 200 with a reason rather than 500 into a dead button."""
     import darktable_install
     app, _ = app_and_db
 
@@ -1380,19 +1420,8 @@ def test_api_darktable_install_available_falls_back_when_api_unreachable(app_and
 
     resp = app.test_client().get('/api/darktable/install/available')
     assert resp.status_code == 200
-    data = resp.get_json()
-    assert data['available'] is False
-    assert data['reason']
-
-
-def test_api_darktable_install_available_handles_unsupported_platform(app_and_db, monkeypatch):
-    import darktable_install
-    app, _ = app_and_db
-    monkeypatch.setattr(darktable_install, "resolve_release", lambda: None)
-
-    data = app.test_client().get('/api/darktable/install/available').get_json()
-    assert data['available'] is False
-    assert data['reason']
+    assert resp.get_json()['available'] is False
+    assert resp.get_json()['reason']
 ```
 
 - [ ] **Step 2: Run to verify they fail**
@@ -1415,19 +1444,22 @@ In `vireo/app.py`, immediately after `api_darktable_status` ends (line 15930):
         import darktable_install
 
         try:
-            release = darktable_install.resolve_release()
+            release, reason = darktable_install.resolve_release()
         except Exception as e:
+            # resolve_release is documented never to raise; this is belt and
+            # braces so an unexpected bug still degrades to a link, not a 500.
             log.warning("darktable release lookup failed: %s", e)
             return jsonify({
                 "available": False,
-                "reason": "Could not reach GitHub to check for a darktable release.",
+                "reason": darktable_install.REASON_UNREACHABLE,
             })
 
         if not release:
-            return jsonify({
-                "available": False,
-                "reason": "No darktable build is published for this platform.",
-            })
+            # Pass the reason through verbatim. Do NOT substitute a generic
+            # message: "we could not reach GitHub" and "no build exists for
+            # your platform" are different facts and users act on them
+            # differently.
+            return jsonify({"available": False, "reason": reason})
 
         return jsonify({"available": True, **release})
 ```
@@ -1442,15 +1474,23 @@ _RELEASE_CACHE_SECS = 600
 
 
 def resolve_release_cached():
-    import time
+    """resolve_release() with a short TTL, returning the same 2-tuple.
+
+    Only successes are cached. A transient outage or a rate-limit reply must
+    not pin the fallback link for ten minutes — and caching a failure would
+    also freeze its reason string, so a user who fixed their network would
+    keep being told GitHub is unreachable.
+    """
     now = time.monotonic()
     if _release_cache["value"] is not None and now - _release_cache["at"] < _RELEASE_CACHE_SECS:
-        return _release_cache["value"]
-    value = resolve_release()
-    if value is not None:
-        _release_cache.update(at=now, value=value)
-    return value
+        return _release_cache["value"], None
+    release, reason = resolve_release()
+    if release is not None:
+        _release_cache.update(at=now, value=release)
+    return release, reason
 ```
+
+Add `import time` at module level (it is not currently imported).
 
 Call `resolve_release_cached()` from the route above. Failures are deliberately
 not cached, so a transient outage does not pin the fallback link for ten minutes.
@@ -1497,11 +1537,11 @@ Append to `vireo/tests/test_darktable_api.py`:
 def test_api_job_download_darktable_returns_job_id(app_and_db, monkeypatch):
     import darktable_install
     app, _ = app_and_db
-    monkeypatch.setattr(darktable_install, "resolve_release", lambda: {
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: ({
         "version": "5.6.0", "name": "d.dmg", "size": 100,
         "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
         "digest": None,
-    })
+    }, None))
     monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: 10 ** 12)
     monkeypatch.setattr(darktable_install, "download", lambda *a, **k: ("/tmp/d.dmg", "ok"))
     monkeypatch.setattr(darktable_install, "hand_off",
@@ -1526,11 +1566,11 @@ def test_api_job_download_darktable_refuses_without_disk_space(app_and_db, monke
     """Refuse before downloading 87MB, and say what is needed vs free."""
     import darktable_install
     app, _ = app_and_db
-    monkeypatch.setattr(darktable_install, "resolve_release", lambda: {
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: ({
         "version": "5.6.0", "name": "d.dmg", "size": 87094261,
         "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
         "digest": None,
-    })
+    }, None))
     monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: 1024)
 
     resp = app.test_client().post('/api/jobs/download-darktable')
@@ -1541,10 +1581,13 @@ def test_api_job_download_darktable_refuses_without_disk_space(app_and_db, monke
 def test_api_job_download_darktable_400_when_unavailable(app_and_db, monkeypatch):
     import darktable_install
     app, _ = app_and_db
-    monkeypatch.setattr(darktable_install, "resolve_release", lambda: None)
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (None, darktable_install.REASON_NO_PLATFORM_BUILD))
 
     resp = app.test_client().post('/api/jobs/download-darktable')
     assert resp.status_code == 400
+    # The 400 body must carry the specific reason, not a generic message.
+    assert resp.get_json()['error'] == darktable_install.REASON_NO_PLATFORM_BUILD
 ```
 
 - [ ] **Step 2: Run to verify they fail**
@@ -1566,11 +1609,14 @@ In `vireo/app.py`, after `api_job_download_taxonomy`:
         active_ws = _get_db()._active_workspace_id
 
         try:
-            asset = darktable_install.resolve_release()
+            asset, reason = darktable_install.resolve_release()
         except Exception:
-            asset = None
+            asset, reason = None, darktable_install.REASON_UNREACHABLE
         if not asset:
-            return json_error("No darktable build is available for this platform.")
+            # Surface the specific reason. resolve_release distinguishes
+            # "could not reach GitHub" from "no build for your platform";
+            # collapsing them here would re-introduce the lie Task 5 fixed.
+            return json_error(reason or darktable_install.REASON_UNREACHABLE)
 
         # Refuse before spending 87MB, and say what is needed vs what is free.
         target = darktable_install.install_dir()

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -1015,6 +1015,21 @@ Download URLs are allowlisted to GitHub hosts under darktable-org/darktable."
 - Modify: `vireo/darktable_install.py`
 - Test: `vireo/tests/test_darktable_install.py`
 
+**Contract note for Tasks 7, 9 and 10: `ok=True` does NOT always mean
+"verified".** The no-digest-published case also returns `True`, because refusing
+would break the feature over something the user cannot fix. So downstream code
+must surface `detail` **verbatim** and must never render its own "Verified ✓"
+from the boolean — doing so would claim an integrity guarantee that was not
+obtained, which is precisely what this function's wording exists to prevent.
+
+**The mismatch test below is vacuous on its own** — verified by mutation.
+`"0"*64` differs from the real hash at character 0, so comparing only a prefix
+(`actual[:8] == want[:8]`) still passes it. Add a test parametrized over
+single-character differences at indices 0, 31, 32 and 63. Also test that a
+non-SHA256 algorithm prefix fails closed *and says so distinctly from a
+mismatch* — including a `blake2s:<64 hex>` value shaped exactly like a SHA256,
+where only the algorithm name can catch it.
+
 - [ ] **Step 1: Write the failing tests**
 
 Append to `vireo/tests/test_darktable_install.py`:

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -778,6 +778,22 @@ def test_select_asset_never_picks_zsync():
     assert asset["size"] > 10 * 1024 * 1024
 
 
+def test_select_asset_skips_zsync_listed_before_the_appimage():
+    """THE test above is vacuous on its own — verified by mutation.
+
+    The fixture lists each AppImage before its .zsync sibling, and
+    select_asset returns on the first suffix match, so a substring matcher
+    still returns the real AppImage and the test above passes. GitHub makes
+    no ordering promise, so re-sort the assets to put the decoys first.
+    """
+    from darktable_install import select_asset
+
+    release = _release()
+    release["assets"].sort(key=lambda a: not a["name"].endswith(".zsync"))
+    asset = select_asset(release, "linux", "x86_64")
+    assert asset["name"] == "Darktable-5.6.0-x86_64.AppImage"
+
+
 def test_select_asset_unknown_platform_returns_none():
     from darktable_install import select_asset
 

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -1595,13 +1595,23 @@ async function loadDarktableStatus() {
         '  </div>' +
         '  <div id="dtProgressText" style="font-size:12px;color:var(--text-dim);margin-top:4px;"></div>' +
         '</div>';
+      // The user's OWN configured path is the highest-priority probe and the
+      // one they are most likely asking about. find_darktable falls through
+      // silently when darktable_bin points at a path that no longer exists
+      // (develop.py), and checked_paths deliberately does not include it — so
+      // say it explicitly, or the panel never answers the actual question.
+      if (data.configured_bin) {
+        el.innerHTML += '<div style="color:var(--danger);font-size:12px;margin-top:6px;">' +
+          'Configured path not found: ' + escapeHtml(data.configured_bin) + '</div>';
+      }
       // Say where we looked, so a bare ✗ can explain itself.
+      // 'Checked:' not 'Checked PATH and:' — element 0 of checked_paths is
+      // already "$PATH (darktable-cli)" (Task 2 composes it in), so the older
+      // prefix named PATH twice and implied the rest were additional to it.
+      // Task 2 also guarantees the list is never empty, so no else branch.
       if (data.checked_paths && data.checked_paths.length) {
         el.innerHTML += '<div style="font-size:11px;color:var(--text-ghost);margin-top:6px;">' +
-          'Checked PATH and: ' + data.checked_paths.map(escapeHtml).join(', ') + '</div>';
-      } else {
-        el.innerHTML += '<div style="font-size:11px;color:var(--text-ghost);margin-top:6px;">' +
-          'Checked PATH for darktable-cli.</div>';
+          'Checked: ' + data.checked_paths.map(escapeHtml).join(', ') + '</div>';
       }
       needsGetOption = true;
     }

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -26,6 +26,11 @@
 - Flask routes live inside `create_app` in `vireo/app.py` and are registered with `@app.route`. Imports are function-local by convention in this file.
 - Every new route must be added to `vireo/tests/contracts/routes.txt` or a contract test fails.
 - Job progress should use `progress_event()` / `failure_event()` from `vireo/job_contract.py` for a consistent payload shape. (`vireo/tests/test_job_contract.py` unit-tests those helpers; it does not enforce their use across `app.py`, so this is convention, not a failing test.)
+- **Run `ruff check vireo/ tests/` before every commit.** That is exactly what CI
+  runs (`.github/workflows/test.yml:258`), and it is repo-wide — a lint error
+  anywhere fails the PR. Task 4 left it red with 6 errors (a `B904` plus 5
+  `I001` import-sort errors in new test code), caught only a review round later.
+  Linting just the files you touched is not sufficient.
 
 ---
 
@@ -536,6 +541,32 @@ def test_download_with_resume_cancels_midstream(tmp_path):
 `_start_test_server(handler_class, port=0)` returns `(server, port)`
 (`test_taxonomy.py:543-548`); the URL is built from the port, as above. Add
 `import pytest` at the top of the file if it is not already there.
+
+**These two tests are NOT sufficient — proven by mutation, not guessed.** During
+implementation, forcing `progress_base = downloaded_before` always (i.e. exactly
+the "bar past 100%" bug this step spends a paragraph warning about) passed both
+tests above. Four more are required, each closing a mutation that otherwise
+survives the whole suite:
+
+- `..._bytes_reset_when_server_ignores_range` — a server that ignores `Range` and
+  returns 200 on the retry. Assert the reported total never exceeds the real file
+  size and progress restarts from 0 rather than continuing from
+  `downloaded_before`.
+- **Pin `except DownloadCancelled: raise`** — pass a `progress_callback`, assert
+  no message contains `"retrying"`, and assert the server was hit exactly once.
+  Without it, deleting that clause still passes: the backoff cancel check catches
+  the exception one beat later, but the user is then told the *connection
+  dropped* after pressing Cancel.
+- **Pin the backoff cancel check** — a 500 handler plus a `should_cancel` that
+  flips after the first attempt. Assert it raises well under the 3 s backoff and
+  hit the server once. Without it, reverting to `time.sleep(3)` still passes,
+  masked by the re-raise. **Each of these two gaps hides the other's removal** —
+  the weakest possible state.
+- **Pin the throttle interval, not just its existence.** Extract it as a private
+  keyword-only `_emit_interval=0.25` param; assert `_emit_interval=0` fires ~once
+  per chunk and a huge value fires exactly once. Otherwise setting the interval to
+  `1e9` passes every test while the real 178 MB progress bar never moves until
+  completion — the exact failure Task 10 exists to prevent.
 
 - [ ] **Step 2: Run to verify they fail**
 

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -1223,6 +1223,9 @@ def download(asset, dest_dir=None, byte_callback=None, should_cancel=None):
     """
     from taxonomy import _download_with_resume
 
+    # NOTE from Task 4: should_cancel is checked BEFORE the first read, so an
+    # immediately-cancelled download leaves a 0-byte .partial. Do not treat an
+    # empty .partial as a corrupt-download signal — it is a normal resume state.
     dest_dir = dest_dir or install_dir()
     os.makedirs(dest_dir, exist_ok=True)
     dest = os.path.join(dest_dir, asset["name"])
@@ -1533,6 +1536,9 @@ In `vireo/app.py`, after `api_job_download_taxonomy`:
             )
 
         def work(job):
+            # NOTE from Task 4: byte_callback runs on the download thread
+            # inside the write loop. Keep it cheap — a queue put, never a DB
+            # write or anything that can block the transfer.
             def on_bytes(done, total):
                 runner.push_event(job["id"], "progress", progress_event(
                     phase="Downloading darktable",
@@ -1731,6 +1737,10 @@ async function downloadDarktable() {
   }
 
   safeEventSource('/api/jobs/' + resp.job_id + '/stream', {
+    // NOTE from Task 4: p.current can move BACKWARDS. When a server ignores
+    // Range, the retry truncates the .partial and restarts from 0, so the bar
+    // must tolerate a decreasing current rather than assuming monotonicity.
+    // That is honest — the bytes really were discarded — so do not clamp it.
     onProgress: function(p) {
       if (p.total) {
         fill.style.width = Math.round((p.current / p.total) * 100) + '%';

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -216,7 +216,27 @@ to the user, with a test asserting the two cannot drift."
 - Modify: `vireo/app.py:15910-15930`
 - Test: `vireo/tests/test_darktable_api.py`
 
-- [ ] **Step 1: Write the failing test**
+**Required reading before starting.** Task 1's code review established two
+constraints that this task exists to satisfy, and returning
+`darktable_search_paths()` raw would violate both:
+
+1. **It omits the two highest-priority probes.** `find_darktable` checks the
+   configured path and `shutil.which("darktable-cli")` *before* that list, and
+   neither appears in it. A panel saying "we checked here" while silently
+   omitting `$PATH` — the probe most likely to explain a Homebrew or distro
+   user's miss — answers a cheaper question than the one the user is reading,
+   which `CLAUDE.md` forbids.
+2. **On Linux it is empty until darktable is installed.** It returns the
+   AppImages actually present in `~/.vireo/tools/darktable`, so a fresh Linux box
+   gets `[]` — an empty "checked locations" list is *less* informative than the
+   bare ✗ this feature exists to fix, on exactly the platform where the download
+   matters most.
+
+So **the route composes the user-facing list**; the detector function stays the
+detector's concrete candidate list. Every entry the route adds must be something
+`find_darktable` genuinely probes, or the claim becomes a lie.
+
+- [ ] **Step 1: Write the failing tests**
 
 Append to `vireo/tests/test_darktable_api.py`:
 
@@ -230,25 +250,79 @@ def test_api_darktable_status_reports_checked_paths(app_and_db):
     assert 'checked_paths' in data
     assert isinstance(data['checked_paths'], list)
     assert all(isinstance(p, str) for p in data['checked_paths'])
+
+
+def test_api_darktable_status_checked_paths_mentions_path_probe(app_and_db):
+    """$PATH is the probe most likely to explain a miss, so it must be listed.
+
+    find_darktable tries shutil.which() before any filesystem candidate;
+    omitting it would make "we checked here" untrue by omission.
+    """
+    app, _ = app_and_db
+    data = app.test_client().get('/api/darktable/status').get_json()
+
+    assert any('PATH' in p for p in data['checked_paths'])
+
+
+def test_api_darktable_status_checked_paths_never_empty(app_and_db):
+    """Never render an empty 'we checked here' list.
+
+    darktable_search_paths() returns [] on a Linux box with no AppImage
+    installed — precisely the user this feature targets.
+    """
+    import develop
+    app, _ = app_and_db
+    original = develop.darktable_search_paths
+    develop.darktable_search_paths = lambda: []
+    try:
+        data = app.test_client().get('/api/darktable/status').get_json()
+    finally:
+        develop.darktable_search_paths = original
+
+    assert data['checked_paths'], "checked_paths must never be empty"
 ```
 
-- [ ] **Step 2: Run it to verify it fails**
+- [ ] **Step 2: Run them to verify they fail**
 
 Run: `python -m pytest vireo/tests/test_darktable_api.py -k checked_paths -v`
 Expected: FAIL — `KeyError`/assert on `'checked_paths' in data`.
 
 - [ ] **Step 3: Implement**
 
-In `vireo/app.py`, change the import on line 15913 and add one key to the returned dict:
+In `vireo/app.py`, change the import on line 15913:
 
 ```python
         from develop import find_darktable, find_dng_converter, darktable_search_paths
 ```
 
+Compose the user-facing list before the `return jsonify(...)`:
+
+```python
+        # What the user is told we checked must match what find_darktable
+        # actually probes: shutil.which first, then the filesystem candidates.
+        # darktable_search_paths() covers only the latter and is empty on a
+        # Linux box with no AppImage yet, so compose rather than return it raw.
+        checked_paths = ["$PATH (darktable-cli)"]
+        checked_paths.extend(darktable_search_paths())
+        if not sys.platform.startswith(("darwin", "win")) and os.name != "nt":
+            tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
+            if tools_dir not in checked_paths:
+                checked_paths.append(tools_dir)
+```
+
+and add the key to the returned dict:
+
 ```python
             "output_dir": cfg.get("darktable_output_dir"),
-            "checked_paths": darktable_search_paths(),
+            "checked_paths": checked_paths,
 ```
+
+Check whether `sys` and `os` are already imported at `app.py` module level; use
+whatever is already there rather than adding function-local imports if so.
+
+**If you find a cleaner way to express the Linux condition, take it** — the
+requirement is behavioral (the list always names `$PATH`, is never empty, and
+names the Linux tools directory on Linux), not a specific expression.
 
 - [ ] **Step 4: Run the tests**
 

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -585,7 +585,7 @@ def _download_with_resume(url, dest_path, progress_callback=None,
 
 Add to the docstring's Args:
 
-```
+```text
         byte_callback: optional ``callback(downloaded, total_or_None)`` for
             byte-level progress.  Throttled to ~4 Hz by the caller's clock.
         should_cancel: optional ``callback() -> bool``.  When it returns True
@@ -1516,7 +1516,7 @@ server-side so the URL it downloads is never a stale client-supplied value.
 
 Insert into `vireo/tests/contracts/routes.txt` in sorted position (next to line 38's `GET /api/darktable/status`), matching the file's existing column alignment:
 
-```
+```text
 GET          /api/darktable/install/available
 ```
 
@@ -1695,7 +1695,7 @@ In `vireo/app.py`, after `api_job_download_taxonomy`:
 
 Add to `vireo/tests/contracts/routes.txt` next to the other download jobs (line ~258):
 
-```
+```text
 POST         /api/jobs/download-darktable
 ```
 

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -1826,6 +1826,10 @@ async function downloadDarktable() {
                a.name + ' (' + Math.round(a.size / 1048576) + ' MB)\n' +
                'From: github.com/darktable-org/darktable\n\n' + what)) return;
 
+  // NOTE from Task 9: there is no server-side duplicate-click guard (no other
+  // download job in app.py has one). Two rapid POSTs start two jobs writing the
+  // same .partial; the digest check catches it but BOTH report an error. Hiding
+  // the button here is what prevents that, so do not remove it.
   document.getElementById('darktableGet').style.display = 'none';
   var wrap = document.getElementById('darktableProgress');
   var fill = document.getElementById('dtProgressFill');
@@ -1868,8 +1872,10 @@ async function downloadDarktable() {
         // jobs.py:526 sets status 'cancelled' with empty errors and no
         // failure, so this must be handled before the failure branch or a
         // user-initiated cancel would read as "Download failed".
+        // A cancelled download keeps its .partial and a re-run RESUMES it
+        // (Task 4). Do not imply the bytes were thrown away.
         fill.style.width = '0%';
-        text.innerHTML = 'Download cancelled.' +
+        text.innerHTML = 'Download cancelled — partial progress kept, retrying will resume.' +
           '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Try again</button>';
         return;
       }

--- a/docs/superpowers/plans/2026-07-26-darktable-download.md
+++ b/docs/superpowers/plans/2026-07-26-darktable-download.md
@@ -1,0 +1,1786 @@
+# Download darktable from Settings — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the dead-end "✗ darktable-cli not found" row in Settings into a working download-and-install affordance.
+
+**Architecture:** A new `vireo/darktable_install.py` resolves the correct asset from the GitHub releases API, downloads it with byte-level progress through the existing `_download_with_resume` helper (extended with progress and cancellation hooks), verifies it against the API's published SHA256 digest, and hands off to the platform's installer. Two Flask routes back it: one returning what would be downloaded, one running it as a JobRunner job with SSE progress. Detection in `develop.py` is fixed first, because without it a successful install still reports "not found".
+
+**Tech Stack:** Python 3 / Flask, `urllib.request`, `hashlib`, SQLite-free (no schema changes), vanilla JS + SSE in `settings.html`, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-darktable-download-design.md`
+
+---
+
+## Background you need
+
+**Read the spec first.** It records two traps and one reversal that are not obvious from the code:
+
+1. **The AppImage/`realpath` collision.** `find_darktable` calls `os.path.realpath()` deliberately (see its docstring). darktable's AppImage picks which bundled binary to run from `argv[1]` *or* from the basename of the symlink used to invoke it. So a `darktable-cli` symlink pointing at the AppImage gets resolved away by `realpath`, and darktable launches its **GUI** instead of the CLI — which hangs a headless export job until the 120 s timeout. Task 3 solves this via `argv[1]`, which survives `realpath`.
+2. **The macOS detection gap.** `find_darktable` never probes `/Applications/darktable.app/`, though `find_dng_converter` probes its Adobe equivalent. A normal `.dmg` install is invisible. This is Task 1 and must land first.
+3. **No code-signature check.** darktable does not successfully notarize its macOS builds and its Windows installer is unsigned. A fail-closed `spctl`/Authenticode check would delete every legitimate download. Integrity comes from the GitHub API's `digest` field instead. **Do not add a signature check.**
+
+**Repo conventions:**
+- Run tests from the repo root: `python -m pytest vireo/tests/test_develop.py -v`
+- `vireo/tests/test_develop.py` imports modules bare (`from develop import ...`) because of the `sys.path.insert` at its top. Follow that.
+- Flask routes live inside `create_app` in `vireo/app.py` and are registered with `@app.route`. Imports are function-local by convention in this file.
+- Every new route must be added to `vireo/tests/contracts/routes.txt` or a contract test fails.
+- Job progress should use `progress_event()` / `failure_event()` from `vireo/job_contract.py` for a consistent payload shape. (`vireo/tests/test_job_contract.py` unit-tests those helpers; it does not enforce their use across `app.py`, so this is convention, not a failing test.)
+
+---
+
+## File structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `vireo/develop.py` (modify) | Detection + command construction. Gains `darktable_search_paths()`, `/Applications` probe, AppImage `argv[1]` handling | 1, 3 |
+| `vireo/taxonomy.py` (modify) | Gains `byte_callback` / `should_cancel` on `_download_with_resume` | 4 |
+| `vireo/darktable_install.py` (**new**) | Release resolution, digest verification, download, platform hand-off. No Flask, no DB — pure functions, easy to test | 5, 6, 7 |
+| `vireo/app.py` (modify) | Two new routes + `checked_paths` on the existing status route | 2, 8, 9 |
+| `vireo/templates/settings.html` (modify) | Button, confirmation, progress, re-check, Adobe link | 10, 11 |
+| `vireo/tests/test_darktable_install.py` (**new**) | Unit tests for the new module | 5, 6, 7 |
+| `vireo/tests/test_develop.py` (modify) | Detection + AppImage command tests | 1, 3 |
+| `vireo/tests/test_taxonomy.py` (modify) | New downloader hooks | 4 |
+| `vireo/tests/test_darktable_api.py` (modify) | New route tests | 2, 8, 9 |
+| `vireo/tests/contracts/routes.txt` (modify) | Route contract | 8, 9 |
+
+`darktable_install.py` deliberately holds no Flask or DB code so every function is directly unit-testable without a test client or temp database.
+
+---
+
+## Task 1: Fix darktable detection
+
+Without this, Tasks 8–10 ship a button that downloads 87 MB and still reports "not found".
+
+**Files:**
+- Modify: `vireo/develop.py:39-75`
+- Test: `vireo/tests/test_develop.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `vireo/tests/test_develop.py`:
+
+```python
+def test_find_darktable_finds_macos_app_bundle(monkeypatch):
+    """A normal macOS .dmg install is found even though it is not on PATH."""
+    from develop import find_darktable
+
+    bundle = "/Applications/darktable.app/Contents/MacOS/darktable-cli"
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr("os.path.isfile", lambda p: p == bundle)
+    monkeypatch.setattr("os.path.realpath", lambda p: p)
+
+    assert find_darktable("") == bundle
+
+
+def test_find_darktable_configured_path_wins_over_bundle(tmp_path, monkeypatch):
+    """An explicitly configured path takes precedence over the bundle probe."""
+    from develop import find_darktable
+
+    configured = tmp_path / "darktable-cli"
+    configured.touch()
+    monkeypatch.setattr("sys.platform", "darwin")
+
+    assert find_darktable(str(configured)) == str(configured)
+
+
+def test_darktable_search_paths_matches_find_darktable(monkeypatch):
+    """checked_paths cannot drift from what find_darktable actually probes.
+
+    Every candidate reported to the user must be one find_darktable would
+    accept; otherwise the "we checked here" message is a lie.
+    """
+    from develop import darktable_search_paths, find_darktable
+
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    monkeypatch.setattr("sys.platform", "darwin")
+    paths = darktable_search_paths()
+    assert paths, "expected at least one candidate on darwin"
+
+    for candidate in paths:
+        monkeypatch.setattr("os.path.isfile", lambda p, c=candidate: p == c)
+        monkeypatch.setattr("os.path.realpath", lambda p: p)
+        assert find_darktable("") == candidate
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_develop.py -k "bundle or search_paths" -v`
+Expected: FAIL — `ImportError: cannot import name 'darktable_search_paths'` and the bundle test returns `None`.
+
+- [ ] **Step 3: Implement**
+
+In `vireo/develop.py`, add `import sys` to the imports if absent, then insert `darktable_search_paths` immediately before `find_darktable` and rewrite `find_darktable`'s fallback to consume it:
+
+```python
+def darktable_search_paths():
+    """Locations probed for darktable-cli, in priority order.
+
+    Exposed so the UI can tell the user exactly where we looked when the
+    binary is not found, instead of repeating a bare "not found".
+    ``find_darktable`` walks this same list, so the two cannot drift.
+    """
+    candidates = []
+    # os.name is checked FIRST, not sys.platform. test_find_darktable_detects_
+    # standard_windows_install patches develop.os.name = "nt" while leaving
+    # sys.platform as the host's value, so a leading darwin branch would
+    # shadow the Windows candidates and break that test on a Mac.
+    if os.name == "nt":
+        for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
+            base = os.environ.get(env_var)
+            if base:
+                candidates.extend([
+                    os.path.join(base, "darktable", "bin", "darktable-cli.exe"),
+                    os.path.join(base, "darktable", "darktable-cli.exe"),
+                ])
+    elif sys.platform == "darwin":
+        candidates.extend([
+            "/Applications/darktable.app/Contents/MacOS/darktable-cli",
+            os.path.expanduser("~/Applications/darktable.app/Contents/MacOS/darktable-cli"),
+        ])
+    else:
+        # Linux: an AppImage we installed ourselves. Newest mtime wins, since
+        # installers are kept and this directory accumulates versions.
+        tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
+        if os.path.isdir(tools_dir):
+            appimages = [
+                os.path.join(tools_dir, n)
+                for n in os.listdir(tools_dir)
+                if n.endswith(".AppImage")
+            ]
+            appimages.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+            candidates.extend(appimages)
+    return candidates
+```
+
+Then replace the `if os.name == "nt":` block inside `find_darktable` (currently lines 63-74) with:
+
+```python
+    for candidate in darktable_search_paths():
+        if os.path.isfile(candidate):
+            return os.path.realpath(candidate)
+    return None
+```
+
+Leave the configured-path check and the `shutil.which` probe above it untouched.
+
+- [ ] **Step 4: Neutralize the new probe in two pre-existing tests**
+
+`test_find_darktable_returns_none_when_missing` (`test_develop.py:7-12`) and
+`test_find_darktable_returns_none_for_bad_configured_path` (`:71-76`) only patch
+`shutil.which`. Once the `/Applications` probe exists they will find a real
+darktable on any Mac that has one — including this machine after Task 10's manual
+verification. That is a genuinely under-specified test, not a weakened assertion:
+both intend "nothing is installed anywhere", so make them say it.
+
+Add to each of those two tests:
+
+```python
+    import develop
+    monkeypatch.setattr(develop, "darktable_search_paths", list)
+```
+
+(`test_find_darktable_returns_none_for_bad_configured_path` will need
+`monkeypatch` added to its signature if it does not already take it.)
+
+This is the one sanctioned edit to an existing test in this plan. Do not touch
+any other assertion.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python -m pytest vireo/tests/test_develop.py -v`
+Expected: PASS, including all pre-existing tests — notably
+`test_find_darktable_detects_standard_windows_install`, which the branch ordering
+above is written to preserve.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vireo/develop.py vireo/tests/test_develop.py
+git commit -m "fix: detect darktable installed as a macOS app bundle
+
+find_dng_converter probed /Applications for the Adobe app, but
+find_darktable only tried PATH and Windows Program Files, so a normal
+macOS .dmg install of darktable reported 'not found'.
+
+Adds darktable_search_paths() so the probed locations can also be shown
+to the user, with a test asserting the two cannot drift."
+```
+
+---
+
+## Task 2: Report the searched locations to the user
+
+**Files:**
+- Modify: `vireo/app.py:15910-15930`
+- Test: `vireo/tests/test_darktable_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `vireo/tests/test_darktable_api.py`:
+
+```python
+def test_api_darktable_status_reports_checked_paths(app_and_db):
+    """The status route says where it looked, so a bare 'not found' can explain itself."""
+    app, _ = app_and_db
+    client = app.test_client()
+    data = client.get('/api/darktable/status').get_json()
+
+    assert 'checked_paths' in data
+    assert isinstance(data['checked_paths'], list)
+    assert all(isinstance(p, str) for p in data['checked_paths'])
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_darktable_api.py -k checked_paths -v`
+Expected: FAIL — `KeyError`/assert on `'checked_paths' in data`.
+
+- [ ] **Step 3: Implement**
+
+In `vireo/app.py`, change the import on line 15913 and add one key to the returned dict:
+
+```python
+        from develop import find_darktable, find_dng_converter, darktable_search_paths
+```
+
+```python
+            "output_dir": cfg.get("darktable_output_dir"),
+            "checked_paths": darktable_search_paths(),
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `python -m pytest vireo/tests/test_darktable_api.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_darktable_api.py
+git commit -m "feat: report probed darktable locations from the status route"
+```
+
+---
+
+## Task 3: Run darktable-cli from an AppImage
+
+**Files:**
+- Modify: `vireo/develop.py:118-136` (`build_command`) and `vireo/develop.py:311` (`subprocess.run`)
+- Test: `vireo/tests/test_develop.py`
+
+**Why `argv[1]` and not a symlink:** see "Background" above. A symlink named `darktable-cli` would be resolved away by `os.path.realpath` in `find_darktable`, silently launching the GUI.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `vireo/tests/test_develop.py`:
+
+```python
+def test_build_command_selects_cli_inside_appimage():
+    """darktable's AppImage picks its binary from argv[1]; without this we
+    would launch the GUI and hang the export job."""
+    from develop import build_command
+
+    cmd = build_command(
+        "/home/u/.vireo/tools/darktable/Darktable-5.6.0-x86_64.AppImage",
+        "in.raw", "out.jpg",
+    )
+    assert cmd[1] == "darktable-cli"
+    assert cmd[2:] == ["in.raw", "out.jpg"]
+
+
+def test_build_command_plain_binary_unchanged():
+    from develop import build_command
+
+    cmd = build_command("/usr/bin/darktable-cli", "in.raw", "out.jpg")
+    assert cmd == ["/usr/bin/darktable-cli", "in.raw", "out.jpg"]
+
+
+def test_build_command_appimage_keeps_style_and_width():
+    """Optional args must land after the positional args, not before."""
+    from develop import build_command
+
+    cmd = build_command("/x/D.AppImage", "in.raw", "out.jpg", style="Wild", width=2048)
+    assert cmd == ["/x/D.AppImage", "darktable-cli", "in.raw", "out.jpg",
+                   "--style", "Wild", "--width", "2048"]
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_develop.py -k build_command -v`
+Expected: FAIL — `cmd[1]` is `"in.raw"`, not `"darktable-cli"`.
+
+- [ ] **Step 3: Implement**
+
+Replace the body of `build_command` in `vireo/develop.py` (line 131):
+
+```python
+    cmd = [darktable_bin]
+    if darktable_bin.endswith(".AppImage"):
+        # darktable ships a multi-binary AppImage whose AppRun selects the
+        # binary from argv[1]. The alternative (a symlink named darktable-cli)
+        # does not survive find_darktable's os.path.realpath, which would
+        # silently launch the GUI and hang the job.
+        cmd.append("darktable-cli")
+    cmd.extend([input_path, output_path])
+```
+
+Leave the `style` / `width` `extend` calls that follow unchanged.
+
+- [ ] **Step 4: Set the FUSE fallback at the call site**
+
+`build_command` returns a list and never touches the environment, so this is a separate change. In `vireo/develop.py`, replace the `subprocess.run` at line 311 (inside `develop_photo`):
+
+```python
+        # AppImages need FUSE2 to self-mount; many current distros ship only
+        # FUSE3. This makes the AppImage extract to a temp dir instead of
+        # failing outright. Harmless for non-AppImage binaries.
+        env = {**os.environ, "APPIMAGE_EXTRACT_AND_RUN": "1"}
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=120,
+            env=env, **no_window_kwargs()
+        )
+```
+
+**Do not touch the `subprocess.run` at line 230** — that one is the Adobe DNG Converter.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `python -m pytest vireo/tests/test_develop.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vireo/develop.py vireo/tests/test_develop.py
+git commit -m "feat: invoke darktable-cli inside an AppImage via argv[1]
+
+darktable's AppImage AppRun selects its binary from argv[1] or from the
+basename of the symlink used to invoke it. The symlink route does not
+survive find_darktable's os.path.realpath, which would launch the GUI
+and hang a headless export until the 120s timeout."
+```
+
+---
+
+## Task 4: Byte progress and cancellation in the shared downloader
+
+**Files:**
+- Modify: `vireo/taxonomy.py:39-150`
+- Test: `vireo/tests/test_taxonomy.py`
+
+The existing `progress_callback(message)` contract stays **exactly** as-is so the seven current `test_download_with_resume_*` tests and both callers (`taxonomy.py:458`, `taxonomy.py:944`) keep working untouched. Two keyword-only params are added.
+
+- [ ] **Step 1: Write the failing tests**
+
+**First read `_start_test_server` (`vireo/tests/test_taxonomy.py:539-548`) and one
+existing `test_download_with_resume_*` test.** These tests do not mock `urlopen` —
+they spin a real `http.server` on a random port. Reuse that harness; do not
+introduce a second mocking style.
+
+Append to `vireo/tests/test_taxonomy.py`:
+
+```python
+def test_download_with_resume_reports_bytes(tmp_path):
+    """byte_callback gets real byte counts — this is what the progress bar reads."""
+    import http.server
+    from taxonomy import _download_with_resume
+
+    payload = b"x" * 500_000
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    try:
+        seen = []
+        dest = tmp_path / "out.bin"
+        # chunk_size small enough to force several loop iterations
+        _download_with_resume(
+            f"http://127.0.0.1:{port}/x", str(dest), chunk_size=4096,
+            byte_callback=lambda done, total: seen.append((done, total)),
+        )
+    finally:
+        server.shutdown()
+
+    assert seen, "byte_callback was never called"
+    assert seen[-1][0] == len(payload)
+    assert seen[-1][1] == len(payload)          # from Content-Length
+    assert [d for d, _ in seen] == sorted(d for d, _ in seen)
+
+
+def test_download_with_resume_cancels_midstream(tmp_path):
+    """should_cancel aborts and keeps a non-empty .partial for resume."""
+    import http.server
+    from taxonomy import DownloadCancelled, _download_with_resume
+
+    payload = b"x" * 500_000
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    calls = {"n": 0}
+
+    def cancel_after_two_chunks():
+        calls["n"] += 1
+        return calls["n"] > 2
+
+    try:
+        dest = tmp_path / "out.bin"
+        with pytest.raises(DownloadCancelled):
+            _download_with_resume(
+                f"http://127.0.0.1:{port}/x", str(dest), chunk_size=4096,
+                should_cancel=cancel_after_two_chunks,
+            )
+    finally:
+        server.shutdown()
+
+    assert not dest.exists()
+    partial = tmp_path / "out.bin.partial"
+    assert partial.exists()
+    # Non-empty proves we cancelled mid-stream, not before the first read —
+    # open(..., "wb") would create a 0-byte file either way.
+    assert partial.stat().st_size > 0
+```
+
+`_start_test_server(handler_class, port=0)` returns `(server, port)`
+(`test_taxonomy.py:543-548`); the URL is built from the port, as above. Add
+`import pytest` at the top of the file if it is not already there.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_taxonomy.py -k "reports_bytes or cancels" -v`
+Expected: FAIL — `TypeError: unexpected keyword argument 'byte_callback'`.
+
+- [ ] **Step 3: Implement**
+
+Change the signature at `vireo/taxonomy.py:39`:
+
+```python
+def _download_with_resume(url, dest_path, progress_callback=None,
+                          max_stalled=3, chunk_size=256 * 1024,
+                          *, byte_callback=None, should_cancel=None):
+```
+
+Add to the docstring's Args:
+
+```
+        byte_callback: optional ``callback(downloaded, total_or_None)`` for
+            byte-level progress.  Throttled to ~4 Hz by the caller's clock.
+        should_cancel: optional ``callback() -> bool``.  When it returns True
+            the download aborts, leaving the ``.partial`` file for resume.
+```
+
+Add a cancellation sentinel near the top of the module:
+
+```python
+class DownloadCancelled(Exception):
+    """Raised when should_cancel() asked us to stop."""
+```
+
+Replace the chunk loop (lines 96-102):
+
+```python
+                with open(partial_path, mode) as f:
+                    last_emit = 0.0
+                    while True:
+                        if should_cancel is not None and should_cancel():
+                            raise DownloadCancelled("Download cancelled")
+                        chunk = resp.read(chunk_size)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        received += len(chunk)
+                        if byte_callback is not None:
+                            now = time.monotonic()
+                            if now - last_emit >= 0.25:
+                                last_emit = now
+                                byte_callback(progress_base + received, expected_total)
+                    if byte_callback is not None:
+                        byte_callback(progress_base + received, expected_total)
+```
+
+`progress_base` and `expected_total` are computed next to `expected_bytes`
+(line 92). **This is subtler than it looks.** `mode` is `"wb"` whenever the
+status is not 206 (line 94), which *truncates* the partial file — but
+`downloaded_before` is deliberately not reset, because it is the stall-detection
+baseline (see the comment at lines 87-89). So on a server that ignores `Range`,
+`downloaded_before + received` would over-report and drive the bar past 100%.
+`test_download_with_resume_server_ignores_range` (`test_taxonomy.py:742`) proves
+that branch is live. Use a separate variable for display:
+
+```python
+                # Bytes already on disk that we are keeping. Distinct from
+                # downloaded_before, which stays put as the stall baseline even
+                # when mode == "wb" truncates the partial.
+                progress_base = downloaded_before if resp.status == 206 else 0
+                expected_total = (
+                    expected_bytes + progress_base
+                    if expected_bytes is not None
+                    else None
+                )
+```
+
+Throttling to 4 Hz matters: the SSE subscriber queue is `maxsize=200` (`jobs.py:898`), and an unthrottled 178 MB download would drop events.
+
+Finally, make cancellation escape the retry loop — in the `except Exception as e:` handler at line 111, re-raise immediately before any retry bookkeeping:
+
+```python
+        except DownloadCancelled:
+            raise
+        except Exception as e:
+```
+
+And check before sleeping, so a cancel during backoff is honoured — replace `time.sleep(3)` at line 139:
+
+```python
+            for _ in range(6):
+                if should_cancel is not None and should_cancel():
+                    raise DownloadCancelled("Download cancelled")
+                time.sleep(0.5)
+            continue
+```
+
+- [ ] **Step 4: Run the full taxonomy suite**
+
+Run: `python -m pytest vireo/tests/test_taxonomy.py -v`
+Expected: PASS, **including all seven pre-existing `test_download_with_resume_*` tests unmodified**. If any of them changed behaviour, the contract was broken — revert and rethink rather than editing those tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/taxonomy.py vireo/tests/test_taxonomy.py
+git commit -m "feat: byte-level progress and cancellation in _download_with_resume
+
+Adds optional keyword-only byte_callback and should_cancel. The existing
+progress_callback(message) contract is untouched, so both current callers
+and the seven existing tests keep working unmodified.
+
+Byte events are throttled to 4 Hz because the SSE subscriber queue is
+bounded at 200."
+```
+
+---
+
+## Task 5: Resolve the right release asset
+
+**Files:**
+- Create: `vireo/darktable_install.py`
+- Create: `vireo/tests/test_darktable_install.py`
+- Create: `vireo/tests/fixtures/darktable_release.json`
+
+- [ ] **Step 1: Create the fixture**
+
+`vireo/tests/fixtures/` does not exist yet — create the directory (no
+`__init__.py` needed). Save a trimmed real API response to
+`vireo/tests/fixtures/darktable_release.json`. It **must** include the `.zsync`
+decoys — they are the point of one of the tests:
+
+```json
+{
+  "tag_name": "release-5.6.0",
+  "assets": [
+    {"name": "Darktable-5.6.0-aarch64.AppImage", "size": 170895880,
+     "digest": "sha256:147943bd2eedc33c8d31eb3e6b87b591ac9ca285d00282b2655d8d19caecfca0",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-aarch64.AppImage"},
+    {"name": "Darktable-5.6.0-aarch64.AppImage.zsync", "size": 292297,
+     "digest": "sha256:52a2b5da0dd55c984f3d4c6e77bbd1119b4561cf17c80146a09c9e498ae56da4",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-aarch64.AppImage.zsync"},
+    {"name": "darktable-5.6.0-arm64.dmg", "size": 87094261,
+     "digest": "sha256:49aec447e891ab481e436b4c0231fc3c8d0001aad220762ae8e765d3bda5d102",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-arm64.dmg"},
+    {"name": "darktable-5.6.0-x86_64.dmg", "size": 92795715,
+     "digest": "sha256:24c83655af0d81c2f8cb78b97531a03bb6a650349b7fd49c1679080db675cbcb",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-x86_64.dmg"},
+    {"name": "darktable-5.6.0-win64.exe", "size": 141543364,
+     "digest": "sha256:b42989195dfff44540c0b767b407987329ca99853612304cbbf14c48d1d3f803",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-win64.exe"},
+    {"name": "darktable-5.6.0-woa64.exe", "size": 106943215,
+     "digest": "sha256:b7737d54d6ee007816ae0a1fad3ca3677588735e1432887a917bc55f818f5268",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-woa64.exe"},
+    {"name": "Darktable-5.6.0-x86_64.AppImage", "size": 177752568,
+     "digest": "sha256:cbad7bf4be2607e1725db156d73c799d267a79fc29a572c3136a5deb9c9be948",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-x86_64.AppImage"},
+    {"name": "Darktable-5.6.0-x86_64.AppImage.zsync", "size": 304013,
+     "digest": "sha256:35b038a00c6a8a73bf1b7e2a9ad1d05db471d59ec3feec9edb3df594aee715b9",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-x86_64.AppImage.zsync"},
+    {"name": "darktable-5.6.0.tar.xz", "size": 8179036,
+     "digest": "sha256:157d6d3847af8afcabe78944454786f73a886e08a504b4bd6114c2065fe006e4",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0.tar.xz"}
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `vireo/tests/test_darktable_install.py`:
+
+```python
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures", "darktable_release.json")
+
+
+def _release():
+    with open(FIXTURE) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("platform,machine,expected", [
+    ("darwin", "arm64",   "darktable-5.6.0-arm64.dmg"),
+    ("darwin", "x86_64",  "darktable-5.6.0-x86_64.dmg"),
+    ("win32",  "AMD64",   "darktable-5.6.0-win64.exe"),
+    ("win32",  "ARM64",   "darktable-5.6.0-woa64.exe"),
+    ("linux",  "x86_64",  "Darktable-5.6.0-x86_64.AppImage"),
+    ("linux",  "aarch64", "Darktable-5.6.0-aarch64.AppImage"),
+])
+def test_select_asset_matrix(platform, machine, expected):
+    from darktable_install import select_asset
+
+    asset = select_asset(_release(), platform, machine)
+    assert asset["name"] == expected
+
+
+def test_select_asset_never_picks_zsync():
+    """The release ships ~300KB .zsync manifests next to the 178MB AppImages.
+    A substring match would 'successfully install' a file that is not darktable."""
+    from darktable_install import select_asset
+
+    asset = select_asset(_release(), "linux", "x86_64")
+    assert not asset["name"].endswith(".zsync")
+    assert asset["size"] > 10 * 1024 * 1024
+
+
+def test_select_asset_unknown_platform_returns_none():
+    from darktable_install import select_asset
+
+    assert select_asset(_release(), "sunos5", "sparc") is None
+    assert select_asset(_release(), "linux", "riscv64") is None
+
+
+def test_select_asset_rejects_implausibly_small_asset():
+    from darktable_install import select_asset
+
+    release = _release()
+    for a in release["assets"]:
+        if a["name"] == "darktable-5.6.0-arm64.dmg":
+            a["size"] = 1024
+    assert select_asset(release, "darwin", "arm64") is None
+
+
+@pytest.mark.parametrize("url", [
+    "https://evil.example.com/darktable-5.6.0-arm64.dmg",
+    "https://github.com/attacker/darktable/releases/download/x/darktable-5.6.0-arm64.dmg",
+    "http://github.com/darktable-org/darktable/releases/download/x/darktable-5.6.0-arm64.dmg",
+])
+def test_select_asset_rejects_untrusted_url(url):
+    from darktable_install import select_asset
+
+    release = _release()
+    for a in release["assets"]:
+        if a["name"] == "darktable-5.6.0-arm64.dmg":
+            a["browser_download_url"] = url
+    assert select_asset(release, "darwin", "arm64") is None
+
+
+def test_select_asset_accepts_objects_githubusercontent():
+    from darktable_install import select_asset
+
+    release = _release()
+    for a in release["assets"]:
+        if a["name"] == "darktable-5.6.0-arm64.dmg":
+            a["browser_download_url"] = (
+                "https://objects.githubusercontent.com/darktable-org/darktable/x.dmg"
+            )
+    assert select_asset(release, "darwin", "arm64") is not None
+
+
+def test_select_asset_tolerates_missing_digest():
+    from darktable_install import select_asset
+
+    release = _release()
+    for a in release["assets"]:
+        a.pop("digest", None)
+    asset = select_asset(release, "darwin", "arm64")
+    assert asset is not None
+    assert asset.get("digest") is None
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_darktable_install.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'darktable_install'`.
+
+- [ ] **Step 4: Implement**
+
+Create `vireo/darktable_install.py`:
+
+```python
+"""Download and install darktable from its official GitHub releases.
+
+darktable is GPL and publishes signed-by-nobody but digest-bearing release
+assets on GitHub.  We resolve the latest release at request time rather than
+pinning a version, and verify integrity against the SHA256 digest the GitHub
+API publishes alongside each asset.
+
+There is deliberately no code-signature check: darktable does not successfully
+notarize its macOS builds (upstream issue #19295) and its Windows installer is
+unsigned, so a fail-closed signature check would reject every legitimate
+download.  See docs/superpowers/specs/2026-07-26-darktable-download-design.md.
+"""
+
+import json
+import logging
+import os
+import ssl
+import urllib.parse
+import urllib.request
+
+import certifi
+
+log = logging.getLogger(__name__)
+
+# Use certifi's CA bundle so HTTPS works on macOS without running
+# Install Certificates.command — same convention as taxonomy.py:35,
+# labels.py:17, model_verify.py:29 and places.py:57. Without it this
+# silently degrades to "Could not reach GitHub" on affected installs.
+_ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+
+RELEASES_API = "https://api.github.com/repos/darktable-org/darktable/releases/latest"
+
+_ALLOWED_HOSTS = {"github.com", "objects.githubusercontent.com"}
+_ALLOWED_PATH_PREFIX = "/darktable-org/darktable/"
+
+# Anything smaller than this is not a darktable build.  Guards against the
+# ~300KB .zsync manifests and against a truncated or renamed asset.
+_MIN_ASSET_BYTES = 10 * 1024 * 1024
+
+# (sys.platform, platform.machine()) -> required asset-name suffix.
+# Exact suffixes, never substrings: "Darktable-5.6.0-x86_64.AppImage.zsync"
+# contains "AppImage" but is a 300KB delta manifest, not the application.
+_ASSET_SUFFIXES = {
+    ("darwin", "arm64"): "-arm64.dmg",
+    ("darwin", "x86_64"): "-x86_64.dmg",
+    ("win32", "amd64"): "-win64.exe",
+    ("win32", "arm64"): "-woa64.exe",
+    ("linux", "x86_64"): "-x86_64.AppImage",
+    ("linux", "aarch64"): "-aarch64.AppImage",
+}
+
+
+def _url_is_trusted(url):
+    """True only for HTTPS URLs on a GitHub host under the darktable repo.
+
+    Enforced on the API-supplied browser_download_url only.  GitHub redirects
+    release downloads to release-assets.githubusercontent.com, so applying
+    this to redirect targets would reject every legitimate download.
+    """
+    try:
+        parts = urllib.parse.urlparse(url or "")
+    except ValueError:
+        return False
+    if parts.scheme != "https" or parts.hostname not in _ALLOWED_HOSTS:
+        return False
+    return parts.path.startswith(_ALLOWED_PATH_PREFIX)
+
+
+def select_asset(release, platform_name, machine):
+    """Pick the asset matching this platform, or None.
+
+    Returns a dict with name/size/url/digest, or None when this platform has
+    no build, the only match is implausibly small, or the URL is untrusted.
+    """
+    suffix = _ASSET_SUFFIXES.get((platform_name, str(machine).lower()))
+    if not suffix:
+        log.info("No darktable asset for platform=%s machine=%s", platform_name, machine)
+        return None
+
+    for asset in release.get("assets", []):
+        name = asset.get("name", "")
+        if not name.endswith(suffix):
+            continue
+        size = asset.get("size", 0)
+        if size < _MIN_ASSET_BYTES:
+            log.warning("Rejecting %s: %d bytes is too small to be darktable", name, size)
+            return None
+        url = asset.get("browser_download_url", "")
+        if not _url_is_trusted(url):
+            log.warning("Rejecting %s: untrusted download URL %r", name, url)
+            return None
+        return {
+            "name": name,
+            "size": size,
+            "url": url,
+            "digest": asset.get("digest"),
+        }
+    return None
+
+
+def resolve_release(timeout=15):
+    """Fetch the latest release and select this machine's asset.
+
+    Returns {version, name, size, url, digest} or None.  Never raises for
+    network problems — the caller turns None into a plain "Get darktable"
+    link rather than a dead button.
+    """
+    import platform as platform_mod
+    import sys
+
+    try:
+        req = urllib.request.Request(
+            RELEASES_API,
+            headers={
+                "User-Agent": "vireo-darktable-install/1.0",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=timeout, context=_ssl_ctx) as resp:
+            release = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        log.warning("Could not reach the GitHub releases API", exc_info=True)
+        return None
+
+    asset = select_asset(release, sys.platform, platform_mod.machine())
+    if not asset:
+        return None
+    return {"version": release.get("tag_name", "").replace("release-", ""), **asset}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `python -m pytest vireo/tests/test_darktable_install.py -v`
+Expected: PASS (all parametrized cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vireo/darktable_install.py vireo/tests/test_darktable_install.py vireo/tests/fixtures/darktable_release.json
+git commit -m "feat: resolve the darktable release asset for this platform
+
+Exact-suffix matching, not substring: the release ships ~300KB .zsync
+delta manifests whose names contain 'AppImage', and a substring matcher
+would 'successfully install' one of those instead of darktable.
+
+Download URLs are allowlisted to GitHub hosts under darktable-org/darktable."
+```
+
+---
+
+## Task 6: Verify the download
+
+**Files:**
+- Modify: `vireo/darktable_install.py`
+- Test: `vireo/tests/test_darktable_install.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `vireo/tests/test_darktable_install.py`:
+
+```python
+def test_verify_digest_matches(tmp_path):
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    sha = "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    ok, detail = verify_digest(str(f), sha)
+    assert ok, detail
+
+
+def test_verify_digest_mismatch_is_reported_with_both_hashes(tmp_path):
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"tampered")
+    ok, detail = verify_digest(str(f), "sha256:" + "0" * 64)
+    assert not ok
+    assert "0000" in detail          # expected
+    assert "expected" in detail.lower()
+
+
+def test_verify_digest_absent_says_so_rather_than_silently_passing(tmp_path):
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    ok, detail = verify_digest(str(f), None)
+    assert ok
+    assert "no digest" in detail.lower()
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_darktable_install.py -k verify_digest -v`
+Expected: FAIL — `ImportError: cannot import name 'verify_digest'`.
+
+- [ ] **Step 3: Implement**
+
+Add to `vireo/darktable_install.py` (and `import hashlib` at the top):
+
+```python
+def verify_digest(path, expected):
+    """Compare the file's SHA256 against the digest published by the API.
+
+    Returns (ok, human_readable_detail).  The detail is shown to the user
+    verbatim, so it must be honest about what was and was not checked: a
+    matching digest proves the bytes are what GitHub's API said they are,
+    not that darktable signed them.
+    """
+    if not expected:
+        return True, "No digest published by GitHub — size checked only"
+
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    actual = h.hexdigest()
+    want = expected.split(":", 1)[-1].strip().lower()
+
+    if actual == want:
+        return True, f"SHA256 matches the digest published by GitHub ({actual[:16]}…)"
+    return False, f"SHA256 mismatch — expected {want}, got {actual}"
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `python -m pytest vireo/tests/test_darktable_install.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/darktable_install.py vireo/tests/test_darktable_install.py
+git commit -m "feat: verify downloaded darktable against the API's SHA256 digest"
+```
+
+---
+
+## Task 7: Download and hand off to the platform installer
+
+**Files:**
+- Modify: `vireo/darktable_install.py`
+- Test: `vireo/tests/test_darktable_install.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `vireo/tests/test_darktable_install.py`:
+
+```python
+def test_install_dir_is_under_vireo_home():
+    from darktable_install import install_dir
+
+    assert install_dir().endswith(os.path.join(".vireo", "tools", "darktable"))
+
+
+def test_hand_off_linux_makes_appimage_executable_and_returns_bin_path(tmp_path, monkeypatch):
+    from darktable_install import hand_off
+
+    appimage = tmp_path / "Darktable-5.6.0-x86_64.AppImage"
+    appimage.write_bytes(b"stub")
+    appimage.chmod(0o644)
+
+    result = hand_off(str(appimage), platform_name="linux")
+
+    assert os.access(str(appimage), os.X_OK)
+    assert result["bin_path"] == str(appimage)
+    assert result["action"] == "installed"
+
+
+def test_hand_off_macos_opens_dmg_and_sets_no_bin_path(tmp_path, monkeypatch):
+    """macOS cannot know the final path — the user drags the app themselves."""
+    import darktable_install
+    from darktable_install import hand_off
+
+    calls = []
+    monkeypatch.setattr(darktable_install.subprocess, "run",
+                        lambda *a, **k: calls.append(a) or None)
+
+    dmg = tmp_path / "darktable-5.6.0-arm64.dmg"
+    dmg.write_bytes(b"stub")
+    result = hand_off(str(dmg), platform_name="darwin")
+
+    assert calls, "expected the DMG to be opened"
+    assert result["bin_path"] is None
+    assert result["action"] == "opened-installer"
+
+
+def test_is_quarantined_false_for_plain_file(tmp_path):
+    """Warn about Gatekeeper only when the attribute is really present.
+
+    urllib downloads are not quarantined (LaunchServices applies that, not
+    urllib), so an unconditional warning would scare users about a dialog
+    they will never see.
+    """
+    from darktable_install import is_quarantined
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"x")
+    assert is_quarantined(str(f)) is False
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_darktable_install.py -k "hand_off or install_dir or quarantined" -v`
+Expected: FAIL — names not defined.
+
+- [ ] **Step 3: Implement**
+
+Add to `vireo/darktable_install.py` (and `import subprocess`, `import sys`, `import stat` at the top):
+
+```python
+def install_dir():
+    """Where downloads land, on every platform.
+
+    Also where the .partial resume file lives and which filesystem the
+    free-space check measures.  Installers are kept after hand-off — the
+    user may want to re-run them.
+    """
+    return os.path.expanduser(os.path.join("~", ".vireo", "tools", "darktable"))
+
+
+def is_quarantined(path):
+    """True if macOS tagged the file with com.apple.quarantine.
+
+    Measured behaviour: urllib downloads are NOT quarantined (LaunchServices
+    applies that attribute for browser-style downloads), so this is normally
+    False and the Gatekeeper warning stays hidden.  Checked rather than
+    assumed in either direction.
+    """
+    if sys.platform != "darwin":
+        return False
+    try:
+        result = subprocess.run(
+            ["xattr", "-p", "com.apple.quarantine", path],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def hand_off(path, platform_name=None):
+    """Hand the downloaded artifact to the platform.
+
+    Returns {action, location, bin_path}.  Does NOT write config: bin_path is
+    returned so the job handler writes darktable_bin in one place, next to the
+    message that tells the user it happened.
+    """
+    platform_name = platform_name or sys.platform
+
+    if platform_name == "linux":
+        mode = os.stat(path).st_mode
+        os.chmod(path, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return {"action": "installed", "location": path, "bin_path": path}
+
+    if platform_name == "darwin":
+        subprocess.run(["open", path], timeout=30)
+    else:
+        os.startfile(path)  # noqa: F821 - Windows only
+
+    # The user chooses where the app lands, so we cannot know bin_path here.
+    # Detection (Task 1) finds it on the next re-check.
+    return {"action": "opened-installer", "location": path, "bin_path": None}
+
+
+def download(asset, dest_dir=None, byte_callback=None, should_cancel=None):
+    """Download one resolved asset, verify it, and return (path, detail).
+
+    Raises RuntimeError on a size or digest mismatch, deleting the bad file:
+    a wrong artifact must never be handed to an installer.
+    """
+    from taxonomy import _download_with_resume
+
+    dest_dir = dest_dir or install_dir()
+    os.makedirs(dest_dir, exist_ok=True)
+    dest = os.path.join(dest_dir, asset["name"])
+
+    _download_with_resume(
+        asset["url"], dest,
+        byte_callback=byte_callback,
+        should_cancel=should_cancel,
+    )
+
+    actual_size = os.path.getsize(dest)
+    if asset.get("size") and actual_size != asset["size"]:
+        os.remove(dest)
+        raise RuntimeError(
+            f"Size mismatch — expected {asset['size']} bytes, got {actual_size}"
+        )
+
+    ok, detail = verify_digest(dest, asset.get("digest"))
+    if not ok:
+        os.remove(dest)
+        raise RuntimeError(detail)
+    return dest, detail
+
+
+def free_space_bytes(path):
+    """Bytes free on the filesystem holding path (creating it if needed)."""
+    os.makedirs(path, exist_ok=True)
+    st = os.statvfs(path) if hasattr(os, "statvfs") else None
+    if st is None:
+        import shutil
+        return shutil.disk_usage(path).free
+    return st.f_bavail * st.f_frsize
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `python -m pytest vireo/tests/test_darktable_install.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/darktable_install.py vireo/tests/test_darktable_install.py
+git commit -m "feat: download, verify, and hand off darktable to the OS installer
+
+hand_off returns bin_path rather than writing config, so the single
+config mutation lives with the message that reports it."
+```
+
+---
+
+## Task 8: The "what would be downloaded" route
+
+**Files:**
+- Modify: `vireo/app.py` (add after `api_darktable_status`, ~line 15931)
+- Modify: `vireo/tests/contracts/routes.txt`
+- Test: `vireo/tests/test_darktable_api.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `vireo/tests/test_darktable_api.py`. **The release cache added in Step 3
+is module-level state that leaks between tests** — a cached success would make the
+fallback test see a stale value instead of the raising stub. Reset it in every
+test that touches this route:
+
+```python
+@pytest.fixture(autouse=True)
+def _clear_release_cache():
+    import darktable_install
+    darktable_install._release_cache.update(at=0.0, value=None)
+    yield
+    darktable_install._release_cache.update(at=0.0, value=None)
+```
+
+Add `import pytest` to the file if it is not already there. Then:
+
+```python
+def test_api_darktable_install_available_shape(app_and_db, monkeypatch):
+    """The confirmation needs version, name, size, url and digest."""
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: {
+        "version": "5.6.0",
+        "name": "darktable-5.6.0-arm64.dmg",
+        "size": 87094261,
+        "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
+        "digest": "sha256:" + "a" * 64,
+    })
+
+    data = app.test_client().get('/api/darktable/install/available').get_json()
+    assert data['available'] is True
+    assert data['version'] == "5.6.0"
+    assert data['size'] == 87094261
+    assert data['digest'].startswith("sha256:")
+
+
+def test_api_darktable_install_available_falls_back_when_api_unreachable(app_and_db, monkeypatch):
+    """Never a dead button: an unreachable API yields a reason, not a 500."""
+    import darktable_install
+    app, _ = app_and_db
+
+    def boom():
+        raise OSError("network unreachable")
+    monkeypatch.setattr(darktable_install, "resolve_release", boom)
+
+    resp = app.test_client().get('/api/darktable/install/available')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['available'] is False
+    assert data['reason']
+
+
+def test_api_darktable_install_available_handles_unsupported_platform(app_and_db, monkeypatch):
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: None)
+
+    data = app.test_client().get('/api/darktable/install/available').get_json()
+    assert data['available'] is False
+    assert data['reason']
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_darktable_api.py -k install_available -v`
+Expected: FAIL — 404.
+
+- [ ] **Step 3: Implement**
+
+In `vireo/app.py`, immediately after `api_darktable_status` ends (line 15930):
+
+```python
+    @app.route("/api/darktable/install/available")
+    def api_darktable_install_available():
+        """What a download would fetch, for the confirmation dialog.
+
+        Always 200: when this cannot answer, the panel shows a plain
+        "Get darktable" link and the reason, rather than a dead button.
+        """
+        import darktable_install
+
+        try:
+            release = darktable_install.resolve_release()
+        except Exception as e:
+            log.warning("darktable release lookup failed: %s", e)
+            return jsonify({
+                "available": False,
+                "reason": "Could not reach GitHub to check for a darktable release.",
+            })
+
+        if not release:
+            return jsonify({
+                "available": False,
+                "reason": "No darktable build is published for this platform.",
+            })
+
+        return jsonify({"available": True, **release})
+```
+
+Add a short in-process cache in `darktable_install.py` so repeated Settings loads
+do not burn the unauthenticated GitHub rate limit (60 requests/hour per IP) and
+degrade to the fallback link:
+
+```python
+_release_cache = {"at": 0.0, "value": None}
+_RELEASE_CACHE_SECS = 600
+
+
+def resolve_release_cached():
+    import time
+    now = time.monotonic()
+    if _release_cache["value"] is not None and now - _release_cache["at"] < _RELEASE_CACHE_SECS:
+        return _release_cache["value"]
+    value = resolve_release()
+    if value is not None:
+        _release_cache.update(at=now, value=value)
+    return value
+```
+
+Call `resolve_release_cached()` from the route above. Failures are deliberately
+not cached, so a transient outage does not pin the fallback link for ten minutes.
+**Task 9's job must still call `resolve_release()` directly** — it re-resolves
+server-side so the URL it downloads is never a stale client-supplied value.
+
+- [ ] **Step 4: Add the route to the contract**
+
+Insert into `vireo/tests/contracts/routes.txt` in sorted position (next to line 38's `GET /api/darktable/status`), matching the file's existing column alignment:
+
+```
+GET          /api/darktable/install/available
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `python -m pytest vireo/tests/test_darktable_api.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_darktable_api.py vireo/tests/contracts/routes.txt
+git commit -m "feat: add /api/darktable/install/available
+
+Always returns 200 so the UI degrades to a plain link with a stated
+reason instead of showing a button that cannot work."
+```
+
+---
+
+## Task 9: The download job
+
+**Files:**
+- Modify: `vireo/app.py` (add near the other download jobs, after `api_job_download_taxonomy` ~line 18262)
+- Modify: `vireo/tests/contracts/routes.txt`
+- Test: `vireo/tests/test_darktable_api.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `vireo/tests/test_darktable_api.py`:
+
+```python
+def test_api_job_download_darktable_returns_job_id(app_and_db, monkeypatch):
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: {
+        "version": "5.6.0", "name": "d.dmg", "size": 100,
+        "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
+        "digest": None,
+    })
+    monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: 10 ** 12)
+    monkeypatch.setattr(darktable_install, "download", lambda *a, **k: ("/tmp/d.dmg", "ok"))
+    monkeypatch.setattr(darktable_install, "hand_off",
+                        lambda p, **k: {"action": "opened-installer",
+                                        "location": p, "bin_path": None})
+    monkeypatch.setattr(darktable_install, "is_quarantined", lambda p: False)
+
+    client = app.test_client()
+    resp = client.post('/api/jobs/download-darktable')
+    assert resp.status_code == 200
+    job_id = resp.get_json()['job_id']
+
+    # Wait for the job thread to finish INSIDE the test. Returning early lets
+    # it run after monkeypatch teardown, where it would call the real download
+    # and hit the network.
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+    assert job['status'] == 'completed'
+
+
+def test_api_job_download_darktable_refuses_without_disk_space(app_and_db, monkeypatch):
+    """Refuse before downloading 87MB, and say what is needed vs free."""
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: {
+        "version": "5.6.0", "name": "d.dmg", "size": 87094261,
+        "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
+        "digest": None,
+    })
+    monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: 1024)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+    assert 'space' in resp.get_json()['error'].lower()
+
+
+def test_api_job_download_darktable_400_when_unavailable(app_and_db, monkeypatch):
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: None)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_darktable_api.py -k job_download_darktable -v`
+Expected: FAIL — 404.
+
+- [ ] **Step 3: Implement**
+
+In `vireo/app.py`, after `api_job_download_taxonomy`:
+
+```python
+    @app.route("/api/jobs/download-darktable", methods=["POST"])
+    def api_job_download_darktable():
+        import darktable_install
+        from job_contract import progress_event
+
+        runner = app._job_runner
+        active_ws = _get_db()._active_workspace_id
+
+        try:
+            asset = darktable_install.resolve_release()
+        except Exception:
+            asset = None
+        if not asset:
+            return json_error("No darktable build is available for this platform.")
+
+        # Refuse before spending 87MB, and say what is needed vs what is free.
+        target = darktable_install.install_dir()
+        free = darktable_install.free_space_bytes(target)
+        needed = (asset.get("size") or 0) * 2
+        if free < needed:
+            return json_error(
+                f"Not enough disk space: {needed // (1024*1024)} MB needed in "
+                f"{target}, {free // (1024*1024)} MB free."
+            )
+
+        def work(job):
+            def on_bytes(done, total):
+                runner.push_event(job["id"], "progress", progress_event(
+                    phase="Downloading darktable",
+                    current=done,
+                    total=total or asset.get("size") or 0,
+                    current_file=asset["name"],
+                ))
+
+            path, verify_detail = darktable_install.download(
+                asset,
+                byte_callback=on_bytes,
+                should_cancel=lambda: runner.is_cancelled(job["id"]),
+            )
+
+            # total=0 on purpose: the UI treats a non-zero total as a byte
+            # count and would render "Verifying: 0 of 0 MB" instead of the
+            # verification detail.
+            runner.push_event(job["id"], "progress", progress_event(
+                phase="Verifying", current=0, total=0, current_file=verify_detail,
+            ))
+
+            result = darktable_install.hand_off(path)
+
+            # Single place config is mutated, next to the message reporting it.
+            config_written = False
+            if result.get("bin_path"):
+                import config as cfg
+                cfg.set("darktable_bin", result["bin_path"])
+                config_written = True
+
+            return {
+                "version": asset["version"],
+                "downloaded_to": path,
+                "verified": verify_detail,
+                "action": result["action"],
+                "bin_path": result.get("bin_path"),
+                "config_written": config_written,
+                "quarantined": darktable_install.is_quarantined(path),
+            }
+
+        job_id = runner.start("download-darktable", work, workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+```
+
+- [ ] **Step 4: Add the route to the contract**
+
+Add to `vireo/tests/contracts/routes.txt` next to the other download jobs (line ~258):
+
+```
+POST         /api/jobs/download-darktable
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `python -m pytest vireo/tests/test_darktable_api.py vireo/tests/test_job_contract.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_darktable_api.py vireo/tests/contracts/routes.txt
+git commit -m "feat: add the download-darktable job
+
+Refuses up front when disk space is short rather than failing at 90%.
+Reports byte-level progress and honours job cancellation."
+```
+
+---
+
+## Task 10: The Settings UI
+
+**Files:**
+- Modify: `vireo/templates/settings.html:2166-2187` (`loadDarktableStatus`)
+
+No unit test — this is inline template JS with no test harness in this repo. Verified manually in Step 4 and by the e2e suite.
+
+- [ ] **Step 1: Rewrite `loadDarktableStatus`**
+
+Replace lines 2166-2187 of `vireo/templates/settings.html`:
+
+```javascript
+async function loadDarktableStatus() {
+  try {
+    var data = await safeFetch('/api/darktable/status', {}, { toast: false });
+    var el = document.getElementById('darktableStatus');
+    var needsGetOption = false;
+    if (data.available) {
+      el.innerHTML = '<span style="color:var(--accent);font-size:13px;">&#10003; darktable-cli found</span>' +
+        '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">' + escapeHtml(data.bin) + '</span>';
+    } else {
+      el.innerHTML = '<span style="color:var(--danger);font-size:13px;">&#10007; darktable-cli not found</span>' +
+        '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">Install darktable or set the path below</span>' +
+        '<div id="darktableGet" style="margin-top:6px;"></div>' +
+        '<div id="darktableProgress" style="display:none;margin-top:8px;">' +
+        '  <div style="background:var(--bg-tertiary);border-radius:3px;height:6px;overflow:hidden;">' +
+        '    <div id="dtProgressFill" style="background:var(--accent);height:100%;width:0%;"></div>' +
+        '  </div>' +
+        '  <div id="dtProgressText" style="font-size:12px;color:var(--text-dim);margin-top:4px;"></div>' +
+        '</div>';
+      // Say where we looked, so a bare ✗ can explain itself.
+      if (data.checked_paths && data.checked_paths.length) {
+        el.innerHTML += '<div style="font-size:11px;color:var(--text-ghost);margin-top:6px;">' +
+          'Checked PATH and: ' + data.checked_paths.map(escapeHtml).join(', ') + '</div>';
+      } else {
+        el.innerHTML += '<div style="font-size:11px;color:var(--text-ghost);margin-top:6px;">' +
+          'Checked PATH for darktable-cli.</div>';
+      }
+      needsGetOption = true;
+    }
+    if (data.auto_convert_dng) {
+      if (data.dng_available) {
+        el.innerHTML += '<div style="color:var(--accent);font-size:13px;margin-top:4px;">&#10003; Adobe DNG Converter found' +
+          '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">' + escapeHtml(data.dng_bin) + '</span></div>';
+      } else {
+        el.innerHTML += '<div style="color:var(--danger);font-size:13px;margin-top:4px;">&#10007; Adobe DNG Converter not found' +
+          '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">Install it or set the path below &mdash; ' +
+          '<a href="https://helpx.adobe.com/camera-raw/digital-negative.html" target="_blank" rel="noopener" ' +
+          'style="color:var(--accent);">Get it from Adobe &#8599;</a></span></div>';
+      }
+    }
+    // MUST run after the DNG block. That block does `el.innerHTML +=`, which
+    // re-parses the subtree and detaches any node captured earlier — so
+    // rendering the button before it would write into a dead node and the
+    // button would never appear. darktable_auto_convert_dng defaults to true
+    // (config.py:66), so this is the default path, not an edge case.
+    if (needsGetOption) await renderDarktableGetOption();
+  } catch(e) {}
+}
+
+// The button must say what it actually does. On macOS/Windows we hand off to
+// the OS installer and the user finishes the job, so it says "Download
+// installer" — never "Install darktable".
+async function renderDarktableGetOption() {
+  var host = document.getElementById('darktableGet');
+  if (!host) return;
+  var info;
+  try {
+    info = await safeFetch('/api/darktable/install/available', {}, { toast: false });
+  } catch(e) {
+    info = { available: false, reason: 'Could not check for a darktable release.' };
+  }
+
+  if (!info.available) {
+    host.innerHTML = '<a href="https://www.darktable.org/install/" target="_blank" rel="noopener" ' +
+      'style="color:var(--accent);font-size:13px;">Get darktable &#8599;</a>' +
+      '<span style="color:var(--text-ghost);font-size:11px;margin-left:8px;">' +
+      escapeHtml(info.reason || '') + '</span>';
+    return;
+  }
+
+  var isLinux = /Linux/.test(navigator.userAgent) && !/Android/.test(navigator.userAgent);
+  var label = isLinux ? 'Download and set up' : 'Download installer';
+  window._dtAsset = info;
+  host.innerHTML = '<button class="btn" onclick="downloadDarktable()">' + label + '</button>' +
+    '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">' +
+    'darktable ' + escapeHtml(info.version) + ' &mdash; ' + escapeHtml(info.name) + ', ' +
+    Math.round(info.size / 1048576) + ' MB, from github.com/darktable-org</span>';
+}
+
+async function downloadDarktable() {
+  var a = window._dtAsset || {};
+  var isLinux = /Linux/.test(navigator.userAgent) && !/Android/.test(navigator.userAgent);
+  var what = isLinux
+    ? 'Vireo will download it and set the darktable-cli path for you.'
+    : 'Vireo will download the installer and open it. You finish the install.';
+  if (!confirm('Download darktable ' + a.version + '?\n\n' +
+               a.name + ' (' + Math.round(a.size / 1048576) + ' MB)\n' +
+               'From: github.com/darktable-org/darktable\n\n' + what)) return;
+
+  document.getElementById('darktableGet').style.display = 'none';
+  var wrap = document.getElementById('darktableProgress');
+  var fill = document.getElementById('dtProgressFill');
+  var text = document.getElementById('dtProgressText');
+  wrap.style.display = 'block';
+  text.textContent = 'Starting...';
+
+  // The route 400s on insufficient disk space. Without this guard the panel
+  // sits on "Starting..." forever with the button hidden.
+  var resp;
+  try {
+    resp = await safeFetch('/api/jobs/download-darktable', { method: 'POST' });
+  } catch(e) {
+    wrap.style.display = 'none';
+    document.getElementById('darktableGet').style.display = '';
+    return;
+  }
+
+  safeEventSource('/api/jobs/' + resp.job_id + '/stream', {
+    onProgress: function(p) {
+      if (p.total) {
+        fill.style.width = Math.round((p.current / p.total) * 100) + '%';
+        text.textContent = p.phase + ': ' +
+          Math.round(p.current / 1048576) + ' of ' + Math.round(p.total / 1048576) + ' MB';
+      } else {
+        text.textContent = p.phase + (p.current_file ? ': ' + p.current_file : '');
+      }
+    },
+    onComplete: function(r) {
+      // Job FAILURES arrive here with status !== 'completed' — not via
+      // onError, which only fires on EventSource connection loss and is
+      // called with no arguments. A digest mismatch lands here; rendering it
+      // as a success with an empty message would be exactly the black box
+      // CORE_PHILOSOPHY.md forbids. Same shape as downloadModel (:2800).
+      if (r && r.status === 'cancelled') {
+        // jobs.py:526 sets status 'cancelled' with empty errors and no
+        // failure, so this must be handled before the failure branch or a
+        // user-initiated cancel would read as "Download failed".
+        fill.style.width = '0%';
+        text.innerHTML = 'Download cancelled.' +
+          '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Try again</button>';
+        return;
+      }
+      if (!r || r.status !== 'completed') {
+        var why = (r && r.failure && r.failure.message) ||
+                  ((r && r.errors) || []).join(', ') || 'Download failed';
+        fill.style.width = '0%';
+        text.innerHTML = '<span style="color:var(--danger);">' + escapeHtml(why) + '</span>' +
+          '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Try again</button>';
+        return;
+      }
+      fill.style.width = '100%';
+      var res = r.result || {};
+      var lines = [];
+      if (res.verified) lines.push(res.verified);
+      if (res.config_written) {
+        lines.push('Installed to ' + res.bin_path + ' and set the darktable-cli path in Settings.');
+      } else if (res.downloaded_to) {
+        lines.push('Downloaded to ' + res.downloaded_to + ' — opening the installer. ' +
+                   'Drag darktable to Applications, then click Re-check.');
+      }
+      // Only warn about Gatekeeper if the file really is quarantined.
+      if (res.quarantined) {
+        lines.push('macOS quarantined this download. darktable does not notarize its ' +
+                   'macOS builds, so you may see "damaged". To clear it, run: ' +
+                   'xattr -d com.apple.quarantine ' + res.downloaded_to);
+      }
+      text.innerHTML = lines.map(escapeHtml).join('<br>') +
+        '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Re-check</button>';
+    },
+    // safeEventSource calls onError with NO arguments (_navbar.html:10241),
+    // and only for connection loss. Do not try to read an error off it.
+    onError: function() {
+      text.innerHTML = '<span style="color:var(--danger);">Lost connection to the ' +
+        'download job. It may still be running.</span>' +
+        '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Re-check</button>';
+    }
+  });
+}
+```
+
+- [ ] **Step 2: Confirm the SSE completion payload shape**
+
+Read `safeEventSource` at `vireo/templates/_navbar.html:10225` and one existing consumer (`downloadModel`, `settings.html:2776-2820`) to confirm whether `onComplete` receives the job envelope or the result directly. **Adjust `res` in `onComplete` to match** — do not guess.
+
+- [ ] **Step 3: Run the app and drive the flow**
+
+```bash
+python vireo/app.py --db ~/.vireo/vireo.db --port 8080
+```
+
+Open Settings → RAW Development. With darktable not installed, confirm:
+- the ✗ row shows a "Download installer" button plus version/size/source
+- the "Checked:" line lists real paths
+- clicking shows the confirmation with the exact filename and size
+- the progress bar advances with real MB counts
+- on completion the installer opens and "Re-check" appears
+- no Gatekeeper text appears unless the file is genuinely quarantined
+
+- [ ] **Step 4: Verify the fallback path**
+
+Temporarily make `resolve_release` raise, reload, and confirm the panel shows the plain "Get darktable ↗" link with a reason — **not** a dead button. Revert the change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/templates/settings.html
+git commit -m "feat: offer a darktable download from the RAW Development panel
+
+Button labels state what actually happens: 'Download installer' on
+macOS/Windows where the user finishes the install, 'Download and set up'
+on Linux where we complete it. The panel lists the locations checked,
+shows real byte progress, and falls back to a plain link with a stated
+reason when the release cannot be resolved."
+```
+
+---
+
+## Task 11: Full verification
+
+- [ ] **Step 1: Run the repo's required suite**
+
+```bash
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py \
+  vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
+  vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
+```
+
+- [ ] **Step 2: Run the suites this work touched**
+
+```bash
+python -m pytest vireo/tests/test_develop.py vireo/tests/test_darktable_install.py \
+  vireo/tests/test_taxonomy.py vireo/tests/test_job_contract.py \
+  vireo/tests/test_platform_support.py -v
+```
+
+Expected: all pass. **Note:** per the local baseline there are ~4 pre-existing failures in the wider `vireo/tests` suite unrelated to this work — confirm any failure you see is one of those before treating it as a regression, and do not "fix" a test by weakening its assertion.
+
+- [ ] **Step 3: Use the verify skill**
+
+Invoke the `verify` skill to drive the flow end-to-end in the real app rather than relying on tests alone.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --base main --title "Offer a darktable download from Settings" --body "$(cat <<'EOF'
+## What
+
+Turns the dead-end "✗ darktable-cli not found" row in Settings → RAW Development
+into a working download, with byte-level progress and an OS installer hand-off.
+
+Design: `docs/superpowers/specs/2026-07-26-darktable-download-design.md`
+
+## Notable decisions
+
+- **darktable only.** Adobe DNG Converter is proprietary and EULA-gated, so that
+  row gets a "Get it from Adobe ↗" link and nothing more.
+- **Latest release resolved from the GitHub API** at click time rather than a
+  pinned version, with integrity verified against the API's own SHA256 digest.
+- **No code-signature check.** darktable does not successfully notarize its macOS
+  builds (upstream #19295) and its Windows installer is unsigned — a fail-closed
+  signature check would have deleted every legitimate download.
+- **Gatekeeper warning is conditional** on `com.apple.quarantine` actually being
+  present. urllib downloads are not quarantined, so it normally stays hidden.
+
+## Bugs fixed along the way
+
+- `find_darktable` never probed `/Applications/darktable.app`, so a normal macOS
+  install reported "not found" (`find_dng_converter` already probed its Adobe
+  equivalent). Without this, a successful download still ended in ✗.
+- Asset matching is exact-suffix: the release ships ~300KB `.zsync` manifests
+  whose names contain "AppImage", and a substring matcher would have installed
+  one of those instead of darktable.
+
+## Test results
+
+<!-- paste the output of Task 11 Steps 1-2 here -->
+EOF
+)"
+```
+
+---
+
+## Out of scope (recorded so it is not silently dropped)
+
+- **flatpak detection** — needs `find_darktable` to return a command list rather
+  than a path, changing every caller. Separate change.
+- **A download button on the dependency-readiness panel.** It reads the same
+  `find_darktable`, so it inherits the detection fix and cannot disagree about
+  availability; its hint already points at Settings.
+- **Confirming quarantine behaviour inside the packaged Tauri app.** The
+  conditional check makes either outcome correct, but the finding should be
+  recorded when someone next builds a release.

--- a/docs/superpowers/specs/2026-07-26-darktable-download-design.md
+++ b/docs/superpowers/specs/2026-07-26-darktable-download-design.md
@@ -8,7 +8,7 @@
 The "RAW Development (darktable)" panel in Settings shows two red rows when the
 tools are missing:
 
-```
+```text
 ✗ darktable-cli not found        Install darktable or set the path below
 ✗ Adobe DNG Converter not found  Install it or set the path below
 ```
@@ -81,7 +81,7 @@ reject every legitimate download.
 The GitHub releases API returns a `digest` field per asset, and darktable's
 release assets have one:
 
-```
+```text
 darktable-5.6.0-arm64.dmg  →  sha256:49aec447e891ab481e436b4c0231fc3c8d0001aad220762ae8e765d3bda5d102
 ```
 
@@ -424,7 +424,7 @@ at `:2776-2820`: POST, reveal a progress div, `safeEventSource` on
 
 ## Data flow
 
-```
+```text
 loadDarktableStatus()
   → GET /api/darktable/status          (already exists)
   → GET /api/darktable/install/available

--- a/docs/superpowers/specs/2026-07-26-darktable-download-design.md
+++ b/docs/superpowers/specs/2026-07-26-darktable-download-design.md
@@ -1,0 +1,454 @@
+# Download darktable from Settings
+
+**Date:** 2026-07-26
+**Status:** Approved (design)
+
+## Problem
+
+The "RAW Development (darktable)" panel in Settings shows two red rows when the
+tools are missing:
+
+```
+✗ darktable-cli not found        Install darktable or set the path below
+✗ Adobe DNG Converter not found  Install it or set the path below
+```
+
+Both rows are dead ends. They tell the user something is missing and leave them
+to find, download, and install it on their own. `develop.py:217` says as much in
+its error text: *"Adobe DNG Converter not found or not configured. You will need
+to download it from Adobe."*
+
+There is also a detection gap that makes the darktable row wrong for some users
+who have already installed it — see "Detection gap" below.
+
+## Scope
+
+**In scope:** downloading darktable.
+
+**Out of scope:** downloading Adobe DNG Converter. It is proprietary and
+EULA-gated, with no stable public URL we can legitimately hotlink. That row gets
+a plain "Get it from Adobe ↗" link and nothing more.
+
+**Out of scope:** flatpak detection. A flatpak install has no invokable path; it
+requires `flatpak run --command=darktable-cli org.darktable.Darktable`. Supporting
+it means `find_darktable` returns a command list instead of a path, and every
+caller changes. Worth doing, but separately.
+
+## Source of truth
+
+darktable is GPL and publishes official release assets on GitHub. As of
+`release-5.6.0`:
+
+| Asset | Size |
+|---|---|
+| `darktable-5.6.0-arm64.dmg` | 87 MB |
+| `darktable-5.6.0-x86_64.dmg` | 93 MB |
+| `darktable-5.6.0-win64.exe` | 142 MB |
+| `darktable-5.6.0-woa64.exe` | 107 MB |
+| `Darktable-5.6.0-x86_64.AppImage` | 178 MB |
+| `Darktable-5.6.0-aarch64.AppImage` | 171 MB |
+
+### Version resolution
+
+Query the GitHub releases API for `latest` at click time, then hard-allowlist the
+host (`github.com` / `objects.githubusercontent.com`) and the repo path
+(`darktable-org/darktable`).
+
+**Why not pin a version + SHA256** like `scripts/fetch_exiftool.py` does: darktable
+releases a few times a year, so a pinned build goes stale between Vireo releases,
+and a pinned URL 404s if an asset is ever renamed. Fetching from darktable's own
+GitHub releases over HTTPS is the same trust boundary the user gets by clicking
+through to darktable.org themselves — this does not lower the bar.
+
+The allowlist is enforced on the `browser_download_url` returned by the API, **not
+on redirect targets** — GitHub redirects release assets to
+`release-assets.githubusercontent.com`, so an allowlist applied to redirects would
+reject every legitimate download.
+
+### Integrity: the API's own SHA256 digest
+
+The GitHub releases API returns a `digest` field per asset, and darktable's
+release assets have one:
+
+```
+darktable-5.6.0-arm64.dmg  →  sha256:49aec447e891ab481e436b4c0231fc3c8d0001aad220762ae8e765d3bda5d102
+```
+
+We hash the downloaded file and compare. This **fails closed**: on mismatch the
+job errors and the file is deleted. Unlike a pinned hash this is never stale, and
+unlike a code-signature check it is something darktable actually publishes.
+
+**What this proves, stated honestly, because the UI will say it:** the bytes on
+disk match what GitHub's API said the asset is. It catches truncation, CDN
+corruption, and a wrong-asset mixup. It does **not** prove darktable signed the
+build — the digest arrives over the same HTTPS response as the URL, so it shares
+that trust boundary. If the `digest` field is absent for an asset, we say
+"no digest published — size checked only" rather than silently skipping. That
+fallback message is backed by a real check: `download_asset` compares the final
+file size to the API's `size` field. (This is a different claim from
+`_download_with_resume`'s existing `Content-Length` truncation check, which the
+serving host supplies.)
+
+### No code-signature check
+
+An earlier draft specified `spctl --assess` on macOS and Authenticode on Windows.
+**That would have deleted every legitimate download.** darktable's macOS build is
+not successfully notarized — upstream issue #19295 says notarization "is
+implemented but — as it seems — currently not working," it was closed as not
+planned, and Homebrew disabled the darktable cask over it. The Windows installer
+trips SmartScreen as an unknown publisher. The only signature on `release-5.6.0`
+is `darktable-5.6.0.tar.xz.asc`, which covers the **source tarball only**.
+
+So there is no signature to check, and pretending to check one is worse than not
+checking. (Also worth recording so nobody re-adds it: `spctl --assess` is a
+Gatekeeper *policy* assessment, not a signature-validity check — that would be
+`codesign --verify --strict`. They are different questions.)
+
+### Gatekeeper: conditional, not assumed
+
+An earlier draft of this section made an unconditional pre-download warning that
+macOS would call the DMG "damaged," with an `xattr -d com.apple.quarantine`
+remedy. That was wrong in the other direction, and it is worth recording why.
+
+`com.apple.quarantine` is applied by LaunchServices for browser-style downloads,
+not by `urllib`. Measured on macOS 15 (Darwin 25.5.0), a file fetched with
+`urllib.request.urlretrieve` carries only `com.apple.provenance`; `xattr -p
+com.apple.quarantine` reports *"No such xattr"* and the suggested `xattr -d`
+remedy exits 1. Vireo's download runs in the Python sidecar, and
+`src-tauri/Entitlements.plist` sets hardened runtime without
+`com.apple.security.app-sandbox` or `LSFileQuarantineEnabled`, so there is no
+quarantine-propagation path either.
+
+The likely real outcome is therefore **no Gatekeeper dialog at all** — our
+download path is quieter than the user fetching the DMG in a browser, precisely
+because it bypasses LaunchServices.
+
+Since we cannot promise that for every macOS version, the warning is
+**conditional and evidence-based**, never unconditional:
+
+- After download, check for `com.apple.quarantine` on the file.
+- Present, and on macOS → show the explanation and the `xattr -d` command.
+- Absent → show nothing. Do not warn about a dialog the user will not see.
+
+**Open item for implementation:** confirm the attribute is genuinely absent when
+the download runs inside the *packaged* Tauri app, not just under a dev-mode
+Python process. The conditional check makes either outcome correct, so this does
+not block planning — but the finding should be recorded.
+
+## Per-platform behavior
+
+The three platforms genuinely differ, and the UI does not pretend otherwise.
+
+| Platform | Asset | What Vireo does | What the user does |
+|---|---|---|---|
+| macOS | `.dmg` | Download, verify SHA256 digest, open the DMG | Drag darktable to Applications, click Re-check |
+| Windows | `.exe` | Download, verify SHA256 digest, launch the installer | Click through the installer, click Re-check |
+| Linux | `.AppImage` | Download, `chmod +x`, place in `~/.vireo/tools/darktable/`, set `darktable_bin` | Nothing |
+
+On Linux this is a fully managed install, because no installer exists to hand off
+to. That asymmetry is stated in the UI rather than papered over.
+
+## Transparency requirements
+
+Per `CORE_PHILOSOPHY.md` ("Show the user what's happening / No black boxes"),
+every one of these is a requirement, not a nicety:
+
+1. **Button labels state what actually happens.** macOS/Windows say **"Download
+   installer"**, not "Install darktable" — we do not install it. Linux says
+   **"Download and set up"**, because there we do.
+2. **The confirmation names the exact artifact before any bytes move**: version,
+   filename, size, and source host. *"darktable 5.6.0 — `darktable-5.6.0-arm64.dmg`,
+   87 MB, from github.com/darktable-org/darktable"*.
+3. **Progress reports real bytes**, not a spinner: downloaded / total and current
+   phase, via the existing job progress payload.
+4. **The integrity check reports its result either way** — "SHA256 matches the
+   digest published by GitHub" on success, both hashes on mismatch — and says
+   what that does and does not prove rather than implying darktable signed it.
+   The two OS-trust warnings land at different moments, because the two things
+   happen at different moments: the macOS quarantine notice is **post-download and
+   conditional** on the attribute actually being present (see "Gatekeeper:
+   conditional, not assumed"), while the Windows SmartScreen unknown-publisher
+   prompt fires when the *installer launches*, so it is stated **just before
+   hand-off**, not at download time.
+5. **The landing place is named.** On macOS/Windows: "Downloaded to `<path>` —
+   opening the installer." On Linux: "Installed to `<path>` and set the
+   darktable-cli path in Settings."
+6. **No silent config mutation.** Linux sets `darktable_bin`; the UI says so, and
+   the field visibly updates.
+7. **A failed re-check explains itself.** If darktable is still not found after
+   the hand-off, list the locations that were checked rather than repeating the
+   same bare ✗. Nothing today can produce that list — `find_darktable` returns a
+   path or `None` and discards its candidate set, and `/api/darktable/status`
+   (`app.py:15910-15930`) exposes only the resolved outcome — of its ten fields,
+   the darktable-detection ones are `available` / `bin` / `configured_bin`, and
+   none is the candidate list. So this requires a real mechanism, specified under
+   Components: a `darktable_search_paths()` companion function and a
+   `checked_paths` field on the status response. Without this the requirement
+   silently becomes a
+   `COUNT(*) > 0`-style proxy, which `CLAUDE.md` forbids.
+8. **The button is never dead.** If the GitHub API is unreachable, rate-limited,
+   or has no asset for this platform/arch, the panel shows the plain
+   "Get darktable ↗" link and states why the download option is unavailable.
+
+## Two traps
+
+### The AppImage / realpath collision
+
+`find_darktable` calls `os.path.realpath()` on the configured path
+(`develop.py:59`). That is deliberate — the docstring explains that invoking
+darktable-cli through the Homebrew cask's symlink dies in `dt_init` because
+darktable locates its bundled resources by walking up from `argv[0]`.
+
+darktable's AppImage `AppRun` is multi-binary and selects which binary to run in
+one of two ways: `argv[1]` naming the binary, or the basename of `$ARGV0` when
+invoked through a symlink. So the obvious approach — symlink
+`~/.vireo/tools/darktable/darktable-cli` at the AppImage — would be destroyed by
+`realpath`, and Vireo would **launch the darktable GUI instead of the CLI**,
+hanging a headless export job.
+
+**Resolution:** point `darktable_bin` at the `.AppImage` itself, and teach
+`build_command()` (`develop.py:118-136`) to prepend `darktable-cli` as `argv[1]`
+when the binary path ends in `.AppImage`. This survives `realpath`, and it is a
+localized change: `build_command` is the only command constructor and has a single
+call site at `develop.py:307`.
+
+Separately — and this is a *different* place in the file — set
+`APPIMAGE_EXTRACT_AND_RUN=1` as a fallback for distributions without FUSE2.
+`build_command` returns a list and never touches the environment, so this belongs
+at the `subprocess.run` in `develop_photo` (`develop.py:311`), which today passes
+only `**no_window_kwargs()` and no `env`. It gains an `env=` derived from
+`os.environ`. Note `develop.py` has two `subprocess.run` sites — line 230 is the
+DNG converter and must not be touched.
+
+### Detection gap
+
+`find_dng_converter` probes `/Applications/Adobe DNG Converter.app/...`
+(`develop.py:110`), but `find_darktable` does not probe the equivalent darktable
+bundle — it only tries `shutil.which("darktable-cli")` and Windows Program Files
+(`develop.py:58-75`). A normal macOS `.dmg` install of darktable is therefore
+invisible to Vireo, and the panel reports ✗ for a user who has it installed.
+
+This is not optional inside this feature: the macOS hand-off ends with the user
+dragging `darktable.app` to `/Applications`, which puts nothing on `PATH`. Without
+the fix, a successful download is followed by the same ✗.
+
+`find_darktable` gains, after the `which` probe:
+- `/Applications/darktable.app/Contents/MacOS/darktable-cli`
+- `~/Applications/darktable.app/Contents/MacOS/darktable-cli`
+- `~/.vireo/tools/darktable/*.AppImage`
+
+## Components
+
+### `vireo/darktable_install.py` (new)
+
+One module, four functions, each independently testable:
+
+- `resolve_release()` → `{version, name, size, url, digest}` or `None`. Queries the
+  GitHub releases API, selects the asset by `(sys.platform, machine)`, enforces the
+  host and repo-path allowlist.
+
+  **Asset matching must be exact-suffix, not substring.** The release also carries
+  `Darktable-5.6.0-x86_64.AppImage.zsync` and `…-aarch64.AppImage.zsync` — ~300 KB
+  delta-update manifests sitting right next to the 178 MB AppImages. A matcher
+  looking for `"AppImage"` anywhere in the name will happily pick the `.zsync` and
+  "successfully" install a 300 KB file that is not darktable. Match on the name
+  *ending* in the expected extension, and reject any asset whose size is
+  implausibly small.
+
+  `digest` is the API's `sha256:…` string, or `None`
+  when the API published none — it is the only source of the expected hash, so it
+  must be carried through here and echoed on `/api/darktable/install/available`.
+- `download_asset(url, dest, progress_cb, should_cancel, expected_size)` → path.
+  Resumable and cancellable; verifies the final file size against the API's `size`
+  field, which is what backs the "size checked only" message.
+- `verify_digest(path, expected)` → `(ok, detail)`. SHA256 the file and compare
+  against the API's `digest`. Returns `(True, "no digest published")` when the
+  API supplied none.
+- `hand_off(path)` → `{action, location, bin_path}`. Opens the DMG, launches the
+  EXE, or installs the AppImage. It does **not** write config — it returns
+  `bin_path` and the job handler writes `darktable_bin`, so config mutation stays
+  in one place alongside the message that reports it (transparency requirement #6).
+
+### `vireo/develop.py` (modified)
+
+- `darktable_search_paths()` (new) returns the ordered list of locations
+  `find_darktable` probes on this platform. `find_darktable` is refactored to walk
+  that list so the two can never drift. This is what backs transparency
+  requirement #7.
+- `build_command()` gains the `.AppImage` `argv[1]` prefix described above.
+
+### Download location
+
+All downloads land in `~/.vireo/tools/darktable/`, on every platform — that is
+where the `.partial` resume file lives, which filesystem the free-space check
+measures, and where the installer is left after hand-off on macOS/Windows (we do
+not delete it; the user may want to re-run it). On Linux it is also the final
+install location.
+
+Because installers are deliberately kept, this directory accumulates versions over
+time. When `find_darktable` falls back to probing
+`~/.vireo/tools/darktable/*.AppImage` it picks the **newest mtime**, so detection
+is deterministic. On Linux the explicitly written `darktable_bin` takes precedence
+anyway; the glob only matters if config was cleared.
+
+### The second "darktable is missing" surface
+
+`platform_support.dependency_readiness()` (`platform_support.py:154-209`) reports
+darktable independently, and it is surfaced through `platform_support_info()` at
+`app.py:18955` and `app.py:24728`. It is subject to the same transparency rule, so
+it must not disagree with the settings panel.
+
+It already calls `find_darktable(config.get("darktable_bin", ""))` at
+`platform_support.py:157`, so it **inherits the detection fix for free** — no
+change needed, and the two surfaces cannot diverge on availability. The same holds
+for the third production caller, inside the develop job at `app.py:25527-25530`:
+every consumer resolves darktable through `find_darktable`, so fixing the detector
+fixes all of them at once. Its hint text
+("Install Darktable or configure darktable-cli under Settings → Paths") stays
+accurate, since Settings is exactly where the new button lives.
+
+Adding a download button to the readiness panel is **out of scope**. One entry
+point is enough, and the hint already points at it.
+
+### Extending `_download_with_resume`
+
+`taxonomy._download_with_resume` (`taxonomy.py:39-150`) is promoted to a shared
+helper rather than duplicated — it already handles `.partial` files, HTTP `Range`
+resume, truncation detection, and stall counting, all of which matter for a
+90–180 MB download on unreliable wifi.
+
+But it cannot satisfy this spec as written, and that gap is the single largest
+piece of work here:
+
+- Its `progress_callback(message)` takes a **status string**, emitted only at
+  attempt start, interruption, and completion. It never reports
+  `downloaded / total`. Transparency requirement #3 demands real byte counts, and
+  the front-end pattern at `settings.html:2776-2820` reads `p.current` / `p.total`
+  — reusing it unchanged renders a permanently empty progress bar.
+- It has **no cancellation hook** and retries indefinitely with `time.sleep(3)`.
+  Vireo job cancellation is cooperative via `runner.is_cancelled(job_id)`
+  (`jobs.py:1241`), so "the job is cancellable" is currently false for it.
+
+No existing downloader in the repo emits byte progress, so there is nothing to
+copy. (`models.py:731-738` and `models.py:859-863` do pass `current=` / `total=`
+through to `app.py:18090`, but those are **file counts**, not bytes.)
+
+**Resolution, chosen to keep the blast radius small:** add two *optional*
+keyword-only parameters and leave the existing `progress_callback(message)`
+contract untouched, so both current callers (`taxonomy.py:458`, `taxonomy.py:944`)
+and the seven existing `test_download_with_resume_*` tests in
+`vireo/tests/test_taxonomy.py` — including `test_download_with_resume_callback` —
+keep passing without modification.
+
+```python
+def _download_with_resume(url, dest_path, progress_callback=None,
+                          max_stalled=3, chunk_size=256 * 1024,
+                          *, byte_callback=None, should_cancel=None):
+```
+
+- `byte_callback(downloaded, total_or_None)` fires from the existing chunk loop
+  (`taxonomy.py:97-102`), throttled to at most once per 250 ms so a 178 MB
+  AppImage does not flood the SSE ring buffer (`maxsize=200`).
+- `should_cancel()` is checked in the same loop and before each retry sleep;
+  returning `True` aborts, leaves the `.partial` in place, and raises a
+  cancellation error the job handler translates into a cancelled status.
+
+### Routes in `vireo/app.py`
+
+- `GET /api/darktable/install/available` → the resolved release info for the
+  confirmation, or `{available: false, reason}` for the fallback link.
+- `POST /api/jobs/download-darktable` → JobRunner job, following the
+  `api_job_develop` shape at `app.py:25519-25520`.
+- `GET /api/darktable/status` (existing, `app.py:15910-15930`) gains a
+  `checked_paths` field populated from `darktable_search_paths()`.
+
+Both new routes are added to `vireo/tests/contracts/routes.txt`. The job emits
+progress via the shared `progress_event()` / `failure_event()` helpers in
+`vireo/job_contract.py`, which `vireo/tests/test_job_contract.py` enforces.
+
+Linux writes `darktable_bin` to the global `~/.vireo/config.json`, not to a
+workspace `config_overrides` entry — `config_schema.py:263-266` declares
+`darktable_bin` as `scope: "global"`, and an installed binary is a property of the
+machine, not of a workspace.
+
+### Front end in `vireo/templates/settings.html`
+
+`loadDarktableStatus()` (`:2166-2187`) additionally calls
+`/api/darktable/install/available` and renders either the download button or the
+fallback link in the ✗ row. The download flow reuses the model-download pattern
+at `:2776-2820`: POST, reveal a progress div, `safeEventSource` on
+`/api/jobs/<id>/stream`.
+
+## Data flow
+
+```
+loadDarktableStatus()
+  → GET /api/darktable/status          (already exists)
+  → GET /api/darktable/install/available
+      ├─ available  → render "Download installer" / "Download and set up"
+      └─ unavailable→ render "Get darktable ↗" + reason
+
+click → confirm(version, name, size, host)
+  → POST /api/jobs/download-darktable
+      → resolve_release()      (re-resolved server-side; the client value is display only)
+      → download_asset()       → byte progress events, cancellable
+      → verify_digest()        → mismatch: delete file, error the job
+      → hand_off()             → macOS: open dmg | Windows: startfile | Linux: install, return bin_path
+      → job handler writes darktable_bin (Linux only) and reports that it did
+  → SSE complete → re-run loadDarktableStatus()
+```
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| GitHub API unreachable or rate-limited | `available: false`; panel shows the plain link and the reason |
+| No asset matches platform/arch | `available: false` with that reason |
+| Insufficient disk space on the `~/.vireo/tools/` filesystem (< 2× asset size) | Refuse before starting, state the requirement and what is free |
+| Download interrupted | Resumes from `.partial`; the job is cancellable |
+| SHA256 does not match the API's `digest` | Job errors showing both hashes; file deleted |
+| Downloaded size does not match the API's `size` | Job errors showing both sizes; file deleted |
+| API published no `digest` for the asset | Proceed; state "no digest published — size checked only" |
+| Hand-off fails (no installer app, permission denied) | Job errors and names the downloaded file's path so the user can open it manually |
+| Still not found after re-check | List the locations that were checked |
+
+## Testing
+
+**New — `vireo/tests/test_darktable_install.py`:**
+- asset selection matrix across `(darwin, arm64)`, `(darwin, x86_64)`,
+  `(win32, AMD64)`, `(win32, ARM64)`, `(linux, x86_64)`, `(linux, aarch64)`,
+  against a recorded releases JSON fixture
+- unknown platform/arch → `None`, not a wrong asset
+- Linux selection picks `Darktable-5.6.0-x86_64.AppImage`, **never**
+  `Darktable-5.6.0-x86_64.AppImage.zsync` — the decoy is in the fixture
+- host allowlist rejects a spoofed `browser_download_url`, and accepts a
+  legitimate one whose redirect target is `release-assets.githubusercontent.com`
+- resume path picks up an existing `.partial`
+- `build_command` prepends `darktable-cli` for an `.AppImage` and does not for a
+  plain binary
+- `verify_digest` returns `(False, detail)` on a hash mismatch and the caller
+  deletes the file; returns `(True, "no digest published")` when the fixture's
+  asset has no `digest` field
+
+**Extended — `vireo/tests/test_taxonomy.py`:**
+- `byte_callback` receives increasing `downloaded` values and the total when
+  `Content-Length` is present, and `None` when it is absent
+- `should_cancel` returning `True` mid-stream aborts and leaves the `.partial`
+- existing `test_download_with_resume_callback` still passes unmodified, proving
+  the `progress_callback(message)` contract is intact
+
+**Extended — `vireo/tests/test_darktable_api.py`:**
+- `/api/darktable/install/available` response shape
+- fallback shape when `resolve_release` raises
+- `POST /api/jobs/download-darktable` returns a `job_id`
+
+**Extended — `vireo/tests/test_develop.py`:**
+- `find_darktable` locates `/Applications/darktable.app/...` with a monkeypatched
+  `os.path.isfile`
+- a configured path still wins over the bundle probe
+- `darktable_search_paths()` and `find_darktable` probe the same locations in the
+  same order, so `checked_paths` can never drift from reality
+
+No test hits the network; `resolve_release` is exercised against a fixture.
+`vireo/tests/contracts/api_responses.json` is opt-in and is deliberately not
+touched — the new routes only need entries in `routes.txt`.

--- a/docs/superpowers/specs/2026-07-26-darktable-download-design.md
+++ b/docs/superpowers/specs/2026-07-26-darktable-download-design.md
@@ -51,8 +51,19 @@ darktable is GPL and publishes official release assets on GitHub. As of
 ### Version resolution
 
 Query the GitHub releases API for `latest` at click time, then hard-allowlist the
-host (`github.com` / `objects.githubusercontent.com`) and the repo path
-(`darktable-org/darktable`).
+host (`github.com`) and the release-download path
+(`/darktable-org/darktable/releases/download/`).
+
+**`objects.githubusercontent.com` was removed from the allowlist** after Task 5's
+review: against the live API every `browser_download_url` is on `github.com`, the
+redirect goes to `release-assets.githubusercontent.com` (which we deliberately do
+not check — see below), and that host serves arbitrary user blobs. It was
+unreachable in practice and widened the trust boundary for nothing.
+
+The path prefix is the full `releases/download/` path, not just the repo, and is
+normalised before comparison — `startswith` on a raw path let
+`/darktable-org/darktable/releases/download/../../../../attacker/evil.dmg` through,
+since GitHub normalises `..` on receipt.
 
 **Why not pin a version + SHA256** like `scripts/fetch_exiftool.py` does: darktable
 releases a few times a year, so a pinned build goes stale between Vireo releases,
@@ -243,9 +254,27 @@ the fix, a successful download is followed by the same ✗.
 
 One module, four functions, each independently testable:
 
-- `resolve_release()` → `{version, name, size, url, digest}` or `None`. Queries the
-  GitHub releases API, selects the asset by `(sys.platform, machine)`, enforces the
-  host and repo-path allowlist.
+- `resolve_release()` → `({version, name, size, url, digest}, None)` on success, or
+  `(None, reason)` on failure. Queries the GitHub releases API, selects the asset by
+  `(sys.platform, machine)`, enforces the host and repo-path allowlist.
+
+  **It returns a reason, not a bare `None`, because the failure modes are not
+  interchangeable.** A bare `None` conflated four outcomes — unsupported platform,
+  no matching asset, asset rejected as suspicious, and network failure — and the
+  route mapped all of them to *"No darktable build is published for this
+  platform."* For a user on a plane, behind a corporate proxy, or over GitHub's
+  60/hr unauthenticated rate limit, that sentence is simply false. Three
+  constants are exported so callers never duplicate the strings:
+  `REASON_UNREACHABLE`, `REASON_NO_PLATFORM_BUILD`, `REASON_NO_USABLE_ASSET`.
+
+  Note that GitHub's rate-limit reply is itself a well-formed JSON *dict*
+  (`{"message": "API rate limit exceeded…"}`), so "did it parse?" is not enough
+  to tell success from throttling — the payload must be checked for a release
+  shape before it is trusted, or throttling reports as "no usable build".
+
+  `resolve_release` **never raises**, including on a non-dict or non-JSON body:
+  Task 9's job calls it directly, outside any route's error handling, so a
+  captive-portal HTML response would otherwise crash the job thread.
 
   **Asset matching must be exact-suffix, not substring.** The release also carries
   `Darktable-5.6.0-x86_64.AppImage.zsync` and `…-aarch64.AppImage.zsync` — ~300 KB

--- a/docs/superpowers/specs/2026-07-26-darktable-download-design.md
+++ b/docs/superpowers/specs/2026-07-26-darktable-download-design.md
@@ -360,7 +360,21 @@ def _download_with_resume(url, dest_path, progress_callback=None,
 - `POST /api/jobs/download-darktable` → JobRunner job, following the
   `api_job_develop` shape at `app.py:25519-25520`.
 - `GET /api/darktable/status` (existing, `app.py:15910-15930`) gains a
-  `checked_paths` field populated from `darktable_search_paths()`.
+  `checked_paths` field **composed by the route**, not returned raw from
+  `darktable_search_paths()`. The invariant is *every entry names a location
+  `find_darktable` genuinely probes* — which is why the route may add entries
+  the detector's own list does not contain:
+  - `"$PATH (darktable-cli)"`, because `find_darktable` tries `shutil.which`
+    before any filesystem candidate. Omitting it would make "we checked here"
+    untrue by omission, and it is the probe most likely to explain a Homebrew
+    or distro user's miss.
+  - the Linux tools directory, because `darktable_search_paths()` returns only
+    AppImages *already present* there — so a fresh Linux box would otherwise
+    get an empty list, on exactly the platform the download targets.
+
+  Do not "simplify" this to return the detector's list directly; both of the
+  above are load-bearing. The configured path stays out of `checked_paths` and
+  is surfaced separately by the UI from the existing `configured_bin` field.
 
 Both new routes are added to `vireo/tests/contracts/routes.txt`. The job emits
 progress via the shared `progress_event()` / `failure_event()` helpers in

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15910,7 +15910,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/darktable/status")
     def api_darktable_status():
         import config as cfg
-        from develop import darktable_search_paths, find_darktable, find_dng_converter
+        from develop import (
+            darktable_search_paths,
+            darktable_tools_dir,
+            darktable_uses_tools_dir,
+            find_darktable,
+            find_dng_converter,
+        )
 
         configured = cfg.get("darktable_bin")
         binary = find_darktable(configured)
@@ -15921,17 +15927,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # actually probes: shutil.which("darktable-cli") first, then the
         # filesystem candidates. darktable_search_paths() covers only the
         # latter, and on Linux it lists just the AppImages already present in
-        # ~/.vireo/tools/darktable — so a box with none yet would get an empty
-        # "we checked here" list, on exactly the platform the download targets.
-        # Hence compose here rather than returning that list raw. The platform
-        # check below mirrors darktable_search_paths()'s own branching so the
-        # directory is named on, and only on, the platform that probes it.
+        # our tools dir — so a box with none yet would get an empty "we checked
+        # here" list, on exactly the platform the download targets. Hence
+        # compose here rather than returning that list raw.
+        # darktable_uses_tools_dir() is the same predicate darktable_search_paths()
+        # branches on, so the directory is named on, and only on, the platform
+        # that probes it. It cannot already be in the list: the detector only
+        # ever emits files *inside* the directory, never the directory itself.
         checked_paths = ["$PATH (darktable-cli)"]
         checked_paths.extend(darktable_search_paths())
-        if os.name != "nt" and sys.platform != "darwin":
-            tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
-            if tools_dir not in checked_paths:
-                checked_paths.append(tools_dir)
+        if darktable_uses_tools_dir():
+            checked_paths.append(darktable_tools_dir())
 
         return jsonify({
             "available": binary is not None,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18322,19 +18322,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         runner = app._job_runner
         active_ws = _get_db()._active_workspace_id
 
-        # If a darktable download is already running, return its id instead of
-        # starting a second worker.  Both workers would target the same
-        # <asset>.partial and race truncation, rename, verification, and
-        # deletion — the second one's cleanup could delete the first one's
-        # verified installer.  Joining rather than rejecting means opening
-        # Settings in two tabs (or double-clicking Download) still ends in one
-        # download the user watches, not an error.
-        for existing in runner.list_jobs():
-            if (
-                existing.get("type") == "download-darktable"
-                and existing.get("status") in ("running", "queued", "pausing", "paused")
-            ):
-                return jsonify({"job_id": existing["id"], "joined_existing": True})
+        # Read the identity the user confirmed BEFORE any other check.  If a
+        # download is already running and we are about to join it, the join
+        # must be conditional on this matching the running job's stored
+        # artifact — otherwise a second tab that saw a fresh release would
+        # join an old, stale download and receive different bytes than the
+        # dialog confirmed.
+        body = request.get_json(silent=True) or {}
+        expected_name = body.get("expected_name")
+        expected_version = body.get("expected_version")
+        # digest is compared verbatim (the API sends "sha256:<hex>"); None on
+        # either side means the client did not send one, not that they match.
+        expected_digest = body.get("expected_digest")
+
+        def _artifact_matches(stored):
+            """True when the stored artifact identity matches expected_*."""
+            if not stored:
+                return not expected_name
+            if expected_name and expected_name != stored.get("asset_name"):
+                return False
+            if expected_version and expected_version != stored.get("asset_version"):
+                return False
+            return not (
+                expected_digest and expected_digest != stored.get("asset_digest")
+            )
 
         # resolve_release(), never the cached variant: this re-resolves
         # server-side so the URL we actually download can't be a ten-minute-old
@@ -18361,12 +18372,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # confirmation would silently swap the artifact the user OK'd for a
         # different one.  code=darktable_asset_changed lets the client re-fetch
         # availability and re-prompt with the fresh identity.
-        body = request.get_json(silent=True) or {}
-        expected_name = body.get("expected_name")
-        expected_version = body.get("expected_version")
-        # digest is compared verbatim (the API sends "sha256:<hex>"); None on
-        # either side means the client did not send one, not that they match.
-        expected_digest = body.get("expected_digest")
         if expected_name and (
             expected_name != asset.get("name")
             or (expected_version and expected_version != asset.get("version"))
@@ -18442,10 +18447,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # the installer anyway (Linux would also chmod the AppImage), then
             # jobs.py would still label the job "cancelled" — the user would
             # see cancellation but the side effect they cancelled happened.
-            # download() polls cancellation up through verify_digest, so a
-            # cancel there raises DownloadCancelled; this covers the narrow
-            # window between verify returning and hand_off starting.
-            if runner.cancellation_requested(job["id"]):
+            # begin_uncancellable is the atomic version of that check: it
+            # returns False (leaving the cancel flag intact so _run_job
+            # records the job as cancelled) if a cancel is already pending,
+            # otherwise it enters the uninterruptible phase so a Cancel that
+            # arrives during hand_off is rejected rather than flipping the
+            # terminal status once the side effect has already committed.
+            if not runner.begin_uncancellable(job["id"]):
                 raise DownloadCancelled("Download cancelled")
 
             result = darktable_install.hand_off(path)
@@ -18472,7 +18480,46 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "quarantined": darktable_install.is_quarantined(path),
             }
 
-        job_id = runner.start("download-darktable", work, workspace_id=active_ws)
+        # Atomic singleton: the earlier check-then-start pattern (list_jobs()
+        # followed by runner.start()) let two concurrent POSTs both see "no
+        # existing job" and both start a worker on the same .partial.
+        # start_singleton does the existence check and the registration under
+        # one lock acquisition, so a second POST arriving between the check
+        # and the start joins the first instead of racing it.
+        #
+        # The stored config carries the artifact identity so a later POST for
+        # a DIFFERENT artifact (e.g. a new release published while an older
+        # download is still in flight) can be rejected instead of quietly
+        # joining a download of the wrong bytes.
+        job_id, joined, existing_snapshot = runner.start_singleton(
+            "download-darktable", work,
+            singleton_key="darktable-download",
+            config={
+                "asset_name": asset["name"],
+                "asset_version": asset["version"],
+                "asset_digest": asset.get("digest"),
+            },
+            workspace_id=active_ws,
+        )
+        if joined:
+            # Only join a running download whose artifact matches what THIS
+            # request confirmed. Without this check, a fresh POST for a new
+            # release would silently receive an old release's bytes from an
+            # already-running worker.
+            existing_config = (existing_snapshot or {}).get("config") or {}
+            if not _artifact_matches(existing_config):
+                return json_error(
+                    (
+                        "A different darktable download is already in progress "
+                        f"({existing_config.get('asset_name') or 'unknown'}). "
+                        f"Confirmation showed {asset.get('name')}. Wait for the "
+                        "in-flight download to finish (or cancel it) before "
+                        "starting this one."
+                    ),
+                    status=409,
+                    code="darktable_asset_changed",
+                )
+            return jsonify({"job_id": job_id, "joined_existing": True})
         return jsonify({"job_id": job_id})
 
     # -- Labels API routes --

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18313,6 +18313,109 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         job_id = runner.start("download-taxonomy", work, workspace_id=active_ws)
         return jsonify({"job_id": job_id})
 
+    @app.route("/api/jobs/download-darktable", methods=["POST"])
+    def api_job_download_darktable():
+        """Download the latest darktable build and hand it to the platform."""
+        import darktable_install
+        from job_contract import progress_event
+
+        runner = app._job_runner
+        active_ws = _get_db()._active_workspace_id
+
+        # resolve_release(), never the cached variant: this re-resolves
+        # server-side so the URL we actually download can't be a ten-minute-old
+        # value from whatever /install/available last showed.
+        try:
+            asset, reason = darktable_install.resolve_release()
+        except Exception as e:
+            # resolve_release is documented never to raise; belt and braces so
+            # an unexpected bug degrades to a message, not a 500.
+            log.warning("darktable release lookup failed: %s", e)
+            asset, reason = None, darktable_install.REASON_UNREACHABLE
+        if not asset:
+            # Surface the specific reason. resolve_release distinguishes
+            # "could not reach GitHub" from "no build for your platform";
+            # collapsing them here would tell a user behind a proxy that their
+            # platform is unsupported, which is false.
+            return json_error(reason or darktable_install.REASON_UNREACHABLE)
+
+        # Refuse before spending 87MB, and say what is needed vs what is free.
+        # 2x the asset size, per the design's error table: the artifact is kept
+        # after hand-off and the installer still has to unpack alongside it, so
+        # a check for exactly the download size would succeed and then strand
+        # the user on a full disk.
+        target = darktable_install.install_dir()
+        try:
+            free = darktable_install.free_space_bytes(target)
+        except OSError as e:
+            # free_space_bytes creates the directory, so this is where a
+            # read-only or otherwise unusable ~/.vireo surfaces. Name the
+            # directory and the OS error: a 500 would tell the user nothing.
+            log.warning("Cannot use the darktable download directory %s: %s", target, e)
+            return json_error(
+                f"Cannot use the download directory {target}: {e.strerror or e}"
+            )
+        needed = (asset.get("size") or 0) * 2
+        if free < needed:
+            return json_error(
+                f"Not enough disk space: {needed // (1024 * 1024)} MB needed in "
+                f"{target}, {free // (1024 * 1024)} MB free."
+            )
+
+        def work(job):
+            # byte_callback runs on the download thread inside the write loop,
+            # so this must stay cheap — a queue put, never a DB write or
+            # anything else that can stall the transfer.
+            def on_bytes(done, total):
+                runner.push_event(job["id"], "progress", progress_event(
+                    phase="Downloading darktable",
+                    current=done,
+                    total=total or asset.get("size") or 0,
+                    current_file=asset["name"],
+                ))
+
+            path, verify_detail = darktable_install.download(
+                asset,
+                byte_callback=on_bytes,
+                should_cancel=lambda: runner.is_cancelled(job["id"]),
+            )
+
+            # total=0 on purpose: the UI treats a non-zero total as a byte
+            # count and would render "Verifying: 0 of 0 MB" instead of the
+            # verification detail. That detail is passed through verbatim —
+            # it is the only thing that distinguishes "the digest matched"
+            # from "GitHub published no digest to check against".
+            runner.push_event(job["id"], "progress", progress_event(
+                phase="Verifying", current=0, total=0, current_file=verify_detail,
+            ))
+
+            result = darktable_install.hand_off(path)
+
+            # The single place config is mutated, right next to the field that
+            # tells the user it happened. hand_off deliberately does not write
+            # it. bin_path is only set where the download IS the binary
+            # (Linux AppImage); after an installer hand-off the user chooses
+            # where the app lands, so there is nothing truthful to record.
+            config_written = False
+            if result.get("bin_path"):
+                import config as cfg
+
+                cfg.set("darktable_bin", result["bin_path"])
+                config_written = True
+
+            return {
+                "version": asset["version"],
+                "downloaded_to": path,
+                "verified": verify_detail,
+                "action": result["action"],
+                "bin_path": result.get("bin_path"),
+                "config_written": config_written,
+                "quarantined": darktable_install.is_quarantined(path),
+            }
+
+        job_id = runner.start("download-darktable", work, workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+
     # -- Labels API routes --
 
     @app.route("/api/labels/search-places")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18413,13 +18413,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # headroom.  Gate on the API-supplied size (same rule download() uses)
         # so an unrelated file the user dropped in the tools directory does
         # not get credited against the check.
+        #
+        # A cancelled- or connection-lost-during-transfer attempt leaves a
+        # ``.partial`` sibling that _download_with_resume will resume from,
+        # so those bytes are also already on disk and the retry only needs
+        # ``asset_size - partial_size`` more download bytes plus the unpack
+        # headroom.  Cap the credit at ``asset_size`` — a ``.partial`` bigger
+        # than the API-published size is a sign of a stale file from a
+        # different release, and crediting more than we can actually reuse
+        # would let the retry through only for the disk to fill mid-transfer.
         reusable_bytes = 0
         asset_name = asset.get("name") or ""
         if asset_name:
             existing_dest = os.path.join(target, os.path.basename(asset_name))
+            existing_partial = existing_dest + ".partial"
             try:
                 if os.path.isfile(existing_dest) and os.path.getsize(existing_dest) == asset_size:
                     reusable_bytes = asset_size
+                elif os.path.isfile(existing_partial) and asset_size:
+                    reusable_bytes = min(os.path.getsize(existing_partial), asset_size)
             except OSError:
                 reusable_bytes = 0
         needed = max(0, asset_size * 2 - reusable_bytes)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18334,6 +18334,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # digest is compared verbatim (the API sends "sha256:<hex>"); None on
         # either side means the client did not send one, not that they match.
         expected_digest = body.get("expected_digest")
+        # Size is the fallback identity for digestless releases: if GitHub
+        # deletes and re-uploads an asset under the same tag+filename during
+        # the availability cache's TTL, name/version match but bytes differ,
+        # and without a digest the name/version check alone would silently
+        # accept the swap.  Compare when the client sent one — an int on the
+        # wire, coerced defensively so a stray string does not throw here.
+        try:
+            expected_size = int(body["expected_size"]) if body.get("expected_size") is not None else None
+        except (TypeError, ValueError):
+            expected_size = None
 
         def _artifact_matches(stored):
             """True when the stored artifact identity matches expected_*."""
@@ -18343,8 +18353,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return False
             if expected_version and expected_version != stored.get("asset_version"):
                 return False
+            if expected_digest and expected_digest != stored.get("asset_digest"):
+                return False
             return not (
-                expected_digest and expected_digest != stored.get("asset_digest")
+                expected_size is not None
+                and stored.get("asset_size") is not None
+                and expected_size != stored.get("asset_size")
             )
 
         # resolve_release(), never the cached variant: this re-resolves
@@ -18376,6 +18390,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             expected_name != asset.get("name")
             or (expected_version and expected_version != asset.get("version"))
             or (expected_digest and expected_digest != asset.get("digest"))
+            or (
+                expected_size is not None
+                and asset.get("size") is not None
+                and expected_size != asset.get("size")
+            )
         ):
             # Refresh the availability cache with the release we just resolved.
             # Without this, the UI's Re-check would fetch /install/available,
@@ -18543,6 +18562,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "asset_name": asset["name"],
                 "asset_version": asset["version"],
                 "asset_digest": asset.get("digest"),
+                "asset_size": asset.get("size"),
             },
             workspace_id=active_ws,
         )

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18377,6 +18377,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             or (expected_version and expected_version != asset.get("version"))
             or (expected_digest and expected_digest != asset.get("digest"))
         ):
+            # Refresh the availability cache with the release we just resolved.
+            # Without this, the UI's Re-check would fetch /install/available,
+            # get the same ten-minute-old cached asset back, re-confirm it, and
+            # get bounced by the same 409 in a loop until the TTL expires.
+            darktable_install.update_release_cache(asset)
             return json_error(
                 (
                     "The darktable release changed since this dialog opened. "
@@ -18548,6 +18553,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # already-running worker.
             existing_config = (existing_snapshot or {}).get("config") or {}
             if not _artifact_matches(existing_config):
+                # Same reason as above: the cache may hold whatever asset the
+                # first tab's download targeted, so a Re-check without this
+                # refresh would re-render the stale identity and the user
+                # would re-confirm it into the same 409.
+                darktable_install.update_release_cache(asset)
                 return json_error(
                     (
                         "A different darktable download is already in progress "

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18322,6 +18322,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         runner = app._job_runner
         active_ws = _get_db()._active_workspace_id
 
+        # If a darktable download is already running, return its id instead of
+        # starting a second worker.  Both workers would target the same
+        # <asset>.partial and race truncation, rename, verification, and
+        # deletion — the second one's cleanup could delete the first one's
+        # verified installer.  Joining rather than rejecting means opening
+        # Settings in two tabs (or double-clicking Download) still ends in one
+        # download the user watches, not an error.
+        for existing in runner.list_jobs():
+            if (
+                existing.get("type") == "download-darktable"
+                and existing.get("status") in ("running", "queued", "pausing", "paused")
+            ):
+                return jsonify({"job_id": existing["id"], "joined_existing": True})
+
         # resolve_release(), never the cached variant: this re-resolves
         # server-side so the URL we actually download can't be a ten-minute-old
         # value from whatever /install/available last showed.
@@ -18338,6 +18352,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # collapsing them here would tell a user behind a proxy that their
             # platform is unsupported, which is false.
             return json_error(reason or darktable_install.REASON_UNREACHABLE)
+
+        # Bind the download to the exact artifact the user confirmed.  Between
+        # /install/available populating its 10-minute cache and this POST,
+        # darktable-org can publish a new release; the confirmation dialog
+        # still names the cached version and digest, but resolve_release() just
+        # returned the newer asset.  Downloading it here without another
+        # confirmation would silently swap the artifact the user OK'd for a
+        # different one.  code=darktable_asset_changed lets the client re-fetch
+        # availability and re-prompt with the fresh identity.
+        body = request.get_json(silent=True) or {}
+        expected_name = body.get("expected_name")
+        expected_version = body.get("expected_version")
+        # digest is compared verbatim (the API sends "sha256:<hex>"); None on
+        # either side means the client did not send one, not that they match.
+        expected_digest = body.get("expected_digest")
+        if expected_name and (
+            expected_name != asset.get("name")
+            or (expected_version and expected_version != asset.get("version"))
+            or (expected_digest and expected_digest != asset.get("digest"))
+        ):
+            return json_error(
+                (
+                    "The darktable release changed since this dialog opened. "
+                    f"Confirmation showed {expected_name}; the current release "
+                    f"is {asset.get('name')}. Re-check to see the new build "
+                    "before downloading."
+                ),
+                status=409,
+                code="darktable_asset_changed",
+            )
 
         # Refuse before spending 87MB, and say what is needed vs what is free.
         # 2x the asset size, per the design's error table: the artifact is kept
@@ -18363,6 +18407,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
 
         def work(job):
+            try:
+                from .taxonomy import DownloadCancelled
+            except ImportError:
+                from taxonomy import DownloadCancelled
+
             # byte_callback runs on the download thread inside the write loop,
             # so this must stay cheap — a queue put, never a DB write or
             # anything else that can stall the transfer.
@@ -18388,6 +18437,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             runner.push_event(job["id"], "progress", progress_event(
                 phase="Verifying", current=0, total=0, current_file=verify_detail,
             ))
+
+            # A Stop press after verification and before hand_off would open
+            # the installer anyway (Linux would also chmod the AppImage), then
+            # jobs.py would still label the job "cancelled" — the user would
+            # see cancellation but the side effect they cancelled happened.
+            # download() polls cancellation up through verify_digest, so a
+            # cancel there raises DownloadCancelled; this covers the narrow
+            # window between verify returning and hand_off starting.
+            if runner.cancellation_requested(job["id"]):
+                raise DownloadCancelled("Download cancelled")
 
             result = darktable_install.hand_off(path)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15953,6 +15953,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "checked_paths": checked_paths,
         })
 
+    @app.route("/api/darktable/install/available")
+    def api_darktable_install_available():
+        """What a download would fetch, for the confirmation dialog.
+
+        Always 200: when this cannot answer, the panel shows a plain
+        "Get darktable" link and the reason, rather than a dead button.
+        """
+        import darktable_install
+
+        try:
+            release, reason = darktable_install.resolve_release_cached()
+        except Exception as e:
+            # resolve_release is documented never to raise; this is belt and
+            # braces so an unexpected bug still degrades to a link, not a 500.
+            log.warning("darktable release lookup failed: %s", e)
+            return jsonify({
+                "available": False,
+                "reason": darktable_install.REASON_UNREACHABLE,
+            })
+
+        if not release:
+            # Pass the reason through verbatim. Do NOT substitute a generic
+            # message: "we could not reach GitHub" and "no build exists for
+            # your platform" are different facts and users act on them
+            # differently.
+            return jsonify({"available": False, "reason": reason})
+
+        return jsonify({"available": True, **release})
+
     @app.route("/api/exiftool/status")
     def api_exiftool_status():
         """Report whether the exiftool binary is installed.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15910,12 +15910,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/darktable/status")
     def api_darktable_status():
         import config as cfg
-        from develop import find_darktable, find_dng_converter
+        from develop import darktable_search_paths, find_darktable, find_dng_converter
 
         configured = cfg.get("darktable_bin")
         binary = find_darktable(configured)
         dng_configured = cfg.get("dng_converter_bin")
         dng_binary = find_dng_converter(dng_configured)
+
+        # What we tell the user we checked has to match what find_darktable
+        # actually probes: shutil.which("darktable-cli") first, then the
+        # filesystem candidates. darktable_search_paths() covers only the
+        # latter, and on Linux it lists just the AppImages already present in
+        # ~/.vireo/tools/darktable — so a box with none yet would get an empty
+        # "we checked here" list, on exactly the platform the download targets.
+        # Hence compose here rather than returning that list raw. The platform
+        # check below mirrors darktable_search_paths()'s own branching so the
+        # directory is named on, and only on, the platform that probes it.
+        checked_paths = ["$PATH (darktable-cli)"]
+        checked_paths.extend(darktable_search_paths())
+        if os.name != "nt" and sys.platform != "darwin":
+            tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
+            if tools_dir not in checked_paths:
+                checked_paths.append(tools_dir)
+
         return jsonify({
             "available": binary is not None,
             "bin": binary or "",
@@ -15927,6 +15944,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "style": cfg.get("darktable_style"),
             "output_format": cfg.get("darktable_output_format"),
             "output_dir": cfg.get("darktable_output_dir"),
+            "checked_paths": checked_paths,
         })
 
     @app.route("/api/exiftool/status")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18404,7 +18404,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(
                 f"Cannot use the download directory {target}: {e.strerror or e}"
             )
-        needed = (asset.get("size") or 0) * 2
+        asset_size = asset.get("size") or 0
+        # A previous cancelled-during-verify attempt leaves the full artifact
+        # already sitting at the final destination — download() fast-paths to
+        # verify in that case and spends zero download bytes.  Counting those
+        # bytes as still-to-be-downloaded blocks the promised retry with a
+        # "not enough space" error even though the retry only needs unpacking
+        # headroom.  Gate on the API-supplied size (same rule download() uses)
+        # so an unrelated file the user dropped in the tools directory does
+        # not get credited against the check.
+        reusable_bytes = 0
+        asset_name = asset.get("name") or ""
+        if asset_name:
+            existing_dest = os.path.join(target, os.path.basename(asset_name))
+            try:
+                if os.path.isfile(existing_dest) and os.path.getsize(existing_dest) == asset_size:
+                    reusable_bytes = asset_size
+            except OSError:
+                reusable_bytes = 0
+        needed = max(0, asset_size * 2 - reusable_bytes)
         if free < needed:
             return json_error(
                 f"Not enough disk space: {needed // (1024 * 1024)} MB needed in "
@@ -18463,11 +18481,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # it. bin_path is only set where the download IS the binary
             # (Linux AppImage); after an installer hand-off the user chooses
             # where the app lands, so there is nothing truthful to record.
+            #
+            # Route the write through _settings_write_lock and the raw
+            # read-modify-write pattern the settings endpoints use.  cfg.set()
+            # takes only config._lock, so a concurrent /api/config save (or an
+            # autosave from the All-settings region) could otherwise interleave
+            # its own read-modify-write with this one and either lose
+            # darktable_bin or overwrite whatever field the user just changed.
             config_written = False
             if result.get("bin_path"):
                 import config as cfg
 
-                cfg.set("darktable_bin", result["bin_path"])
+                with _settings_write_lock:
+                    raw = _read_raw_config_file()
+                    raw["darktable_bin"] = result["bin_path"]
+                    cfg.save(raw)
                 config_written = True
 
             return {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15959,7 +15959,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         Always 200: when this cannot answer, the panel shows a plain
         "Get darktable" link and the reason, rather than a dead button.
+
+        Includes the Flask host's ``platform`` (linux/darwin/win32) so the
+        UI's "Download installer" vs "Download and set up" label and its
+        Gatekeeper/SmartScreen warnings describe the machine that will
+        actually run the installer — not the browser device, which can be
+        a phone or a different desktop on the LAN.
         """
+        import sys
+
         import darktable_install
 
         try:
@@ -15971,6 +15979,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return jsonify({
                 "available": False,
                 "reason": darktable_install.REASON_UNREACHABLE,
+                "platform": sys.platform,
             })
 
         if not release:
@@ -15978,9 +15987,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # message: "we could not reach GitHub" and "no build exists for
             # your platform" are different facts and users act on them
             # differently.
-            return jsonify({"available": False, "reason": reason})
+            return jsonify({
+                "available": False,
+                "reason": reason,
+                "platform": sys.platform,
+            })
 
-        return jsonify({"available": True, **release})
+        return jsonify({"available": True, "platform": sys.platform, **release})
 
     @app.route("/api/exiftool/status")
     def api_exiftool_status():

--- a/vireo/darktable_install.py
+++ b/vireo/darktable_install.py
@@ -11,6 +11,7 @@ unsigned, so a fail-closed signature check would reject every legitimate
 download.  See docs/superpowers/specs/2026-07-26-darktable-download-design.md.
 """
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -464,11 +465,37 @@ def download(asset, dest_dir=None, byte_callback=None, should_cancel=None):
     os.makedirs(dest_dir, exist_ok=True)
     dest = os.path.join(dest_dir, name)
 
-    _download_with_resume(
-        asset["url"], dest,
-        byte_callback=byte_callback,
-        should_cancel=should_cancel,
+    # Fast path: a previous attempt already finished the transfer but was
+    # cancelled during verify_digest.  _download_with_resume renames its
+    # .partial to dest on success, so cancellation observed inside the
+    # hash loop leaves no .partial to resume from — a naive retry would
+    # re-download the whole 87-178 MB asset even though the complete file
+    # is sitting right there.  If dest already exists at exactly the size
+    # the API published, skip straight to verify: verify_digest still
+    # decides whether the bytes are good (delete on mismatch, keep on
+    # match).  We deliberately gate on the API-supplied size so an
+    # unrelated file the user dropped in the tools directory does not get
+    # accepted as this asset.
+    expected_size = asset.get("size")
+    already_complete = bool(
+        expected_size
+        and os.path.exists(dest)
+        and os.path.getsize(dest) == expected_size
     )
+    if already_complete:
+        # Emit final progress so the UI's byte counter jumps to full instead
+        # of stalling at 0 while the (skipped) download "runs".  Match
+        # _download_with_resume's contract that callbacks may not raise —
+        # there they would be misreported as network failures.
+        if byte_callback is not None:
+            with contextlib.suppress(Exception):
+                byte_callback(expected_size, expected_size)
+    else:
+        _download_with_resume(
+            asset["url"], dest,
+            byte_callback=byte_callback,
+            should_cancel=should_cancel,
+        )
 
     actual_size = os.path.getsize(dest)
     if asset.get("size") and actual_size != asset["size"]:

--- a/vireo/darktable_install.py
+++ b/vireo/darktable_install.py
@@ -232,7 +232,7 @@ _HASH_CHUNK_BYTES = 1024 * 1024
 _SHA256_HEX_RE = re.compile(r"\A[0-9a-f]{64}\Z")
 
 
-def verify_digest(path, expected):
+def verify_digest(path, expected, *, should_cancel=None):
     """Compare the file's SHA256 against the digest published by the API.
 
     Returns ``(ok, human_readable_detail)``.  The detail is shown to the user
@@ -249,6 +249,12 @@ def verify_digest(path, expected):
     that is not a 64-character hexdigest, a non-string — fails closed with its
     own sentence rather than being reported as a mismatch, which would blame an
     intact file, or silently passing, which would leave the download unchecked.
+
+    ``should_cancel`` is polled between chunks so a Stop press during the
+    ~178MB hash is felt within a chunk instead of after the whole file: raising
+    taxonomy.DownloadCancelled propagates out through download() to the job
+    thread, where it is reported as cancelled rather than as an installer
+    hand-off (which would happen anyway if the digest matched).
     """
     if not expected:
         # Passing here is deliberate: every asset ships a digest today, and
@@ -296,6 +302,18 @@ def verify_digest(path, expected):
     try:
         with open(path, "rb") as f:
             for chunk in iter(lambda: f.read(_HASH_CHUNK_BYTES), b""):
+                # Poll BEFORE the update so a cancel-just-before-EOF is felt on
+                # the last iteration rather than after the hexdigest is
+                # computed.  Do it here rather than inside a try/except in the
+                # caller: verify_digest is what actually holds the file open,
+                # and skipping the update on cancel avoids one more chunk of
+                # work per polling interval.
+                if should_cancel is not None and should_cancel():
+                    try:
+                        from .taxonomy import DownloadCancelled
+                    except ImportError:
+                        from taxonomy import DownloadCancelled
+                    raise DownloadCancelled("Download cancelled")
                 h.update(chunk)
     except OSError as exc:
         # Task 9 calls this from a job thread with no except clause of its own.
@@ -459,7 +477,7 @@ def download(asset, dest_dir=None, byte_callback=None, should_cancel=None):
             f"Size mismatch — expected {asset['size']} bytes, got {actual_size}"
         )
 
-    ok, detail = verify_digest(dest, asset.get("digest"))
+    ok, detail = verify_digest(dest, asset.get("digest"), should_cancel=should_cancel)
     if not ok:
         os.remove(dest)
         raise RuntimeError(detail)

--- a/vireo/darktable_install.py
+++ b/vireo/darktable_install.py
@@ -14,15 +14,24 @@ download.  See docs/superpowers/specs/2026-07-26-darktable-download-design.md.
 import hashlib
 import json
 import logging
+import os
 import platform
 import posixpath
 import re
+import shutil
 import ssl
+import stat
+import subprocess
 import sys
 import urllib.parse
 import urllib.request
 
 import certifi
+
+try:
+    from . import develop
+except ImportError:
+    import develop
 
 log = logging.getLogger(__name__)
 
@@ -277,3 +286,164 @@ def verify_digest(path, expected):
         f"SHA256 mismatch — expected {want}, got {actual}. The download does not match "
         "the digest GitHub published, so it was truncated, corrupted or replaced."
     )
+
+
+def install_dir():
+    """Where downloads land, on every platform.
+
+    Also where the ``.partial`` resume file lives and which filesystem the
+    free-space check measures.  Installers are kept after hand-off — the user
+    may want to re-run them.
+
+    Delegates to develop.darktable_tools_dir() rather than re-deriving the
+    path: on Linux that is the *only* directory darktable_search_paths probes,
+    so downloading anywhere else would install darktable and still report it
+    missing.
+    """
+    return develop.darktable_tools_dir()
+
+
+def is_quarantined(path):
+    """True if macOS tagged the file with com.apple.quarantine.
+
+    Measured behaviour: urllib downloads are NOT quarantined (LaunchServices
+    applies that attribute for browser-style downloads), so this is normally
+    False and the Gatekeeper warning stays hidden.  Checked rather than
+    assumed in either direction.
+
+    Never raises: a platform without the attribute, or without the xattr tool,
+    is simply "not quarantined" — an install that otherwise worked must not
+    fail over a cosmetic warning.
+    """
+    if sys.platform != "darwin":
+        return False
+    try:
+        result = subprocess.run(
+            ["xattr", "-p", "com.apple.quarantine", path],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:
+        log.debug("Could not check the quarantine attribute of %s", path, exc_info=True)
+        return False
+
+
+def _installs_into_tools_dir(platform_name=None):
+    """True where the downloaded artifact *is* the runnable binary.
+
+    With no override this is develop.darktable_uses_tools_dir() verbatim, so
+    hand_off cannot branch differently from the directory darktable_search_paths
+    probes.  ``platform_name`` is an explicit-platform override for tests and
+    for callers that already know which build they fetched.
+    """
+    if platform_name is None:
+        return develop.darktable_uses_tools_dir()
+    return platform_name not in ("darwin", "win32")
+
+
+def hand_off(path, platform_name=None):
+    """Hand the downloaded artifact to the platform.
+
+    Returns ``{action, location, bin_path}``.  Does NOT write config: bin_path
+    is returned so the job handler writes darktable_bin in one place, next to
+    the message that tells the user it happened.
+
+    Raises RuntimeError if the installer could not be opened.  The message
+    names the downloaded file, because it is still on disk and opening it by
+    hand is the user's way forward — reporting "opened-installer" anyway would
+    leave them waiting for a window that never appears.
+    """
+    if _installs_into_tools_dir(platform_name):
+        # Linux: the AppImage we just downloaded is the program itself.  It is
+        # deliberately left as-is rather than pre-extracted; see the AppImage
+        # note in docs/superpowers/plans/2026-07-26-darktable-download.md.
+        mode = os.stat(path).st_mode
+        os.chmod(path, mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return {"action": "installed", "location": path, "bin_path": path}
+
+    if (platform_name or sys.platform) == "darwin":
+        # No capture_output: `open` hands the file to LaunchServices and exits,
+        # and piping its streams risks blocking on a handle the launched app
+        # inherits.  The exit status is the part we need.
+        result = subprocess.run(["open", path], timeout=30)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Downloaded to {path}, but macOS could not open it "
+                f"(exit code {result.returncode}). Open it yourself to install darktable."
+            )
+    else:
+        try:
+            os.startfile(path)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Downloaded to {path}, but Windows could not open it ({exc}). "
+                "Open it yourself to install darktable."
+            ) from exc
+
+    # The user chooses where the app lands, so we cannot know bin_path here.
+    # Detection (Task 1) finds it on the next re-check.
+    return {"action": "opened-installer", "location": path, "bin_path": None}
+
+
+def download(asset, dest_dir=None, byte_callback=None, should_cancel=None):
+    """Download one resolved asset, verify it, and return ``(path, detail)``.
+
+    ``detail`` is verify_digest's sentence, returned verbatim: ok=True covers
+    both "the digest matched" and "GitHub published no digest", and only that
+    sentence distinguishes them.  Callers must show it rather than deriving
+    their own "verified" wording from the boolean.
+
+    Raises RuntimeError on a size or digest mismatch, deleting the bad file: a
+    wrong artifact must never be handed to an installer.  A cancellation
+    propagates as taxonomy.DownloadCancelled with the ``.partial`` left in
+    place for resume — should_cancel is checked before the first read, so an
+    immediately cancelled download leaves a 0-byte ``.partial``, which is a
+    normal resume state and not a corrupt-download signal.
+    """
+    try:
+        from .taxonomy import _download_with_resume
+    except ImportError:
+        from taxonomy import _download_with_resume
+
+    # The name comes from the GitHub API, so it is joined only after being
+    # reduced to a bare filename: a name carrying path separators would
+    # otherwise write outside the tools directory.
+    name = os.path.basename(asset["name"])
+    if name != asset["name"] or name in ("", ".", ".."):
+        raise RuntimeError(
+            f"Refusing to download an asset with a suspicious name: {asset['name']!r}"
+        )
+
+    dest_dir = dest_dir or install_dir()
+    os.makedirs(dest_dir, exist_ok=True)
+    dest = os.path.join(dest_dir, name)
+
+    _download_with_resume(
+        asset["url"], dest,
+        byte_callback=byte_callback,
+        should_cancel=should_cancel,
+    )
+
+    actual_size = os.path.getsize(dest)
+    if asset.get("size") and actual_size != asset["size"]:
+        os.remove(dest)
+        raise RuntimeError(
+            f"Size mismatch — expected {asset['size']} bytes, got {actual_size}"
+        )
+
+    ok, detail = verify_digest(dest, asset.get("digest"))
+    if not ok:
+        os.remove(dest)
+        raise RuntimeError(detail)
+    return dest, detail
+
+
+def free_space_bytes(path):
+    """Bytes free on the filesystem holding path (creating it if needed).
+
+    shutil.disk_usage rather than os.statvfs: it works on all three platforms
+    (statvfs does not exist on Windows) and reports the same non-root-reserved
+    free figure, so there is nothing to fall back to.
+    """
+    os.makedirs(path, exist_ok=True)
+    return shutil.disk_usage(path).free

--- a/vireo/darktable_install.py
+++ b/vireo/darktable_install.py
@@ -225,6 +225,25 @@ def resolve_release_cached():
     return release, reason
 
 
+def update_release_cache(release):
+    """Overwrite the cached release with a freshly resolved one.
+
+    Called by the download endpoint when its uncached resolve_release() has
+    already proved the stored value stale — the asset the user just confirmed
+    disagrees with what darktable-org is publishing right now.  Without this,
+    the client's Re-check would hit /install/available, get the same
+    ten-minute-old cached asset back, re-confirm it, and receive the same 409
+    in a loop until the TTL expires.  Writing the fresh release here means the
+    next Re-check shows what the server actually intends to download.
+
+    Does nothing on a falsy release: a failed resolution must never pin the
+    fallback link (mirrors resolve_release_cached's "only cache successes").
+    """
+    if not release:
+        return
+    _release_cache.update(at=time.monotonic(), value=release)
+
+
 # Read the asset a megabyte at a time: these builds are 87-178MB and hashing
 # happens right after the download, so f.read() with no size would hold the
 # whole file in RAM on top of whatever the download already cost.

--- a/vireo/darktable_install.py
+++ b/vireo/darktable_install.py
@@ -11,10 +11,12 @@ unsigned, so a fail-closed signature check would reject every legitimate
 download.  See docs/superpowers/specs/2026-07-26-darktable-download-design.md.
 """
 
+import hashlib
 import json
 import logging
 import platform
 import posixpath
+import re
 import ssl
 import sys
 import urllib.parse
@@ -183,3 +185,95 @@ def resolve_release(timeout=15):
     tag = release.get("tag_name")
     version = tag.removeprefix("release-") if isinstance(tag, str) else ""
     return {"version": version, **asset}, None
+
+
+# Read the asset a megabyte at a time: these builds are 87-178MB and hashing
+# happens right after the download, so f.read() with no size would hold the
+# whole file in RAM on top of whatever the download already cost.
+_HASH_CHUNK_BYTES = 1024 * 1024
+
+_SHA256_HEX_RE = re.compile(r"\A[0-9a-f]{64}\Z")
+
+
+def verify_digest(path, expected):
+    """Compare the file's SHA256 against the digest published by the API.
+
+    Returns ``(ok, human_readable_detail)``.  The detail is shown to the user
+    verbatim, so it must be honest about what was and was not checked: a
+    matching digest proves the bytes are what GitHub's API said they are, not
+    that darktable signed them.  The digest arrives in the same HTTPS response
+    as the download URL, so it shares that response's trust boundary — it is
+    not an independent signature, and there is none to check (see the module
+    docstring).  This is the only integrity check the feature has.
+
+    ``expected`` comes from an external API, so its cosmetics are tolerated:
+    the ``sha256:`` prefix is optional, hex case and surrounding whitespace are
+    ignored.  Anything we cannot actually evaluate — another algorithm, a value
+    that is not a 64-character hexdigest, a non-string — fails closed with its
+    own sentence rather than being reported as a mismatch, which would blame an
+    intact file, or silently passing, which would leave the download unchecked.
+    """
+    if not expected:
+        # Passing here is deliberate: every asset ships a digest today, and
+        # refusing the download if one is ever missing would break the feature
+        # over something the user cannot fix.  Say so instead of implying a
+        # check happened.
+        log.warning("No digest published for %s — accepting it unverified", path)
+        return True, (
+            "GitHub published no digest for this asset, so its contents could not be "
+            "verified. The download came from darktable's official GitHub release, but "
+            "nothing confirms the bytes arrived intact."
+        )
+
+    if not isinstance(expected, str):
+        log.warning("Cannot verify %s: digest is %r, not a string", path, type(expected).__name__)
+        return False, (
+            "Could not verify the download: GitHub sent a digest in a form Vireo does "
+            "not understand."
+        )
+
+    # rpartition, not partition: with no ":" at all it puts the whole string in
+    # the last field, so a bare hexdigest is read as a hash with no algorithm
+    # rather than as an algorithm with no hash.  The strips also absorb any
+    # whitespace around the value, since leading whitespace lands on the
+    # algorithm and trailing whitespace on the hash.
+    algorithm, _, value = expected.rpartition(":")
+    algorithm = algorithm.strip().lower() or "sha256"
+    want = value.strip().lower()
+
+    if algorithm != "sha256":
+        log.warning("Cannot verify %s: digest algorithm is %r, not sha256", path, algorithm)
+        return False, (
+            # Truncated: this is an API-supplied string being rendered in the UI.
+            f'Could not verify the download: GitHub published the digest as "'
+            f'{algorithm[:20]}" and Vireo only checks SHA256.'
+        )
+    if not _SHA256_HEX_RE.match(want):
+        log.warning("Cannot verify %s: %r is not a SHA256 hexdigest", path, expected)
+        return False, (
+            "Could not verify the download: the digest GitHub published is not a valid "
+            "SHA256 hash."
+        )
+
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(_HASH_CHUNK_BYTES), b""):
+                h.update(chunk)
+    except OSError as exc:
+        # Task 9 calls this from a job thread with no except clause of its own.
+        log.warning("Could not read %s to verify it: %s", path, exc)
+        return False, f"Could not read the downloaded file to verify it: {exc.strerror or exc}"
+    actual = h.hexdigest()
+
+    if actual == want:
+        return True, (
+            f"SHA256 matches the digest GitHub published for this asset ({actual[:16]}…). "
+            "That confirms the bytes are what GitHub said to expect; darktable does not "
+            "sign its builds, so there is no signature to check."
+        )
+    log.warning("Digest mismatch for %s: expected %s, got %s", path, want, actual)
+    return False, (
+        f"SHA256 mismatch — expected {want}, got {actual}. The download does not match "
+        "the digest GitHub published, so it was truncated, corrupted or replaced."
+    )

--- a/vireo/darktable_install.py
+++ b/vireo/darktable_install.py
@@ -13,7 +13,10 @@ download.  See docs/superpowers/specs/2026-07-26-darktable-download-design.md.
 
 import json
 import logging
+import platform
+import posixpath
 import ssl
+import sys
 import urllib.parse
 import urllib.request
 
@@ -29,11 +32,18 @@ _ssl_ctx = ssl.create_default_context(cafile=certifi.where())
 
 RELEASES_API = "https://api.github.com/repos/darktable-org/darktable/releases/latest"
 
-_ALLOWED_HOSTS = {"github.com", "objects.githubusercontent.com"}
-_ALLOWED_PATH_PREFIX = "/darktable-org/darktable/"
+_ALLOWED_HOSTS = {"github.com"}
+# Every real browser_download_url is
+# https://github.com/darktable-org/darktable/releases/download/<tag>/<file>.
+# Constraining to the release-download path (not just the repo) means a URL
+# pointing at repo *content* — /raw/master/evil.sh — cannot pass.
+_ALLOWED_PATH_PREFIX = "/darktable-org/darktable/releases/download/"
 
-# Anything smaller than this is not a darktable build.  Guards against the
-# ~300KB .zsync manifests and against a truncated or renamed asset.
+# Anything smaller than this is not a darktable build.  This compares the size
+# the GitHub API *reports*, so it filters out the small siblings listed next to
+# the real builds (the ~300KB .zsync manifests, the 195-byte .asc signature) and
+# an asset renamed to look like a build.  It cannot detect a truncated download —
+# that is the digest check's job.
 _MIN_ASSET_BYTES = 10 * 1024 * 1024
 
 # (sys.platform, platform.machine()) -> required asset-name suffix.
@@ -48,46 +58,79 @@ _ASSET_SUFFIXES = {
     ("linux", "aarch64"): "-aarch64.AppImage",
 }
 
+# User-facing failure sentences returned by resolve_release().  These are shown
+# verbatim next to a plain "Get darktable" link, so each one must state the
+# fact the user needs in order to act: retry later, or stop looking.
+REASON_UNREACHABLE = "Could not reach GitHub to check for a darktable release."
+REASON_NO_PLATFORM_BUILD = "No darktable build is published for this platform."
+REASON_NO_USABLE_ASSET = (
+    "The latest darktable release did not contain a usable build for this platform."
+)
+
 
 def _url_is_trusted(url):
-    """True only for HTTPS URLs on a GitHub host under the darktable repo.
+    """True only for HTTPS release-asset URLs under the darktable repo.
 
     Enforced on the API-supplied browser_download_url only.  GitHub redirects
     release downloads to release-assets.githubusercontent.com, so applying
     this to redirect targets would reject every legitimate download.
+
+    The path is percent-decoded and normalised before the prefix test: GitHub
+    resolves ".." on receipt, so a raw startswith() would accept
+    /darktable-org/darktable/../../attacker/evil/releases/download/x/evil.exe.
     """
+    if not isinstance(url, str):
+        return False
     try:
-        parts = urllib.parse.urlparse(url or "")
+        parts = urllib.parse.urlparse(url)
     except ValueError:
         return False
-    if parts.scheme != "https" or parts.hostname not in _ALLOWED_HOSTS:
+    if parts.scheme != "https":
         return False
-    return parts.path.startswith(_ALLOWED_PATH_PREFIX)
+    if (parts.hostname or "").lower() not in _ALLOWED_HOSTS:
+        return False
+    path = posixpath.normpath(urllib.parse.unquote(parts.path)).lower()
+    return path.startswith(_ALLOWED_PATH_PREFIX)
 
 
 def select_asset(release, platform_name, machine):
     """Pick the asset matching this platform, or None.
 
     Returns a dict with name/size/url/digest, or None when this platform has
-    no build, the only match is implausibly small, or the URL is untrusted.
+    no build and when every asset whose name matches this platform's suffix was
+    rejected as implausibly small or as having an untrusted URL.  A rejected
+    candidate is skipped, not fatal: a single poisoned entry ahead of the
+    genuine asset must not take the feature down.
+
+    Tolerates a malformed release payload (anything that is not a dict, or an
+    "assets" list holding non-dict entries) by returning None.
     """
+    if not isinstance(release, dict):
+        return None
+
     suffix = _ASSET_SUFFIXES.get((platform_name, str(machine).lower()))
     if not suffix:
         log.info("No darktable asset for platform=%s machine=%s", platform_name, machine)
         return None
 
-    for asset in release.get("assets", []):
-        name = asset.get("name", "")
-        if not name.endswith(suffix):
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        return None
+
+    for asset in assets:
+        if not isinstance(asset, dict):
             continue
-        size = asset.get("size", 0)
-        if size < _MIN_ASSET_BYTES:
-            log.warning("Rejecting %s: %d bytes is too small to be darktable", name, size)
-            return None
+        name = asset.get("name")
+        if not isinstance(name, str) or not name.endswith(suffix):
+            continue
+        size = asset.get("size")
+        if not isinstance(size, int) or size < _MIN_ASSET_BYTES:
+            log.warning("Rejecting %s: %r bytes is too small to be darktable", name, size)
+            continue
         url = asset.get("browser_download_url", "")
         if not _url_is_trusted(url):
             log.warning("Rejecting %s: untrusted download URL %r", name, url)
-            return None
+            continue
         return {
             "name": name,
             "size": size,
@@ -100,28 +143,43 @@ def select_asset(release, platform_name, machine):
 def resolve_release(timeout=15):
     """Fetch the latest release and select this machine's asset.
 
-    Returns {version, name, size, url, digest} or None.  Never raises for
-    network problems — the caller turns None into a plain "Get darktable"
-    link rather than a dead button.
+    Returns ``(release, None)`` on success, or ``(None, reason)`` where reason
+    is a user-facing sentence explaining which failure occurred.  The caller
+    shows that sentence next to a plain "Get darktable" link, so it must be
+    true and specific: "no build for your platform" and "we could not reach
+    GitHub" are different facts and users act on them differently.
+
+    Never raises.
     """
-    import platform as platform_mod
-    import sys
+    machine = platform.machine()
+    if (sys.platform, str(machine).lower()) not in _ASSET_SUFFIXES:
+        log.info("No darktable build for platform=%s machine=%s", sys.platform, machine)
+        return None, REASON_NO_PLATFORM_BUILD
 
     try:
         req = urllib.request.Request(
             RELEASES_API,
             headers={
+                # GitHub answers 403 to requests with no User-Agent.
                 "User-Agent": "vireo-darktable-install/1.0",
                 "Accept": "application/vnd.github+json",
             },
         )
         with urllib.request.urlopen(req, timeout=timeout, context=_ssl_ctx) as resp:
             release = json.loads(resp.read().decode("utf-8"))
+        if not isinstance(release, dict) or not isinstance(release.get("assets"), list):
+            # A rate-limit body, a captive-portal login page or a truncated
+            # response parses fine but is not a release.  Saying "no usable
+            # build in the latest release" here would be a lie.
+            raise ValueError("GitHub returned something that is not a release object")
+        asset = select_asset(release, sys.platform, machine)
     except Exception:
         log.warning("Could not reach the GitHub releases API", exc_info=True)
-        return None
+        return None, REASON_UNREACHABLE
 
-    asset = select_asset(release, sys.platform, platform_mod.machine())
     if not asset:
-        return None
-    return {"version": release.get("tag_name", "").replace("release-", ""), **asset}
+        return None, REASON_NO_USABLE_ASSET
+
+    tag = release.get("tag_name")
+    version = tag.removeprefix("release-") if isinstance(tag, str) else ""
+    return {"version": version, **asset}, None

--- a/vireo/darktable_install.py
+++ b/vireo/darktable_install.py
@@ -1,0 +1,127 @@
+"""Download and install darktable from its official GitHub releases.
+
+darktable is GPL and publishes signed-by-nobody but digest-bearing release
+assets on GitHub.  We resolve the latest release at request time rather than
+pinning a version, and verify integrity against the SHA256 digest the GitHub
+API publishes alongside each asset.
+
+There is deliberately no code-signature check: darktable does not successfully
+notarize its macOS builds (upstream issue #19295) and its Windows installer is
+unsigned, so a fail-closed signature check would reject every legitimate
+download.  See docs/superpowers/specs/2026-07-26-darktable-download-design.md.
+"""
+
+import json
+import logging
+import ssl
+import urllib.parse
+import urllib.request
+
+import certifi
+
+log = logging.getLogger(__name__)
+
+# Use certifi's CA bundle so HTTPS works on macOS without running
+# Install Certificates.command — same convention as taxonomy.py:35,
+# labels.py:17, model_verify.py:29 and places.py:57. Without it this
+# silently degrades to "Could not reach GitHub" on affected installs.
+_ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+
+RELEASES_API = "https://api.github.com/repos/darktable-org/darktable/releases/latest"
+
+_ALLOWED_HOSTS = {"github.com", "objects.githubusercontent.com"}
+_ALLOWED_PATH_PREFIX = "/darktable-org/darktable/"
+
+# Anything smaller than this is not a darktable build.  Guards against the
+# ~300KB .zsync manifests and against a truncated or renamed asset.
+_MIN_ASSET_BYTES = 10 * 1024 * 1024
+
+# (sys.platform, platform.machine()) -> required asset-name suffix.
+# Exact suffixes, never substrings: "Darktable-5.6.0-x86_64.AppImage.zsync"
+# contains "AppImage" but is a 300KB delta manifest, not the application.
+_ASSET_SUFFIXES = {
+    ("darwin", "arm64"): "-arm64.dmg",
+    ("darwin", "x86_64"): "-x86_64.dmg",
+    ("win32", "amd64"): "-win64.exe",
+    ("win32", "arm64"): "-woa64.exe",
+    ("linux", "x86_64"): "-x86_64.AppImage",
+    ("linux", "aarch64"): "-aarch64.AppImage",
+}
+
+
+def _url_is_trusted(url):
+    """True only for HTTPS URLs on a GitHub host under the darktable repo.
+
+    Enforced on the API-supplied browser_download_url only.  GitHub redirects
+    release downloads to release-assets.githubusercontent.com, so applying
+    this to redirect targets would reject every legitimate download.
+    """
+    try:
+        parts = urllib.parse.urlparse(url or "")
+    except ValueError:
+        return False
+    if parts.scheme != "https" or parts.hostname not in _ALLOWED_HOSTS:
+        return False
+    return parts.path.startswith(_ALLOWED_PATH_PREFIX)
+
+
+def select_asset(release, platform_name, machine):
+    """Pick the asset matching this platform, or None.
+
+    Returns a dict with name/size/url/digest, or None when this platform has
+    no build, the only match is implausibly small, or the URL is untrusted.
+    """
+    suffix = _ASSET_SUFFIXES.get((platform_name, str(machine).lower()))
+    if not suffix:
+        log.info("No darktable asset for platform=%s machine=%s", platform_name, machine)
+        return None
+
+    for asset in release.get("assets", []):
+        name = asset.get("name", "")
+        if not name.endswith(suffix):
+            continue
+        size = asset.get("size", 0)
+        if size < _MIN_ASSET_BYTES:
+            log.warning("Rejecting %s: %d bytes is too small to be darktable", name, size)
+            return None
+        url = asset.get("browser_download_url", "")
+        if not _url_is_trusted(url):
+            log.warning("Rejecting %s: untrusted download URL %r", name, url)
+            return None
+        return {
+            "name": name,
+            "size": size,
+            "url": url,
+            "digest": asset.get("digest"),
+        }
+    return None
+
+
+def resolve_release(timeout=15):
+    """Fetch the latest release and select this machine's asset.
+
+    Returns {version, name, size, url, digest} or None.  Never raises for
+    network problems — the caller turns None into a plain "Get darktable"
+    link rather than a dead button.
+    """
+    import platform as platform_mod
+    import sys
+
+    try:
+        req = urllib.request.Request(
+            RELEASES_API,
+            headers={
+                "User-Agent": "vireo-darktable-install/1.0",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=timeout, context=_ssl_ctx) as resp:
+            release = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        log.warning("Could not reach the GitHub releases API", exc_info=True)
+        return None
+
+    asset = select_asset(release, sys.platform, platform_mod.machine())
+    if not asset:
+        return None
+    return {"version": release.get("tag_name", "").replace("release-", ""), **asset}

--- a/vireo/darktable_install.py
+++ b/vireo/darktable_install.py
@@ -23,6 +23,7 @@ import ssl
 import stat
 import subprocess
 import sys
+import time
 import urllib.parse
 import urllib.request
 
@@ -194,6 +195,33 @@ def resolve_release(timeout=15):
     tag = release.get("tag_name")
     version = tag.removeprefix("release-") if isinstance(tag, str) else ""
     return {"version": version, **asset}, None
+
+
+# Unauthenticated GitHub API calls are limited to 60/hour per IP.  Settings can
+# be opened repeatedly in a session, so cache the answer briefly rather than
+# spending that budget and degrading everyone on the IP to the fallback link.
+_release_cache = {"at": 0.0, "value": None}
+_RELEASE_CACHE_SECS = 600
+
+
+def resolve_release_cached():
+    """resolve_release() with a short TTL, returning the same 2-tuple.
+
+    Only successes are cached.  A transient outage or a rate-limit reply must
+    not pin the fallback link for ten minutes — and caching a failure would
+    also freeze its reason string, so a user who fixed their network would keep
+    being told GitHub is unreachable.
+
+    Never raises, for the same reason resolve_release does not.
+    """
+    now = time.monotonic()
+    cached = _release_cache["value"]
+    if cached is not None and now - _release_cache["at"] < _RELEASE_CACHE_SECS:
+        return cached, None
+    release, reason = resolve_release()
+    if release is not None:
+        _release_cache.update(at=now, value=release)
+    return release, reason
 
 
 # Read the asset a megabyte at a time: these builds are 87-178MB and hashing

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -49,6 +49,27 @@ def _mtime_or_missing(path):
         return -1.0
 
 
+def darktable_tools_dir():
+    """Where Vireo installs darktable itself; probed by darktable_search_paths.
+
+    A function rather than a module constant so tests (and any caller that
+    relocates HOME) can patch os.path.expanduser and still be obeyed; a
+    constant would freeze the expansion at import time.
+    """
+    return os.path.expanduser("~/.vireo/tools/darktable")
+
+
+def darktable_uses_tools_dir():
+    """True on the platforms where we install darktable into our own tools dir.
+
+    darktable_search_paths() branches on this same predicate, so the two cannot
+    drift: callers that need to name the directory (the status route telling
+    the user where we looked, the downloader deciding where to write) ask here
+    instead of re-deriving the platform test.
+    """
+    return os.name != "nt" and sys.platform != "darwin"
+
+
 def darktable_search_paths():
     """Filesystem locations probed for darktable-cli, in priority order.
 
@@ -68,27 +89,16 @@ def darktable_search_paths():
     candidates = []
     # Windows is os.name == "nt" *and* sys.platform == "win32", and macOS is
     # neither, so these branches are mutually exclusive on every real platform
-    # and their order is immaterial there. Don't reorder anyway:
-    # test_find_darktable_detects_standard_windows_install patches os.name on
-    # its own, leaving sys.platform as the host's value, so a leading darwin
-    # branch would shadow the Windows candidates on a Mac.
-    if os.name == "nt":
-        for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
-            base = os.environ.get(env_var)
-            if base:
-                candidates.extend([
-                    os.path.join(base, "darktable", "bin", "darktable-cli.exe"),
-                    os.path.join(base, "darktable", "darktable-cli.exe"),
-                ])
-    elif sys.platform == "darwin":
-        candidates.extend([
-            "/Applications/darktable.app/Contents/MacOS/darktable-cli",
-            os.path.expanduser("~/Applications/darktable.app/Contents/MacOS/darktable-cli"),
-        ])
-    else:
+    # and their order is immaterial there. The tools-dir branch leads because
+    # its predicate is the shared darktable_uses_tools_dir(); that predicate
+    # already excludes os.name == "nt", so
+    # test_find_darktable_detects_standard_windows_install — which patches
+    # os.name on its own, leaving sys.platform as the host's value — still
+    # reaches the Windows candidates on a Mac.
+    if darktable_uses_tools_dir():
         # Linux: an AppImage we installed ourselves. Newest mtime wins, since
         # installers are kept and this directory accumulates versions.
-        tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
+        tools_dir = darktable_tools_dir()
         if os.path.isdir(tools_dir):
             appimages = [
                 os.path.join(tools_dir, n)
@@ -97,6 +107,20 @@ def darktable_search_paths():
             ]
             appimages.sort(key=_mtime_or_missing, reverse=True)
             candidates.extend(appimages)
+    elif os.name == "nt":
+        for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
+            base = os.environ.get(env_var)
+            if base:
+                candidates.extend([
+                    os.path.join(base, "darktable", "bin", "darktable-cli.exe"),
+                    os.path.join(base, "darktable", "darktable-cli.exe"),
+                ])
+    else:
+        # macOS: the .app bundle, system-wide or per-user.
+        candidates.extend([
+            "/Applications/darktable.app/Contents/MacOS/darktable-cli",
+            os.path.expanduser("~/Applications/darktable.app/Contents/MacOS/darktable-cli"),
+        ])
     return candidates
 
 

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -37,18 +37,41 @@ def _format_subprocess_diag(stdout, stderr):
     return combined
 
 
-def darktable_search_paths():
-    """Locations probed for darktable-cli, in priority order.
+def _mtime_or_missing(path):
+    """mtime of ``path``, or -1 if it cannot be stat'd.
 
-    Exposed so the UI can tell the user exactly where we looked when the
-    binary is not found, instead of repeating a bare "not found".
-    ``find_darktable`` walks this same list, so the two cannot drift.
+    Keeps ``darktable_search_paths`` from raising when a file disappears
+    between the listdir that found it and the sort that orders it.
+    """
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return -1.0
+
+
+def darktable_search_paths():
+    """Filesystem locations probed for darktable-cli, in priority order.
+
+    These are the *additional* locations ``find_darktable`` checks after the
+    configured path and ``shutil.which("darktable-cli")``; both of those take
+    precedence and neither appears in this list. The list is platform-specific
+    and holds only paths that could plausibly exist on this machine — on Linux
+    it is the AppImages actually present in ~/.vireo/tools/darktable, so it is
+    empty until we have installed one.
+
+    Exposed so the UI can tell the user where we looked instead of repeating a
+    bare "not found". Because $PATH is the probe most likely to explain a miss
+    (Homebrew, distro packages), any caller showing this list to a user must
+    mention the $PATH probe alongside it rather than presenting these entries
+    as the whole search.
     """
     candidates = []
-    # os.name is checked FIRST, not sys.platform. test_find_darktable_detects_
-    # standard_windows_install patches develop.os.name = "nt" while leaving
-    # sys.platform as the host's value, so a leading darwin branch would
-    # shadow the Windows candidates and break that test on a Mac.
+    # Windows is os.name == "nt" *and* sys.platform == "win32", and macOS is
+    # neither, so these branches are mutually exclusive on every real platform
+    # and their order is immaterial there. Don't reorder anyway:
+    # test_find_darktable_detects_standard_windows_install patches os.name on
+    # its own, leaving sys.platform as the host's value, so a leading darwin
+    # branch would shadow the Windows candidates on a Mac.
     if os.name == "nt":
         for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
             base = os.environ.get(env_var)
@@ -72,7 +95,7 @@ def darktable_search_paths():
                 for n in os.listdir(tools_dir)
                 if n.endswith(".AppImage")
             ]
-            appimages.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+            appimages.sort(key=_mtime_or_missing, reverse=True)
             candidates.extend(appimages)
     return candidates
 

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -205,9 +205,18 @@ def build_command(darktable_bin, input_path, output_path, style=None, width=None
         width: optional max output width in pixels
 
     Returns:
-        list of command arguments
+        list of command arguments: the binary, then "darktable-cli" when the
+        binary is an AppImage, then the input and output paths, then any
+        optional flags.
     """
-    cmd = [darktable_bin, input_path, output_path]
+    cmd = [darktable_bin]
+    if darktable_bin.endswith(".AppImage"):
+        # darktable ships a multi-binary AppImage whose AppRun selects the
+        # binary from argv[1]. The alternative (a symlink named darktable-cli)
+        # does not survive find_darktable's os.path.realpath, which would
+        # silently launch the GUI and hang the job.
+        cmd.append("darktable-cli")
+    cmd.extend([input_path, output_path])
     if style:
         cmd.extend(["--style", style])
     if width:
@@ -387,8 +396,13 @@ def develop_photo(
 
     try:
         log.info("Developing %s -> %s", os.path.basename(input_path), output_path)
+        # AppImages need FUSE2 to self-mount; many current distros ship only
+        # FUSE3. This makes the AppImage extract to a temp dir instead of
+        # failing outright. Harmless for non-AppImage binaries.
+        env = {**os.environ, "APPIMAGE_EXTRACT_AND_RUN": "1"}
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=120, **no_window_kwargs()
+            cmd, capture_output=True, text=True, timeout=120,
+            env=env, **no_window_kwargs()
         )
         if result.returncode != 0:
             # darktable-cli writes init/IO failures to stdout, not stderr.

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 
 try:
@@ -36,6 +37,46 @@ def _format_subprocess_diag(stdout, stderr):
     return combined
 
 
+def darktable_search_paths():
+    """Locations probed for darktable-cli, in priority order.
+
+    Exposed so the UI can tell the user exactly where we looked when the
+    binary is not found, instead of repeating a bare "not found".
+    ``find_darktable`` walks this same list, so the two cannot drift.
+    """
+    candidates = []
+    # os.name is checked FIRST, not sys.platform. test_find_darktable_detects_
+    # standard_windows_install patches develop.os.name = "nt" while leaving
+    # sys.platform as the host's value, so a leading darwin branch would
+    # shadow the Windows candidates and break that test on a Mac.
+    if os.name == "nt":
+        for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
+            base = os.environ.get(env_var)
+            if base:
+                candidates.extend([
+                    os.path.join(base, "darktable", "bin", "darktable-cli.exe"),
+                    os.path.join(base, "darktable", "darktable-cli.exe"),
+                ])
+    elif sys.platform == "darwin":
+        candidates.extend([
+            "/Applications/darktable.app/Contents/MacOS/darktable-cli",
+            os.path.expanduser("~/Applications/darktable.app/Contents/MacOS/darktable-cli"),
+        ])
+    else:
+        # Linux: an AppImage we installed ourselves. Newest mtime wins, since
+        # installers are kept and this directory accumulates versions.
+        tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
+        if os.path.isdir(tools_dir):
+            appimages = [
+                os.path.join(tools_dir, n)
+                for n in os.listdir(tools_dir)
+                if n.endswith(".AppImage")
+            ]
+            appimages.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+            candidates.extend(appimages)
+    return candidates
+
+
 def find_darktable(configured_path):
     """Find the darktable-cli binary.
 
@@ -60,18 +101,9 @@ def find_darktable(configured_path):
     found = shutil.which("darktable-cli")
     if found:
         return os.path.realpath(found)
-    if os.name == "nt":
-        candidates = []
-        for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
-            base = os.environ.get(env_var)
-            if base:
-                candidates.extend([
-                    os.path.join(base, "darktable", "bin", "darktable-cli.exe"),
-                    os.path.join(base, "darktable", "darktable-cli.exe"),
-                ])
-        for candidate in candidates:
-            if os.path.isfile(candidate):
-                return os.path.realpath(candidate)
+    for candidate in darktable_search_paths():
+        if os.path.isfile(candidate):
+            return os.path.realpath(candidate)
     return None
 
 

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -22,6 +22,44 @@ _NIKON_HE_COMPRESSION_VALUES = {13, 14}
 # an ordinary executable.
 _APPIMAGE_MAGIC = b"AI\x02"
 
+# Per-binary result of the "does FUSE work here?" probe. Keys are binary paths
+# and values are "direct" (ran without APPIMAGE_EXTRACT_AND_RUN) or "extract"
+# (needed the flag because FUSE was unavailable). Populated on the first
+# develop_photo call for a binary and reused thereafter so a batch of N photos
+# pays the probe cost once, not N times. Setting APPIMAGE_EXTRACT_AND_RUN on
+# every call forces the AppImage runtime to skip FUSE and unpack the whole
+# ~178 MB squashfs each time — the whole point of caching is to avoid that.
+_APPIMAGE_MODE_CACHE = {}
+
+# Substrings that identify an AppImage FUSE failure in the runtime's own
+# error output — lowercase and matched case-insensitively so kernel messages
+# in either case are covered. When we see one of these on a nonzero exit,
+# retrying with APPIMAGE_EXTRACT_AND_RUN=1 is what turns "fails outright"
+# into "runs". Other nonzero exits (bad RAW, missing style, etc.) must NOT
+# trigger the fallback: reopening subprocess.run with the extract flag on an
+# unrelated darktable error would waste a full unpack and still fail.
+_APPIMAGE_FUSE_FAILURE_MARKERS = (
+    "appimages require fuse",
+    "libfuse.so.2",
+    "libfuse.so",
+    "fusermount",
+    "cannot mount appimage",
+    "dlopen(): error loading libfuse",
+)
+
+
+def _looks_like_appimage_fuse_failure(stdout, stderr):
+    """True when subprocess output points at a missing/broken FUSE, not darktable.
+
+    Only these strings — printed by the AppImage runtime itself before darktable
+    starts — should trigger the APPIMAGE_EXTRACT_AND_RUN retry. A darktable
+    exit code with no FUSE marker is a real develop failure and must surface
+    as-is instead of being retried under an environment change that would
+    silently unpack ~178 MB.
+    """
+    combined = ((stdout or "") + "\n" + (stderr or "")).lower()
+    return any(marker in combined for marker in _APPIMAGE_FUSE_FAILURE_MARKERS)
+
 
 def _is_appimage(path):
     """True when ``path`` is a type-2 AppImage bundle.
@@ -435,18 +473,48 @@ def develop_photo(
 
     try:
         log.info("Developing %s -> %s", os.path.basename(input_path), output_path)
+        is_appimage = _is_appimage(binary)
+
+        # AppImages need FUSE2 to self-mount, and many current distros ship
+        # only FUSE3. APPIMAGE_EXTRACT_AND_RUN=1 makes the runtime bypass FUSE
+        # and unpack the whole ~178 MB squashfs into a temp dir — a fix when
+        # FUSE is missing, but a heavy cost when it is not, because this
+        # function runs once per photo. So probe once per binary and cache:
+        # try direct execution first, fall back to extract only on a real
+        # FUSE failure, and remember the outcome so the next photo pays
+        # nothing.
+        def _run(env):
+            return subprocess.run(
+                cmd, capture_output=True, text=True, timeout=120,
+                env=env, **no_window_kwargs()
+            )
+
         env = dict(os.environ)
-        if _is_appimage(binary):
-            # AppImages need FUSE2 to self-mount; many current distros ship
-            # only FUSE3. This makes the AppImage extract to a temp dir
-            # instead of failing outright. Gated because when set the runtime
-            # skips the FUSE probe entirely and *always* unpacks the whole
-            # ~178MB squashfs, and this runs once per photo.
+        cached_mode = _APPIMAGE_MODE_CACHE.get(binary) if is_appimage else None
+        if cached_mode == "extract":
             env["APPIMAGE_EXTRACT_AND_RUN"] = "1"
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=120,
-            env=env, **no_window_kwargs()
-        )
+
+        result = _run(env)
+
+        if (
+            is_appimage
+            and cached_mode is None
+            and result.returncode != 0
+            and _looks_like_appimage_fuse_failure(result.stdout, result.stderr)
+        ):
+            # FUSE is the problem: retry once with the extract flag and
+            # cache the answer so subsequent photos skip the probe.
+            log.info(
+                "AppImage FUSE probe failed for %s; retrying with "
+                "APPIMAGE_EXTRACT_AND_RUN=1", binary,
+            )
+            env["APPIMAGE_EXTRACT_AND_RUN"] = "1"
+            result = _run(env)
+            if result.returncode == 0:
+                _APPIMAGE_MODE_CACHE[binary] = "extract"
+        elif is_appimage and cached_mode is None and result.returncode == 0:
+            _APPIMAGE_MODE_CACHE[binary] = "direct"
+
         if result.returncode != 0:
             # darktable-cli writes init/IO failures to stdout, not stderr.
             diag = _format_subprocess_diag(result.stdout, result.stderr)

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -78,8 +78,13 @@ def darktable_tools_dir():
     A function rather than a module constant so tests (and any caller that
     relocates HOME) can patch os.path.expanduser and still be obeyed; a
     constant would freeze the expansion at import time.
+
+    Built with os.path.join, not by embedding "/" in the literal, so Windows
+    gets native backslashes throughout: the settings panel shows this path in
+    the "checked here" list, and the mixed-separator form from expanding a
+    forward-slash literal reads as broken.
     """
-    return os.path.expanduser("~/.vireo/tools/darktable")
+    return os.path.join(os.path.expanduser("~"), ".vireo", "tools", "darktable")
 
 
 def darktable_uses_tools_dir():

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -49,6 +49,17 @@ _APPIMAGE_APPRUN_CACHE = {}
 # every extraction ends up isolated next to its source AppImage.
 _APPIMAGE_EXTRACT_SUBDIR = "squashfs-root"
 
+# Marker file inside <binary>.extracted/ recording the source AppImage's
+# fingerprint at the moment extraction succeeded. --appimage-extract preserves
+# AppRun's embedded build timestamp (from when darktable was built), while a
+# freshly downloaded AppImage carries a download-time mtime — so AppRun is
+# typically OLDER than the source it came from. Comparing the two mtimes
+# directly would therefore invalidate every fresh extraction on its next
+# reuse and re-unpack the ~500 MB tree per photo. The marker sidesteps that:
+# we record what the source looked like at extraction time and reuse only
+# while it still matches.
+_APPIMAGE_SOURCE_MARKER = ".vireo-source-fingerprint"
+
 # Cap the one-time --appimage-extract subprocess. A 178 MB darktable AppImage
 # unpacks in ~5–15 s on a spinning disk; 300 s is generous headroom without
 # hanging a develop job forever if the extraction is truly wedged.
@@ -150,20 +161,55 @@ def _apprun_path_for(binary):
     return os.path.join(binary + ".extracted", _APPIMAGE_EXTRACT_SUBDIR, "AppRun")
 
 
+def _source_fingerprint(source_binary):
+    """Identity used to detect an in-place replacement of ``source_binary``.
+
+    Combines mtime (nanoseconds) and size: mtime alone can be forged by
+    os.utime, size alone misses same-size rebuilds, together they identify
+    the file well enough to spot an actual reinstall.
+    """
+    st = os.stat(source_binary)
+    return f"{st.st_mtime_ns}:{st.st_size}"
+
+
+def _marker_path_for_apprun(apprun):
+    """Location of the source-fingerprint marker for ``apprun``'s extraction.
+
+    ``apprun`` sits at ``<extract_dir>/squashfs-root/AppRun``; the marker
+    lives at ``<extract_dir>/`` so it is a peer of the squashfs-root that
+    ``--appimage-extract`` creates, and so a full rmtree of ``extract_dir``
+    removes it alongside the tree.
+    """
+    return os.path.join(
+        os.path.dirname(os.path.dirname(apprun)), _APPIMAGE_SOURCE_MARKER,
+    )
+
+
 def _is_reusable_apprun(apprun, source_binary):
     """True when ``apprun`` is a valid extraction of ``source_binary``.
 
-    Compares mtimes so a source AppImage replaced in place (in-place
-    Vireo update, manual overwrite) invalidates the extracted tree; a
-    check that only asserts existence and the exec bit would keep serving
-    the old darktable version until the process restarted.
+    Reuse is gated on the marker file written when extraction completed, not
+    on a comparison of the two mtimes: ``--appimage-extract`` preserves
+    AppRun's embedded build timestamp (from when darktable was built),
+    whereas the source AppImage carries a fresh download-time mtime, so
+    AppRun is typically OLDER than the source it was extracted from. An
+    mtime comparison would therefore invalidate every fresh extraction on
+    its next reuse and re-unpack the ~500 MB tree per photo. Instead we
+    persist the source's fingerprint at extraction time and reuse only
+    while it still matches, so an in-place source replacement (in-place
+    Vireo update, manual overwrite) still invalidates the tree.
+
+    A missing or unreadable marker counts as "not reusable" so a partial
+    extraction, a tree seeded outside this module, or a marker cleared
+    on disk all force a rebuild rather than silently reusing state whose
+    provenance is unknown.
     """
     try:
-        return (
-            os.path.isfile(apprun)
-            and os.access(apprun, os.X_OK)
-            and os.path.getmtime(apprun) >= os.path.getmtime(source_binary)
-        )
+        if not (os.path.isfile(apprun) and os.access(apprun, os.X_OK)):
+            return False
+        with open(_marker_path_for_apprun(apprun)) as f:
+            stored = f.read().strip()
+        return bool(stored) and stored == _source_fingerprint(source_binary)
     except OSError:
         return False
 
@@ -181,9 +227,10 @@ def _extract_appimage_once(binary):
     so the resulting darktable-cli has the same environment either way.
 
     Reuses an existing extraction if AppRun is still there, executable, and
-    not older than the source AppImage; a newer source (Vireo replaced the
-    installer) invalidates the tree and re-extracts. Returns ``None`` when
-    the extraction cannot be produced (subprocess failure, unwritable dir,
+    the persisted source fingerprint still matches; a source AppImage
+    replaced in place (Vireo installed a newer build, manual overwrite)
+    invalidates the tree and re-extracts. Returns ``None`` when the
+    extraction cannot be produced (subprocess failure, unwritable dir,
     truncated output); the caller falls back to APPIMAGE_EXTRACT_AND_RUN=1
     on that binary so develop still succeeds, just at the per-photo cost.
     """
@@ -247,6 +294,29 @@ def _extract_appimage_once(binary):
             log.warning(
                 "AppImage --appimage-extract left no usable AppRun at %s "
                 "(exit=%s)", apprun, result.returncode,
+            )
+            shutil.rmtree(extract_dir, ignore_errors=True)
+            return None
+
+        # Record the source's fingerprint so _is_reusable_apprun can decide
+        # whether this tree still matches without comparing AppRun's mtime
+        # (which the extract runtime preserves as darktable's build
+        # timestamp and is therefore older than the source AppImage). If
+        # the marker cannot be written the tree is unsafe to reuse, so
+        # discard it rather than let a subsequent call read a stale or
+        # absent marker as "the source must have changed" and re-unpack
+        # every photo.
+        try:
+            with open(
+                os.path.join(extract_dir, _APPIMAGE_SOURCE_MARKER), "w"
+            ) as f:
+                f.write(_source_fingerprint(binary))
+        except OSError as e:
+            log.warning(
+                "AppImage extraction succeeded but source-fingerprint marker "
+                "could not be written for %s: %s; discarding tree so the "
+                "caller falls back to per-photo extraction",
+                binary, e,
             )
             shutil.rmtree(extract_dir, ignore_errors=True)
             return None
@@ -672,8 +742,9 @@ def develop_photo(
             apprun = _APPIMAGE_APPRUN_CACHE.get(binary)
             # Same predicate as _extract_appimage_once, so a source AppImage
             # replaced in place (in-place Vireo update, manual overwrite)
-            # invalidates the cached tree here too instead of silently
-            # running the old darktable until the process restarts.
+            # invalidates the cached tree here too — the source-fingerprint
+            # marker no longer matches — instead of silently running the
+            # old darktable until the process restarts.
             if apprun and _is_reusable_apprun(apprun, binary):
                 # Reuse the one-time extraction: swap the AppImage entry point
                 # for its AppRun and keep every following argv slot (including

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -23,13 +23,35 @@ _NIKON_HE_COMPRESSION_VALUES = {13, 14}
 _APPIMAGE_MAGIC = b"AI\x02"
 
 # Per-binary result of the "does FUSE work here?" probe. Keys are binary paths
-# and values are "direct" (ran without APPIMAGE_EXTRACT_AND_RUN) or "extract"
-# (needed the flag because FUSE was unavailable). Populated on the first
-# develop_photo call for a binary and reused thereafter so a batch of N photos
-# pays the probe cost once, not N times. Setting APPIMAGE_EXTRACT_AND_RUN on
-# every call forces the AppImage runtime to skip FUSE and unpack the whole
-# ~178 MB squashfs each time — the whole point of caching is to avoid that.
+# and values are:
+#   "direct"          — FUSE works, run the AppImage as-is.
+#   "extracted"       — persistent tree lives at _APPIMAGE_APPRUN_CACHE[binary];
+#                       run that AppRun directly.
+#   "extract-per-run" — extraction itself failed, so we fall back to setting
+#                       APPIMAGE_EXTRACT_AND_RUN=1 on every call. This still
+#                       works, just at the ~178 MB-unpack-per-photo cost we
+#                       hoped to avoid.
+# Populated on the first develop_photo call for a binary and reused thereafter
+# so a batch of N photos pays the probe cost (and, in "extracted" mode, the
+# unpack cost) once, not N times.
 _APPIMAGE_MODE_CACHE = {}
+
+# For binaries cached as "extracted", the path to the persistent AppRun inside
+# the one-time extraction tree. Kept separate so the mode cache stays a simple
+# string map (matching how it is inspected in tests) and so a caller can find
+# out which entrypoint will be invoked without reaching into the mode value.
+_APPIMAGE_APPRUN_CACHE = {}
+
+# Where --appimage-extract lands its output. AppImage type-2 runtimes
+# unconditionally create a directory literally named "squashfs-root" in the
+# working directory; we set the working directory to <binary>.extracted so
+# every extraction ends up isolated next to its source AppImage.
+_APPIMAGE_EXTRACT_SUBDIR = "squashfs-root"
+
+# Cap the one-time --appimage-extract subprocess. A 178 MB darktable AppImage
+# unpacks in ~5–15 s on a spinning disk; 300 s is generous headroom without
+# hanging a develop job forever if the extraction is truly wedged.
+_APPIMAGE_EXTRACT_TIMEOUT_SECONDS = 300
 
 # Substrings that identify an AppImage FUSE failure in the runtime's own
 # error output — lowercase and matched case-insensitively so kernel messages
@@ -78,6 +100,72 @@ def _is_appimage(path):
             return f.read(11)[8:11] == _APPIMAGE_MAGIC
     except OSError:
         return False
+
+
+def _extract_appimage_once(binary):
+    """Extract ``binary`` once and return the path to its AppRun, or None.
+
+    Called on the FUSE-less fallback path: instead of setting
+    APPIMAGE_EXTRACT_AND_RUN=1 on every develop_photo() invocation — which
+    makes the AppImage runtime unpack the whole ~178 MB squashfs into a temp
+    dir and delete it again for every photo — we run --appimage-extract once
+    at ``<binary>.extracted/squashfs-root/`` and invoke that AppRun for every
+    photo thereafter. AppRun sets up CAMLIBS/IOLIBS/GIO_EXTRA_MODULES for the
+    extracted binary just as the AppImage runtime does for the mounted one,
+    so the resulting darktable-cli has the same environment either way.
+
+    Reuses an existing extraction if AppRun is still there, executable, and
+    not older than the source AppImage; a newer source (Vireo replaced the
+    installer) invalidates the tree and re-extracts. Returns ``None`` when
+    the extraction cannot be produced (subprocess failure, unwritable dir,
+    truncated output); the caller falls back to APPIMAGE_EXTRACT_AND_RUN=1
+    on that binary so develop still succeeds, just at the per-photo cost.
+    """
+    extract_dir = binary + ".extracted"
+    apprun = os.path.join(extract_dir, _APPIMAGE_EXTRACT_SUBDIR, "AppRun")
+
+    with contextlib.suppress(OSError):
+        if (
+            os.path.isfile(apprun)
+            and os.access(apprun, os.X_OK)
+            and os.path.getmtime(apprun) >= os.path.getmtime(binary)
+        ):
+            return apprun
+
+    # Stale or absent — clear anything left behind (a half-finished previous
+    # extraction, or a tree from an older AppImage version) before extracting
+    # fresh, so a partial write cannot masquerade as a valid AppRun.
+    shutil.rmtree(extract_dir, ignore_errors=True)
+    try:
+        os.makedirs(extract_dir, exist_ok=True)
+    except OSError as e:
+        log.warning("Could not create AppImage extract dir %s: %s", extract_dir, e)
+        return None
+
+    try:
+        result = subprocess.run(
+            [binary, "--appimage-extract"],
+            capture_output=True, text=True,
+            timeout=_APPIMAGE_EXTRACT_TIMEOUT_SECONDS,
+            cwd=extract_dir, **no_window_kwargs(),
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        log.warning("AppImage --appimage-extract failed for %s: %s", binary, e)
+        shutil.rmtree(extract_dir, ignore_errors=True)
+        return None
+
+    if (
+        result.returncode != 0
+        or not os.path.isfile(apprun)
+        or not os.access(apprun, os.X_OK)
+    ):
+        log.warning(
+            "AppImage --appimage-extract left no usable AppRun at %s "
+            "(exit=%s)", apprun, result.returncode,
+        )
+        shutil.rmtree(extract_dir, ignore_errors=True)
+        return None
+    return apprun
 
 
 def _format_subprocess_diag(stdout, stderr):
@@ -477,24 +565,43 @@ def develop_photo(
 
         # AppImages need FUSE2 to self-mount, and many current distros ship
         # only FUSE3. APPIMAGE_EXTRACT_AND_RUN=1 makes the runtime bypass FUSE
-        # and unpack the whole ~178 MB squashfs into a temp dir — a fix when
-        # FUSE is missing, but a heavy cost when it is not, because this
-        # function runs once per photo. So probe once per binary and cache:
-        # try direct execution first, fall back to extract only on a real
-        # FUSE failure, and remember the outcome so the next photo pays
-        # nothing.
-        def _run(env):
+        # and unpack the whole ~178 MB squashfs into a temp dir — a working
+        # workaround when FUSE is missing, but a heavy cost when it is not,
+        # because this function runs once per photo. So probe once per binary
+        # and cache: try direct execution first, and on a real FUSE failure
+        # switch to a persistent extraction (_extract_appimage_once) whose
+        # AppRun the batch reuses without unpacking anything again. The old
+        # APPIMAGE_EXTRACT_AND_RUN behaviour only survives as a last-resort
+        # fallback if the one-time extraction itself fails.
+        def _run(cmd_to_run, env):
             return subprocess.run(
-                cmd, capture_output=True, text=True, timeout=120,
+                cmd_to_run, capture_output=True, text=True, timeout=120,
                 env=env, **no_window_kwargs()
             )
 
         env = dict(os.environ)
+        cmd_to_run = cmd
         cached_mode = _APPIMAGE_MODE_CACHE.get(binary) if is_appimage else None
-        if cached_mode == "extract":
+
+        if is_appimage and cached_mode == "extracted":
+            apprun = _APPIMAGE_APPRUN_CACHE.get(binary)
+            if apprun and os.path.isfile(apprun) and os.access(apprun, os.X_OK):
+                # Reuse the one-time extraction: swap the AppImage entry point
+                # for its AppRun and keep every following argv slot (including
+                # the "darktable-cli" selector build_command inserted). No
+                # env-var toggle needed — AppRun runs the extracted binary
+                # with the full CAMLIBS/IOLIBS/GIO_EXTRA_MODULES setup.
+                cmd_to_run = [apprun] + cmd[1:]
+            else:
+                # Extraction tree disappeared under us (user cleaned tmp,
+                # reinstall, whatever). Reset and re-probe from scratch.
+                _APPIMAGE_MODE_CACHE.pop(binary, None)
+                _APPIMAGE_APPRUN_CACHE.pop(binary, None)
+                cached_mode = None
+        elif is_appimage and cached_mode == "extract-per-run":
             env["APPIMAGE_EXTRACT_AND_RUN"] = "1"
 
-        result = _run(env)
+        result = _run(cmd_to_run, env)
 
         if (
             is_appimage
@@ -502,16 +609,32 @@ def develop_photo(
             and result.returncode != 0
             and _looks_like_appimage_fuse_failure(result.stdout, result.stderr)
         ):
-            # FUSE is the problem: retry once with the extract flag and
-            # cache the answer so subsequent photos skip the probe.
+            # FUSE is the problem. Extract once to a persistent tree so this
+            # cost is paid a single time for the whole batch, then rerun
+            # against the extracted AppRun.
             log.info(
-                "AppImage FUSE probe failed for %s; retrying with "
-                "APPIMAGE_EXTRACT_AND_RUN=1", binary,
+                "AppImage FUSE probe failed for %s; extracting once", binary,
             )
-            env["APPIMAGE_EXTRACT_AND_RUN"] = "1"
-            result = _run(env)
-            if result.returncode == 0:
-                _APPIMAGE_MODE_CACHE[binary] = "extract"
+            apprun = _extract_appimage_once(binary)
+            if apprun is not None:
+                extracted_cmd = [apprun] + cmd[1:]
+                result = _run(extracted_cmd, env)
+                if result.returncode == 0:
+                    _APPIMAGE_MODE_CACHE[binary] = "extracted"
+                    _APPIMAGE_APPRUN_CACHE[binary] = apprun
+            else:
+                # Extraction itself failed — dir not writable, subprocess
+                # blew up, etc. Fall back to the runtime workaround so
+                # develop still succeeds; the cost is per-photo unpacking,
+                # but that beats reporting the whole batch as broken.
+                log.warning(
+                    "AppImage extraction failed for %s; falling back to "
+                    "APPIMAGE_EXTRACT_AND_RUN per photo", binary,
+                )
+                env["APPIMAGE_EXTRACT_AND_RUN"] = "1"
+                result = _run(cmd, env)
+                if result.returncode == 0:
+                    _APPIMAGE_MODE_CACHE[binary] = "extract-per-run"
         elif is_appimage and cached_mode is None and result.returncode == 0:
             _APPIMAGE_MODE_CACHE[binary] = "direct"
 

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -126,12 +126,22 @@ def darktable_search_paths():
     if darktable_uses_tools_dir():
         # Linux: an AppImage we installed ourselves. Newest mtime wins, since
         # installers are kept and this directory accumulates versions.
+        #
+        # The exec bit is the hand-off marker: a download cancelled during
+        # digest verification (or right before hand_off) leaves the AppImage
+        # at its final .AppImage path with the default 0o644 mode urllib
+        # writes.  Reporting it here would make /api/darktable/status say
+        # darktable is installed, hide the Try again affordance, and hand a
+        # non-executable file to darktable-cli for every RAW export.  Gating
+        # on os.X_OK matches what hand_off actually sets — no separate marker
+        # file to drift or clean up.
         tools_dir = darktable_tools_dir()
         if os.path.isdir(tools_dir):
             appimages = [
                 os.path.join(tools_dir, n)
                 for n in os.listdir(tools_dir)
                 if n.endswith(".AppImage")
+                and os.access(os.path.join(tools_dir, n), os.X_OK)
             ]
             appimages.sort(key=_mtime_or_missing, reverse=True)
             candidates.extend(appimages)

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -145,6 +145,29 @@ def _is_appimage(path):
         return False
 
 
+def _apprun_path_for(binary):
+    """Where _extract_appimage_once would place ``binary``'s AppRun."""
+    return os.path.join(binary + ".extracted", _APPIMAGE_EXTRACT_SUBDIR, "AppRun")
+
+
+def _is_reusable_apprun(apprun, source_binary):
+    """True when ``apprun`` is a valid extraction of ``source_binary``.
+
+    Compares mtimes so a source AppImage replaced in place (in-place
+    Vireo update, manual overwrite) invalidates the extracted tree; a
+    check that only asserts existence and the exec bit would keep serving
+    the old darktable version until the process restarted.
+    """
+    try:
+        return (
+            os.path.isfile(apprun)
+            and os.access(apprun, os.X_OK)
+            and os.path.getmtime(apprun) >= os.path.getmtime(source_binary)
+        )
+    except OSError:
+        return False
+
+
 def _extract_appimage_once(binary):
     """Extract ``binary`` once and return the path to its AppRun, or None.
 
@@ -165,22 +188,12 @@ def _extract_appimage_once(binary):
     on that binary so develop still succeeds, just at the per-photo cost.
     """
     extract_dir = binary + ".extracted"
-    apprun = os.path.join(extract_dir, _APPIMAGE_EXTRACT_SUBDIR, "AppRun")
-
-    def _reusable_apprun():
-        try:
-            return (
-                os.path.isfile(apprun)
-                and os.access(apprun, os.X_OK)
-                and os.path.getmtime(apprun) >= os.path.getmtime(binary)
-            )
-        except OSError:
-            return False
+    apprun = _apprun_path_for(binary)
 
     # Fast path — a valid tree from a prior call satisfies the request
     # without touching the lock. Two workers racing on this fast path is
     # safe because both would read the same on-disk state.
-    if _reusable_apprun():
+    if _is_reusable_apprun(apprun, binary):
         return apprun
 
     # Serialize the delete → extract → publish sequence per binary. Without
@@ -191,7 +204,7 @@ def _extract_appimage_once(binary):
     with _get_extract_lock(binary):
         # Re-check under the lock: another worker may have finished the
         # extraction while we were blocked, in which case we reuse it.
-        if _reusable_apprun():
+        if _is_reusable_apprun(apprun, binary):
             return apprun
 
         parent_dir = os.path.dirname(extract_dir) or "."
@@ -657,7 +670,11 @@ def develop_photo(
 
         if is_appimage and cached_mode == "extracted":
             apprun = _APPIMAGE_APPRUN_CACHE.get(binary)
-            if apprun and os.path.isfile(apprun) and os.access(apprun, os.X_OK):
+            # Same predicate as _extract_appimage_once, so a source AppImage
+            # replaced in place (in-place Vireo update, manual overwrite)
+            # invalidates the cached tree here too instead of silently
+            # running the old darktable until the process restarts.
+            if apprun and _is_reusable_apprun(apprun, binary):
                 # Reuse the one-time extraction: swap the AppImage entry point
                 # for its AppRun and keep every following argv slot (including
                 # the "darktable-cli" selector build_command inserted). No
@@ -665,8 +682,10 @@ def develop_photo(
                 # with the full CAMLIBS/IOLIBS/GIO_EXTRA_MODULES setup.
                 cmd_to_run = [apprun] + cmd[1:]
             else:
-                # Extraction tree disappeared under us (user cleaned tmp,
-                # reinstall, whatever). Reset and re-probe from scratch.
+                # Extraction is stale (source replaced) or gone (user cleaned
+                # tmp, reinstall, whatever). Reset and re-probe from scratch;
+                # _extract_appimage_once will re-run --appimage-extract for
+                # the new source under the per-binary lock.
                 _APPIMAGE_MODE_CACHE.pop(binary, None)
                 _APPIMAGE_APPRUN_CACHE.pop(binary, None)
                 cached_mode = None

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -17,6 +17,29 @@ log = logging.getLogger(__name__)
 
 _DIAG_MAX_CHARS = 500
 _NIKON_HE_COMPRESSION_VALUES = {13, 14}
+# Bytes 8..10 of a type-2 AppImage. They sit in the ELF header's EI_PAD
+# region, which real toolchains leave zeroed, so this does not collide with
+# an ordinary executable.
+_APPIMAGE_MAGIC = b"AI\x02"
+
+
+def _is_appimage(path):
+    """True when ``path`` is a type-2 AppImage bundle.
+
+    Detected by magic bytes rather than filename: users commonly rename an
+    AppImage (~/.local/bin/darktable) or keep a lowercase .appimage suffix,
+    and find_darktable hands back any configured file as-is. A missed
+    detection launches darktable's GUI and stalls a headless export for the
+    full 120s timeout with an error naming nothing the user could act on.
+
+    Never raises: a missing path, a directory, or an unreadable file is
+    simply "not an AppImage".
+    """
+    try:
+        with open(path, "rb") as f:
+            return f.read(11)[8:11] == _APPIMAGE_MAGIC
+    except OSError:
+        return False
 
 
 def _format_subprocess_diag(stdout, stderr):
@@ -198,7 +221,8 @@ def build_command(darktable_bin, input_path, output_path, style=None, width=None
     """Build the darktable-cli command list.
 
     Args:
-        darktable_bin: path to darktable-cli binary
+        darktable_bin: path to a darktable-cli binary or to a darktable
+            AppImage bundle (detected by content, so its name is irrelevant)
         input_path: path to input RAW file
         output_path: path for output file
         style: optional darktable style name
@@ -210,7 +234,7 @@ def build_command(darktable_bin, input_path, output_path, style=None, width=None
         optional flags.
     """
     cmd = [darktable_bin]
-    if darktable_bin.endswith(".AppImage"):
+    if _is_appimage(darktable_bin):
         # darktable ships a multi-binary AppImage whose AppRun selects the
         # binary from argv[1]. The alternative (a symlink named darktable-cli)
         # does not survive find_darktable's os.path.realpath, which would
@@ -396,10 +420,14 @@ def develop_photo(
 
     try:
         log.info("Developing %s -> %s", os.path.basename(input_path), output_path)
-        # AppImages need FUSE2 to self-mount; many current distros ship only
-        # FUSE3. This makes the AppImage extract to a temp dir instead of
-        # failing outright. Harmless for non-AppImage binaries.
-        env = {**os.environ, "APPIMAGE_EXTRACT_AND_RUN": "1"}
+        env = dict(os.environ)
+        if _is_appimage(binary):
+            # AppImages need FUSE2 to self-mount; many current distros ship
+            # only FUSE3. This makes the AppImage extract to a temp dir
+            # instead of failing outright. Gated because when set the runtime
+            # skips the FUSE probe entirely and *always* unpacks the whole
+            # ~178MB squashfs, and this runs once per photo.
+            env["APPIMAGE_EXTRACT_AND_RUN"] = "1"
         result = subprocess.run(
             cmd, capture_output=True, text=True, timeout=120,
             env=env, **no_window_kwargs()

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 
 try:
     from .proc import no_window_kwargs
@@ -52,6 +53,48 @@ _APPIMAGE_EXTRACT_SUBDIR = "squashfs-root"
 # unpacks in ~5–15 s on a spinning disk; 300 s is generous headroom without
 # hanging a develop job forever if the extraction is truly wedged.
 _APPIMAGE_EXTRACT_TIMEOUT_SECONDS = 300
+
+# Ratio of extracted-tree size to AppImage size on disk. Measured against
+# darktable: a ~178 MB AppImage unpacks to ~500 MB, so ~3x; the multiplier
+# adds headroom so a marginal disk that would just barely fit triggers the
+# per-run fallback instead of half-extracting and failing mid-batch.
+_APPIMAGE_EXTRACTION_SIZE_MULTIPLIER = 3.5
+
+# Per-binary lock guarding the "check for stale extraction, delete, extract,
+# publish" sequence in _extract_appimage_once. Two concurrent develop jobs on
+# a FUSE-less host would otherwise both observe an empty mode cache and race
+# on the shared <binary>.extracted directory, so one worker could rmtree or
+# execute the other's partial tree. The outer lock only protects insertion
+# into the dict; the returned per-binary Lock is held for the extraction
+# itself so concurrent callers for the SAME binary serialize while callers
+# for DIFFERENT binaries do not block one another.
+_APPIMAGE_EXTRACT_LOCKS_LOCK = threading.Lock()
+_APPIMAGE_EXTRACT_LOCKS = {}
+
+
+def _get_extract_lock(binary):
+    """Return (and lazily create) the per-binary extraction lock."""
+    with _APPIMAGE_EXTRACT_LOCKS_LOCK:
+        lock = _APPIMAGE_EXTRACT_LOCKS.get(binary)
+        if lock is None:
+            lock = threading.Lock()
+            _APPIMAGE_EXTRACT_LOCKS[binary] = lock
+        return lock
+
+
+def _has_space_for_extraction(binary, extract_dir_parent):
+    """True when there is plausibly enough free disk to unpack ``binary``.
+
+    Returns True on OSError so a transient stat failure does not block
+    extraction on a working disk; the extraction itself will surface a real
+    ENOSPC as a subprocess failure that the caller already handles.
+    """
+    try:
+        source_size = os.path.getsize(binary)
+        free_bytes = shutil.disk_usage(extract_dir_parent).free
+    except OSError:
+        return True
+    return free_bytes >= int(source_size * _APPIMAGE_EXTRACTION_SIZE_MULTIPLIER)
 
 # Substrings that identify an AppImage FUSE failure in the runtime's own
 # error output — lowercase and matched case-insensitively so kernel messages
@@ -124,48 +167,77 @@ def _extract_appimage_once(binary):
     extract_dir = binary + ".extracted"
     apprun = os.path.join(extract_dir, _APPIMAGE_EXTRACT_SUBDIR, "AppRun")
 
-    with contextlib.suppress(OSError):
-        if (
-            os.path.isfile(apprun)
-            and os.access(apprun, os.X_OK)
-            and os.path.getmtime(apprun) >= os.path.getmtime(binary)
-        ):
+    def _reusable_apprun():
+        try:
+            return (
+                os.path.isfile(apprun)
+                and os.access(apprun, os.X_OK)
+                and os.path.getmtime(apprun) >= os.path.getmtime(binary)
+            )
+        except OSError:
+            return False
+
+    # Fast path — a valid tree from a prior call satisfies the request
+    # without touching the lock. Two workers racing on this fast path is
+    # safe because both would read the same on-disk state.
+    if _reusable_apprun():
+        return apprun
+
+    # Serialize the delete → extract → publish sequence per binary. Without
+    # this, two concurrent develop jobs both observe an empty extraction,
+    # both rmtree() the shared directory, both write into it, and one can
+    # end up executing the other's partial output. A per-binary Lock means
+    # different binaries still extract in parallel.
+    with _get_extract_lock(binary):
+        # Re-check under the lock: another worker may have finished the
+        # extraction while we were blocked, in which case we reuse it.
+        if _reusable_apprun():
             return apprun
 
-    # Stale or absent — clear anything left behind (a half-finished previous
-    # extraction, or a tree from an older AppImage version) before extracting
-    # fresh, so a partial write cannot masquerade as a valid AppRun.
-    shutil.rmtree(extract_dir, ignore_errors=True)
-    try:
-        os.makedirs(extract_dir, exist_ok=True)
-    except OSError as e:
-        log.warning("Could not create AppImage extract dir %s: %s", extract_dir, e)
-        return None
+        parent_dir = os.path.dirname(extract_dir) or "."
+        if not _has_space_for_extraction(binary, parent_dir):
+            log.warning(
+                "Not enough free disk in %s to unpack %s (~%.1fx its size); "
+                "falling back to per-photo APPIMAGE_EXTRACT_AND_RUN",
+                parent_dir, binary, _APPIMAGE_EXTRACTION_SIZE_MULTIPLIER,
+            )
+            return None
 
-    try:
-        result = subprocess.run(
-            [binary, "--appimage-extract"],
-            capture_output=True, text=True,
-            timeout=_APPIMAGE_EXTRACT_TIMEOUT_SECONDS,
-            cwd=extract_dir, **no_window_kwargs(),
-        )
-    except (subprocess.TimeoutExpired, OSError) as e:
-        log.warning("AppImage --appimage-extract failed for %s: %s", binary, e)
+        # Stale or absent — clear anything left behind (a half-finished
+        # previous extraction, or a tree from an older AppImage version)
+        # before extracting fresh, so a partial write cannot masquerade as
+        # a valid AppRun.
         shutil.rmtree(extract_dir, ignore_errors=True)
-        return None
+        try:
+            os.makedirs(extract_dir, exist_ok=True)
+        except OSError as e:
+            log.warning("Could not create AppImage extract dir %s: %s", extract_dir, e)
+            return None
 
-    if (
-        result.returncode != 0
-        or not os.path.isfile(apprun)
-        or not os.access(apprun, os.X_OK)
-    ):
-        log.warning(
-            "AppImage --appimage-extract left no usable AppRun at %s "
-            "(exit=%s)", apprun, result.returncode,
-        )
-        shutil.rmtree(extract_dir, ignore_errors=True)
-        return None
-    return apprun
+        try:
+            result = subprocess.run(
+                [binary, "--appimage-extract"],
+                capture_output=True, text=True,
+                timeout=_APPIMAGE_EXTRACT_TIMEOUT_SECONDS,
+                cwd=extract_dir, **no_window_kwargs(),
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            log.warning("AppImage --appimage-extract failed for %s: %s", binary, e)
+            shutil.rmtree(extract_dir, ignore_errors=True)
+            return None
+
+        if (
+            result.returncode != 0
+            or not os.path.isfile(apprun)
+            or not os.access(apprun, os.X_OK)
+        ):
+            log.warning(
+                "AppImage --appimage-extract left no usable AppRun at %s "
+                "(exit=%s)", apprun, result.returncode,
+            )
+            shutil.rmtree(extract_dir, ignore_errors=True)
+            return None
+        return apprun
 
 
 def _format_subprocess_diag(stdout, stderr):

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -503,6 +503,7 @@ class JobRunner:
                 j.get("type") == job_type
                 and j.get("singleton_key") == singleton_key
                 and j.get("status") in ("running", "queued", "pausing", "paused")
+                and jid not in self._cancelled
             ):
                 return jid, j
         return None, None

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -405,21 +405,29 @@ class JobRunner:
         Returns:
             job_id string
         """
-        # Monotonic suffix (shared with enqueue_pipeline) so two same-type
-        # starts in the same millisecond can't collide — a collision makes
-        # the second registration overwrite the first in _jobs/_events and
-        # clobber its history row.
-        with self._lock:
-            self._enqueue_counter += 1
-            seq = self._enqueue_counter
-        job_id = f"{job_type}-{int(time.time() * 1000)}-{seq}"
-        now = datetime.now().isoformat()
+        job, work_fn = self._register_and_prepare(
+            job_type, work_fn,
+            config=config, workspace_id=workspace_id,
+            ephemeral=ephemeral, runtime_warning=runtime_warning,
+            counts_for_badge=counts_for_badge, pausable=pausable,
+            blocks_local_transitions=blocks_local_transitions,
+        )
+        thread = threading.Thread(
+            target=self._run_job, args=(job, work_fn), daemon=True
+        )
+        log.info("Job %s started type=%s", job["id"], job_type)
+        thread.start()
+        return job["id"]
 
-        job = {
+    def _make_job_dict(self, job_id, job_type, *, config, workspace_id,
+                       ephemeral, counts_for_badge, pausable,
+                       blocks_local_transitions, runtime_warning,
+                       singleton_key=None, now=None):
+        return {
             "id": job_id,
             "type": job_type,
             "status": "running",
-            "started_at": now,
+            "started_at": now or datetime.now().isoformat(),
             "finished_at": None,
             "progress": {"current": 0, "total": 0, "current_file": ""},
             "result": None,
@@ -432,6 +440,7 @@ class JobRunner:
             "pausable": bool(pausable),
             "blocks_local_transitions": bool(blocks_local_transitions),
             "runtime_warning": runtime_warning,
+            "singleton_key": singleton_key,
             # Pre-seeded so later writes from worker threads update an
             # existing key instead of inserting a new one: key insertion
             # while a request handler iterates the same dict (jsonify of
@@ -443,18 +452,118 @@ class JobRunner:
             "_fatal_error": None,
         }
 
+    def _register_and_prepare(self, job_type, work_fn, *, config, workspace_id,
+                              ephemeral, runtime_warning, counts_for_badge,
+                              pausable, blocks_local_transitions,
+                              singleton_key=None):
+        """Allocate an id and register the job dict under the runner lock.
+
+        Returns the (job, work_fn) pair the caller should hand to a thread.
+        Kept separate from start()/start_singleton so both paths share the
+        same registration semantics.
+        """
+        # Monotonic suffix (shared with enqueue_pipeline) so two same-type
+        # starts in the same millisecond can't collide — a collision makes
+        # the second registration overwrite the first in _jobs/_events and
+        # clobber its history row.
         with self._lock:
+            self._enqueue_counter += 1
+            seq = self._enqueue_counter
+            job_id = f"{job_type}-{int(time.time() * 1000)}-{seq}"
+            job = self._make_job_dict(
+                job_id, job_type,
+                config=config, workspace_id=workspace_id,
+                ephemeral=ephemeral, counts_for_badge=counts_for_badge,
+                pausable=pausable,
+                blocks_local_transitions=blocks_local_transitions,
+                runtime_warning=runtime_warning,
+                singleton_key=singleton_key,
+            )
+            self._prune_finished_jobs()
+            self._jobs[job_id] = job
+            self._events[job_id] = deque(maxlen=1000)
+            self._subscribers[job_id] = []
+        return job, work_fn
+
+    def _find_singleton_locked(self, job_type, singleton_key):
+        """Find an active singleton job by (job_type, singleton_key).
+
+        Must be called with self._lock held. Returns (job_id, job_dict) or
+        (None, None). "Active" means running/queued/pausing/paused — a
+        completed/failed/cancelled job releases the slot.
+
+        A ``singleton_key`` of None is not a valid key: without this guard,
+        every plain ``start()`` job (which stores singleton_key=None) would
+        match a lookup for the same job_type with key=None.
+        """
+        if singleton_key is None:
+            return None, None
+        for jid, j in self._jobs.items():
+            if (
+                j.get("type") == job_type
+                and j.get("singleton_key") == singleton_key
+                and j.get("status") in ("running", "queued", "pausing", "paused")
+            ):
+                return jid, j
+        return None, None
+
+    def start_singleton(self, job_type, work_fn, *, singleton_key,
+                        config=None, workspace_id=None, ephemeral=False,
+                        runtime_warning=None, counts_for_badge=True,
+                        pausable=False, blocks_local_transitions=True):
+        """Start a job unless one with the same (type, singleton_key) is active.
+
+        The existence check AND the new-job registration happen under a
+        single ``self._lock`` acquisition so two concurrent callers cannot
+        both see "no existing job" and both start a worker — a race that
+        the earlier check-then-start pattern still had even with an
+        explicit ``list_jobs()`` guard.
+
+        Returns ``(job_id, joined_existing, existing_snapshot)``:
+        - ``joined_existing`` True means work_fn was NOT invoked; job_id is
+          the id of the already-active singleton and ``existing_snapshot``
+          is a read-only copy of its state (so callers can inspect its
+          stored config to decide whether joining is actually appropriate).
+        - ``joined_existing`` False means a fresh job was registered and
+          its worker thread was started; ``existing_snapshot`` is None.
+        """
+        # Compute the joined snapshot / register a new job under one lock
+        # acquisition so the check-and-start is genuinely atomic.
+        with self._lock:
+            existing_id, existing = self._find_singleton_locked(
+                job_type, singleton_key,
+            )
+            if existing_id is not None:
+                return existing_id, True, self._snapshot_job(existing)
+            # No active singleton — register inline while still holding the
+            # lock so a second caller arriving between our check and our
+            # registration cannot slip in and register its own.
+            self._enqueue_counter += 1
+            seq = self._enqueue_counter
+            job_id = f"{job_type}-{int(time.time() * 1000)}-{seq}"
+            job = self._make_job_dict(
+                job_id, job_type,
+                config=config, workspace_id=workspace_id,
+                ephemeral=ephemeral, counts_for_badge=counts_for_badge,
+                pausable=pausable,
+                blocks_local_transitions=blocks_local_transitions,
+                runtime_warning=runtime_warning,
+                singleton_key=singleton_key,
+            )
             self._prune_finished_jobs()
             self._jobs[job_id] = job
             self._events[job_id] = deque(maxlen=1000)
             self._subscribers[job_id] = []
 
         thread = threading.Thread(
-            target=self._run_job, args=(job, work_fn), daemon=True
+            target=self._run_job, args=(job, work_fn), daemon=True,
         )
-        log.info("Job %s started type=%s", job_id, job_type)
+        log.info(
+            "Job %s started type=%s singleton_key=%s",
+            job_id, job_type, singleton_key,
+        )
         thread.start()
-        return job_id
+        return job_id, False, None
 
     def _prune_finished_jobs(self):
         """Remove completed/failed jobs older than _JOB_RETENTION_SECS.

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -42,7 +42,8 @@ class DownloadCancelled(Exception):
 
 def _download_with_resume(url, dest_path, progress_callback=None,
                           max_stalled=3, chunk_size=256 * 1024,
-                          *, byte_callback=None, should_cancel=None):
+                          *, byte_callback=None, should_cancel=None,
+                          _emit_interval=0.25):
     """Download a file with retry and resume support.
 
     Streams to ``dest_path + ".partial"``, resuming from the last byte on
@@ -61,6 +62,14 @@ def _download_with_resume(url, dest_path, progress_callback=None,
             byte-level progress.  Throttled to ~4 Hz.
         should_cancel: optional ``callback() -> bool``.  When it returns True
             the download aborts, leaving the ``.partial`` file for resume.
+        _emit_interval: minimum seconds between byte_callback emits (private;
+            for tests).
+
+    Neither ``byte_callback`` nor ``should_cancel`` may raise: they are called
+    inside the transfer's ``try`` block, so an exception from either is caught
+    by the generic handler and misreported to the user as a network failure,
+    triggering a full retry (and discarding the partial when the server
+    answers 200).  Callers must swallow their own errors.
     """
     partial_path = dest_path + ".partial"
     attempt = 0
@@ -123,7 +132,7 @@ def _download_with_resume(url, dest_path, progress_callback=None,
                         received += len(chunk)
                         if byte_callback is not None:
                             now = time.monotonic()
-                            if now - last_emit >= 0.25:
+                            if now - last_emit >= _emit_interval:
                                 last_emit = now
                                 byte_callback(progress_base + received, expected_total)
                     if byte_callback is not None:
@@ -166,9 +175,13 @@ def _download_with_resume(url, dest_path, progress_callback=None,
                     f"try again and the download will resume."
                 ) from e
 
+            # Poll the backoff in short slices so Cancel is felt within ~0.5 s
+            # instead of after the full 3 s wait.  `from None`: the user asked
+            # to stop, so the network error we were backing off from is not the
+            # cause and must not be chained onto the cancel.
             for _ in range(6):
                 if should_cancel is not None and should_cancel():
-                    raise DownloadCancelled("Download cancelled")
+                    raise DownloadCancelled("Download cancelled") from None
                 time.sleep(0.5)
             continue
 

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -36,8 +36,13 @@ log = logging.getLogger(__name__)
 _ssl_ctx = ssl.create_default_context(cafile=certifi.where())
 
 
+class DownloadCancelled(Exception):
+    """Raised when should_cancel() asked us to stop."""
+
+
 def _download_with_resume(url, dest_path, progress_callback=None,
-                          max_stalled=3, chunk_size=256 * 1024):
+                          max_stalled=3, chunk_size=256 * 1024,
+                          *, byte_callback=None, should_cancel=None):
     """Download a file with retry and resume support.
 
     Streams to ``dest_path + ".partial"``, resuming from the last byte on
@@ -52,6 +57,10 @@ def _download_with_resume(url, dest_path, progress_callback=None,
         progress_callback: optional ``callback(message)`` for status updates.
         max_stalled: Give up after this many consecutive zero-progress retries.
         chunk_size: Bytes per read chunk (default 256 KB).
+        byte_callback: optional ``callback(downloaded, total_or_None)`` for
+            byte-level progress.  Throttled to ~4 Hz.
+        should_cancel: optional ``callback() -> bool``.  When it returns True
+            the download aborts, leaving the ``.partial`` file for resume.
     """
     partial_path = dest_path + ".partial"
     attempt = 0
@@ -92,14 +101,33 @@ def _download_with_resume(url, dest_path, progress_callback=None,
                 expected_bytes = int(content_length) if content_length else None
 
                 mode = "ab" if resp.status == 206 else "wb"
+                # Bytes already on disk that we are keeping. Distinct from
+                # downloaded_before, which stays put as the stall baseline even
+                # when mode == "wb" truncates the partial.
+                progress_base = downloaded_before if resp.status == 206 else 0
+                expected_total = (
+                    expected_bytes + progress_base
+                    if expected_bytes is not None
+                    else None
+                )
                 received = 0
                 with open(partial_path, mode) as f:
+                    last_emit = 0.0
                     while True:
+                        if should_cancel is not None and should_cancel():
+                            raise DownloadCancelled("Download cancelled")
                         chunk = resp.read(chunk_size)
                         if not chunk:
                             break
                         f.write(chunk)
                         received += len(chunk)
+                        if byte_callback is not None:
+                            now = time.monotonic()
+                            if now - last_emit >= 0.25:
+                                last_emit = now
+                                byte_callback(progress_base + received, expected_total)
+                    if byte_callback is not None:
+                        byte_callback(progress_base + received, expected_total)
 
                 # Check for truncated response
                 if expected_bytes is not None and received < expected_bytes:
@@ -108,6 +136,8 @@ def _download_with_resume(url, dest_path, progress_callback=None,
                         f"{expected_bytes} bytes"
                     )
 
+        except DownloadCancelled:
+            raise
         except Exception as e:
             current_size = os.path.getsize(partial_path) if os.path.exists(partial_path) else 0
             gained = current_size - downloaded_before
@@ -136,7 +166,10 @@ def _download_with_resume(url, dest_path, progress_callback=None,
                     f"try again and the download will resume."
                 ) from e
 
-            time.sleep(3)
+            for _ in range(6):
+                if should_cancel is not None and should_cancel():
+                    raise DownloadCancelled("Download cancelled")
+                time.sleep(0.5)
             continue
 
         # Success — rename partial to final

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -50,6 +50,12 @@ class DownloadCancelled(Exception):
 # format; a compliant server puts the total after the slash.
 _CONTENT_RANGE_TOTAL_RE = re.compile(r"bytes\s*\*/(\d+)", re.IGNORECASE)
 
+# `Content-Range: bytes <start>-<end>/<total>` — the header a 206 response
+# uses to describe which bytes the body actually spans. If the server (or an
+# intermediary) resumes from a different byte than we asked for, appending
+# would splice mismatched content into the partial file.
+_CONTENT_RANGE_START_RE = re.compile(r"bytes\s+(\d+)\s*-", re.IGNORECASE)
+
 
 def _content_range_total(headers):
     """Total resource size advertised by a Content-Range: bytes */<total>.
@@ -63,6 +69,28 @@ def _content_range_total(headers):
     if not header:
         return None
     match = _CONTENT_RANGE_TOTAL_RE.search(header)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def _content_range_start(headers):
+    """First byte covered by a Content-Range: bytes <start>-<end>/<total>.
+
+    Returns None when the header is absent or malformed. Used to detect a
+    206 that begins at a different byte than the client's Range request so
+    the caller can restart from scratch rather than splice mismatched bytes
+    onto its existing ``.partial``.
+    """
+    if headers is None:
+        return None
+    header = headers.get("Content-Range")
+    if not header:
+        return None
+    match = _CONTENT_RANGE_START_RE.search(header)
     if not match:
         return None
     try:
@@ -189,10 +217,30 @@ def _download_with_resume(url, dest_path, progress_callback=None,
                     expected_bytes = int(content_length) if content_length else None
 
                     mode = "ab" if resp.status == 206 else "wb"
+                    # A 206 must begin exactly at ``downloaded_before`` — the
+                    # byte we asked to resume from. A proxy or rebuilt artifact
+                    # can return a valid range that starts elsewhere; appending
+                    # that body onto our ``.partial`` would silently splice
+                    # mismatched bytes into the file. On mismatch, restart
+                    # from scratch. (For darktable installs the SHA256 check
+                    # catches it; download_taxa() has no digest and would fail
+                    # later as an opaque gzip/CSV parse error.)
+                    if mode == "ab":
+                        range_start = _content_range_start(resp.headers)
+                        if (
+                            range_start is not None
+                            and range_start != downloaded_before
+                        ):
+                            log.warning(
+                                "Server resumed at byte %d, expected %d;"
+                                " restarting download",
+                                range_start, downloaded_before,
+                            )
+                            mode = "wb"
                     # Bytes already on disk that we are keeping. Distinct from
                     # downloaded_before, which stays put as the stall baseline even
                     # when mode == "wb" truncates the partial.
-                    progress_base = downloaded_before if resp.status == 206 else 0
+                    progress_base = downloaded_before if mode == "ab" else 0
                     expected_total = (
                         expected_bytes + progress_base
                         if expected_bytes is not None
@@ -273,9 +321,27 @@ def _download_with_resume(url, dest_path, progress_callback=None,
                     return dest_path
                 # Stale or unverifiable partial: delete so the next iteration
                 # restarts from byte 0 rather than sending the same doomed
-                # Range header on every attempt.
-                with contextlib.suppress(OSError):
+                # Range header on every attempt.  If the removal fails
+                # (permission denied, Windows lock, read-only dir),
+                # ``downloaded_before`` stays > 0 next iteration, the same
+                # Range is sent, the server answers 416 again, and the loop
+                # would spin forever — count it as a stall so ``max_stalled``
+                # eventually breaks us out with a real error.
+                try:
                     os.remove(partial_path)
+                except OSError as remove_error:
+                    stalled_count += 1
+                    log.warning(
+                        "Could not remove stale partial %s after 416: %s"
+                        " (stalled %d/%d)",
+                        partial_path, remove_error, stalled_count, max_stalled,
+                    )
+                    if stalled_count >= max_stalled:
+                        raise RuntimeError(
+                            f"Server rejected resume range and the partial "
+                            f"file {partial_path} could not be removed: "
+                            f"{remove_error}"
+                        ) from e
                 log.warning(
                     "Server returned 416 but partial size (%d) does not match"
                     " advertised total (%r); restarting download",

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -14,13 +14,16 @@ Usage:
 """
 
 import argparse
+import contextlib
 import csv
 import gzip
 import io
 import json
 import logging
 import os
+import socket
 import ssl
+import threading
 import time
 import unicodedata
 import urllib.request
@@ -99,55 +102,114 @@ def _download_with_resume(url, dest_path, progress_callback=None,
                     log.info("Retrying download (attempt %d)", attempt)
 
             with urllib.request.urlopen(req, timeout=120, context=_ssl_ctx) as resp:
-                # If server returned 200 (not 206), it doesn't support Range —
-                # start from scratch.  Don't reset downloaded_before: it's the
-                # stall-detection baseline (did we get further than last time?).
-                if resp.status == 200 and downloaded_before > 0:
-                    log.info("Server does not support Range; restarting download")
-
-                # Determine expected size so we can detect truncated responses
-                content_length = resp.headers.get("Content-Length")
-                expected_bytes = int(content_length) if content_length else None
-
-                mode = "ab" if resp.status == 206 else "wb"
-                # Bytes already on disk that we are keeping. Distinct from
-                # downloaded_before, which stays put as the stall baseline even
-                # when mode == "wb" truncates the partial.
-                progress_base = downloaded_before if resp.status == 206 else 0
-                expected_total = (
-                    expected_bytes + progress_base
-                    if expected_bytes is not None
-                    else None
-                )
-                received = 0
-                with open(partial_path, mode) as f:
-                    last_emit = 0.0
-                    while True:
-                        if should_cancel is not None and should_cancel():
-                            raise DownloadCancelled("Download cancelled")
-                        chunk = resp.read(chunk_size)
-                        if not chunk:
-                            break
-                        f.write(chunk)
-                        received += len(chunk)
-                        if byte_callback is not None:
-                            now = time.monotonic()
-                            if now - last_emit >= _emit_interval:
-                                last_emit = now
-                                byte_callback(progress_base + received, expected_total)
-                    if byte_callback is not None:
-                        byte_callback(progress_base + received, expected_total)
-
-                # Check for truncated response
-                if expected_bytes is not None and received < expected_bytes:
-                    raise OSError(
-                        f"Incomplete download: got {received} of "
-                        f"{expected_bytes} bytes"
+                # Interrupt a stalled resp.read from a watcher thread when the
+                # caller asks to cancel.  Without this, a Stop press during a
+                # stalled read is not felt until the socket read returns or
+                # the 120 s timeout expires — up to two minutes on the
+                # unreliable-network scenario where cancellation is most
+                # needed.  resp.close() would only set a flag; it does not
+                # unblock a blocked recv on the underlying socket.  A
+                # socket.shutdown(SHUT_RDWR) does — it forces the kernel to
+                # return the pending recv with an error, which the outer
+                # handler then reclassifies as DownloadCancelled (see the
+                # should_cancel() check below).
+                cancel_watcher_stop = threading.Event()
+                watcher = None
+                if should_cancel is not None:
+                    # Default-argument bind so the closure captures THIS
+                    # iteration's stop event / resp / cancel callback rather
+                    # than the outer-scope names — otherwise a late thread
+                    # could observe the next iteration's variables (and ruff
+                    # B023 objects to the same issue).
+                    def _close_on_cancel(
+                        _stop=cancel_watcher_stop,
+                        _resp=resp,
+                        _cancel=should_cancel,
+                    ):
+                        while not _stop.wait(0.25):
+                            if _cancel():
+                                # SocketIO -> raw socket.  Not part of the
+                                # public API, but the only reliable way to
+                                # break a recv from another thread — see
+                                # the module comment above.
+                                sock = getattr(getattr(_resp, "fp", None),
+                                               "raw", None)
+                                sock = getattr(sock, "_sock", None)
+                                if sock is not None:
+                                    # Already closed or half-closed — the
+                                    # blocked read will surface the error
+                                    # regardless.
+                                    with contextlib.suppress(OSError):
+                                        sock.shutdown(socket.SHUT_RDWR)
+                                return
+                    watcher = threading.Thread(
+                        target=_close_on_cancel, daemon=True,
+                        name="download-cancel-watcher",
                     )
+                    watcher.start()
+
+                try:
+                    # If server returned 200 (not 206), it doesn't support
+                    # Range — start from scratch.  Don't reset
+                    # downloaded_before: it's the stall-detection baseline
+                    # (did we get further than last time?).
+                    if resp.status == 200 and downloaded_before > 0:
+                        log.info("Server does not support Range; restarting download")
+
+                    # Determine expected size so we can detect truncated responses
+                    content_length = resp.headers.get("Content-Length")
+                    expected_bytes = int(content_length) if content_length else None
+
+                    mode = "ab" if resp.status == 206 else "wb"
+                    # Bytes already on disk that we are keeping. Distinct from
+                    # downloaded_before, which stays put as the stall baseline even
+                    # when mode == "wb" truncates the partial.
+                    progress_base = downloaded_before if resp.status == 206 else 0
+                    expected_total = (
+                        expected_bytes + progress_base
+                        if expected_bytes is not None
+                        else None
+                    )
+                    received = 0
+                    with open(partial_path, mode) as f:
+                        last_emit = 0.0
+                        while True:
+                            if should_cancel is not None and should_cancel():
+                                raise DownloadCancelled("Download cancelled")
+                            chunk = resp.read(chunk_size)
+                            if not chunk:
+                                break
+                            f.write(chunk)
+                            received += len(chunk)
+                            if byte_callback is not None:
+                                now = time.monotonic()
+                                if now - last_emit >= _emit_interval:
+                                    last_emit = now
+                                    byte_callback(progress_base + received, expected_total)
+                        if byte_callback is not None:
+                            byte_callback(progress_base + received, expected_total)
+
+                    # Check for truncated response
+                    if expected_bytes is not None and received < expected_bytes:
+                        raise OSError(
+                            f"Incomplete download: got {received} of "
+                            f"{expected_bytes} bytes"
+                        )
+                finally:
+                    cancel_watcher_stop.set()
+                    if watcher is not None:
+                        watcher.join(timeout=2)
 
         except DownloadCancelled:
             raise
         except Exception as e:
+            # The watcher thread closes ``resp`` on cancel, which surfaces
+            # here as a socket error.  Reclassify it before the stall
+            # detection can turn "user pressed Stop" into "download stalled
+            # after N attempts" — the user asked to cancel, so ``from None``
+            # keeps that unrelated network error out of the traceback.
+            if should_cancel is not None and should_cancel():
+                raise DownloadCancelled("Download cancelled") from None
             current_size = os.path.getsize(partial_path) if os.path.exists(partial_path) else 0
             gained = current_size - downloaded_before
 

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -21,11 +21,13 @@ import io
 import json
 import logging
 import os
+import re
 import socket
 import ssl
 import threading
 import time
 import unicodedata
+import urllib.error
 import urllib.request
 import zipfile
 from datetime import date
@@ -41,6 +43,32 @@ _ssl_ctx = ssl.create_default_context(cafile=certifi.where())
 
 class DownloadCancelled(Exception):
     """Raised when should_cancel() asked us to stop."""
+
+
+# `Content-Range: bytes */<total>` — the header a 416 response uses to tell
+# the client what the actual size of the resource is. RFC 7233 §4.2 pins the
+# format; a compliant server puts the total after the slash.
+_CONTENT_RANGE_TOTAL_RE = re.compile(r"bytes\s*\*/(\d+)", re.IGNORECASE)
+
+
+def _content_range_total(headers):
+    """Total resource size advertised by a Content-Range: bytes */<total>.
+
+    Returns None when the header is absent or malformed — the caller falls
+    back to restarting the download from scratch, which is the safe outcome.
+    """
+    if headers is None:
+        return None
+    header = headers.get("Content-Range")
+    if not header:
+        return None
+    match = _CONTENT_RANGE_TOTAL_RE.search(header)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
 
 
 def _download_with_resume(url, dest_path, progress_callback=None,
@@ -203,6 +231,69 @@ def _download_with_resume(url, dest_path, progress_callback=None,
         except DownloadCancelled:
             raise
         except Exception as e:
+            # 416 Requested Range Not Satisfiable: our Range starts at or
+            # past the end of the resource.  Reachable when cancellation
+            # lands after the final chunk is written but before the
+            # empty-read break — the loop's cancel check raises, leaving a
+            # ``.partial`` already at the full size, so the next attempt
+            # asks for ``bytes=<full>-``.  Without this branch the retry
+            # loop would burn ``max_stalled`` attempts against a permanent
+            # 416 and give up despite promising "try again and the download
+            # will resume".  Verify the total via Content-Range and, when
+            # sizes agree, promote the partial to the final path.  On
+            # mismatch (the release was rebuilt) delete the stale partial
+            # and let the next iteration re-download from byte 0 — that is
+            # safer than shipping bytes of the wrong artifact to the
+            # caller's digest check.
+            if (
+                isinstance(e, urllib.error.HTTPError)
+                and e.code == 416
+                and downloaded_before > 0
+            ):
+                total = _content_range_total(getattr(e, "headers", None))
+                current_size = (
+                    os.path.getsize(partial_path)
+                    if os.path.exists(partial_path)
+                    else 0
+                )
+                if total is not None and current_size == total:
+                    if os.path.exists(dest_path):
+                        os.remove(dest_path)
+                    os.rename(partial_path, dest_path)
+                    if byte_callback is not None:
+                        byte_callback(current_size, total)
+                    mb = current_size // (1024 * 1024)
+                    log.info(
+                        "Server reported 416 with matching total (%d bytes);"
+                        " promoting complete .partial to %s",
+                        total, dest_path,
+                    )
+                    if progress_callback:
+                        progress_callback(f"Downloaded {mb} MB")
+                    return dest_path
+                # Stale or unverifiable partial: delete so the next iteration
+                # restarts from byte 0 rather than sending the same doomed
+                # Range header on every attempt.
+                with contextlib.suppress(OSError):
+                    os.remove(partial_path)
+                log.warning(
+                    "Server returned 416 but partial size (%d) does not match"
+                    " advertised total (%r); restarting download",
+                    current_size, total,
+                )
+                if progress_callback:
+                    progress_callback(
+                        f"Resume rejected by server (attempt {attempt}), "
+                        f"restarting download..."
+                    )
+                # Poll cancellation during the backoff so Stop feels
+                # responsive on a rejected-resume loop too.
+                for _ in range(6):
+                    if should_cancel is not None and should_cancel():
+                        raise DownloadCancelled("Download cancelled") from None
+                    time.sleep(0.5)
+                continue
+
             # The watcher thread closes ``resp`` on cancel, which surfaces
             # here as a socket error.  Reclassify it before the stall
             # detection can turn "user pressed Stop" into "download stalled

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2163,12 +2163,28 @@ async function validateInatToken() {
   }
 }
 
+// Platform must describe the Flask host (which will run the installer), not
+// the browser device (which could be a phone or a different desktop on the
+// LAN). /api/darktable/install/available carries the host's sys.platform;
+// window._dtAsset caches it once we have looked, and installPlatform() falls
+// back to the browser as a last resort so the panel is never blank before
+// the first API round-trip.
+function darktableInstallPlatform() {
+  var asset = window._dtAsset || {};
+  if (typeof asset.platform === 'string' && asset.platform) return asset.platform;
+  var ua = navigator.userAgent || '';
+  if (/Windows/.test(ua)) return 'win32';
+  if (/Mac/.test(ua)) return 'darwin';
+  if (/Linux/.test(ua) && !/Android/.test(ua)) return 'linux';
+  return '';
+}
+
 function darktableIsLinux() {
-  return /Linux/.test(navigator.userAgent) && !/Android/.test(navigator.userAgent);
+  return darktableInstallPlatform() === 'linux';
 }
 
 function darktableIsWindows() {
-  return /Windows/.test(navigator.userAgent);
+  return darktableInstallPlatform() === 'win32';
 }
 
 async function loadDarktableStatus() {
@@ -2241,6 +2257,10 @@ async function renderDarktableGetOption() {
   } catch(e) {
     info = { available: false, reason: 'Could not check for a darktable release.' };
   }
+  // Publish _dtAsset before any darktableIsLinux()/darktableIsWindows() call
+  // so those helpers see the server-derived platform for the Flask host
+  // rather than falling back to navigator.userAgent.
+  window._dtAsset = info;
 
   if (!info.available) {
     // Never a dead button: a plain link, plus the reason verbatim. "GitHub
@@ -2254,7 +2274,6 @@ async function renderDarktableGetOption() {
   }
 
   var label = darktableIsLinux() ? 'Download and set up' : 'Download installer';
-  window._dtAsset = info;
   host.innerHTML = '<button class="btn" onclick="downloadDarktable()">' + label + '</button>' +
     '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">' +
     'darktable ' + escapeHtml(info.version) + ' &mdash; ' + escapeHtml(info.name) + ', ' +

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2324,6 +2324,12 @@ async function downloadDarktable() {
         expected_version: a.version,
         expected_name: a.name,
         expected_digest: a.digest || null,
+        // Size is the fallback identity for a digestless release: if GitHub
+        // deletes and re-uploads the asset under the same tag+filename
+        // during the availability cache's TTL, name+version still match but
+        // the bytes differ. Without this the server would accept the swap
+        // for any release that publishes no digest.
+        expected_size: (typeof a.size === 'number') ? a.size : null,
       }),
     });
   } catch(e) {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2264,14 +2264,33 @@ async function renderDarktableGetOption() {
 async function downloadDarktable() {
   var a = window._dtAsset || {};
   var isLinux = darktableIsLinux();
+  var isWindows = darktableIsWindows();
   var what = isLinux
     ? 'Vireo will download it and set the darktable-cli path for you.'
     : 'Vireo will download the installer and open it. You finish the install.';
+  // Warn about SmartScreen BEFORE the download starts, not after: the server
+  // calls os.startfile() from hand_off() before the SSE 'complete' event
+  // fires, so an onComplete-only warning arrives after the unknown-publisher
+  // prompt has already surfaced — defeating the warning at the exact moment
+  // the user has to decide whether to proceed. Same idea for Gatekeeper on
+  // macOS: naming the expected dialog turns "is this malware?" into
+  // "this is the OS check I was warned about".
+  var osWarning = '';
+  if (isWindows) {
+    osWarning = '\n\nWindows may show a SmartScreen "unknown publisher" ' +
+                'warning after the download finishes — darktable does not ' +
+                'sign its installer. Click "More info" then "Run anyway".';
+  } else if (!isLinux) {
+    osWarning = '\n\nmacOS may show a Gatekeeper warning — darktable does ' +
+                'not notarize its macOS builds. Drag darktable to the ' +
+                'Applications folder from the DMG the installer opens.';
+  }
   // Name the exact artifact before any bytes move: version, filename, size,
   // source host.
   if (!confirm('Download darktable ' + a.version + '?\n\n' +
                a.name + ' (' + Math.round(a.size / 1048576) + ' MB)\n' +
-               'From: github.com/darktable-org/darktable\n\n' + what)) return;
+               'From: github.com/darktable-org/darktable\n\n' + what +
+               osWarning)) return;
 
   // Hiding the button is a UX guard against double-clicks; the server also has
   // a singleton guard (a second POST joins the running job instead of starting

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2273,10 +2273,10 @@ async function downloadDarktable() {
                a.name + ' (' + Math.round(a.size / 1048576) + ' MB)\n' +
                'From: github.com/darktable-org/darktable\n\n' + what)) return;
 
-  // NOTE from Task 9: there is no server-side duplicate-click guard (no other
-  // download job in app.py has one). Two rapid POSTs start two jobs writing the
-  // same .partial; the digest check catches it but BOTH report an error. Hiding
-  // the button here is what prevents that, so do not remove it.
+  // Hiding the button is a UX guard against double-clicks; the server also has
+  // a singleton guard (a second POST joins the running job instead of starting
+  // another worker on the same .partial) so a rapid double click still lands
+  // on one download rather than an error.
   document.getElementById('darktableGet').style.display = 'none';
   var wrap = document.getElementById('darktableProgress');
   var fill = document.getElementById('dtProgressFill');
@@ -2289,11 +2289,35 @@ async function downloadDarktable() {
   // "Starting..." forever with the button hidden. safeFetch throws an Error
   // carrying the route's specific message — render it inline, not just in the
   // toast that scrolls away.
+  //
+  // expected_* pin the download to the exact artifact this dialog confirmed.
+  // /install/available caches for 10 minutes; a new release published in that
+  // window would otherwise mean the server downloads a different artifact from
+  // the one just OK'd — same button click, different bytes.  The server
+  // returns code=darktable_asset_changed when the fresh resolution disagrees
+  // so the panel can re-check and re-prompt with the new identity.
   var resp;
   try {
-    resp = await safeFetch('/api/jobs/download-darktable', { method: 'POST' });
+    resp = await safeFetch('/api/jobs/download-darktable', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        expected_version: a.version,
+        expected_name: a.name,
+        expected_digest: a.digest || null,
+      }),
+    });
   } catch(e) {
     fill.style.width = '0%';
+    if (e && e.code === 'darktable_asset_changed') {
+      // Do not just show a red error — the user's intent was still to
+      // download darktable, and the fresh version is what they should decide
+      // on now. Re-render the panel so it fetches the new availability info,
+      // then explain in-panel why they were bounced back.
+      text.innerHTML = escapeHtml(e.message || 'The darktable release changed since this dialog opened.') +
+        '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Re-check</button>';
+      return;
+    }
     text.innerHTML = '<span style="color:var(--danger);">' +
       escapeHtml(e.message || 'Could not start the download.') + '</span>';
     document.getElementById('darktableGet').style.display = '';

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2163,16 +2163,51 @@ async function validateInatToken() {
   }
 }
 
+function darktableIsLinux() {
+  return /Linux/.test(navigator.userAgent) && !/Android/.test(navigator.userAgent);
+}
+
+function darktableIsWindows() {
+  return /Windows/.test(navigator.userAgent);
+}
+
 async function loadDarktableStatus() {
   try {
     var data = await safeFetch('/api/darktable/status', {}, { toast: false });
     var el = document.getElementById('darktableStatus');
+    var needsGetOption = false;
     if (data.available) {
       el.innerHTML = '<span style="color:var(--accent);font-size:13px;">&#10003; darktable-cli found</span>' +
         '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">' + escapeHtml(data.bin) + '</span>';
     } else {
       el.innerHTML = '<span style="color:var(--danger);font-size:13px;">&#10007; darktable-cli not found</span>' +
-        '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">Install darktable or set the path below</span>';
+        '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">Install darktable or set the path below</span>' +
+        '<div id="darktableGet" style="margin-top:6px;"></div>' +
+        '<div id="darktableProgress" style="display:none;margin-top:8px;">' +
+        '  <div style="background:var(--bg-tertiary);border-radius:3px;height:6px;overflow:hidden;">' +
+        '    <div id="dtProgressFill" style="background:var(--accent);height:100%;width:0%;"></div>' +
+        '  </div>' +
+        '  <div id="dtProgressText" style="font-size:12px;color:var(--text-dim);margin-top:4px;"></div>' +
+        '</div>';
+      // The user's OWN configured path is the highest-priority probe and the
+      // one they are most likely asking about. find_darktable falls through
+      // silently when darktable_bin points at a path that no longer exists
+      // (develop.py), and checked_paths deliberately does not include it — so
+      // say it explicitly, or the panel never answers the actual question.
+      if (data.configured_bin) {
+        el.innerHTML += '<div style="color:var(--danger);font-size:12px;margin-top:6px;">' +
+          'Configured path not found: ' + escapeHtml(data.configured_bin) + '</div>';
+      }
+      // Say where we looked, so a bare ✗ can explain itself.
+      // 'Checked:' not 'Checked PATH and:' — element 0 of checked_paths is
+      // already "$PATH (darktable-cli)" (Task 2 composes it in), so the older
+      // prefix named PATH twice and implied the rest were additional to it.
+      // Task 2 also guarantees the list is never empty, so no else branch.
+      if (data.checked_paths && data.checked_paths.length) {
+        el.innerHTML += '<div style="font-size:11px;color:var(--text-ghost);margin-top:6px;">' +
+          'Checked: ' + data.checked_paths.map(escapeHtml).join(', ') + '</div>';
+      }
+      needsGetOption = true;
     }
     if (data.auto_convert_dng) {
       if (data.dng_available) {
@@ -2180,10 +2215,172 @@ async function loadDarktableStatus() {
           '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">' + escapeHtml(data.dng_bin) + '</span></div>';
       } else {
         el.innerHTML += '<div style="color:var(--danger);font-size:13px;margin-top:4px;">&#10007; Adobe DNG Converter not found' +
-          '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">Install it or set the path below</span></div>';
+          '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">Install it or set the path below &mdash; ' +
+          '<a href="https://helpx.adobe.com/camera-raw/digital-negative.html" target="_blank" rel="noopener" ' +
+          'style="color:var(--accent);">Get it from Adobe &#8599;</a></span></div>';
       }
     }
+    // MUST run after the DNG block. That block does `el.innerHTML +=`, which
+    // re-parses the subtree and detaches any node captured earlier — so
+    // rendering the button before it would write into a dead node and the
+    // button would never appear. darktable_auto_convert_dng defaults to true
+    // (config.py:66), so this is the default path, not an edge case.
+    if (needsGetOption) await renderDarktableGetOption();
   } catch(e) {}
+}
+
+// The button must say what it actually does. On macOS/Windows we hand off to
+// the OS installer and the user finishes the job, so it says "Download
+// installer" — never "Install darktable".
+async function renderDarktableGetOption() {
+  var host = document.getElementById('darktableGet');
+  if (!host) return;
+  var info;
+  try {
+    info = await safeFetch('/api/darktable/install/available', {}, { toast: false });
+  } catch(e) {
+    info = { available: false, reason: 'Could not check for a darktable release.' };
+  }
+
+  if (!info.available) {
+    // Never a dead button: a plain link, plus the reason verbatim. "GitHub
+    // was unreachable" and "no build exists for your platform" are different
+    // facts the user acts on differently, so do not collapse them.
+    host.innerHTML = '<a href="https://www.darktable.org/install/" target="_blank" rel="noopener" ' +
+      'style="color:var(--accent);font-size:13px;">Get darktable &#8599;</a>' +
+      '<span style="color:var(--text-ghost);font-size:11px;margin-left:8px;">' +
+      escapeHtml(info.reason || '') + '</span>';
+    return;
+  }
+
+  var label = darktableIsLinux() ? 'Download and set up' : 'Download installer';
+  window._dtAsset = info;
+  host.innerHTML = '<button class="btn" onclick="downloadDarktable()">' + label + '</button>' +
+    '<span style="color:var(--text-dim);font-size:12px;margin-left:8px;">' +
+    'darktable ' + escapeHtml(info.version) + ' &mdash; ' + escapeHtml(info.name) + ', ' +
+    Math.round(info.size / 1048576) + ' MB, from github.com/darktable-org</span>';
+}
+
+async function downloadDarktable() {
+  var a = window._dtAsset || {};
+  var isLinux = darktableIsLinux();
+  var what = isLinux
+    ? 'Vireo will download it and set the darktable-cli path for you.'
+    : 'Vireo will download the installer and open it. You finish the install.';
+  // Name the exact artifact before any bytes move: version, filename, size,
+  // source host.
+  if (!confirm('Download darktable ' + a.version + '?\n\n' +
+               a.name + ' (' + Math.round(a.size / 1048576) + ' MB)\n' +
+               'From: github.com/darktable-org/darktable\n\n' + what)) return;
+
+  // NOTE from Task 9: there is no server-side duplicate-click guard (no other
+  // download job in app.py has one). Two rapid POSTs start two jobs writing the
+  // same .partial; the digest check catches it but BOTH report an error. Hiding
+  // the button here is what prevents that, so do not remove it.
+  document.getElementById('darktableGet').style.display = 'none';
+  var wrap = document.getElementById('darktableProgress');
+  var fill = document.getElementById('dtProgressFill');
+  var text = document.getElementById('dtProgressText');
+  wrap.style.display = 'block';
+  text.textContent = 'Starting...';
+
+  // The route 400s on insufficient disk space, an unusable download directory,
+  // or a release it can no longer resolve. Without this guard the panel sits on
+  // "Starting..." forever with the button hidden. safeFetch throws an Error
+  // carrying the route's specific message — render it inline, not just in the
+  // toast that scrolls away.
+  var resp;
+  try {
+    resp = await safeFetch('/api/jobs/download-darktable', { method: 'POST' });
+  } catch(e) {
+    fill.style.width = '0%';
+    text.innerHTML = '<span style="color:var(--danger);">' +
+      escapeHtml(e.message || 'Could not start the download.') + '</span>';
+    document.getElementById('darktableGet').style.display = '';
+    return;
+  }
+
+  safeEventSource('/api/jobs/' + resp.job_id + '/stream', {
+    // NOTE from Task 4: p.current can move BACKWARDS. When a server ignores
+    // Range, the retry truncates the .partial and restarts from 0, so the bar
+    // must tolerate a decreasing current rather than assuming monotonicity.
+    // That is honest — the bytes really were discarded — so do not clamp it.
+    onProgress: function(p) {
+      if (p.total) {
+        fill.style.width = Math.round((p.current / p.total) * 100) + '%';
+        text.textContent = p.phase + ': ' +
+          Math.round(p.current / 1048576) + ' of ' + Math.round(p.total / 1048576) + ' MB';
+      } else {
+        text.textContent = p.phase + (p.current_file ? ': ' + p.current_file : '');
+      }
+    },
+    onComplete: function(r) {
+      // Verified against jobs.py: the `complete` SSE event carries the job
+      // ENVELOPE — {job_id, job_type, status, phase, result, duration, errors,
+      // failure} — so the job's return value is r.result, not r.
+      //
+      // Job FAILURES arrive here with status !== 'completed' — not via
+      // onError, which only fires on EventSource connection loss and is
+      // called with no arguments. A digest mismatch lands here; rendering it
+      // as a success with an empty message would be exactly the black box
+      // CORE_PHILOSOPHY.md forbids. Same shape downloadModel() reads below.
+      if (r && r.status === 'cancelled') {
+        // jobs.py sets status 'cancelled' with empty errors and no failure,
+        // so this must be handled before the failure branch or a
+        // user-initiated cancel would read as "Download failed".
+        // A cancelled download keeps its .partial and a re-run RESUMES it
+        // (Task 4). Do not imply the bytes were thrown away.
+        fill.style.width = '0%';
+        text.innerHTML = 'Download cancelled &mdash; partial progress kept, retrying will resume.' +
+          '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Try again</button>';
+        return;
+      }
+      if (!r || r.status !== 'completed') {
+        var why = (r && r.failure && r.failure.message) ||
+                  ((r && r.errors) || []).join(', ') || 'Download failed';
+        fill.style.width = '0%';
+        text.innerHTML = '<span style="color:var(--danger);">' + escapeHtml(why) + '</span>' +
+          '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Try again</button>';
+        return;
+      }
+      fill.style.width = '100%';
+      var res = r.result || {};
+      var lines = [];
+      // verify_digest's ok=True does NOT always mean "verified" — the
+      // no-digest-published case also returns True and the string says so.
+      // Pass the string through; never synthesize "Verified ✓" from a boolean.
+      if (res.verified) lines.push(res.verified);
+      if (res.config_written) {
+        // No silent config mutation: say it, and make the field show it.
+        lines.push('Installed to ' + res.bin_path + ' and set the darktable-cli path in Settings.');
+      } else if (res.downloaded_to) {
+        lines.push('Downloaded to ' + res.downloaded_to + ' — opening the installer. ' +
+                   (darktableIsWindows()
+                     ? 'Windows may warn about an unknown publisher: darktable does not sign ' +
+                       'its installer. Click through the installer, then click Re-check.'
+                     : 'Drag darktable to Applications, then click Re-check.'));
+      }
+      // Only warn about Gatekeeper if the file really is quarantined.
+      if (res.quarantined) {
+        lines.push('macOS quarantined this download. darktable does not notarize its ' +
+                   'macOS builds, so you may see "damaged". To clear it, run: ' +
+                   'xattr -d com.apple.quarantine ' + res.downloaded_to);
+      }
+      if (res.config_written && res.bin_path) {
+        var binInput = document.getElementById('cfgDarktableBin');
+        if (binInput) binInput.value = res.bin_path;
+      }
+      text.innerHTML = lines.map(escapeHtml).join('<br>') +
+        '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Re-check</button>';
+    },
+    // safeEventSource calls onError with NO arguments (_navbar.html:10242),
+    // and only for connection loss. Do not try to read an error off it.
+    onError: function() {
+      text.innerHTML = '<span style="color:var(--danger);">Lost connection to the ' +
+        'download job. It may still be running.</span>' +
+        '<br><button class="btn" style="margin-top:6px;" onclick="loadDarktableStatus()">Re-check</button>';
+    }
+  });
 }
 
 async function loadSystemInfo() {

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -35,6 +35,7 @@ GET          /api/collections/<int:collection_id>/photos
 GET          /api/config
 GET          /api/coverage
 GET          /api/culling/results
+GET          /api/darktable/install/available
 GET          /api/darktable/status
 GET          /api/dashboard/options
 GET          /api/detection-cache/stats

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -256,6 +256,7 @@ POST         /api/jobs/capture-time
 POST         /api/jobs/classify
 POST         /api/jobs/cull
 POST         /api/jobs/develop
+POST         /api/jobs/download-darktable
 POST         /api/jobs/download-hf-model
 POST         /api/jobs/download-model
 POST         /api/jobs/download-taxonomy

--- a/vireo/tests/fixtures/darktable_release.json
+++ b/vireo/tests/fixtures/darktable_release.json
@@ -1,0 +1,32 @@
+{
+  "tag_name": "release-5.6.0",
+  "assets": [
+    {"name": "Darktable-5.6.0-aarch64.AppImage", "size": 170895880,
+     "digest": "sha256:147943bd2eedc33c8d31eb3e6b87b591ac9ca285d00282b2655d8d19caecfca0",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-aarch64.AppImage"},
+    {"name": "Darktable-5.6.0-aarch64.AppImage.zsync", "size": 292297,
+     "digest": "sha256:52a2b5da0dd55c984f3d4c6e77bbd1119b4561cf17c80146a09c9e498ae56da4",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-aarch64.AppImage.zsync"},
+    {"name": "darktable-5.6.0-arm64.dmg", "size": 87094261,
+     "digest": "sha256:49aec447e891ab481e436b4c0231fc3c8d0001aad220762ae8e765d3bda5d102",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-arm64.dmg"},
+    {"name": "darktable-5.6.0-x86_64.dmg", "size": 92795715,
+     "digest": "sha256:24c83655af0d81c2f8cb78b97531a03bb6a650349b7fd49c1679080db675cbcb",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-x86_64.dmg"},
+    {"name": "darktable-5.6.0-win64.exe", "size": 141543364,
+     "digest": "sha256:b42989195dfff44540c0b767b407987329ca99853612304cbbf14c48d1d3f803",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-win64.exe"},
+    {"name": "darktable-5.6.0-woa64.exe", "size": 106943215,
+     "digest": "sha256:b7737d54d6ee007816ae0a1fad3ca3677588735e1432887a917bc55f818f5268",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0-woa64.exe"},
+    {"name": "Darktable-5.6.0-x86_64.AppImage", "size": 177752568,
+     "digest": "sha256:cbad7bf4be2607e1725db156d73c799d267a79fc29a572c3136a5deb9c9be948",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-x86_64.AppImage"},
+    {"name": "Darktable-5.6.0-x86_64.AppImage.zsync", "size": 304013,
+     "digest": "sha256:35b038a00c6a8a73bf1b7e2a9ad1d05db471d59ec3feec9edb3df594aee715b9",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-x86_64.AppImage.zsync"},
+    {"name": "darktable-5.6.0.tar.xz", "size": 8179036,
+     "digest": "sha256:157d6d3847af8afcabe78944454786f73a886e08a504b4bd6114c2065fe006e4",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0.tar.xz"}
+  ]
+}

--- a/vireo/tests/fixtures/darktable_release.json
+++ b/vireo/tests/fixtures/darktable_release.json
@@ -27,6 +27,9 @@
      "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/Darktable-5.6.0-x86_64.AppImage.zsync"},
     {"name": "darktable-5.6.0.tar.xz", "size": 8179036,
      "digest": "sha256:157d6d3847af8afcabe78944454786f73a886e08a504b4bd6114c2065fe006e4",
-     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0.tar.xz"}
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0.tar.xz"},
+    {"name": "darktable-5.6.0.tar.xz.asc", "size": 195,
+     "digest": "sha256:07d8b1f0d63b0f4b6f6c96a3f5b7bb7e8f4a4d8bfa4c05a1f60cb2e0d0a6c9f3",
+     "browser_download_url": "https://github.com/darktable-org/darktable/releases/download/release-5.6.0/darktable-5.6.0.tar.xz.asc"}
   ]
 }

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -492,6 +492,78 @@ def test_api_job_download_darktable_refuses_without_disk_space(app_and_db, monke
     assert 'free' in error.lower(), f"free space missing from {error!r}"
 
 
+def test_api_job_download_darktable_space_check_reuses_completed_download(
+        app_and_db, monkeypatch):
+    """A cancelled-during-verify retry must not be blocked by the preflight.
+
+    When Stop is pressed during verify_digest, download() has already renamed
+    the .partial to the final destination.  A retry fast-paths straight to
+    verify and spends zero download bytes — but the preflight would still
+    demand 2x the asset size free, so a 178 MB download accepted with 400 MB
+    free would leave 222 MB and then refuse the retry.  Count the reusable
+    file against `needed` so the promised resume path actually works.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    release = _fake_release()
+    asset_size = release["size"]
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: (release, None))
+
+    # Simulate the cancelled-verify state: the artifact is already on disk
+    # at the API-published size, ready for verify_digest to re-run.
+    target = darktable_install.install_dir()
+    os.makedirs(target, exist_ok=True)
+    completed = os.path.join(target, release["name"])
+    with open(completed, "wb") as f:
+        f.truncate(asset_size)
+
+    # Only unpacking headroom is available — one asset-size, not two.  Without
+    # the reusable-file credit the preflight would reject this.
+    monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: asset_size)
+
+    def fake_download(asset, **kwargs):
+        return completed, "ok"
+    monkeypatch.setattr(darktable_install, "download", fake_download)
+    monkeypatch.setattr(darktable_install, "hand_off",
+                        lambda p, **k: {"action": "opened-installer",
+                                        "location": p, "bin_path": None})
+    monkeypatch.setattr(darktable_install, "is_quarantined", lambda p: False)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 200, resp.get_json()
+
+
+def test_api_job_download_darktable_space_check_ignores_wrong_size_stray(
+        app_and_db, monkeypatch):
+    """A stray file of the *wrong* size must not credit the preflight.
+
+    Only the API-published size counts — an unrelated file the user dropped
+    into the tools directory could otherwise sneak past the check and leave
+    the retry stranded on a full disk when download() decides it cannot
+    reuse the bytes.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    release = _fake_release()
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: (release, None))
+
+    target = darktable_install.install_dir()
+    os.makedirs(target, exist_ok=True)
+    stray = os.path.join(target, release["name"])
+    with open(stray, "wb") as f:
+        f.truncate(1024)  # wrong size — not a reusable download
+
+    monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: 1024)
+
+    def must_not_download(*a, **k):
+        raise AssertionError("preflight must refuse when the stray is unusable")
+    monkeypatch.setattr(darktable_install, "download", must_not_download)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+    assert 'space' in resp.get_json()['error'].lower()
+
+
 def test_api_job_download_darktable_400_when_the_target_dir_is_unusable(
         app_and_db, monkeypatch):
     """A read-only home must not 500 a button press.
@@ -697,6 +769,78 @@ def test_api_job_download_darktable_writes_config_when_handoff_returns_bin(
     # And the result must say the write happened, so the UI can report it.
     assert job['result']['config_written'] is True
     assert job['result']['bin_path'] == bin_path
+
+
+def test_api_job_download_darktable_config_write_stays_raw_not_pinned(
+        app_and_db, monkeypatch):
+    """The bin_path write must not pin every DEFAULTS value into config.json.
+
+    Regression: the earlier path wrote via ``cfg.set()`` (load-modify-save on
+    the merged config), which pinned the current default for every setting
+    the user had never touched — silently blocking future default upgrades.
+    Routing through ``_settings_write_lock`` + raw read-modify-write leaves
+    the file minimal, the same way every other settings endpoint writes.
+    """
+    import config as cfg
+    app, _ = app_and_db
+    bin_path = "/tmp/darktable-5.6.0-x86_64.AppImage"
+    _stub_happy_path(monkeypatch, hand_off_result={
+        "action": "installed", "location": bin_path, "bin_path": bin_path,
+    })
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, job_id)
+
+    # Read the on-disk file directly, not through cfg.load()/cfg.get(): those
+    # deep-merge DEFAULTS in and would hide a pinned-defaults regression.
+    with open(cfg.CONFIG_PATH) as f:
+        raw = json.load(f)
+    assert raw.get("darktable_bin") == bin_path
+    # If cfg.set had been used, raw would carry every DEFAULTS key (e.g.
+    # thumbnail_size, preview_max_size, DEFAULTS["pipeline"], ...).
+    assert "thumbnail_size" not in raw, (
+        f"config write pinned unrelated defaults into config.json: {sorted(raw.keys())}"
+    )
+    assert "pipeline" not in raw, (
+        f"config write pinned the DEFAULTS pipeline block: {sorted(raw.keys())}"
+    )
+
+
+def test_api_job_download_darktable_config_write_preserves_other_user_settings(
+        app_and_db, monkeypatch):
+    """A user setting saved through /api/config must survive the download.
+
+    Both writers use the raw read-modify-write pattern under
+    ``_settings_write_lock``, so nothing on the on-disk file is lost when the
+    download finishes right after a settings save.
+    """
+    import config as cfg
+    app, _ = app_and_db
+    client = app.test_client()
+
+    # Persist a user setting the normal way — the settings endpoint uses
+    # _settings_write_lock + raw read-modify-write.
+    resp = client.post('/api/config',
+                       data=json.dumps({"darktable_style": "Wildlife"}),
+                       content_type='application/json')
+    assert resp.status_code == 200
+
+    bin_path = "/tmp/darktable-5.6.0-x86_64.AppImage"
+    _stub_happy_path(monkeypatch, hand_off_result={
+        "action": "installed", "location": bin_path, "bin_path": bin_path,
+    })
+
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, job_id)
+
+    # Both the new value and the pre-existing one must be on disk.
+    with open(cfg.CONFIG_PATH) as f:
+        raw = json.load(f)
+    assert raw.get("darktable_bin") == bin_path
+    assert raw.get("darktable_style") == "Wildlife"
 
 
 def test_api_job_download_darktable_leaves_config_alone_without_bin(

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -1093,6 +1093,50 @@ def test_api_job_download_darktable_binds_to_the_confirmed_asset(app_and_db, mon
     assert "5.7.0" in body['error']
 
 
+def test_api_job_download_darktable_409_refreshes_the_availability_cache(
+        app_and_db, monkeypatch):
+    """After a 409 the UI's Re-check must not hit the same stale asset again.
+
+    The availability endpoint caches for 10 minutes.  Without the refresh, a
+    Re-check between the POST that returned 409 and the TTL expiring would
+    hand back the same cached name, the user would re-confirm the same
+    identity, and the endpoint would 409 in a loop until the TTL elapsed.
+    """
+    import darktable_install
+    app, _ = app_and_db
+
+    stale = _fake_release("5.6.0")
+    fresh = dict(_fake_release("5.7.0"))
+    fresh["name"] = "darktable-5.7.0-arm64.dmg"
+
+    # Seed the availability cache with the stale release, as if /install/available
+    # ran once at dialog-open time and pinned 5.6.0.
+    darktable_install._release_cache.update(at=time.monotonic(), value=stale)
+    # The uncached resolver the POST handler calls returns the fresh release.
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: (fresh, None))
+
+    client = app.test_client()
+    resp = client.post(
+        '/api/jobs/download-darktable',
+        data=json.dumps({
+            "expected_version": stale["version"],
+            "expected_name": stale["name"],
+            "expected_digest": stale["digest"],
+        }),
+        content_type='application/json',
+    )
+    assert resp.status_code == 409
+    assert resp.get_json()['code'] == 'darktable_asset_changed'
+
+    # After the 409, /install/available must reflect the fresh release,
+    # not the pre-POST cached one — otherwise the client's Re-check would
+    # confirm the same stale asset and 409 again.
+    data = client.get('/api/darktable/install/available').get_json()
+    assert data['available'] is True
+    assert data['name'] == "darktable-5.7.0-arm64.dmg"
+    assert data['version'] == "5.7.0"
+
+
 def test_api_job_download_darktable_proceeds_when_expected_matches(
         app_and_db, monkeypatch):
     """The confirmation binding must not break the normal flow: when the

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -247,8 +247,10 @@ def test_api_darktable_status_checked_paths_names_linux_tools_dir(app_and_db, mo
 
     data = app.test_client().get('/api/darktable/status').get_json()
 
-    tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
-    assert tools_dir in data['checked_paths']
+    # Use the same helper the route uses so path-separator conventions match on
+    # Windows (os.path.join is bound at import time and ignores monkeypatched
+    # os.name, so a hand-built "~/.vireo/tools/darktable" would drift here).
+    assert develop.darktable_tools_dir() in data['checked_paths']
 
 
 def test_api_darktable_status_checked_paths_omits_linux_tools_dir_on_macos(app_and_db, monkeypatch):
@@ -261,8 +263,7 @@ def test_api_darktable_status_checked_paths_omits_linux_tools_dir_on_macos(app_a
 
     data = app.test_client().get('/api/darktable/status').get_json()
 
-    tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
-    assert tools_dir not in data['checked_paths']
+    assert develop.darktable_tools_dir() not in data['checked_paths']
     assert data['checked_paths'], "checked_paths must never be empty"
 
 

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -1093,6 +1093,43 @@ def test_api_job_download_darktable_binds_to_the_confirmed_asset(app_and_db, mon
     assert "5.7.0" in body['error']
 
 
+def test_api_job_download_darktable_binds_to_the_confirmed_size_for_digestless_assets(
+        app_and_db, monkeypatch):
+    """A release with no digest still needs a size check.
+
+    If GitHub deletes and re-uploads an asset under the same tag and filename
+    within the availability cache's TTL, name and version match but the bytes
+    differ.  With no digest to compare, the name/version check alone would
+    silently accept the swap.  ``expected_size`` closes that gap.
+    """
+    app, _ = app_and_db
+    # A digestless release: this is the case the digest check cannot catch.
+    fresh = _fake_release("5.6.0")
+    fresh["digest"] = None
+    fresh["size"] = 87094261 + 500_000  # Republished asset, same name+version
+
+    def must_not_download(*a, **k):
+        raise AssertionError("mismatched asset must not be downloaded")
+
+    _stub_happy_path(monkeypatch, release=fresh, download=must_not_download)
+
+    resp = app.test_client().post(
+        '/api/jobs/download-darktable',
+        data=json.dumps({
+            "expected_version": "5.6.0",
+            "expected_name": fresh["name"],
+            "expected_digest": None,
+            # Confirmation showed the original size — the republished asset
+            # differs and must be rejected even though digest cannot arbitrate.
+            "expected_size": 87094261,
+        }),
+        content_type='application/json',
+    )
+    assert resp.status_code == 409
+    body = resp.get_json()
+    assert body['code'] == 'darktable_asset_changed'
+
+
 def test_api_job_download_darktable_409_refreshes_the_availability_cache(
         app_and_db, monkeypatch):
     """After a 409 the UI's Re-check must not hit the same stale asset again.
@@ -1369,6 +1406,64 @@ def test_api_job_download_darktable_second_join_matches_when_artifacts_align(
         "matching artifact identity must still join the running job"
     )
     assert second.get('joined_existing') is True
+
+    release_download.set()
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, first_id)
+
+
+def test_api_job_download_darktable_join_rejects_size_mismatch_for_digestless_asset(
+        app_and_db, monkeypatch):
+    """Two tabs, one in-flight digestless download, republished asset between
+    them: the second POST confirms a different size for the same name+version,
+    and must NOT silently join a worker downloading different bytes.
+
+    Covers the join path specifically, which stores ``asset_size`` in the
+    singleton config so ``_artifact_matches`` can arbitrate without a digest.
+    """
+    import threading
+    app, _ = app_and_db
+
+    running = threading.Event()
+    release_download = threading.Event()
+
+    def slow_download(asset, byte_callback=None, should_cancel=None):
+        running.set()
+        assert release_download.wait(timeout=10), "download never released"
+        return "/tmp/d.dmg", "ok"
+
+    first_release = _fake_release("5.6.0")
+    first_release["digest"] = None
+    _stub_happy_path(monkeypatch, release=first_release, download=slow_download)
+
+    client = app.test_client()
+    first_id = client.post(
+        '/api/jobs/download-darktable',
+        data=json.dumps({
+            "expected_version": first_release["version"],
+            "expected_name": first_release["name"],
+            "expected_digest": None,
+            "expected_size": first_release["size"],
+        }),
+        content_type='application/json',
+    ).get_json()['job_id']
+    assert running.wait(timeout=5)
+
+    # Same name+version, no digest, different size — the republished-asset
+    # case.  Without the size guard this would silently return
+    # joined_existing=True and hand back the first job's bytes.
+    resp = client.post(
+        '/api/jobs/download-darktable',
+        data=json.dumps({
+            "expected_version": first_release["version"],
+            "expected_name": first_release["name"],
+            "expected_digest": None,
+            "expected_size": first_release["size"] + 500_000,
+        }),
+        content_type='application/json',
+    )
+    assert resp.status_code == 409, resp.get_json()
+    assert resp.get_json()['code'] == 'darktable_asset_changed'
 
     release_download.set()
     from wait import wait_for_job_via_client

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -564,6 +564,86 @@ def test_api_job_download_darktable_space_check_ignores_wrong_size_stray(
     assert 'space' in resp.get_json()['error'].lower()
 
 
+def test_api_job_download_darktable_space_check_credits_resumable_partial(
+        app_and_db, monkeypatch):
+    """A retry after a mid-transfer cancel must not be rejected on disk space.
+
+    ``_download_with_resume`` resumes from ``<dest>.partial`` — those bytes
+    are already on disk, so the retry only needs the remaining transfer
+    plus the unpack headroom.  For a 100 MB partial of a 178 MB asset the
+    check should demand ~256 MB (178 to unpack + 78 still to transfer),
+    not the unretried 356 MB.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    release = _fake_release()
+    asset_size = release["size"]
+    partial_size = asset_size // 2
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (release, None))
+
+    target = darktable_install.install_dir()
+    os.makedirs(target, exist_ok=True)
+    partial_path = os.path.join(target, release["name"] + ".partial")
+    with open(partial_path, "wb") as f:
+        f.truncate(partial_size)
+
+    # Free space equals what the retry actually needs: one full asset (unpack
+    # headroom) plus the bytes still to transfer.  Without crediting the
+    # partial the preflight demands 2x the asset size and rejects the retry.
+    monkeypatch.setattr(darktable_install, "free_space_bytes",
+                        lambda p: asset_size + (asset_size - partial_size))
+
+    def fake_download(asset, **kwargs):
+        return os.path.join(target, release["name"]), "ok"
+    monkeypatch.setattr(darktable_install, "download", fake_download)
+    monkeypatch.setattr(darktable_install, "hand_off",
+                        lambda p, **k: {"action": "opened-installer",
+                                        "location": p, "bin_path": None})
+    monkeypatch.setattr(darktable_install, "is_quarantined", lambda p: False)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 200, resp.get_json()
+
+
+def test_api_job_download_darktable_space_check_partial_credit_capped_at_asset_size(
+        app_and_db, monkeypatch):
+    """A ``.partial`` larger than the API-published size must not over-credit.
+
+    A stale partial from a different release could otherwise let a retry
+    slip past the preflight and then fill the disk mid-transfer.  Bound
+    the credit at ``asset_size``.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    release = _fake_release()
+    asset_size = release["size"]
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (release, None))
+
+    target = darktable_install.install_dir()
+    os.makedirs(target, exist_ok=True)
+    partial_path = os.path.join(target, release["name"] + ".partial")
+    # Twice the asset size — a stale file that would over-credit the check
+    # if the cap did not exist.
+    with open(partial_path, "wb") as f:
+        f.truncate(asset_size * 2)
+
+    # Free = asset_size - 1 byte.  With no cap the credit would be
+    # 2*asset_size, so ``needed`` = 0 and the check would pass.  Capped at
+    # asset_size, ``needed`` = asset_size and the check must refuse.
+    monkeypatch.setattr(darktable_install, "free_space_bytes",
+                        lambda p: asset_size - 1)
+
+    def must_not_download(*a, **k):
+        raise AssertionError("preflight must refuse when credit would over-count")
+    monkeypatch.setattr(darktable_install, "download", must_not_download)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+    assert 'space' in resp.get_json()['error'].lower()
+
+
 def test_api_job_download_darktable_400_when_the_target_dir_is_unusable(
         app_and_db, monkeypatch):
     """A read-only home must not 500 a button press.

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -773,3 +773,182 @@ def test_api_job_download_darktable_handoff_failure_fails_the_job(app_and_db, mo
 
     assert job['status'] == 'failed', job
     assert any("/tmp/d.dmg" in e for e in job['errors']), job['errors']
+
+
+def test_api_job_download_darktable_joins_a_running_job_instead_of_starting_a_second(
+        app_and_db, monkeypatch):
+    """Two clicks (two tabs, a refresh mid-download, or a double-click) must
+    not start two workers writing the same .partial.  Both would race
+    truncation, rename, verification, and deletion; the second cleanup could
+    delete the first one's verified installer.  The second POST returns the
+    already-running job so the client subscribes to it."""
+    import threading
+
+    app, _ = app_and_db
+
+    started = threading.Event()
+    can_finish = threading.Event()
+
+    def slow_download(asset, byte_callback=None, should_cancel=None):
+        started.set()
+        # Block until the second POST has had its chance.  Any test-timeout
+        # would surface here, not as a mystery hang.
+        assert can_finish.wait(timeout=10), "test never released the download"
+        return "/tmp/d.dmg", "ok"
+
+    _stub_happy_path(monkeypatch, download=slow_download)
+
+    client = app.test_client()
+    first = client.post('/api/jobs/download-darktable').get_json()
+    first_id = first['job_id']
+    assert started.wait(timeout=5), "the first download never started"
+
+    second = client.post('/api/jobs/download-darktable').get_json()
+
+    # Same job — no new worker, no second .partial, no race.
+    assert second['job_id'] == first_id
+    assert second.get('joined_existing') is True
+
+    # Let the (single) worker finish so nothing leaks past this test.
+    can_finish.set()
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, first_id)
+
+
+def test_api_job_download_darktable_rejects_a_new_run_only_while_active(
+        app_and_db, monkeypatch):
+    """The singleton guard has to release when the first job reaches a
+    terminal state.  Otherwise a completed (or cancelled) download would pin
+    the button forever."""
+    app, _ = app_and_db
+    _stub_happy_path(monkeypatch)
+
+    client = app.test_client()
+    first_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, first_id)
+
+    second = client.post('/api/jobs/download-darktable').get_json()
+    assert second['job_id'] != first_id, (
+        "after the first job finishes, a fresh POST must start a new job"
+    )
+    wait_for_job_via_client(client, second['job_id'])
+
+
+def test_api_job_download_darktable_binds_to_the_confirmed_asset(app_and_db, monkeypatch):
+    """If the release changes between the dialog opening and the POST landing,
+    the server must not silently download the new artifact — the user
+    confirmed a different one.  Code=darktable_asset_changed lets the client
+    re-fetch and re-prompt with the new identity."""
+    app, _ = app_and_db
+    fresh = _fake_release("5.7.0")
+    fresh["name"] = "darktable-5.7.0-arm64.dmg"
+
+    def must_not_download(*a, **k):
+        raise AssertionError("mismatched asset must not be downloaded")
+
+    _stub_happy_path(monkeypatch, release=fresh, download=must_not_download)
+
+    resp = app.test_client().post(
+        '/api/jobs/download-darktable',
+        data=json.dumps({
+            "expected_version": "5.6.0",
+            "expected_name": "darktable-5.6.0-arm64.dmg",
+            "expected_digest": "sha256:" + "a" * 64,
+        }),
+        content_type='application/json',
+    )
+
+    assert resp.status_code == 409
+    body = resp.get_json()
+    assert body['code'] == 'darktable_asset_changed'
+    # Must name both the confirmed and the current artifact so the user knows
+    # what changed.
+    assert "5.6.0" in body['error']
+    assert "5.7.0" in body['error']
+
+
+def test_api_job_download_darktable_proceeds_when_expected_matches(
+        app_and_db, monkeypatch):
+    """The confirmation binding must not break the normal flow: when the
+    fresh resolution agrees with what the dialog showed, the download starts."""
+    app, _ = app_and_db
+    release = _fake_release("5.6.0")
+    _stub_happy_path(monkeypatch, release=release)
+
+    client = app.test_client()
+    resp = client.post(
+        '/api/jobs/download-darktable',
+        data=json.dumps({
+            "expected_version": release["version"],
+            "expected_name": release["name"],
+            "expected_digest": release["digest"],
+        }),
+        content_type='application/json',
+    )
+    assert resp.status_code == 200
+    job_id = resp.get_json()['job_id']
+
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+    assert job['status'] == 'completed', job
+
+
+def test_api_job_download_darktable_no_expected_still_works(app_and_db, monkeypatch):
+    """A POST with no body (older client, curl, test harness) still works —
+    the binding check only fires when the client actually sends expected_name."""
+    app, _ = app_and_db
+    _stub_happy_path(monkeypatch)
+
+    client = app.test_client()
+    # No content-type, no body: the JSON parse is silent (json_error's
+    # get_json(silent=True) returns None) so the check is skipped.
+    resp = client.post('/api/jobs/download-darktable')
+    assert resp.status_code == 200
+
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, resp.get_json()['job_id'])
+
+
+def test_api_job_download_darktable_cancellation_between_verify_and_handoff_does_not_hand_off(
+        app_and_db, monkeypatch):
+    """A Stop press after the digest matches but before hand_off runs must
+    NOT open the installer (macOS/Windows) or chmod+install the AppImage
+    (Linux).  jobs.py would still label the job cancelled but the side effect
+    the user cancelled would already have happened."""
+    import darktable_install
+    app, _ = app_and_db
+
+    def fake_download(asset, byte_callback=None, should_cancel=None):
+        # Download and verify succeed; we simulate the user pressing Stop
+        # right at this seam — the request the endpoint already routed to
+        # jobs' cancel set will be observed after download() returns.
+        return "/tmp/d.dmg", "ok"
+
+    hand_off_calls = []
+
+    def spy_hand_off(path, **kwargs):
+        hand_off_calls.append(path)
+        return {"action": "opened-installer", "location": path, "bin_path": None}
+
+    _stub_happy_path(monkeypatch, download=fake_download,
+                     hand_off_result={"action": "opened-installer",
+                                      "location": "/tmp/d.dmg", "bin_path": None})
+    monkeypatch.setattr(darktable_install, "hand_off", spy_hand_off)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+
+    # Cancel racing with the worker: request cancellation from the request
+    # thread, and the check between download() and hand_off() sees it.
+    app._job_runner.cancel_job(job_id)
+
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+
+    # This test can be flaky if download() runs entirely before cancel_job()
+    # lands.  Confirm the state we care about explicitly.
+    if job['status'] == 'cancelled':
+        assert hand_off_calls == [], (
+            "hand_off must not run after a Stop was observed"
+        )

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -197,7 +197,7 @@ def test_api_darktable_status_checked_paths_mentions_path_probe(app_and_db):
     assert any('PATH' in p for p in data['checked_paths'])
 
 
-def test_api_darktable_status_checked_paths_never_empty(app_and_db):
+def test_api_darktable_status_checked_paths_never_empty(app_and_db, monkeypatch):
     """Never render an empty 'we checked here' list.
 
     darktable_search_paths() returns [] on a Linux box with no AppImage
@@ -205,14 +205,29 @@ def test_api_darktable_status_checked_paths_never_empty(app_and_db):
     """
     import develop
     app, _ = app_and_db
-    original = develop.darktable_search_paths
-    develop.darktable_search_paths = lambda: []
-    try:
-        data = app.test_client().get('/api/darktable/status').get_json()
-    finally:
-        develop.darktable_search_paths = original
+    monkeypatch.setattr(develop, "darktable_search_paths", lambda: [])
+
+    data = app.test_client().get('/api/darktable/status').get_json()
 
     assert data['checked_paths'], "checked_paths must never be empty"
+
+
+def test_api_darktable_status_checked_paths_includes_detector_candidates(app_and_db, monkeypatch):
+    """The real detector candidates reach the response, in priority order.
+
+    Asserting the whole list rather than membership also pins ordering, which
+    users read as "we tried these, in this sequence". Pinned to macOS so the
+    tools dir is not appended and the expected list is exact on any host.
+    """
+    import develop
+    app, _ = app_and_db
+    monkeypatch.setattr(develop, "darktable_search_paths", lambda: ["/sentinel/darktable-cli"])
+    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    data = app.test_client().get('/api/darktable/status').get_json()
+
+    assert data['checked_paths'] == ["$PATH (darktable-cli)", "/sentinel/darktable-cli"]
 
 
 def test_api_darktable_status_checked_paths_names_linux_tools_dir(app_and_db, monkeypatch):

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -953,3 +953,208 @@ def test_api_job_download_darktable_cancellation_between_verify_and_handoff_does
         assert hand_off_calls == [], (
             "hand_off must not run after a Stop was observed"
         )
+
+
+def test_api_job_download_darktable_handoff_phase_is_uncancellable(
+        app_and_db, monkeypatch):
+    """A Stop that arrives WHILE hand_off is executing must be rejected —
+    otherwise cancellation "wins" the terminal-status race even though the
+    installer has already been opened / the AppImage chmodded, and the user
+    sees "cancelled" for a side effect that in fact committed.
+
+    Enforced by wrapping hand_off in begin_uncancellable(): once inside,
+    cancel_job() returns False and the run finishes as completed."""
+    import threading
+
+    import darktable_install
+    app, _ = app_and_db
+
+    in_handoff = threading.Event()
+    can_finish_handoff = threading.Event()
+
+    def slow_hand_off(path, **kwargs):
+        # Signal that we are past the cancellation gate; hold long enough
+        # for the test's cancel_job() call to land.
+        in_handoff.set()
+        assert can_finish_handoff.wait(timeout=10), "hand_off never released"
+        return {"action": "opened-installer", "location": path, "bin_path": None}
+
+    _stub_happy_path(monkeypatch)
+    monkeypatch.setattr(darktable_install, "hand_off", slow_hand_off)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+
+    # Wait until the worker is inside hand_off, then request cancellation.
+    assert in_handoff.wait(timeout=5), "hand_off was never entered"
+    cancel_accepted = app._job_runner.cancel_job(job_id)
+    # begin_uncancellable() has already fired, so the cancel is a no-op.
+    assert cancel_accepted is False, (
+        "cancel_job during hand_off must be rejected — otherwise the terminal "
+        "status would flip to cancelled while the side effect already committed"
+    )
+
+    # Let hand_off complete; the job must finish as 'completed', not
+    # 'cancelled', because the side effect DID happen.
+    can_finish_handoff.set()
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+    assert job['status'] == 'completed', job
+    assert job['result']['action'] == "opened-installer"
+
+
+def test_api_job_download_darktable_rejects_a_join_for_a_different_artifact(
+        app_and_db, monkeypatch):
+    """An in-flight download of version X + a fresh POST confirming version
+    Y must NOT join the old job — the user's dialog said Y and Y is what
+    they must receive (or an error). Silently joining a mismatched running
+    job would deliver X's bytes under Y's identity."""
+    import threading
+    app, _ = app_and_db
+
+    running = threading.Event()
+    release_download = threading.Event()
+
+    def slow_download(asset, byte_callback=None, should_cancel=None):
+        running.set()
+        assert release_download.wait(timeout=10), "download never released"
+        return "/tmp/d.dmg", "ok"
+
+    # First job resolves to 5.6.0.
+    first_release = _fake_release("5.6.0")
+    _stub_happy_path(monkeypatch, release=first_release, download=slow_download)
+
+    client = app.test_client()
+    first_id = client.post(
+        '/api/jobs/download-darktable',
+        data=json.dumps({
+            "expected_version": first_release["version"],
+            "expected_name": first_release["name"],
+            "expected_digest": first_release["digest"],
+        }),
+        content_type='application/json',
+    ).get_json()['job_id']
+    assert running.wait(timeout=5), "the first download never started"
+
+    # Second POST confirms a DIFFERENT artifact (a newer release the tab saw
+    # from a separate /install/available call).  Even though a singleton is
+    # running, the endpoint must not join it — it would deliver 5.6.0's bytes.
+    resp = client.post(
+        '/api/jobs/download-darktable',
+        data=json.dumps({
+            "expected_version": "5.7.0",
+            "expected_name": "darktable-5.7.0-arm64.dmg",
+            "expected_digest": "sha256:" + "b" * 64,
+        }),
+        content_type='application/json',
+    )
+    assert resp.status_code == 409, resp.get_json()
+    body = resp.get_json()
+    assert body['code'] == 'darktable_asset_changed'
+    # Message must name the version in flight and the version the user
+    # confirmed so they know why they were bounced back.
+    assert "5.6.0" in body['error']
+    assert "5.7.0" in body['error']
+
+    release_download.set()
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, first_id)
+
+
+def test_api_job_download_darktable_second_join_matches_when_artifacts_align(
+        app_and_db, monkeypatch):
+    """A second POST for the SAME artifact still joins the running job —
+    the mismatch guard must not accidentally reject compatible joins.
+    (Two Settings tabs, a refresh, a double-click — all should share one
+    download.)"""
+    import threading
+    app, _ = app_and_db
+
+    running = threading.Event()
+    release_download = threading.Event()
+
+    def slow_download(asset, byte_callback=None, should_cancel=None):
+        running.set()
+        assert release_download.wait(timeout=10), "download never released"
+        return "/tmp/d.dmg", "ok"
+
+    release = _fake_release("5.6.0")
+    _stub_happy_path(monkeypatch, release=release, download=slow_download)
+
+    client = app.test_client()
+    body = {
+        "expected_version": release["version"],
+        "expected_name": release["name"],
+        "expected_digest": release["digest"],
+    }
+    first_id = client.post(
+        '/api/jobs/download-darktable',
+        data=json.dumps(body), content_type='application/json',
+    ).get_json()['job_id']
+    assert running.wait(timeout=5)
+
+    second = client.post(
+        '/api/jobs/download-darktable',
+        data=json.dumps(body), content_type='application/json',
+    ).get_json()
+    assert second['job_id'] == first_id, (
+        "matching artifact identity must still join the running job"
+    )
+    assert second.get('joined_existing') is True
+
+    release_download.set()
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, first_id)
+
+
+def test_api_job_download_darktable_singleton_check_and_start_are_atomic(
+        app_and_db, monkeypatch):
+    """The earlier check-then-start pattern let two concurrent POSTs both
+    see "no running job" and both call runner.start(), racing on the same
+    ``.partial``. The fix is to check-and-start under a single lock
+    acquisition inside JobRunner. Exercise it by hitting the endpoint from
+    many threads at once and asserting exactly one worker was started."""
+    import threading
+    app, _ = app_and_db
+
+    workers_started = []
+    workers_lock = threading.Lock()
+    release_download = threading.Event()
+
+    def slow_download(asset, byte_callback=None, should_cancel=None):
+        with workers_lock:
+            workers_started.append(1)
+        assert release_download.wait(timeout=10), "download never released"
+        return "/tmp/d.dmg", "ok"
+
+    _stub_happy_path(monkeypatch, download=slow_download)
+
+    client = app.test_client()
+    ids = []
+    ids_lock = threading.Lock()
+    barrier = threading.Barrier(8)
+
+    def fire():
+        barrier.wait()
+        r = client.post('/api/jobs/download-darktable').get_json()
+        with ids_lock:
+            ids.append(r['job_id'])
+
+    threads = [threading.Thread(target=fire) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(ids)) == 1, (
+        f"all concurrent POSTs must return the same job id, got {set(ids)}"
+    )
+    # This is the load-bearing assertion: no matter how many callers slipped
+    # between the old list_jobs() check and start(), only ONE download worker
+    # ran. Two would race the same .partial and installer.
+    release_download.set()
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, ids[0])
+    assert len(workers_started) == 1, (
+        f"exactly one download worker must run, got {len(workers_started)}"
+    )

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import time
 
 
@@ -171,3 +172,78 @@ def test_api_job_develop_mixed_outcomes_marks_job_failed(app_and_db, tmp_path, m
     errs = data.get('errors') or []
     assert len(errs) == 1, f"expected exactly one error entry, got {len(errs)}: {errs}"
     assert any('fake failure on second photo' in e for e in errs), errs
+
+
+def test_api_darktable_status_reports_checked_paths(app_and_db):
+    """The status route says where it looked, so a bare 'not found' can explain itself."""
+    app, _ = app_and_db
+    client = app.test_client()
+    data = client.get('/api/darktable/status').get_json()
+
+    assert 'checked_paths' in data
+    assert isinstance(data['checked_paths'], list)
+    assert all(isinstance(p, str) for p in data['checked_paths'])
+
+
+def test_api_darktable_status_checked_paths_mentions_path_probe(app_and_db):
+    """$PATH is the probe most likely to explain a miss, so it must be listed.
+
+    find_darktable tries shutil.which() before any filesystem candidate;
+    omitting it would make "we checked here" untrue by omission.
+    """
+    app, _ = app_and_db
+    data = app.test_client().get('/api/darktable/status').get_json()
+
+    assert any('PATH' in p for p in data['checked_paths'])
+
+
+def test_api_darktable_status_checked_paths_never_empty(app_and_db):
+    """Never render an empty 'we checked here' list.
+
+    darktable_search_paths() returns [] on a Linux box with no AppImage
+    installed — precisely the user this feature targets.
+    """
+    import develop
+    app, _ = app_and_db
+    original = develop.darktable_search_paths
+    develop.darktable_search_paths = lambda: []
+    try:
+        data = app.test_client().get('/api/darktable/status').get_json()
+    finally:
+        develop.darktable_search_paths = original
+
+    assert data['checked_paths'], "checked_paths must never be empty"
+
+
+def test_api_darktable_status_checked_paths_names_linux_tools_dir(app_and_db, monkeypatch):
+    """On Linux the list names the AppImage directory even when it's empty.
+
+    darktable_search_paths() only reports AppImages that already exist, so a
+    fresh Linux box contributes nothing; the route must still name the
+    directory find_darktable looks in, since that is where a download lands.
+    """
+    import develop
+    app, _ = app_and_db
+    monkeypatch.setattr(develop, "darktable_search_paths", lambda: [])
+    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    data = app.test_client().get('/api/darktable/status').get_json()
+
+    tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
+    assert tools_dir in data['checked_paths']
+
+
+def test_api_darktable_status_checked_paths_omits_linux_tools_dir_on_macos(app_and_db, monkeypatch):
+    """macOS never probes the Linux AppImage directory, so don't claim we did."""
+    import develop
+    app, _ = app_and_db
+    monkeypatch.setattr(develop, "darktable_search_paths", lambda: [])
+    monkeypatch.setattr(os, "name", "posix")
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    data = app.test_client().get('/api/darktable/status').get_json()
+
+    tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
+    assert tools_dir not in data['checked_paths']
+    assert data['checked_paths'], "checked_paths must never be empty"

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -408,3 +408,368 @@ def test_api_darktable_install_available_does_not_cache_failures(app_and_db, mon
     assert first['reason'] == darktable_install.REASON_UNREACHABLE
     assert second['available'] is True, "a failure must not be cached over a later success"
     assert second['version'] == "5.6.0"
+
+
+# --- POST /api/jobs/download-darktable -------------------------------------
+
+
+def _stub_happy_path(monkeypatch, *, release=None, detail="ok",
+                     hand_off_result=None, download=None):
+    """Stub every darktable_install call the job makes. No network, ever."""
+    import darktable_install
+    release = release or _fake_release()
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: (release, None))
+    monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: 10 ** 12)
+    monkeypatch.setattr(
+        darktable_install, "download",
+        download or (lambda *a, **k: ("/tmp/d.dmg", detail)),
+    )
+    monkeypatch.setattr(
+        darktable_install, "hand_off",
+        lambda p, **k: hand_off_result or {
+            "action": "opened-installer", "location": p, "bin_path": None,
+        },
+    )
+    monkeypatch.setattr(darktable_install, "is_quarantined", lambda p: False)
+    return release
+
+
+def test_api_job_download_darktable_returns_job_id(app_and_db, monkeypatch):
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: ({
+        "version": "5.6.0", "name": "d.dmg", "size": 100,
+        "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
+        "digest": None,
+    }, None))
+    monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: 10 ** 12)
+    monkeypatch.setattr(darktable_install, "download", lambda *a, **k: ("/tmp/d.dmg", "ok"))
+    monkeypatch.setattr(darktable_install, "hand_off",
+                        lambda p, **k: {"action": "opened-installer",
+                                        "location": p, "bin_path": None})
+    monkeypatch.setattr(darktable_install, "is_quarantined", lambda p: False)
+
+    client = app.test_client()
+    resp = client.post('/api/jobs/download-darktable')
+    assert resp.status_code == 200
+    job_id = resp.get_json()['job_id']
+
+    # Wait for the job thread to finish INSIDE the test. Returning early lets
+    # it run after monkeypatch teardown, where it would call the real download
+    # and hit the network.
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+    assert job['status'] == 'completed'
+    result = job['result']
+    assert result['version'] == "5.6.0"
+    assert result['downloaded_to'] == "/tmp/d.dmg"
+    assert result['action'] == "opened-installer"
+
+
+def test_api_job_download_darktable_refuses_without_disk_space(app_and_db, monkeypatch):
+    """Refuse before downloading 87MB, and say what is needed vs free."""
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: ({
+        "version": "5.6.0", "name": "d.dmg", "size": 87094261,
+        "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
+        "digest": None,
+    }, None))
+    monkeypatch.setattr(darktable_install, "free_space_bytes", lambda p: 1024)
+
+    def must_not_download(*a, **k):
+        raise AssertionError("preflight must refuse before spending bandwidth")
+    monkeypatch.setattr(darktable_install, "download", must_not_download)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+    error = resp.get_json()['error']
+    assert 'space' in error.lower()
+    # Both halves of the fact the user acts on: how much is needed, and how
+    # much they have. "Not enough disk space." alone tells them nothing.
+    assert '166' in error, f"needed size (2x87MB) missing from {error!r}"
+    assert 'free' in error.lower(), f"free space missing from {error!r}"
+
+
+def test_api_job_download_darktable_400_when_the_target_dir_is_unusable(
+        app_and_db, monkeypatch):
+    """A read-only home must not 500 a button press.
+
+    free_space_bytes creates the tools directory, so it raises when ~/.vireo
+    is not writable. A 500 tells the user nothing they can act on.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (_fake_release(), None))
+
+    def denied(path):
+        raise PermissionError(13, "Permission denied")
+    monkeypatch.setattr(darktable_install, "free_space_bytes", denied)
+
+    def must_not_download(*a, **k):
+        raise AssertionError("must not download into an unusable directory")
+    monkeypatch.setattr(darktable_install, "download", must_not_download)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+    error = resp.get_json()['error']
+    assert 'Permission denied' in error, error
+    assert 'darktable' in error, f"the message must name the directory: {error!r}"
+
+
+def test_api_job_download_darktable_400_when_unavailable(app_and_db, monkeypatch):
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (None, darktable_install.REASON_NO_PLATFORM_BUILD))
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+    # The 400 body must carry the specific reason, not a generic message.
+    assert resp.get_json()['error'] == darktable_install.REASON_NO_PLATFORM_BUILD
+
+
+def test_api_job_download_darktable_400_says_unreachable_not_unsupported(
+        app_and_db, monkeypatch):
+    """A user behind a proxy must not be told their platform is unsupported.
+
+    Paired with the test above, this pins that the route relays whichever
+    reason resolve_release gave rather than collapsing both to one sentence.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (None, darktable_install.REASON_UNREACHABLE))
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+    assert resp.get_json()['error'] == darktable_install.REASON_UNREACHABLE
+
+
+def test_api_job_download_darktable_400_when_resolve_raises(app_and_db, monkeypatch):
+    """resolve_release is documented never to raise; if it does, no 500."""
+    import darktable_install
+    app, _ = app_and_db
+
+    def boom():
+        raise OSError("network unreachable")
+    monkeypatch.setattr(darktable_install, "resolve_release", boom)
+
+    resp = app.test_client().post('/api/jobs/download-darktable')
+    assert resp.status_code == 400
+    assert resp.get_json()['error'] == darktable_install.REASON_UNREACHABLE
+
+
+def test_api_job_download_darktable_resolves_fresh_not_from_cache(app_and_db, monkeypatch):
+    """The job re-resolves server-side so it never downloads a stale URL.
+
+    /api/darktable/install/available caches for 10 minutes; if the job read
+    that cache it could fetch a URL the user never saw confirmed, or one
+    GitHub has since replaced.
+    """
+    import darktable_install
+    app, _ = app_and_db
+
+    stale = dict(_fake_release("5.0.0"),
+                 url="https://github.com/darktable-org/darktable/releases/download/x/stale.dmg")
+    fresh = dict(_fake_release("5.6.0"),
+                 url="https://github.com/darktable-org/darktable/releases/download/x/fresh.dmg")
+    darktable_install._release_cache.update(at=time.monotonic(), value=stale)
+
+    captured = {}
+
+    def fake_download(asset, **kwargs):
+        captured['asset'] = asset
+        return "/tmp/fresh.dmg", "ok"
+
+    _stub_happy_path(monkeypatch, release=fresh, download=fake_download)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+
+    assert job['status'] == 'completed', job
+    assert captured['asset']['url'].endswith("fresh.dmg"), captured['asset']
+    assert job['result']['version'] == "5.6.0"
+
+
+def test_api_job_download_darktable_reports_verification_detail_verbatim(
+        app_and_db, monkeypatch):
+    """download() returns the only sentence that says WHAT was checked.
+
+    verify_digest returns ok=True both when the digest matched and when GitHub
+    published no digest at all. Synthesizing "Verified" from that boolean would
+    tell a user their unverifiable download was verified.
+    """
+    app, _ = app_and_db
+    detail = ("GitHub published no digest for this asset, so its contents could not "
+              "be verified.")
+    _stub_happy_path(monkeypatch, detail=detail)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+
+    assert job['status'] == 'completed', job
+    assert job['result']['verified'] == detail
+
+
+def test_api_job_download_darktable_verifying_progress_carries_the_detail(
+        app_and_db, monkeypatch):
+    """The Verifying event must send total=0 and carry the detail.
+
+    A non-zero total makes the Settings progress UI take its byte-count branch
+    and render "Verifying: 0 of 0 MB" instead of what was actually checked.
+    """
+    app, _ = app_and_db
+    detail = "SHA256 matches the digest GitHub published for this asset (abc…)."
+    _stub_happy_path(monkeypatch, detail=detail)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    wait_for_job_via_client(client, job_id)
+
+    events = app._job_runner.get_events(job_id)
+    verifying = [e['data'] for e in events
+                 if e['type'] == 'progress' and e['data'].get('phase') == 'Verifying']
+    assert verifying, f"no Verifying progress event in {events!r}"
+    assert verifying[-1]['total'] == 0
+    assert verifying[-1]['current_file'] == detail
+
+
+def test_api_job_download_darktable_reports_byte_progress(app_and_db, monkeypatch):
+    """byte_callback must reach the job's event stream, unclamped.
+
+    Progress moving backwards is honest: when a server ignores Range the
+    retry truncates the .partial and restarts from 0.
+    """
+    app, _ = app_and_db
+
+    def fake_download(asset, byte_callback=None, should_cancel=None):
+        byte_callback(1024, 87094261)
+        byte_callback(4096, 87094261)
+        byte_callback(0, 87094261)  # server ignored Range; restarted
+        return "/tmp/d.dmg", "ok"
+
+    _stub_happy_path(monkeypatch, download=fake_download)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+    assert job['status'] == 'completed', job
+
+    events = app._job_runner.get_events(job_id)
+    downloading = [e['data'] for e in events
+                   if e['type'] == 'progress'
+                   and e['data'].get('phase') == 'Downloading darktable']
+    assert [d['current'] for d in downloading] == [1024, 4096, 0]
+    assert all(d['total'] == 87094261 for d in downloading)
+    assert all(d['current_file'] == "darktable-5.6.0-arm64.dmg" for d in downloading)
+
+
+def test_api_job_download_darktable_writes_config_when_handoff_returns_bin(
+        app_and_db, monkeypatch):
+    """Linux: the AppImage we downloaded IS the binary, so record it.
+
+    Without this the user installs darktable and Settings still says it is
+    missing.
+    """
+    import config as cfg
+    app, _ = app_and_db
+    bin_path = "/tmp/darktable-5.6.0-x86_64.AppImage"
+    _stub_happy_path(monkeypatch, hand_off_result={
+        "action": "installed", "location": bin_path, "bin_path": bin_path,
+    })
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+
+    assert job['status'] == 'completed', job
+    assert cfg.get("darktable_bin") == bin_path
+    # And the result must say the write happened, so the UI can report it.
+    assert job['result']['config_written'] is True
+    assert job['result']['bin_path'] == bin_path
+
+
+def test_api_job_download_darktable_leaves_config_alone_without_bin(
+        app_and_db, monkeypatch):
+    """macOS/Windows hand off to an installer; where the app lands is unknown.
+
+    Writing a guessed darktable_bin here would overwrite a path the user
+    configured with one that does not exist.
+    """
+    import config as cfg
+    app, _ = app_and_db
+    cfg.set("darktable_bin", "/sentinel/darktable-cli")
+    _stub_happy_path(monkeypatch)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+
+    assert job['status'] == 'completed', job
+    assert cfg.get("darktable_bin") == "/sentinel/darktable-cli"
+    assert job['result']['config_written'] is False
+
+
+def test_api_job_download_darktable_cancel_ends_cancelled_not_failed(
+        app_and_db, monkeypatch):
+    """A user pressing Stop must not see a red "failed" job.
+
+    The UI distinguishes the two, and a cancelled job carries no errors.
+    """
+    app, _ = app_and_db
+    import taxonomy
+
+    def fake_download(asset, byte_callback=None, should_cancel=None):
+        deadline = time.monotonic() + 20
+        while not should_cancel():
+            if time.monotonic() > deadline:
+                raise AssertionError("cancellation never reached the download")
+            time.sleep(0.01)
+        raise taxonomy.DownloadCancelled("cancelled")
+
+    _stub_happy_path(monkeypatch, download=fake_download)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    assert client.post(f'/api/jobs/{job_id}/cancel').status_code == 200
+
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+    assert job['status'] == 'cancelled', job
+    assert not job['errors'], job['errors']
+
+
+def test_api_job_download_darktable_handoff_failure_fails_the_job(app_and_db, monkeypatch):
+    """hand_off raises after a good download; the message names the saved file.
+
+    That path is the user's way forward, so it must survive into job errors
+    rather than being swallowed into a generic failure.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    _stub_happy_path(monkeypatch)
+
+    def boom(path, **kwargs):
+        raise RuntimeError(
+            f"Downloaded to {path}, but macOS could not open it (exit code 1). "
+            "Open it yourself to install darktable."
+        )
+    monkeypatch.setattr(darktable_install, "hand_off", boom)
+
+    client = app.test_client()
+    job_id = client.post('/api/jobs/download-darktable').get_json()['job_id']
+    from wait import wait_for_job_via_client
+    job = wait_for_job_via_client(client, job_id)
+
+    assert job['status'] == 'failed', job
+    assert any("/tmp/d.dmg" in e for e in job['errors']), job['errors']

--- a/vireo/tests/test_darktable_api.py
+++ b/vireo/tests/test_darktable_api.py
@@ -3,6 +3,8 @@ import os
 import sys
 import time
 
+import pytest
+
 
 def test_api_darktable_status(app_and_db):
     """GET /api/darktable/status returns availability info."""
@@ -262,3 +264,147 @@ def test_api_darktable_status_checked_paths_omits_linux_tools_dir_on_macos(app_a
     tools_dir = os.path.expanduser("~/.vireo/tools/darktable")
     assert tools_dir not in data['checked_paths']
     assert data['checked_paths'], "checked_paths must never be empty"
+
+
+@pytest.fixture(autouse=True)
+def _clear_release_cache():
+    """The release cache is module-level state that would leak between tests.
+
+    Without this, a test that stubs a failure would see the previous test's
+    cached success and pass for the wrong reason.
+    """
+    import darktable_install
+    darktable_install._release_cache.update(at=0.0, value=None)
+    yield
+    darktable_install._release_cache.update(at=0.0, value=None)
+
+
+def _fake_release(version="5.6.0"):
+    return {
+        "version": version,
+        "name": f"darktable-{version}-arm64.dmg",
+        "size": 87094261,
+        "url": "https://github.com/darktable-org/darktable/releases/download/x/d.dmg",
+        "digest": "sha256:" + "a" * 64,
+    }
+
+
+def test_api_darktable_install_available_shape(app_and_db, monkeypatch):
+    """The confirmation needs version, name, size, url and digest."""
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: (_fake_release(), None))
+
+    data = app.test_client().get('/api/darktable/install/available').get_json()
+    assert data['available'] is True
+    assert data['version'] == "5.6.0"
+    assert data['name'] == "darktable-5.6.0-arm64.dmg"
+    assert data['size'] == 87094261
+    assert data['url'].startswith("https://github.com/darktable-org/darktable/releases/download/")
+    assert data['digest'].startswith("sha256:")
+
+
+def test_api_darktable_install_available_reports_network_failure_honestly(app_and_db, monkeypatch):
+    """A user behind a proxy must not be told their platform is unsupported."""
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (None, darktable_install.REASON_UNREACHABLE))
+
+    resp = app.test_client().get('/api/darktable/install/available')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['available'] is False
+    assert data['reason'] == darktable_install.REASON_UNREACHABLE
+    assert 'platform' not in data['reason'].lower()
+
+
+def test_api_darktable_install_available_handles_unsupported_platform(app_and_db, monkeypatch):
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (None, darktable_install.REASON_NO_PLATFORM_BUILD))
+
+    data = app.test_client().get('/api/darktable/install/available').get_json()
+    assert data['available'] is False
+    assert data['reason'] == darktable_install.REASON_NO_PLATFORM_BUILD
+
+
+def test_api_darktable_install_available_distinguishes_no_usable_asset(app_and_db, monkeypatch):
+    """"Release had no build we could use" is a third, distinct fact.
+
+    Together with the two tests above this pins that the route relays whatever
+    resolve_release said rather than collapsing every miss to one sentence.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    monkeypatch.setattr(darktable_install, "resolve_release",
+                        lambda: (None, darktable_install.REASON_NO_USABLE_ASSET))
+
+    data = app.test_client().get('/api/darktable/install/available').get_json()
+    assert data['available'] is False
+    assert data['reason'] == darktable_install.REASON_NO_USABLE_ASSET
+
+
+def test_api_darktable_install_available_survives_an_unexpected_raise(app_and_db, monkeypatch):
+    """Belt and braces: resolve_release should never raise, but if it does the
+    route must still 200 with a reason rather than 500 into a dead button."""
+    import darktable_install
+    app, _ = app_and_db
+
+    def boom():
+        raise OSError("network unreachable")
+    monkeypatch.setattr(darktable_install, "resolve_release", boom)
+
+    resp = app.test_client().get('/api/darktable/install/available')
+    assert resp.status_code == 200
+    assert resp.get_json()['available'] is False
+    assert resp.get_json()['reason']
+
+
+def test_api_darktable_install_available_caches_a_successful_lookup(app_and_db, monkeypatch):
+    """Repeated Settings loads must not burn GitHub's 60 unauthenticated req/hr.
+
+    Once that budget is gone every user on the IP gets the fallback link, so a
+    second call within the TTL must not reach the API at all.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    calls = []
+
+    def counting():
+        calls.append(1)
+        return _fake_release(), None
+    monkeypatch.setattr(darktable_install, "resolve_release", counting)
+
+    client = app.test_client()
+    first = client.get('/api/darktable/install/available').get_json()
+    second = client.get('/api/darktable/install/available').get_json()
+
+    assert first['available'] is True
+    assert second == first
+    assert len(calls) == 1, f"expected one API lookup, got {len(calls)}"
+
+
+def test_api_darktable_install_available_does_not_cache_failures(app_and_db, monkeypatch):
+    """A transient outage must not pin the fallback link for the whole TTL.
+
+    Caching a failure would also freeze its reason string, so a user who fixed
+    their network would keep being told GitHub is unreachable.
+    """
+    import darktable_install
+    app, _ = app_and_db
+    outcomes = [
+        (None, darktable_install.REASON_UNREACHABLE),
+        (_fake_release(), None),
+    ]
+    monkeypatch.setattr(darktable_install, "resolve_release", lambda: outcomes.pop(0))
+
+    client = app.test_client()
+    first = client.get('/api/darktable/install/available').get_json()
+    second = client.get('/api/darktable/install/available').get_json()
+
+    assert first['available'] is False
+    assert first['reason'] == darktable_install.REASON_UNREACHABLE
+    assert second['available'] is True, "a failure must not be cached over a later success"
+    assert second['version'] == "5.6.0"

--- a/vireo/tests/test_darktable_install.py
+++ b/vireo/tests/test_darktable_install.py
@@ -1,0 +1,189 @@
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures", "darktable_release.json")
+
+
+def _release():
+    with open(FIXTURE) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("platform,machine,expected", [
+    ("darwin", "arm64",   "darktable-5.6.0-arm64.dmg"),
+    ("darwin", "x86_64",  "darktable-5.6.0-x86_64.dmg"),
+    ("win32",  "AMD64",   "darktable-5.6.0-win64.exe"),
+    ("win32",  "ARM64",   "darktable-5.6.0-woa64.exe"),
+    ("linux",  "x86_64",  "Darktable-5.6.0-x86_64.AppImage"),
+    ("linux",  "aarch64", "Darktable-5.6.0-aarch64.AppImage"),
+])
+def test_select_asset_matrix(platform, machine, expected):
+    from darktable_install import select_asset
+
+    asset = select_asset(_release(), platform, machine)
+    assert asset["name"] == expected
+
+
+def test_select_asset_never_picks_zsync():
+    """The release ships ~300KB .zsync manifests next to the 178MB AppImages.
+    A substring match would 'successfully install' a file that is not darktable."""
+    from darktable_install import select_asset
+
+    asset = select_asset(_release(), "linux", "x86_64")
+    assert not asset["name"].endswith(".zsync")
+    assert asset["size"] > 10 * 1024 * 1024
+
+
+@pytest.mark.parametrize("machine,expected", [
+    ("x86_64", "Darktable-5.6.0-x86_64.AppImage"),
+    ("aarch64", "Darktable-5.6.0-aarch64.AppImage"),
+])
+def test_select_asset_skips_zsync_listed_before_the_appimage(machine, expected):
+    """Order must not decide the outcome.
+
+    The fixture happens to list each AppImage before its .zsync sibling, which
+    lets a substring matcher pass by luck. GitHub makes no ordering promise, so
+    re-run the match with the decoys first: a substring matcher then picks the
+    ~300KB manifest and this fails.
+    """
+    from darktable_install import select_asset
+
+    release = _release()
+    release["assets"] = sorted(
+        release["assets"], key=lambda a: not a["name"].endswith(".zsync")
+    )
+    assert release["assets"][0]["name"].endswith(".zsync")
+
+    asset = select_asset(release, "linux", machine)
+    assert asset is not None
+    assert asset["name"] == expected
+
+
+def test_select_asset_unknown_platform_returns_none():
+    from darktable_install import select_asset
+
+    assert select_asset(_release(), "sunos5", "sparc") is None
+    assert select_asset(_release(), "linux", "riscv64") is None
+
+
+def test_select_asset_rejects_implausibly_small_asset():
+    from darktable_install import select_asset
+
+    release = _release()
+    for a in release["assets"]:
+        if a["name"] == "darktable-5.6.0-arm64.dmg":
+            a["size"] = 1024
+    assert select_asset(release, "darwin", "arm64") is None
+
+
+@pytest.mark.parametrize("url", [
+    "https://evil.example.com/darktable-5.6.0-arm64.dmg",
+    "https://github.com/attacker/darktable/releases/download/x/darktable-5.6.0-arm64.dmg",
+    "http://github.com/darktable-org/darktable/releases/download/x/darktable-5.6.0-arm64.dmg",
+])
+def test_select_asset_rejects_untrusted_url(url):
+    from darktable_install import select_asset
+
+    release = _release()
+    for a in release["assets"]:
+        if a["name"] == "darktable-5.6.0-arm64.dmg":
+            a["browser_download_url"] = url
+    assert select_asset(release, "darwin", "arm64") is None
+
+
+def test_select_asset_accepts_objects_githubusercontent():
+    from darktable_install import select_asset
+
+    release = _release()
+    for a in release["assets"]:
+        if a["name"] == "darktable-5.6.0-arm64.dmg":
+            a["browser_download_url"] = (
+                "https://objects.githubusercontent.com/darktable-org/darktable/x.dmg"
+            )
+    assert select_asset(release, "darwin", "arm64") is not None
+
+
+def test_select_asset_tolerates_missing_digest():
+    from darktable_install import select_asset
+
+    release = _release()
+    for a in release["assets"]:
+        a.pop("digest", None)
+    asset = select_asset(release, "darwin", "arm64")
+    assert asset is not None
+    assert asset.get("digest") is None
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object urlopen returns."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _stub_github(monkeypatch, payload):
+    """Point resolve_release at a canned response instead of the live API."""
+    import urllib.request
+
+    def fake_urlopen(req, timeout=None, context=None):
+        assert req.full_url.startswith("https://api.github.com/"), req.full_url
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+
+def test_resolve_release_strips_the_release_tag_prefix(monkeypatch):
+    """version is what the UI shows, so it must be "5.6.0", not "release-5.6.0"."""
+    import platform as platform_mod
+
+    from darktable_install import resolve_release
+
+    _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(platform_mod, "machine", lambda: "arm64")
+
+    info = resolve_release()
+    assert info["version"] == "5.6.0"
+    assert info["name"] == "darktable-5.6.0-arm64.dmg"
+    assert info["url"].endswith("/darktable-5.6.0-arm64.dmg")
+    assert info["size"] == 87094261
+
+
+def test_resolve_release_returns_none_on_network_failure(monkeypatch):
+    """A dead network must degrade to a plain link, never to a traceback."""
+    import urllib.error
+    import urllib.request
+
+    from darktable_install import resolve_release
+
+    def boom(req, timeout=None, context=None):
+        raise urllib.error.URLError("no route to host")
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    assert resolve_release() is None
+
+
+def test_resolve_release_returns_none_for_unsupported_platform(monkeypatch):
+    import platform as platform_mod
+
+    from darktable_install import resolve_release
+
+    _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
+    monkeypatch.setattr(sys, "platform", "freebsd14")
+    monkeypatch.setattr(platform_mod, "machine", lambda: "amd64")
+
+    assert resolve_release() is None

--- a/vireo/tests/test_darktable_install.py
+++ b/vireo/tests/test_darktable_install.py
@@ -844,12 +844,18 @@ def test_hand_off_default_platform_agrees_with_develop(tmp_path, monkeypatch):
 
     result = hand_off(str(artifact))
 
+    # os.access(..., X_OK) is Unix-specific: Windows has no execute bit and
+    # returns True for any existing file, so the "did chmod run" cross-check
+    # only means anything on POSIX. bin_path is the platform-agnostic signal
+    # for whether hand_off took the tools-dir branch.
     if develop.darktable_uses_tools_dir():
         assert result["bin_path"] == str(artifact)
-        assert os.access(str(artifact), os.X_OK)
+        if os.name != "nt":
+            assert os.access(str(artifact), os.X_OK)
     else:
         assert result["bin_path"] is None
-        assert not os.access(str(artifact), os.X_OK)
+        if os.name != "nt":
+            assert not os.access(str(artifact), os.X_OK)
 
 
 def test_is_quarantined_false_for_plain_file(tmp_path):

--- a/vireo/tests/test_darktable_install.py
+++ b/vireo/tests/test_darktable_install.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import sys
@@ -408,3 +409,243 @@ def test_resolve_release_never_raises_on_a_malformed_body(monkeypatch, payload, 
     assert reason == (
         REASON_UNREACHABLE if expected_reason == "unreachable" else REASON_NO_USABLE_ASSET
     )
+
+
+# --------------------------------------------------------------------------
+# verify_digest
+# --------------------------------------------------------------------------
+
+# sha256(b"hello")
+HELLO_SHA256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+
+def test_verify_digest_matches(tmp_path):
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    sha = "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    ok, detail = verify_digest(str(f), sha)
+    assert ok, detail
+
+
+def test_verify_digest_mismatch_is_reported_with_both_hashes(tmp_path):
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"tampered")
+    ok, detail = verify_digest(str(f), "sha256:" + "0" * 64)
+    assert not ok
+    assert "0000" in detail          # expected
+    assert "expected" in detail.lower()
+    # ...and the hash we actually computed, so a support thread can tell a
+    # truncated download from a substituted one.
+    assert "d121be3103007b41edf96f8262925f8c7d61894afe9a041843b631f69445bc57" in detail
+
+
+@pytest.mark.parametrize("differ_at", [0, 7, 8, 15, 16, 31, 32, 62, 63])
+def test_verify_digest_compares_the_whole_hash_not_a_prefix(tmp_path, differ_at):
+    """A near-miss digest must still be rejected.
+
+    The obvious mismatch case (expected 0*64) is caught even by a
+    `actual[:8] == want[:8]` comparison, so on its own it does not prove the
+    whole hash was checked.  These differ from the true digest in exactly one
+    position, spread across its length, so any truncated comparison passes one
+    of them and fails this test.
+    """
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+
+    chars = list(HELLO_SHA256)
+    chars[differ_at] = "0" if chars[differ_at] != "0" else "1"
+    near_miss = "".join(chars)
+    assert near_miss != HELLO_SHA256
+
+    ok, detail = verify_digest(str(f), "sha256:" + near_miss)
+    assert not ok, f"accepted a digest differing at index {differ_at}: {detail}"
+    assert "mismatch" in detail.lower()
+
+
+def test_verify_digest_absent_says_so_rather_than_silently_passing(tmp_path):
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    ok, detail = verify_digest(str(f), None)
+    assert ok
+    assert "no digest" in detail.lower()
+    # ...and it must not imply a check that did not happen.
+    assert "could not be verified" in detail.lower(), detail
+
+
+def test_verify_digest_success_detail_does_not_overclaim(tmp_path):
+    """The detail is shown to the user verbatim.
+
+    A matching digest proves the bytes are what GitHub's API *said* to expect.
+    It is not a signature: the digest arrived over the same HTTPS response as
+    the download URL, so it shares that response's trust boundary.  The string
+    must not let a user believe darktable signed anything.
+    """
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    ok, detail = verify_digest(str(f), "sha256:" + HELLO_SHA256)
+
+    assert ok
+    lower = detail.lower()
+    assert "github" in lower, detail
+    # It has to say where the expectation came from *and* that no signature was
+    # involved, so nobody reads "verified" as "vouched for by darktable".
+    assert "no signature" in lower or "does not sign" in lower, detail
+    for overclaim in ("authentic", "safe to run", "trusted", "signed by darktable"):
+        assert overclaim not in lower, f"{overclaim!r} overclaims: {detail}"
+
+
+@pytest.mark.parametrize("expected", [
+    "sha256:" + HELLO_SHA256,                    # exactly what the API sends today
+    "SHA256:" + HELLO_SHA256.upper(),            # algorithm and hex upper-cased
+    "sha256:" + HELLO_SHA256.upper(),
+    "  sha256:" + HELLO_SHA256 + "  \n",         # stray whitespace
+    HELLO_SHA256,                                # bare hash, no algorithm prefix
+    "  " + HELLO_SHA256.upper() + "\t",
+])
+def test_verify_digest_accepts_every_shape_a_correct_sha256_can_arrive_in(tmp_path, expected):
+    """`expected` comes from an external API; hex case, padding and the
+    presence of the `sha256:` prefix are all cosmetic.  Rejecting a correct
+    digest over cosmetics would delete a perfectly good 178MB download."""
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    ok, detail = verify_digest(str(f), expected)
+    assert ok, detail
+
+
+@pytest.mark.parametrize("algorithm,digest", [
+    # The *right* hash of the *right* file under a different algorithm.
+    ("md5", "5d41402abc4b2a76b9719d911017c592"),
+    ("sha1", "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"),
+    ("sha512", "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7"
+               "2323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043"),
+    # 64 hex characters, so it is shaped exactly like a SHA256 and only the
+    # algorithm name gives it away.  This is the case that would otherwise be
+    # reported as "mismatch — the download was replaced" about an intact file.
+    ("blake2s", hashlib.blake2s(b"hello").hexdigest()),
+])
+def test_verify_digest_rejects_a_digest_from_another_algorithm_by_name(tmp_path, algorithm, digest):
+    """Stripping the prefix blindly would compare, say, an MD5 against a
+    SHA256 and blame the file.  The detail has to name the algorithm GitHub
+    actually sent, otherwise a format change that silently weakens (or
+    disables) verification looks identical to a corrupt download."""
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    ok, detail = verify_digest(str(f), f"{algorithm}:{digest}")
+
+    assert not ok, f"{algorithm} digest was accepted as if it were SHA256"
+    assert "mismatch" not in detail.lower(), f"{detail!r} blames an intact file"
+    assert "verif" in detail.lower(), detail
+    assert algorithm in detail.lower(), f"{detail!r} does not say GitHub sent a {algorithm} digest"
+
+
+@pytest.mark.parametrize("expected,label", [
+    # Malformed values that can never equal a SHA256 hexdigest.
+    ("sha256:" + "z" * 64, "non-hex"),
+    ("sha256:" + HELLO_SHA256[:32], "too short"),
+    ("sha256:" + HELLO_SHA256 + "ff", "too long"),
+    ("sha256:" + "ff" + HELLO_SHA256, "prefixed with junk"),
+    ("sha256:", "empty"),
+    ({"sha256": HELLO_SHA256}, "not a string"),
+])
+def test_verify_digest_fails_closed_and_says_why_when_it_cannot_check(tmp_path, expected, label):
+    """Fail closed, but with its own sentence.
+
+    An unusable digest is not evidence of tampering, so it must not be reported
+    as a mismatch — and it must not pass, because the digest is the only
+    integrity check this feature has.  If GitHub ever changes the format this
+    breaks loudly on the next release instead of quietly verifying nothing.
+    """
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    ok, detail = verify_digest(str(f), expected)
+
+    assert not ok, f"{label}: an unverifiable digest must not pass"
+    assert "mismatch" not in detail.lower(), f"{label}: {detail!r} blames the file"
+    assert "verif" in detail.lower(), f"{label}: {detail!r} does not say it could not verify"
+
+
+def test_verify_digest_reads_in_chunks_not_all_at_once(tmp_path, monkeypatch):
+    """These assets are 87-178MB and Task 7 verifies right after download.
+    f.read() with no size would pull the whole file into RAM."""
+    import darktable_install
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello" * 1000)
+
+    reads = []
+    real_open = open
+
+    class _SpyFile:
+        def __init__(self, fh):
+            self._fh = fh
+
+        def read(self, *args):
+            reads.append(args)
+            return self._fh.read(*args)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return self._fh.__exit__(*exc)
+
+    def spy_open(path, *args, **kwargs):
+        return _SpyFile(real_open(path, *args, **kwargs))
+
+    monkeypatch.setattr(darktable_install, "open", spy_open, raising=False)
+
+    ok, detail = verify_digest(str(f), hashlib.sha256(b"hello" * 1000).hexdigest())
+
+    assert ok, detail
+    assert reads, "expected the file to be read"
+    assert all(args and isinstance(args[0], int) and args[0] > 0 for args in reads), (
+        f"every read() must pass an explicit chunk size, got {reads}"
+    )
+
+
+def test_verify_digest_hashes_the_whole_file_across_chunk_boundaries(tmp_path):
+    """A chunked loop that drops or reorders a chunk still 'verifies' small
+    test files.  Use a payload several chunks long with distinct content."""
+    from darktable_install import verify_digest
+
+    payload = bytes(range(256)) * (5 * 1024)  # 1.25MB, spans >1 chunk at 1MB
+    f = tmp_path / "big.bin"
+    f.write_bytes(payload)
+
+    ok, detail = verify_digest(str(f), "sha256:" + hashlib.sha256(payload).hexdigest())
+    assert ok, detail
+
+    # ...and flipping a single byte in the middle must be caught.
+    tampered = bytearray(payload)
+    tampered[len(tampered) // 2] ^= 0xFF
+    f.write_bytes(bytes(tampered))
+    ok, detail = verify_digest(str(f), "sha256:" + hashlib.sha256(payload).hexdigest())
+    assert not ok
+    assert "mismatch" in detail.lower()
+
+
+def test_verify_digest_reports_an_unreadable_file_instead_of_raising(tmp_path):
+    """Task 9's job calls this from a background thread; an OSError escaping
+    here would kill the job with no user-facing explanation."""
+    from darktable_install import verify_digest
+
+    ok, detail = verify_digest(str(tmp_path / "does-not-exist.bin"), "sha256:" + HELLO_SHA256)
+    assert not ok
+    assert "read" in detail.lower()

--- a/vireo/tests/test_darktable_install.py
+++ b/vireo/tests/test_darktable_install.py
@@ -85,6 +85,30 @@ def test_select_asset_rejects_implausibly_small_asset():
     "https://evil.example.com/darktable-5.6.0-arm64.dmg",
     "https://github.com/attacker/darktable/releases/download/x/darktable-5.6.0-arm64.dmg",
     "http://github.com/darktable-org/darktable/releases/download/x/darktable-5.6.0-arm64.dmg",
+    # Path traversal: GitHub resolves ".." on receipt, so this actually serves
+    # /attacker/evil/... A raw startswith() on the unnormalised path accepts it.
+    "https://github.com/darktable-org/darktable/../../attacker/evil"
+    "/releases/download/x/darktable-5.6.0-arm64.dmg",
+    # Percent-encoded flavour of the same traversal.
+    "https://github.com/darktable-org/darktable/%2e%2e/%2e%2e/attacker/evil"
+    "/releases/download/x/darktable-5.6.0-arm64.dmg",
+    # Traversal that climbs out *after* satisfying the prefix. The narrowed
+    # prefix alone does not catch this one — only normalising the path does.
+    "https://github.com/darktable-org/darktable/releases/download/../../../../"
+    "attacker/evil/darktable-5.6.0-arm64.dmg",
+    "https://github.com/darktable-org/darktable/releases/download/%2e%2e/%2e%2e/"
+    "%2e%2e/%2e%2e/attacker/evil/darktable-5.6.0-arm64.dmg",
+    # Inside the real repo, but repo *content* rather than a release asset:
+    # anyone who can open a PR branch can host a file here.
+    "https://github.com/darktable-org/darktable/raw/master/darktable-5.6.0-arm64.dmg",
+    # Every real browser_download_url is on github.com; the redirect target we
+    # deliberately do not check is release-assets.githubusercontent.com. So this
+    # host is unreachable in practice and serves arbitrary user blobs.
+    "https://objects.githubusercontent.com/darktable-org/darktable"
+    "/releases/download/x/darktable-5.6.0-arm64.dmg",
+    # Credentials in the userinfo section must not fool the host check.
+    "https://github.com@evil.example.com/darktable-org/darktable"
+    "/releases/download/x/darktable-5.6.0-arm64.dmg",
 ])
 def test_select_asset_rejects_untrusted_url(url):
     from darktable_install import select_asset
@@ -96,16 +120,46 @@ def test_select_asset_rejects_untrusted_url(url):
     assert select_asset(release, "darwin", "arm64") is None
 
 
-def test_select_asset_accepts_objects_githubusercontent():
+def test_select_asset_accepts_a_real_release_asset_url():
+    """The allowlist must not be so tight that it rejects the genuine URL."""
+    from darktable_install import select_asset
+
+    asset = select_asset(_release(), "darwin", "arm64")
+    assert asset is not None
+    assert asset["url"] == (
+        "https://github.com/darktable-org/darktable/releases/download/release-5.6.0"
+        "/darktable-5.6.0-arm64.dmg"
+    )
+
+
+@pytest.mark.parametrize("field,bad_value", [
+    ("size", 1024),
+    ("browser_download_url", "https://evil.example.com/x.dmg"),
+])
+def test_select_asset_skips_a_poisoned_entry_and_keeps_looking(field, bad_value):
+    """A rejected candidate must not kill the whole lookup.
+
+    Returning None on the first bad entry hands anyone who can inject one asset
+    a reliable DoS on the feature. Skipping cannot accept anything untrusted —
+    the rejection already happened — and the digest check is the integrity gate.
+    """
     from darktable_install import select_asset
 
     release = _release()
-    for a in release["assets"]:
-        if a["name"] == "darktable-5.6.0-arm64.dmg":
-            a["browser_download_url"] = (
-                "https://objects.githubusercontent.com/darktable-org/darktable/x.dmg"
-            )
-    assert select_asset(release, "darwin", "arm64") is not None
+    poison = {
+        "name": "darktable-9.9.9-arm64.dmg",
+        "size": 90_000_000,
+        "browser_download_url": "https://github.com/darktable-org/darktable"
+                                "/releases/download/release-9.9.9/darktable-9.9.9-arm64.dmg",
+    }
+    # Make exactly one field bad so each rejection branch is exercised alone.
+    poison[field] = bad_value
+    release["assets"].insert(0, poison)
+
+    asset = select_asset(release, "darwin", "arm64")
+    assert asset is not None
+    assert asset["name"] == "darktable-5.6.0-arm64.dmg"
+    assert asset["size"] == 87094261
 
 
 def test_select_asset_tolerates_missing_digest():
@@ -117,6 +171,32 @@ def test_select_asset_tolerates_missing_digest():
     asset = select_asset(release, "darwin", "arm64")
     assert asset is not None
     assert asset.get("digest") is None
+
+
+@pytest.mark.parametrize("release", [
+    None,
+    [],
+    "rate limited",
+    42,
+    {"assets": "nope"},
+    {"assets": 5},
+    {"assets": [1, 2]},
+    {"assets": [{"name": 7}]},
+    {"assets": [{"name": "darktable-5.6.0-arm64.dmg", "size": "big"}]},
+])
+def test_select_asset_tolerates_malformed_payloads(release):
+    from darktable_install import select_asset
+
+    assert select_asset(release, "darwin", "arm64") is None
+
+
+class _StubContractError(BaseException):
+    """The request resolve_release() made violated the stub's contract.
+
+    Deliberately a BaseException: resolve_release catches ``Exception`` and
+    turns it into "could not reach GitHub", which would mask a downloader that
+    silently stopped sending its User-Agent or its SSL context.
+    """
 
 
 class _FakeResponse:
@@ -136,54 +216,195 @@ class _FakeResponse:
 
 
 def _stub_github(monkeypatch, payload):
-    """Point resolve_release at a canned response instead of the live API."""
+    """Point resolve_release at a canned response instead of the live API.
+
+    Returns the list of recorded calls. The contract checks here are the only
+    thing standing between us and shipping a downloader that 403s in
+    production: GitHub rejects requests with no User-Agent, and without the
+    certifi context HTTPS fails on stock macOS.
+    """
     import urllib.request
 
+    calls = []
+
     def fake_urlopen(req, timeout=None, context=None):
-        assert req.full_url.startswith("https://api.github.com/"), req.full_url
+        if not req.full_url.startswith("https://api.github.com/"):
+            raise _StubContractError(f"unexpected URL {req.full_url!r}")
+        if context is None:
+            raise _StubContractError("must pass the certifi SSL context")
+        if not req.get_header("User-agent"):
+            raise _StubContractError("GitHub 403s requests with no User-Agent")
+        if req.get_header("Accept") != "application/vnd.github+json":
+            raise _StubContractError(f"bad Accept header {req.get_header('Accept')!r}")
+        calls.append({"url": req.full_url, "timeout": timeout, "context": context})
         return _FakeResponse(payload)
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return calls
+
+
+def _on_supported_platform(monkeypatch):
+    import platform as platform_mod
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(platform_mod, "machine", lambda: "arm64")
 
 
 def test_resolve_release_strips_the_release_tag_prefix(monkeypatch):
     """version is what the UI shows, so it must be "5.6.0", not "release-5.6.0"."""
-    import platform as platform_mod
-
     from darktable_install import resolve_release
 
     _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
-    monkeypatch.setattr(sys, "platform", "darwin")
-    monkeypatch.setattr(platform_mod, "machine", lambda: "arm64")
+    _on_supported_platform(monkeypatch)
 
-    info = resolve_release()
+    info, reason = resolve_release()
+    assert reason is None
     assert info["version"] == "5.6.0"
     assert info["name"] == "darktable-5.6.0-arm64.dmg"
     assert info["url"].endswith("/darktable-5.6.0-arm64.dmg")
     assert info["size"] == 87094261
 
 
-def test_resolve_release_returns_none_on_network_failure(monkeypatch):
-    """A dead network must degrade to a plain link, never to a traceback."""
+def test_resolve_release_only_strips_a_leading_release_prefix(monkeypatch):
+    """str.replace() would also gut a tag that contains "release-" mid-string."""
+    from darktable_install import resolve_release
+
+    release = _release()
+    release["tag_name"] = "5.6.0-prerelease-2"
+    _stub_github(monkeypatch, json.dumps(release).encode("utf-8"))
+    _on_supported_platform(monkeypatch)
+
+    info, reason = resolve_release()
+    assert reason is None
+    assert info["version"] == "5.6.0-prerelease-2"
+
+
+def test_resolve_release_passes_the_timeout_through(monkeypatch):
+    """A hung GitHub must not hang the job thread forever."""
+    from darktable_install import resolve_release
+
+    calls = _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
+    _on_supported_platform(monkeypatch)
+
+    assert resolve_release(timeout=3)[1] is None
+    assert calls[0]["timeout"] == 3
+
+    assert resolve_release()[1] is None
+    assert calls[1]["timeout"] == 15
+
+
+def test_resolve_release_reports_network_failure_as_unreachable(monkeypatch):
+    """A dead network must degrade to a plain link, never to a traceback —
+    and never to "no build for your platform", which is a different fact."""
     import urllib.error
     import urllib.request
 
-    from darktable_install import resolve_release
+    from darktable_install import REASON_UNREACHABLE, resolve_release
 
     def boom(req, timeout=None, context=None):
         raise urllib.error.URLError("no route to host")
 
     monkeypatch.setattr(urllib.request, "urlopen", boom)
-    assert resolve_release() is None
+    _on_supported_platform(monkeypatch)
+
+    info, reason = resolve_release()
+    assert info is None
+    assert reason == REASON_UNREACHABLE
+    assert reason == "Could not reach GitHub to check for a darktable release."
 
 
-def test_resolve_release_returns_none_for_unsupported_platform(monkeypatch):
+def test_resolve_release_reports_http_errors_as_unreachable(monkeypatch):
+    """The 60/hr unauthenticated rate limit is a 403, and it is temporary.
+    Telling that user "no build for your platform" sends them away for good."""
+    import urllib.error
+    import urllib.request
+
+    from darktable_install import REASON_UNREACHABLE, resolve_release
+
+    def rate_limited(req, timeout=None, context=None):
+        raise urllib.error.HTTPError(req.full_url, 403, "rate limit exceeded", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", rate_limited)
+    _on_supported_platform(monkeypatch)
+
+    assert resolve_release() == (None, REASON_UNREACHABLE)
+
+
+def test_resolve_release_reports_unsupported_platform_distinctly(monkeypatch):
     import platform as platform_mod
 
-    from darktable_install import resolve_release
+    from darktable_install import REASON_NO_PLATFORM_BUILD, resolve_release
 
-    _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
+    calls = _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
     monkeypatch.setattr(sys, "platform", "freebsd14")
     monkeypatch.setattr(platform_mod, "machine", lambda: "amd64")
 
-    assert resolve_release() is None
+    info, reason = resolve_release()
+    assert info is None
+    assert reason == REASON_NO_PLATFORM_BUILD
+    assert reason == "No darktable build is published for this platform."
+    # No release can ever carry a build for a platform we have no suffix for,
+    # so there is nothing to ask GitHub about.
+    assert calls == []
+
+
+def test_resolve_release_reports_a_release_with_no_usable_asset(monkeypatch):
+    """Supported platform, GitHub answered — but the build is missing from the
+    release. That is neither a network problem nor an unsupported platform."""
+    from darktable_install import REASON_NO_USABLE_ASSET, resolve_release
+
+    release = _release()
+    release["assets"] = [a for a in release["assets"] if not a["name"].endswith(".dmg")]
+    _stub_github(monkeypatch, json.dumps(release).encode("utf-8"))
+    _on_supported_platform(monkeypatch)
+
+    info, reason = resolve_release()
+    assert info is None
+    assert reason == REASON_NO_USABLE_ASSET
+    assert reason == (
+        "The latest darktable release did not contain a usable build for this platform."
+    )
+
+
+def test_resolve_release_survives_select_asset_blowing_up(monkeypatch):
+    """"Never raises" is a contract Task 9's job thread relies on, and it must
+    hold for the whole body — not just the part that talks to the network."""
+    import darktable_install
+    from darktable_install import REASON_UNREACHABLE, resolve_release
+
+    _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
+    _on_supported_platform(monkeypatch)
+
+    def explode(*a, **kw):
+        raise TypeError("a shape select_asset did not anticipate")
+
+    monkeypatch.setattr(darktable_install, "select_asset", explode)
+
+    assert resolve_release() == (None, REASON_UNREACHABLE)
+
+
+@pytest.mark.parametrize("payload,expected_reason", [
+    # Not a release object at all: a rate-limit body, a captive-portal page or
+    # a truncated response. Claiming the release lacked a build would be a lie.
+    (b"[]", "unreachable"),
+    (b"null", "unreachable"),
+    (b'"rate limited"', "unreachable"),
+    (b'{"assets": "nope"}', "unreachable"),
+    (b"<html>Sign in to the hotel wifi</html>", "unreachable"),
+    (b"", "unreachable"),
+    # Well-shaped release whose assets list is junk: we did reach GitHub.
+    (b'{"assets": [1,2]}', "no_usable"),
+])
+def test_resolve_release_never_raises_on_a_malformed_body(monkeypatch, payload, expected_reason):
+    """Task 9's job calls resolve_release() directly, with no except clause of
+    its own, so anything that escapes here crashes the job thread."""
+    from darktable_install import REASON_NO_USABLE_ASSET, REASON_UNREACHABLE, resolve_release
+
+    _stub_github(monkeypatch, payload)
+    _on_supported_platform(monkeypatch)
+
+    info, reason = resolve_release()
+    assert info is None
+    assert reason == (
+        REASON_UNREACHABLE if expected_reason == "unreachable" else REASON_NO_USABLE_ASSET
+    )

--- a/vireo/tests/test_darktable_install.py
+++ b/vireo/tests/test_darktable_install.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import subprocess
 import sys
 
 import pytest
@@ -649,3 +650,403 @@ def test_verify_digest_reports_an_unreadable_file_instead_of_raising(tmp_path):
     ok, detail = verify_digest(str(tmp_path / "does-not-exist.bin"), "sha256:" + HELLO_SHA256)
     assert not ok
     assert "read" in detail.lower()
+
+
+# --- Task 7: install_dir / is_quarantined / hand_off / download / free_space_bytes ---
+
+
+def _completed(returncode=0, stderr=""):
+    """A stand-in for subprocess.run's return value.
+
+    Returning None here instead (a bare recording lambda) would make any test
+    that inspects the exit status pass by accident, so the fake keeps the one
+    field the caller reads.
+    """
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+
+
+def test_install_dir_is_under_vireo_home():
+    from darktable_install import install_dir
+
+    assert install_dir().endswith(os.path.join(".vireo", "tools", "darktable"))
+
+
+def test_install_dir_is_exactly_the_directory_develop_probes(monkeypatch):
+    """Downloading anywhere else would 'install' darktable and still report it
+    missing: darktable_search_paths only lists AppImages in that one dir."""
+    import develop
+    from darktable_install import install_dir
+
+    assert install_dir() == develop.darktable_tools_dir()
+
+    # ...by asking develop every call, not by re-deriving the same string: a
+    # copy would silently keep the old path the day that one moves, and would
+    # ignore a relocated HOME because expansion happened at import time.
+    monkeypatch.setattr(develop, "darktable_tools_dir", lambda: "/somewhere/else")
+    assert install_dir() == "/somewhere/else"
+
+
+def test_hand_off_linux_makes_appimage_executable_and_returns_bin_path(tmp_path):
+    from darktable_install import hand_off
+
+    appimage = tmp_path / "Darktable-5.6.0-x86_64.AppImage"
+    appimage.write_bytes(b"stub")
+    appimage.chmod(0o644)
+
+    result = hand_off(str(appimage), platform_name="linux")
+
+    assert os.access(str(appimage), os.X_OK)
+    assert result["bin_path"] == str(appimage)
+    assert result["action"] == "installed"
+    assert result["location"] == str(appimage)
+
+
+def test_hand_off_macos_opens_dmg_and_sets_no_bin_path(tmp_path, monkeypatch):
+    """macOS cannot know the final path — the user drags the app themselves."""
+    import darktable_install
+    from darktable_install import hand_off
+
+    calls = []
+    monkeypatch.setattr(darktable_install.subprocess, "run",
+                        lambda *a, **k: calls.append(a) or _completed(0))
+
+    dmg = tmp_path / "darktable-5.6.0-arm64.dmg"
+    dmg.write_bytes(b"stub")
+    result = hand_off(str(dmg), platform_name="darwin")
+
+    assert calls, "expected the DMG to be opened"
+    assert list(calls[0][0]) == ["open", str(dmg)]
+    assert result["bin_path"] is None
+    assert result["action"] == "opened-installer"
+    assert result["location"] == str(dmg)
+
+
+def test_hand_off_windows_launches_the_installer_and_sets_no_bin_path(tmp_path, monkeypatch):
+    import darktable_install
+    from darktable_install import hand_off
+
+    opened = []
+    monkeypatch.setattr(darktable_install.os, "startfile",
+                        lambda p: opened.append(p), raising=False)
+
+    exe = tmp_path / "darktable-5.6.0-win64.exe"
+    exe.write_bytes(b"stub")
+    result = hand_off(str(exe), platform_name="win32")
+
+    assert opened == [str(exe)]
+    assert result["bin_path"] is None
+    assert result["action"] == "opened-installer"
+
+
+def test_hand_off_says_so_when_the_installer_could_not_be_opened(tmp_path, monkeypatch):
+    """A corrupt DMG makes `open` fail. Reporting "opened-installer" anyway
+    would leave the user waiting for a window that never appears."""
+    import darktable_install
+    from darktable_install import hand_off
+
+    monkeypatch.setattr(darktable_install.subprocess, "run",
+                        lambda *a, **k: _completed(1, "no mountable file systems"))
+
+    dmg = tmp_path / "darktable-5.6.0-arm64.dmg"
+    dmg.write_bytes(b"stub")
+
+    with pytest.raises(RuntimeError) as exc:
+        hand_off(str(dmg), platform_name="darwin")
+    # The download is still on disk, so the message must name it.
+    assert str(dmg) in str(exc.value)
+
+
+def test_hand_off_default_platform_agrees_with_develop(tmp_path, monkeypatch):
+    """With no override, hand_off must branch the same way darktable_search_paths
+    does — otherwise we chmod a file nothing probes, or open an AppImage."""
+    import darktable_install
+    import develop
+    from darktable_install import hand_off
+
+    monkeypatch.setattr(darktable_install.subprocess, "run", lambda *a, **k: _completed(0))
+    monkeypatch.setattr(darktable_install.os, "startfile", lambda p: None, raising=False)
+
+    artifact = tmp_path / "artifact.bin"
+    artifact.write_bytes(b"stub")
+    artifact.chmod(0o644)
+
+    result = hand_off(str(artifact))
+
+    if develop.darktable_uses_tools_dir():
+        assert result["bin_path"] == str(artifact)
+        assert os.access(str(artifact), os.X_OK)
+    else:
+        assert result["bin_path"] is None
+        assert not os.access(str(artifact), os.X_OK)
+
+
+def test_is_quarantined_false_for_plain_file(tmp_path):
+    """Warn about Gatekeeper only when the attribute is really present.
+
+    urllib downloads are not quarantined (LaunchServices applies that, not
+    urllib), so an unconditional warning would scare users about a dialog
+    they will never see.
+    """
+    from darktable_install import is_quarantined
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"x")
+    assert is_quarantined(str(f)) is False
+
+
+def test_is_quarantined_true_when_xattr_reports_the_attribute(tmp_path, monkeypatch):
+    import darktable_install
+    from darktable_install import is_quarantined
+
+    monkeypatch.setattr(darktable_install.sys, "platform", "darwin")
+    seen = []
+    monkeypatch.setattr(darktable_install.subprocess, "run",
+                        lambda *a, **k: seen.append(a[0]) or _completed(0, ""))
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"x")
+    assert is_quarantined(str(f)) is True
+    assert seen == [["xattr", "-p", "com.apple.quarantine", str(f)]]
+
+
+def test_is_quarantined_false_when_xattr_is_missing(tmp_path, monkeypatch):
+    """Never raise: a missing tool must not fail an otherwise good install."""
+    import darktable_install
+    from darktable_install import is_quarantined
+
+    monkeypatch.setattr(darktable_install.sys, "platform", "darwin")
+
+    def boom(*a, **k):
+        raise FileNotFoundError("xattr")
+
+    monkeypatch.setattr(darktable_install.subprocess, "run", boom)
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"x")
+    assert is_quarantined(str(f)) is False
+
+
+def test_is_quarantined_does_not_shell_out_off_macos(tmp_path, monkeypatch):
+    import darktable_install
+    from darktable_install import is_quarantined
+
+    monkeypatch.setattr(darktable_install.sys, "platform", "linux")
+
+    # Recorded, not raised: is_quarantined swallows every exception, so a stub
+    # that raises would be absorbed and the test would pass with the check gone.
+    seen = []
+    monkeypatch.setattr(darktable_install.subprocess, "run",
+                        lambda *a, **k: seen.append(a) or _completed(0))
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"x")
+    assert is_quarantined(str(f)) is False
+    assert seen == [], "xattr is macOS-only; do not run it elsewhere"
+
+
+def _asset(payload, **overrides):
+    asset = {
+        "name": "darktable-5.6.0-arm64.dmg",
+        "url": "https://github.com/darktable-org/darktable/releases/download/"
+               "release-5.6.0/darktable-5.6.0-arm64.dmg",
+        "size": len(payload),
+        "digest": "sha256:" + hashlib.sha256(payload).hexdigest(),
+    }
+    asset.update(overrides)
+    return asset
+
+
+def _stub_download(monkeypatch, payload=b"", *, record=None, raises=None):
+    """Replace the real network download. No test may touch the network."""
+    import taxonomy
+
+    def fake(url, dest_path, **kwargs):
+        if record is not None:
+            record.append({"url": url, "dest_path": dest_path, **kwargs})
+        if raises is not None:
+            # Mirror the real function: a cancelled download leaves its
+            # .partial behind (0 bytes when cancelled before the first read).
+            open(dest_path + ".partial", "wb").close()
+            raise raises
+        with open(dest_path, "wb") as f:
+            f.write(payload)
+        return dest_path
+
+    monkeypatch.setattr(taxonomy, "_download_with_resume", fake)
+
+
+def test_download_writes_the_asset_and_returns_the_verification_detail(tmp_path, monkeypatch):
+    from darktable_install import download
+
+    payload = b"darktable" * 100
+    _stub_download(monkeypatch, payload)
+
+    path, detail = download(_asset(payload), dest_dir=str(tmp_path))
+
+    assert path == str(tmp_path / "darktable-5.6.0-arm64.dmg")
+    assert open(path, "rb").read() == payload
+    assert "SHA256 matches" in detail
+
+
+def test_download_defaults_to_install_dir_and_creates_it(tmp_path, monkeypatch):
+    import darktable_install
+    from darktable_install import download
+
+    payload = b"x" * 64
+    _stub_download(monkeypatch, payload)
+    target = tmp_path / "nested" / "tools" / "darktable"
+    monkeypatch.setattr(darktable_install, "install_dir", lambda: str(target))
+
+    path, _detail = download(_asset(payload))
+
+    assert path == str(target / "darktable-5.6.0-arm64.dmg")
+    assert os.path.isfile(path)
+
+
+def test_download_deletes_the_file_and_raises_on_a_size_mismatch(tmp_path, monkeypatch):
+    """A wrong-length artifact must never reach an installer."""
+    from darktable_install import download
+
+    payload = b"short"
+    _stub_download(monkeypatch, payload)
+
+    with pytest.raises(RuntimeError) as exc:
+        download(_asset(payload, size=999999), dest_dir=str(tmp_path))
+
+    assert "size mismatch" in str(exc.value).lower()
+    assert not os.path.exists(str(tmp_path / "darktable-5.6.0-arm64.dmg")), (
+        "the bad download must be deleted, not left for the installer"
+    )
+
+
+def test_download_deletes_the_file_and_raises_on_a_digest_mismatch(tmp_path, monkeypatch):
+    from darktable_install import download
+
+    payload = b"y" * 32
+    _stub_download(monkeypatch, payload)
+    wrong = "sha256:" + hashlib.sha256(b"something else").hexdigest()
+
+    with pytest.raises(RuntimeError) as exc:
+        download(_asset(payload, digest=wrong), dest_dir=str(tmp_path))
+
+    assert "mismatch" in str(exc.value).lower()
+    assert not os.path.exists(str(tmp_path / "darktable-5.6.0-arm64.dmg")), (
+        "the bad download must be deleted, not left for the installer"
+    )
+
+
+def test_download_returns_the_unverified_detail_verbatim(tmp_path, monkeypatch):
+    """verify_digest returns ok=True for a *missing* digest too, so download
+    must pass its sentence through rather than inventing 'verified' wording."""
+    from darktable_install import download, verify_digest
+
+    payload = b"z" * 16
+    _stub_download(monkeypatch, payload)
+
+    path, detail = download(_asset(payload, digest=None), dest_dir=str(tmp_path))
+
+    assert detail == verify_digest(path, None)[1]
+    assert "could not be verified" in detail
+    assert "matches" not in detail
+
+
+def test_download_forwards_progress_and_cancellation_hooks(tmp_path, monkeypatch):
+    """byte_callback and should_cancel are keyword-only on _download_with_resume;
+    dropping either silently kills the progress bar and the Cancel button."""
+    from darktable_install import download
+
+    payload = b"w" * 8
+    record = []
+    _stub_download(monkeypatch, payload, record=record)
+
+    def on_bytes(done, total):
+        pass
+
+    def cancelled():
+        return False
+
+    download(_asset(payload), dest_dir=str(tmp_path),
+             byte_callback=on_bytes, should_cancel=cancelled)
+
+    assert len(record) == 1
+    assert record[0]["url"] == _asset(payload)["url"]
+    assert record[0]["byte_callback"] is on_bytes
+    assert record[0]["should_cancel"] is cancelled
+
+
+def test_download_propagates_cancellation_and_keeps_the_empty_partial(tmp_path, monkeypatch):
+    """should_cancel is checked before the first read, so an immediately
+    cancelled download leaves a 0-byte .partial. That is a normal resume
+    state, not corruption: keep it and let the cancel surface as itself."""
+    import taxonomy
+    from darktable_install import download
+
+    _stub_download(monkeypatch, raises=taxonomy.DownloadCancelled("Download cancelled"))
+
+    with pytest.raises(taxonomy.DownloadCancelled):
+        download(_asset(b"q" * 8), dest_dir=str(tmp_path), should_cancel=lambda: True)
+
+    partial = tmp_path / "darktable-5.6.0-arm64.dmg.partial"
+    assert partial.exists(), "the .partial must survive for resume"
+    assert partial.stat().st_size == 0
+    assert not (tmp_path / "darktable-5.6.0-arm64.dmg").exists()
+
+
+def test_free_space_bytes_creates_the_directory_and_reports_free_not_total(
+    tmp_path, monkeypatch
+):
+    import collections
+
+    import darktable_install
+
+    usage = collections.namedtuple("usage", "total used free")
+    seen = []
+    monkeypatch.setattr(darktable_install.shutil, "disk_usage",
+                        lambda p: seen.append(p) or usage(total=100, used=70, free=30))
+
+    target = tmp_path / "made" / "here"
+    assert darktable_install.free_space_bytes(str(target)) == 30
+    assert os.path.isdir(str(target))
+    assert seen == [str(target)]
+
+
+def test_free_space_bytes_returns_a_real_number_on_this_filesystem(tmp_path):
+    from darktable_install import free_space_bytes
+
+    assert free_space_bytes(str(tmp_path / "sub")) > 0
+
+
+def test_download_refuses_an_asset_name_that_escapes_the_directory(tmp_path, monkeypatch):
+    """The name is API-supplied. Joining it unchecked would let one write
+    outside the tools dir — every other field from that response is already
+    constrained, and this one must be too."""
+    from darktable_install import download
+
+    payload = b"p" * 8
+    called = []
+    _stub_download(monkeypatch, payload, record=called)
+
+    with pytest.raises(RuntimeError) as exc:
+        download(_asset(payload, name="../escaped.dmg"), dest_dir=str(tmp_path / "dl"))
+
+    assert "suspicious" in str(exc.value).lower()
+    assert called == [], "nothing should be fetched for a rejected name"
+    assert not os.path.exists(str(tmp_path / "escaped.dmg"))
+
+
+def test_hand_off_does_not_write_config(tmp_path, monkeypatch):
+    """bin_path is *returned* so the job handler writes darktable_bin in one
+    place, next to the message that tells the user it happened."""
+    import config as cfg
+    from darktable_install import hand_off
+
+    def boom(*a, **k):
+        raise AssertionError("hand_off must not write config")
+
+    monkeypatch.setattr(cfg, "set", boom)
+    monkeypatch.setattr(cfg, "save", boom)
+
+    appimage = tmp_path / "Darktable-5.6.0-x86_64.AppImage"
+    appimage.write_bytes(b"stub")
+    result = hand_off(str(appimage), platform_name="linux")
+    assert result["bin_path"] == str(appimage)

--- a/vireo/tests/test_darktable_install.py
+++ b/vireo/tests/test_darktable_install.py
@@ -652,6 +652,78 @@ def test_verify_digest_reports_an_unreadable_file_instead_of_raising(tmp_path):
     assert "read" in detail.lower()
 
 
+def test_verify_digest_honors_should_cancel_between_chunks(tmp_path):
+    """Hashing an ~178MB AppImage takes long enough that a Stop press during
+    it must not have to wait for the whole file to finish before the job
+    reports cancelled.  A True from should_cancel raises DownloadCancelled so
+    the caller (download()) propagates it out to the job runner."""
+    import taxonomy
+    from darktable_install import verify_digest
+
+    # Big enough to span several chunks (chunk size is 1MB).
+    payload = bytes(range(256)) * (5 * 1024)  # 1.25MB
+    f = tmp_path / "big.bin"
+    f.write_bytes(payload)
+
+    with pytest.raises(taxonomy.DownloadCancelled):
+        verify_digest(
+            str(f),
+            "sha256:" + hashlib.sha256(payload).hexdigest(),
+            should_cancel=lambda: True,
+        )
+
+
+def test_verify_digest_does_not_call_should_cancel_when_none(tmp_path):
+    """The signature change must be backwards compatible: existing callers
+    that pass no should_cancel keep working."""
+    from darktable_install import verify_digest
+
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"hello")
+    ok, detail = verify_digest(str(f), "sha256:" + HELLO_SHA256)
+    assert ok, detail
+
+
+def test_download_passes_should_cancel_through_to_verify_digest(tmp_path, monkeypatch):
+    """A cancel that arrives during the ~178MB hash must reach verify_digest,
+    not only the network read.  Without threading should_cancel through, the
+    Stop button appears dead for the whole verification phase."""
+    import darktable_install
+    import taxonomy
+    from darktable_install import download
+
+    payload = b"z" * 64
+    _stub_download(monkeypatch, payload)
+
+    seen = []
+
+    def spy_verify(path, expected, *, should_cancel=None):
+        seen.append(should_cancel)
+        return True, "ok"
+
+    monkeypatch.setattr(darktable_install, "verify_digest", spy_verify)
+
+    def sentinel_cancel():
+        return False
+
+    download(
+        _asset(payload), dest_dir=str(tmp_path),
+        should_cancel=sentinel_cancel,
+    )
+    assert seen == [sentinel_cancel], (
+        "download() must forward its should_cancel into verify_digest"
+    )
+
+    # And a cancel from verify_digest propagates as DownloadCancelled,
+    # not swallowed into a RuntimeError that would report as "failed".
+    def cancelling_verify(path, expected, *, should_cancel=None):
+        raise taxonomy.DownloadCancelled("cancelled during hash")
+
+    monkeypatch.setattr(darktable_install, "verify_digest", cancelling_verify)
+    with pytest.raises(taxonomy.DownloadCancelled):
+        download(_asset(payload), dest_dir=str(tmp_path))
+
+
 # --- Task 7: install_dir / is_quarantined / hand_off / download / free_space_bytes ---
 
 

--- a/vireo/tests/test_darktable_install.py
+++ b/vireo/tests/test_darktable_install.py
@@ -1128,3 +1128,123 @@ def test_hand_off_does_not_write_config(tmp_path, monkeypatch):
     appimage.write_bytes(b"stub")
     result = hand_off(str(appimage), platform_name="linux")
     assert result["bin_path"] == str(appimage)
+
+
+def test_download_reuses_a_completed_file_after_a_hash_cancellation(
+    tmp_path, monkeypatch
+):
+    """A Stop pressed during verify_digest leaves the finished file at dest
+    (``.partial`` was already renamed) and no ``.partial`` to resume from.
+    The next attempt must re-verify that file instead of downloading the
+    whole 87-178 MB asset all over again — the UI promises retry will
+    resume, and re-fetching everything violates that promise."""
+    from darktable_install import download
+
+    payload = b"already-here" * 100
+    dest = tmp_path / "darktable-5.6.0-arm64.dmg"
+    dest.write_bytes(payload)
+
+    def must_not_download(*a, **k):
+        raise AssertionError(
+            "download must reuse the complete dest file, not re-fetch it"
+        )
+
+    import taxonomy
+    monkeypatch.setattr(taxonomy, "_download_with_resume", must_not_download)
+
+    path, detail = download(_asset(payload), dest_dir=str(tmp_path))
+
+    assert path == str(dest)
+    assert dest.read_bytes() == payload, "the reused file must not be truncated"
+    assert "SHA256 matches" in detail
+
+
+def test_download_reuses_only_when_size_matches_exactly(tmp_path, monkeypatch):
+    """A file at dest with the wrong size is NOT the completed artifact —
+    a partial write left over from an unrelated crash, or a random file
+    the user dropped in the tools directory. Skipping the fetch there
+    would either accept a wrong-length file, or trigger the size-mismatch
+    branch that deletes a file the user might have wanted to keep. So the
+    reuse fast-path must gate strictly on the API-supplied size."""
+    from darktable_install import download
+
+    payload = b"real-content" * 100
+    dest = tmp_path / "darktable-5.6.0-arm64.dmg"
+    # Wrong size on disk — must NOT be reused.
+    dest.write_bytes(b"leftover-junk")
+
+    fetched = {"called": False}
+
+    def fake(url, dest_path, **kwargs):
+        fetched["called"] = True
+        # Real fetch overwrites the leftover with the real payload.
+        with open(dest_path, "wb") as f:
+            f.write(payload)
+        return dest_path
+
+    import taxonomy
+    monkeypatch.setattr(taxonomy, "_download_with_resume", fake)
+
+    path, detail = download(_asset(payload), dest_dir=str(tmp_path))
+
+    assert fetched["called"], (
+        "a wrong-length existing file must not be treated as the completed asset"
+    )
+    assert path == str(dest)
+    assert dest.read_bytes() == payload
+    assert "SHA256 matches" in detail
+
+
+def test_download_emits_final_byte_progress_when_reusing(tmp_path, monkeypatch):
+    """Reusing a completed file must still push a final byte_callback so
+    the UI's progress bar jumps to 100% instead of stalling at whatever
+    the previous run last reported. Silent reuse looks identical to a
+    hung download."""
+    from darktable_install import download
+
+    payload = b"cached-bytes" * 10
+    dest = tmp_path / "darktable-5.6.0-arm64.dmg"
+    dest.write_bytes(payload)
+
+    def must_not_download(*a, **k):
+        raise AssertionError("reused file must not trigger a fetch")
+
+    import taxonomy
+    monkeypatch.setattr(taxonomy, "_download_with_resume", must_not_download)
+
+    seen = []
+    download(
+        _asset(payload), dest_dir=str(tmp_path),
+        byte_callback=lambda done, total: seen.append((done, total)),
+    )
+
+    assert seen, "byte_callback must fire even on the reuse path"
+    # Whatever intermediate values the reuse path emits, the final one must
+    # be "complete": otherwise the UI has no signal that the phase is done.
+    assert seen[-1] == (len(payload), len(payload))
+
+
+def test_download_verify_failure_deletes_a_reused_file(tmp_path, monkeypatch):
+    """Reuse is a shortcut — it does not skip verification. A corrupt file
+    at dest with the right SIZE but the wrong BYTES must be deleted, same
+    as a corrupt fresh download. Otherwise the reuse fast-path would
+    become a way for a bad file to survive across attempts."""
+    from darktable_install import download
+
+    payload = b"real" * 100
+    dest = tmp_path / "darktable-5.6.0-arm64.dmg"
+    # Same length as payload, but different bytes → digest won't match.
+    dest.write_bytes(b"corr" * 100)
+
+    def must_not_download(*a, **k):
+        raise AssertionError("reused file must not trigger a fetch")
+
+    import taxonomy
+    monkeypatch.setattr(taxonomy, "_download_with_resume", must_not_download)
+
+    with pytest.raises(RuntimeError) as exc:
+        download(_asset(payload), dest_dir=str(tmp_path))
+    assert "mismatch" in str(exc.value).lower()
+    assert not dest.exists(), (
+        "a corrupt reused file must be deleted, same as a corrupt fresh one"
+    )

--- a/vireo/tests/test_darktable_install.py
+++ b/vireo/tests/test_darktable_install.py
@@ -413,6 +413,135 @@ def test_resolve_release_never_raises_on_a_malformed_body(monkeypatch, payload, 
 
 
 # --------------------------------------------------------------------------
+# resolve_release_cached — cache-hit, TTL expiry, and "only successes cached"
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def _clean_release_cache():
+    """Reset the module-level cache before and after each cache test.
+
+    Cache state leaks across tests would otherwise turn a hit into a miss
+    (or vice versa) depending on which test ran first.
+    """
+    import darktable_install
+
+    darktable_install._release_cache.update(at=0.0, value=None)
+    yield
+    darktable_install._release_cache.update(at=0.0, value=None)
+
+
+def test_resolve_release_cached_hits_return_the_stored_value(
+    monkeypatch, _clean_release_cache,
+):
+    """A second call within the TTL must not hit the network."""
+    import darktable_install
+    from darktable_install import resolve_release_cached
+
+    calls = _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
+    _on_supported_platform(monkeypatch)
+
+    # Freeze the clock so the second call is guaranteed to be inside the TTL.
+    monkeypatch.setattr(darktable_install.time, "monotonic", lambda: 100.0)
+
+    first, first_reason = resolve_release_cached()
+    second, second_reason = resolve_release_cached()
+
+    assert first_reason is None and second_reason is None
+    assert first is second
+    assert len(calls) == 1
+
+
+def test_resolve_release_cached_expires_after_ttl(
+    monkeypatch, _clean_release_cache,
+):
+    """Past _RELEASE_CACHE_SECS the cache must be re-fetched, not served stale.
+
+    Without this the panel could keep showing a build for ten minutes after
+    darktable-org shipped a new release, and the POST would then 409 the user
+    who confirmed the stale one.
+    """
+    import darktable_install
+    from darktable_install import resolve_release_cached
+
+    calls = _stub_github(monkeypatch, json.dumps(_release()).encode("utf-8"))
+    _on_supported_platform(monkeypatch)
+
+    clock = {"now": 100.0}
+    monkeypatch.setattr(darktable_install.time, "monotonic", lambda: clock["now"])
+
+    resolve_release_cached()
+    clock["now"] += darktable_install._RELEASE_CACHE_SECS + 1
+    resolve_release_cached()
+
+    assert len(calls) == 2
+
+
+def test_resolve_release_cached_only_caches_successes(
+    monkeypatch, _clean_release_cache,
+):
+    """A transient failure must not pin the fallback link and its reason
+    string. The user who fixed their network within the TTL would otherwise
+    keep being told GitHub is unreachable long after it started working."""
+    import urllib.error
+    import urllib.request
+
+    import darktable_install
+    from darktable_install import REASON_UNREACHABLE, resolve_release_cached
+
+    _on_supported_platform(monkeypatch)
+    monkeypatch.setattr(darktable_install.time, "monotonic", lambda: 100.0)
+
+    call_count = {"n": 0}
+
+    def flaky(req, timeout=None, context=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise urllib.error.URLError("no route to host")
+        return _FakeResponse(json.dumps(_release()).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "urlopen", flaky)
+
+    first, first_reason = resolve_release_cached()
+    assert first is None
+    assert first_reason == REASON_UNREACHABLE
+    assert darktable_install._release_cache["value"] is None
+
+    second, second_reason = resolve_release_cached()
+    assert second is not None
+    assert second_reason is None
+    assert call_count["n"] == 2
+
+
+def test_update_release_cache_overwrites_a_stale_entry(_clean_release_cache):
+    """The download endpoint calls update_release_cache after its own uncached
+    resolve_release proves the cached value stale; the next /install/available
+    must see the fresh asset instead of the ten-minute-old one."""
+    from darktable_install import resolve_release_cached, update_release_cache
+
+    fresh = {"version": "9.9.9", "name": "fresh.dmg", "size": 1, "url": "https://example/x", "digest": None}
+    update_release_cache(fresh)
+
+    cached, reason = resolve_release_cached()
+    assert reason is None
+    assert cached is fresh
+
+
+def test_update_release_cache_ignores_a_falsy_release(_clean_release_cache):
+    """A failed resolution must never pin the fallback link — mirrors
+    resolve_release_cached's own only-cache-successes rule."""
+    import darktable_install
+    from darktable_install import update_release_cache
+
+    update_release_cache(None)
+    assert darktable_install._release_cache["value"] is None
+
+    fresh = {"version": "9.9.9", "name": "fresh.dmg", "size": 1, "url": "https://example/x"}
+    update_release_cache(fresh)
+    update_release_cache({})
+    assert darktable_install._release_cache["value"] is fresh
+
+
+# --------------------------------------------------------------------------
 # verify_digest
 # --------------------------------------------------------------------------
 

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -923,6 +923,61 @@ def test_develop_photo_appimage_extracted_cache_recovers_from_deleted_tree(tmp_p
     assert str(fake_bin) not in develop._APPIMAGE_APPRUN_CACHE
 
 
+def test_develop_photo_appimage_extracted_cache_reprobes_when_source_is_newer(tmp_path, monkeypatch):
+    """When the source AppImage is replaced in place (in-place Vireo update,
+    manual overwrite), the cached extraction points at the OLD darktable
+    version. Reusing it silently would keep running the old build until the
+    process restarts — same failure mode _extract_appimage_once already
+    guards against with the mtime check. Verify the develop_photo cache
+    branch checks it too.
+    """
+    import subprocess
+
+    import develop
+
+    develop._APPIMAGE_MODE_CACHE.clear()
+    develop._APPIMAGE_APPRUN_CACHE.clear()
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+    out = tmp_path / "out" / "bird.jpg"
+
+    # Pre-seed the cache with a real, executable AppRun. The mtime check is
+    # what should invalidate it, not the exec/exists check.
+    stale_apprun_dir = tmp_path / "old_extraction" / "squashfs-root"
+    stale_apprun_dir.mkdir(parents=True)
+    stale_apprun = stale_apprun_dir / "AppRun"
+    stale_apprun.write_text("#!/bin/sh\nexec /old/darktable-cli \"$@\"\n")
+    stale_apprun.chmod(0o755)
+    # Make the AppRun clearly older than the source.
+    ancient = os.path.getmtime(str(fake_bin)) - 3600
+    os.utime(str(stale_apprun), (ancient, ancient))
+
+    develop._APPIMAGE_MODE_CACHE[str(fake_bin)] = "extracted"
+    develop._APPIMAGE_APPRUN_CACHE[str(fake_bin)] = str(stale_apprun)
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        # The stale AppRun must not be invoked; the cache should have been
+        # evicted and the re-probe should take the direct path.
+        assert cmd[0] != str(stale_apprun)
+        os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
+        with open(cmd[-1], "w") as f:
+            f.write("jpg")
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert result["success"] is True
+    # The stale cache entries were cleared and the re-probe succeeded direct.
+    assert develop._APPIMAGE_MODE_CACHE[str(fake_bin)] == "direct"
+    assert str(fake_bin) not in develop._APPIMAGE_APPRUN_CACHE
+
+
 def test_develop_photo_appimage_non_fuse_failure_is_not_retried(tmp_path, monkeypatch):
     """A darktable-side failure (bad RAW, missing style, etc.) must NOT be
     retried under APPIMAGE_EXTRACT_AND_RUN — that would waste a full squashfs

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
@@ -515,6 +517,15 @@ def test_darktable_search_paths_linux_ignores_non_appimages(tmp_path, monkeypatc
     assert darktable_search_paths() == [str(appimage)]
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason=(
+        "Windows has no POSIX exec bit — os.access(_, X_OK) returns True for "
+        "any readable file regardless of chmod, so the abandoned 0o644 "
+        "AppImage cannot be distinguished from the installed 0o755 one here. "
+        "The gate itself is only reachable on the Linux branch in production."
+    ),
+)
 def test_darktable_search_paths_linux_ignores_non_executable_appimages(tmp_path, monkeypatch):
     """A download cancelled during digest verification leaves the AppImage at
     its final path but with the default non-executable mode (hand_off never

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -550,3 +550,71 @@ def test_darktable_search_paths_linux_survives_vanishing_appimage(tmp_path, monk
     paths = darktable_search_paths()
     assert str(survivor) in paths
     assert paths[0] == str(survivor)
+
+
+def test_build_command_selects_cli_inside_appimage():
+    """darktable's AppImage picks its binary from argv[1]; without this we
+    would launch the GUI and hang the export job."""
+    from develop import build_command
+
+    cmd = build_command(
+        "/home/u/.vireo/tools/darktable/Darktable-5.6.0-x86_64.AppImage",
+        "in.raw", "out.jpg",
+    )
+    assert cmd[1] == "darktable-cli"
+    assert cmd[2:] == ["in.raw", "out.jpg"]
+
+
+def test_build_command_plain_binary_unchanged():
+    from develop import build_command
+
+    cmd = build_command("/usr/bin/darktable-cli", "in.raw", "out.jpg")
+    assert cmd == ["/usr/bin/darktable-cli", "in.raw", "out.jpg"]
+
+
+def test_build_command_appimage_keeps_style_and_width():
+    """Optional args must land after the positional args, not before."""
+    from develop import build_command
+
+    cmd = build_command("/x/D.AppImage", "in.raw", "out.jpg", style="Wild", width=2048)
+    assert cmd == ["/x/D.AppImage", "darktable-cli", "in.raw", "out.jpg",
+                   "--style", "Wild", "--width", "2048"]
+
+
+def test_develop_photo_sets_appimage_extract_and_run(tmp_path, monkeypatch):
+    """AppImages need FUSE2 to self-mount; distros shipping only FUSE3 fail
+    outright unless APPIMAGE_EXTRACT_AND_RUN is set. The rest of the parent
+    environment must survive — darktable needs HOME, XDG_*, DISPLAY, etc.
+    """
+    import subprocess
+
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = tmp_path / "Darktable-5.6.0-x86_64.AppImage"
+    fake_bin.touch()
+    fake_bin.chmod(0o755)
+    out = tmp_path / "out" / "bird.jpg"
+
+    monkeypatch.setenv("VIREO_TEST_INHERITED_VAR", "inherited-value")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
+        with open(cmd[-1], "w") as f:
+            f.write("jpg")
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert result["success"] is True
+
+    env = captured["env"]
+    assert env is not None, "subprocess.run was called without an env"
+    assert env["APPIMAGE_EXTRACT_AND_RUN"] == "1"
+    # Not a bare dict: the parent environment is carried through.
+    assert env["VIREO_TEST_INHERITED_VAR"] == "inherited-value"
+    assert set(os.environ) <= set(env)

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -463,16 +463,16 @@ def _force_linux_tools_dir(monkeypatch, tools_dir):
 
     A Linux box is os.name == "posix" *and* sys.platform == "linux"; pin both
     so this exercises the AppImage branch on macOS and Windows CI legs too.
+
+    Redirects darktable_tools_dir() rather than patching expanduser: the
+    function composes the path with os.path.join for native separators, so
+    an expanduser mock keyed on a specific literal would no longer intercept.
     """
     import develop
 
     monkeypatch.setattr(develop.os, "name", "posix")
     monkeypatch.setattr("sys.platform", "linux")
-    monkeypatch.setattr(
-        develop.os.path,
-        "expanduser",
-        lambda p: str(tools_dir) if p == "~/.vireo/tools/darktable" else p,
-    )
+    monkeypatch.setattr(develop, "darktable_tools_dir", lambda: str(tools_dir))
 
 
 def test_darktable_search_paths_linux_orders_appimages_newest_first(tmp_path, monkeypatch):

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -9,6 +9,8 @@ def test_find_darktable_returns_none_when_missing(monkeypatch):
     from develop import find_darktable
 
     monkeypatch.setattr("shutil.which", lambda x: None)
+    import develop
+    monkeypatch.setattr(develop, "darktable_search_paths", list)
     assert find_darktable("") is None
 
 
@@ -73,6 +75,8 @@ def test_find_darktable_returns_none_for_bad_configured_path(monkeypatch):
     from develop import find_darktable
 
     monkeypatch.setattr("shutil.which", lambda x: None)
+    import develop
+    monkeypatch.setattr(develop, "darktable_search_paths", list)
     assert find_darktable("/nonexistent/darktable-cli") is None
 
 
@@ -403,3 +407,52 @@ def test_develop_photo_reports_missing_dng_converter_for_nikon_he(tmp_path, monk
     assert "Nikon High Efficiency NEF" in result["error"]
     assert "DNG conversion failed" in result["error"]
     assert "download it from Adobe" in result["error"]
+
+
+def test_find_darktable_finds_macos_app_bundle(monkeypatch):
+    """A normal macOS .dmg install is found even though it is not on PATH."""
+    import develop
+    from develop import find_darktable
+
+    bundle = "/Applications/darktable.app/Contents/MacOS/darktable-cli"
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    # A Mac is os.name == "posix" *and* sys.platform == "darwin". Pin both, or
+    # this test exercises the Windows branch on the windows-latest CI leg.
+    monkeypatch.setattr(develop.os, "name", "posix")
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr("os.path.isfile", lambda p: p == bundle)
+    monkeypatch.setattr("os.path.realpath", lambda p: p)
+
+    assert find_darktable("") == bundle
+
+
+def test_find_darktable_configured_path_wins_over_bundle(tmp_path, monkeypatch):
+    """An explicitly configured path takes precedence over the bundle probe."""
+    from develop import find_darktable
+
+    configured = tmp_path / "darktable-cli"
+    configured.touch()
+    monkeypatch.setattr("sys.platform", "darwin")
+
+    assert find_darktable(str(configured)) == str(configured)
+
+
+def test_darktable_search_paths_matches_find_darktable(monkeypatch):
+    """checked_paths cannot drift from what find_darktable actually probes.
+
+    Every candidate reported to the user must be one find_darktable would
+    accept; otherwise the "we checked here" message is a lie.
+    """
+    import develop
+    from develop import darktable_search_paths, find_darktable
+
+    monkeypatch.setattr("shutil.which", lambda x: None)
+    monkeypatch.setattr(develop.os, "name", "posix")
+    monkeypatch.setattr("sys.platform", "darwin")
+    paths = darktable_search_paths()
+    assert paths, "expected at least one candidate on darwin"
+
+    for candidate in paths:
+        monkeypatch.setattr("os.path.isfile", lambda p, c=candidate: p == c)
+        monkeypatch.setattr("os.path.realpath", lambda p: p)
+        assert find_darktable("") == candidate

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -485,6 +485,10 @@ def test_darktable_search_paths_linux_orders_appimages_newest_first(tmp_path, mo
     newer = tools_dir / "darktable-5.0.AppImage"
     older.write_bytes(b"old")
     newer.write_bytes(b"new")
+    # Match hand_off's post-download chmod: search_paths gates on the exec
+    # bit precisely to skip AppImages that never got there.
+    older.chmod(0o755)
+    newer.chmod(0o755)
     os.utime(older, (1_000_000, 1_000_000))
     os.utime(newer, (2_000_000, 2_000_000))
 
@@ -501,6 +505,7 @@ def test_darktable_search_paths_linux_ignores_non_appimages(tmp_path, monkeypatc
     tools_dir.mkdir(parents=True)
     appimage = tools_dir / "darktable-5.0.AppImage"
     appimage.write_bytes(b"app")
+    appimage.chmod(0o755)
     (tools_dir / "darktable-5.0.AppImage.part").write_bytes(b"partial")
     (tools_dir / "SHA256SUMS").write_bytes(b"sums")
     (tools_dir / "README.txt").write_bytes(b"readme")
@@ -508,6 +513,28 @@ def test_darktable_search_paths_linux_ignores_non_appimages(tmp_path, monkeypatc
     _force_linux_tools_dir(monkeypatch, tools_dir)
 
     assert darktable_search_paths() == [str(appimage)]
+
+
+def test_darktable_search_paths_linux_ignores_non_executable_appimages(tmp_path, monkeypatch):
+    """A download cancelled during digest verification leaves the AppImage at
+    its final path but with the default non-executable mode (hand_off never
+    ran the chmod).  find_darktable would otherwise report the abandoned file
+    as darktable — the Try again button would hide and every RAW export would
+    invoke darktable-cli on an unrunnable file."""
+    from develop import darktable_search_paths
+
+    tools_dir = tmp_path / "tools" / "darktable"
+    tools_dir.mkdir(parents=True)
+    installed = tools_dir / "darktable-5.6.AppImage"
+    abandoned = tools_dir / "darktable-5.7.AppImage"
+    installed.write_bytes(b"app")
+    installed.chmod(0o755)
+    abandoned.write_bytes(b"app")
+    abandoned.chmod(0o644)  # what urllib leaves it as; hand_off's chmod never ran
+
+    _force_linux_tools_dir(monkeypatch, tools_dir)
+
+    assert darktable_search_paths() == [str(installed)]
 
 
 def test_darktable_search_paths_linux_missing_dir_is_empty(tmp_path, monkeypatch):
@@ -534,7 +561,9 @@ def test_darktable_search_paths_linux_survives_vanishing_appimage(tmp_path, monk
     survivor = tools_dir / "darktable-5.0.AppImage"
     vanished = tools_dir / "darktable-4.6.AppImage"
     survivor.write_bytes(b"app")
+    survivor.chmod(0o755)
     vanished.write_bytes(b"doomed")
+    vanished.chmod(0o755)
 
     _force_linux_tools_dir(monkeypatch, tools_dir)
 

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -1056,6 +1056,113 @@ def test_extract_appimage_once_returns_none_when_subprocess_fails(tmp_path, monk
     assert not os.path.exists(str(fake_bin) + ".extracted")
 
 
+def test_extract_appimage_once_serializes_concurrent_calls(tmp_path, monkeypatch):
+    """Two concurrent workers for the same binary must not race on the
+    shared <binary>.extracted directory: the extraction subprocess runs
+    exactly once and both callers get the same valid AppRun.
+    """
+    import subprocess
+    import threading
+
+    import develop
+
+    develop._APPIMAGE_EXTRACT_LOCKS.clear()
+
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+
+    subprocess_started = threading.Event()
+    allow_finish = threading.Event()
+    call_count = 0
+    call_count_lock = threading.Lock()
+
+    def fake_run(cmd, **kwargs):
+        nonlocal call_count
+        with call_count_lock:
+            call_count += 1
+        subprocess_started.set()
+        # Hold the "extraction subprocess" open long enough that a second
+        # concurrent caller has time to enter _extract_appimage_once. Without
+        # the per-binary lock, that second caller would rmtree the extract_dir
+        # while this thread's fake_run is still writing into it.
+        assert allow_finish.wait(timeout=5.0), "test lock never released"
+        root = os.path.join(kwargs["cwd"], "squashfs-root")
+        os.makedirs(root, exist_ok=True)
+        apprun = os.path.join(root, "AppRun")
+        with open(apprun, "w") as f:
+            f.write("#!/bin/sh\nexec /usr/bin/darktable-cli \"$@\"\n")
+        os.chmod(apprun, 0o755)
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    results = {}
+
+    def worker(key):
+        results[key] = develop._extract_appimage_once(str(fake_bin))
+
+    t1 = threading.Thread(target=worker, args=("a",))
+    t2 = threading.Thread(target=worker, args=("b",))
+    t1.start()
+    assert subprocess_started.wait(timeout=5.0), "first extraction never started"
+    t2.start()
+    # Give the second thread a moment to reach the lock — if the lock is
+    # missing, it will race ahead and rmtree the extract_dir the first
+    # thread is still populating.
+    allow_finish.set()
+    t1.join(timeout=5.0)
+    t2.join(timeout=5.0)
+
+    assert not t1.is_alive() and not t2.is_alive()
+    assert call_count == 1, "extraction subprocess must run exactly once"
+    assert results["a"] is not None
+    assert results["b"] == results["a"]
+    assert os.path.isfile(results["a"])
+
+
+def test_extract_appimage_once_returns_none_when_disk_is_full(tmp_path, monkeypatch):
+    """Extraction must not proceed when the disk cannot fit the unpacked
+    tree — the download preflight only reserves ~2x the compressed AppImage
+    size, but the extracted tree is ~3.5x. Returning None here lets the
+    caller fall back to per-run APPIMAGE_EXTRACT_AND_RUN mode rather than
+    half-extracting and failing mid-batch.
+    """
+    import subprocess
+
+    import develop
+
+    develop._APPIMAGE_EXTRACT_LOCKS.clear()
+
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+    # Pad the AppImage to a size where the space check kicks in on realistic
+    # disks; the test then reports free space below that so extraction is
+    # rejected before the subprocess is invoked.
+    with open(fake_bin, "r+b") as f:
+        f.seek(1024 * 1024 - 1)
+        f.write(b"\x00")
+
+    ran = []
+
+    def fake_run(cmd, **kwargs):
+        ran.append(list(cmd))
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # Report free space smaller than the required multiple. shutil.disk_usage
+    # returns a named tuple, so a plain object with the same attributes works.
+    class _StingyUsage:
+        total = 10 * 1024 * 1024
+        used = 9 * 1024 * 1024
+        free = 100 * 1024  # far below the extraction requirement
+
+    monkeypatch.setattr(develop.shutil, "disk_usage", lambda path: _StingyUsage())
+
+    assert develop._extract_appimage_once(str(fake_bin)) is None
+    assert ran == [], "extraction subprocess must not run when disk is full"
+    # No half-written extraction dir should have been left behind.
+    assert not os.path.exists(str(fake_bin) + ".extracted")
+
+
 def test_develop_photo_omits_appimage_extract_and_run_for_plain_binary(tmp_path, monkeypatch):
     """A packaged darktable-cli is not an AppImage; the flag must never be
     set for it and the FUSE probe/cache must not touch its binary path."""

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -676,14 +676,16 @@ def test_build_command_appimage_named_like_anything_keeps_style_and_width(tmp_pa
                    "--style", "Wild", "--width", "2048"]
 
 
-def test_develop_photo_sets_appimage_extract_and_run(tmp_path, monkeypatch):
-    """AppImages need FUSE2 to self-mount; distros shipping only FUSE3 fail
-    outright unless APPIMAGE_EXTRACT_AND_RUN is set. The rest of the parent
-    environment must survive — darktable needs HOME, XDG_*, DISPLAY, etc.
+def test_develop_photo_appimage_direct_first_when_fuse_works(tmp_path, monkeypatch):
+    """On a system with working FUSE the AppImage must run directly — setting
+    APPIMAGE_EXTRACT_AND_RUN would force a ~178 MB squashfs unpack per photo.
+    The parent env still has to be carried through (HOME, XDG_*, DISPLAY, …).
     """
     import subprocess
 
     import develop
+
+    develop._APPIMAGE_MODE_CACHE.clear()
 
     raw = tmp_path / "bird.NEF"
     raw.touch()
@@ -691,11 +693,10 @@ def test_develop_photo_sets_appimage_extract_and_run(tmp_path, monkeypatch):
     out = tmp_path / "out" / "bird.jpg"
 
     monkeypatch.setenv("VIREO_TEST_INHERITED_VAR", "inherited-value")
-    captured = {}
+    calls = []
 
     def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        captured["env"] = kwargs.get("env")
+        calls.append(kwargs.get("env"))
         os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
         with open(cmd[-1], "w") as f:
             f.write("jpg")
@@ -705,26 +706,110 @@ def test_develop_photo_sets_appimage_extract_and_run(tmp_path, monkeypatch):
 
     result = develop.develop_photo(str(fake_bin), str(raw), str(out))
     assert result["success"] is True
+    assert len(calls) == 1, "unconditional retry would defeat the whole point"
 
-    # develop_photo must hand the *resolved* binary to build_command rather
-    # than assembling argv itself, or the AppImage launches its GUI.
-    assert captured["cmd"][1] == "darktable-cli"
-
-    env = captured["env"]
-    assert env is not None, "subprocess.run was called without an env"
-    assert env["APPIMAGE_EXTRACT_AND_RUN"] == "1"
-    # Not a bare dict: the parent environment is carried through.
+    env = calls[0]
+    assert env is not None
+    assert "APPIMAGE_EXTRACT_AND_RUN" not in env
     assert env["VIREO_TEST_INHERITED_VAR"] == "inherited-value"
     assert set(os.environ) <= set(env)
+    # Cached as "direct" so future photos skip the probe.
+    assert develop._APPIMAGE_MODE_CACHE[str(fake_bin)] == "direct"
 
 
-def test_develop_photo_omits_appimage_extract_and_run_for_plain_binary(tmp_path, monkeypatch):
-    """When set, the AppImage runtime skips the FUSE probe and unconditionally
-    unpacks the whole ~178MB squashfs — once per photo. A packaged
-    darktable-cli must not pay that, so the var is gated on real AppImages."""
+def test_develop_photo_appimage_falls_back_to_extract_on_fuse_failure(tmp_path, monkeypatch):
+    """When the AppImage runtime fails with a FUSE error, retry once with
+    APPIMAGE_EXTRACT_AND_RUN=1 and cache the answer so subsequent photos skip
+    the probe. Without the cache, every photo in a batch would pay the retry.
+    """
     import subprocess
 
     import develop
+
+    develop._APPIMAGE_MODE_CACHE.clear()
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+    out = tmp_path / "out" / "bird.jpg"
+
+    calls = []
+    fuse_stderr = (
+        "AppImages require FUSE to run.\n"
+        "You might still be able to extract the contents of this AppImage "
+        "if you run it with the --appimage-extract option.\n"
+    )
+
+    def fake_run(cmd, **kwargs):
+        env = kwargs.get("env") or {}
+        calls.append(env.get("APPIMAGE_EXTRACT_AND_RUN"))
+        if env.get("APPIMAGE_EXTRACT_AND_RUN") != "1":
+            # First call: simulate the runtime's FUSE failure.
+            return _fake_completed(1, stdout="", stderr=fuse_stderr)
+        os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
+        with open(cmd[-1], "w") as f:
+            f.write("jpg")
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert result["success"] is True
+    assert calls == [None, "1"], "expected one probe then one fallback"
+    assert develop._APPIMAGE_MODE_CACHE[str(fake_bin)] == "extract"
+
+    # Second call for the same binary skips the probe and goes straight to
+    # extract mode — no more wasted probe subprocess per photo.
+    calls.clear()
+    out2 = tmp_path / "out" / "bird2.jpg"
+    result2 = develop.develop_photo(str(fake_bin), str(raw), str(out2))
+    assert result2["success"] is True
+    assert calls == ["1"]
+
+
+def test_develop_photo_appimage_non_fuse_failure_is_not_retried(tmp_path, monkeypatch):
+    """A darktable-side failure (bad RAW, missing style, etc.) must NOT be
+    retried under APPIMAGE_EXTRACT_AND_RUN — that would waste a full squashfs
+    unpack on an error the fallback cannot fix, and surface the wrong error.
+    """
+    import subprocess
+
+    import develop
+
+    develop._APPIMAGE_MODE_CACHE.clear()
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+    out = tmp_path / "out" / "bird.jpg"
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        env = kwargs.get("env") or {}
+        calls.append(env.get("APPIMAGE_EXTRACT_AND_RUN"))
+        return _fake_completed(
+            1, stdout="[dt_init] ERROR: can't init develop system, aborting.",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert result["success"] is False
+    assert calls == [None], "must not retry when the failure is not FUSE-shaped"
+    # Nothing cached — a transient darktable error should not lock the mode.
+    assert str(fake_bin) not in develop._APPIMAGE_MODE_CACHE
+
+
+def test_develop_photo_omits_appimage_extract_and_run_for_plain_binary(tmp_path, monkeypatch):
+    """A packaged darktable-cli is not an AppImage; the flag must never be
+    set for it and the FUSE probe/cache must not touch its binary path."""
+    import subprocess
+
+    import develop
+
+    develop._APPIMAGE_MODE_CACHE.clear()
 
     raw = tmp_path / "bird.NEF"
     raw.touch()
@@ -749,3 +834,4 @@ def test_develop_photo_omits_appimage_extract_and_run_for_plain_binary(tmp_path,
     assert captured["cmd"] == [str(plain_bin), str(raw), str(out)]
     assert "APPIMAGE_EXTRACT_AND_RUN" not in captured["env"]
     assert set(os.environ) <= set(captured["env"])
+    assert str(plain_bin) not in develop._APPIMAGE_MODE_CACHE

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -552,32 +552,98 @@ def test_darktable_search_paths_linux_survives_vanishing_appimage(tmp_path, monk
     assert paths[0] == str(survivor)
 
 
-def test_build_command_selects_cli_inside_appimage():
+def _write_appimage(path):
+    """Write a file that looks like a type-2 AppImage to a magic-byte probe.
+
+    The ELF ident bytes are padding up to offset 8, where the AppImage spec
+    puts 0x41 0x49 0x02.
+    """
+    path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"AI\x02" + b"\x00" * 32)
+    path.chmod(0o755)
+    return path
+
+
+def _write_plain_elf(path):
+    """An ordinary ELF executable: same header, EI_PAD left zeroed."""
+    path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 40)
+    path.chmod(0o755)
+    return path
+
+
+def test_is_appimage_detects_magic_bytes(tmp_path):
+    """Name-independent detection: users rename AppImages to ~/.local/bin/darktable."""
+    from develop import _is_appimage
+
+    assert _is_appimage(str(_write_appimage(tmp_path / "darktable"))) is True
+
+
+def test_is_appimage_rejects_plain_elf(tmp_path):
+    """A real darktable-cli binary must not get the AppImage argv[1] prefix."""
+    from develop import _is_appimage
+
+    assert _is_appimage(str(_write_plain_elf(tmp_path / "darktable-cli"))) is False
+
+
+def test_is_appimage_missing_path_is_false(tmp_path):
+    """build_command is still called with paths that may not exist; never raise."""
+    from develop import _is_appimage
+
+    assert _is_appimage(str(tmp_path / "nope.AppImage")) is False
+
+
+def test_is_appimage_short_file_is_false(tmp_path):
+    """A truncated download is shorter than the magic offset; must not raise."""
+    from develop import _is_appimage
+
+    short = tmp_path / "partial.AppImage"
+    short.write_bytes(b"\x7fELF")
+    assert _is_appimage(str(short)) is False
+
+
+def test_is_appimage_directory_is_false(tmp_path):
+    """Opening a directory raises IsADirectoryError, an OSError; swallow it."""
+    from develop import _is_appimage
+
+    assert _is_appimage(str(tmp_path)) is False
+
+
+def test_build_command_selects_cli_inside_appimage(tmp_path):
     """darktable's AppImage picks its binary from argv[1]; without this we
     would launch the GUI and hang the export job."""
     from develop import build_command
 
-    cmd = build_command(
-        "/home/u/.vireo/tools/darktable/Darktable-5.6.0-x86_64.AppImage",
-        "in.raw", "out.jpg",
-    )
+    appimage = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+    cmd = build_command(str(appimage), "in.raw", "out.jpg")
     assert cmd[1] == "darktable-cli"
     assert cmd[2:] == ["in.raw", "out.jpg"]
 
 
-def test_build_command_plain_binary_unchanged():
+def test_build_command_selects_cli_inside_renamed_appimage(tmp_path):
+    """The conventional Linux move is to rename the AppImage to ~/.local/bin/darktable
+    and point Settings at it. find_darktable returns configured paths without
+    consulting darktable_search_paths, so filename-based detection would miss it."""
     from develop import build_command
 
-    cmd = build_command("/usr/bin/darktable-cli", "in.raw", "out.jpg")
-    assert cmd == ["/usr/bin/darktable-cli", "in.raw", "out.jpg"]
+    appimage = _write_appimage(tmp_path / "darktable")
+    cmd = build_command(str(appimage), "in.raw", "out.jpg")
+    assert cmd[1] == "darktable-cli"
 
 
-def test_build_command_appimage_keeps_style_and_width():
+def test_build_command_plain_binary_unchanged(tmp_path):
+    from develop import build_command
+
+    plain = _write_plain_elf(tmp_path / "darktable-cli")
+    cmd = build_command(str(plain), "in.raw", "out.jpg")
+    assert cmd == [str(plain), "in.raw", "out.jpg"]
+
+
+def test_build_command_appimage_named_like_anything_keeps_style_and_width(tmp_path):
     """Optional args must land after the positional args, not before."""
     from develop import build_command
 
-    cmd = build_command("/x/D.AppImage", "in.raw", "out.jpg", style="Wild", width=2048)
-    assert cmd == ["/x/D.AppImage", "darktable-cli", "in.raw", "out.jpg",
+    appimage = _write_appimage(tmp_path / "D.AppImage")
+    cmd = build_command(str(appimage), "in.raw", "out.jpg", style="Wild", width=2048)
+    assert cmd == [str(appimage), "darktable-cli", "in.raw", "out.jpg",
                    "--style", "Wild", "--width", "2048"]
 
 
@@ -592,15 +658,14 @@ def test_develop_photo_sets_appimage_extract_and_run(tmp_path, monkeypatch):
 
     raw = tmp_path / "bird.NEF"
     raw.touch()
-    fake_bin = tmp_path / "Darktable-5.6.0-x86_64.AppImage"
-    fake_bin.touch()
-    fake_bin.chmod(0o755)
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
     out = tmp_path / "out" / "bird.jpg"
 
     monkeypatch.setenv("VIREO_TEST_INHERITED_VAR", "inherited-value")
     captured = {}
 
     def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
         captured["env"] = kwargs.get("env")
         os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
         with open(cmd[-1], "w") as f:
@@ -612,9 +677,46 @@ def test_develop_photo_sets_appimage_extract_and_run(tmp_path, monkeypatch):
     result = develop.develop_photo(str(fake_bin), str(raw), str(out))
     assert result["success"] is True
 
+    # develop_photo must hand the *resolved* binary to build_command rather
+    # than assembling argv itself, or the AppImage launches its GUI.
+    assert captured["cmd"][1] == "darktable-cli"
+
     env = captured["env"]
     assert env is not None, "subprocess.run was called without an env"
     assert env["APPIMAGE_EXTRACT_AND_RUN"] == "1"
     # Not a bare dict: the parent environment is carried through.
     assert env["VIREO_TEST_INHERITED_VAR"] == "inherited-value"
     assert set(os.environ) <= set(env)
+
+
+def test_develop_photo_omits_appimage_extract_and_run_for_plain_binary(tmp_path, monkeypatch):
+    """When set, the AppImage runtime skips the FUSE probe and unconditionally
+    unpacks the whole ~178MB squashfs — once per photo. A packaged
+    darktable-cli must not pay that, so the var is gated on real AppImages."""
+    import subprocess
+
+    import develop
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    plain_bin = _write_plain_elf(tmp_path / "darktable-cli")
+    out = tmp_path / "out" / "bird.jpg"
+
+    monkeypatch.delenv("APPIMAGE_EXTRACT_AND_RUN", raising=False)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env")
+        os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
+        with open(cmd[-1], "w") as f:
+            f.write("jpg")
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = develop.develop_photo(str(plain_bin), str(raw), str(out))
+    assert result["success"] is True
+    assert captured["cmd"] == [str(plain_bin), str(raw), str(out)]
+    assert "APPIMAGE_EXTRACT_AND_RUN" not in captured["env"]
+    assert set(os.environ) <= set(captured["env"])

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -10,7 +10,7 @@ def test_find_darktable_returns_none_when_missing(monkeypatch):
 
     monkeypatch.setattr("shutil.which", lambda x: None)
     import develop
-    monkeypatch.setattr(develop, "darktable_search_paths", list)
+    monkeypatch.setattr(develop, "darktable_search_paths", lambda: [])
     assert find_darktable("") is None
 
 
@@ -76,7 +76,7 @@ def test_find_darktable_returns_none_for_bad_configured_path(monkeypatch):
 
     monkeypatch.setattr("shutil.which", lambda x: None)
     import develop
-    monkeypatch.setattr(develop, "darktable_search_paths", list)
+    monkeypatch.setattr(develop, "darktable_search_paths", lambda: [])
     assert find_darktable("/nonexistent/darktable-cli") is None
 
 
@@ -456,3 +456,97 @@ def test_darktable_search_paths_matches_find_darktable(monkeypatch):
         monkeypatch.setattr("os.path.isfile", lambda p, c=candidate: p == c)
         monkeypatch.setattr("os.path.realpath", lambda p: p)
         assert find_darktable("") == candidate
+
+
+def _force_linux_tools_dir(monkeypatch, tools_dir):
+    """Pin the platform branch to Linux and point it at ``tools_dir``.
+
+    A Linux box is os.name == "posix" *and* sys.platform == "linux"; pin both
+    so this exercises the AppImage branch on macOS and Windows CI legs too.
+    """
+    import develop
+
+    monkeypatch.setattr(develop.os, "name", "posix")
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr(
+        develop.os.path,
+        "expanduser",
+        lambda p: str(tools_dir) if p == "~/.vireo/tools/darktable" else p,
+    )
+
+
+def test_darktable_search_paths_linux_orders_appimages_newest_first(tmp_path, monkeypatch):
+    """The tools dir accumulates versions; the most recent install must win."""
+    from develop import darktable_search_paths
+
+    tools_dir = tmp_path / "tools" / "darktable"
+    tools_dir.mkdir(parents=True)
+    older = tools_dir / "darktable-4.6.AppImage"
+    newer = tools_dir / "darktable-5.0.AppImage"
+    older.write_bytes(b"old")
+    newer.write_bytes(b"new")
+    os.utime(older, (1_000_000, 1_000_000))
+    os.utime(newer, (2_000_000, 2_000_000))
+
+    _force_linux_tools_dir(monkeypatch, tools_dir)
+
+    assert darktable_search_paths() == [str(newer), str(older)]
+
+
+def test_darktable_search_paths_linux_ignores_non_appimages(tmp_path, monkeypatch):
+    """Download leftovers (partials, checksums) are not runnable candidates."""
+    from develop import darktable_search_paths
+
+    tools_dir = tmp_path / "tools" / "darktable"
+    tools_dir.mkdir(parents=True)
+    appimage = tools_dir / "darktable-5.0.AppImage"
+    appimage.write_bytes(b"app")
+    (tools_dir / "darktable-5.0.AppImage.part").write_bytes(b"partial")
+    (tools_dir / "SHA256SUMS").write_bytes(b"sums")
+    (tools_dir / "README.txt").write_bytes(b"readme")
+
+    _force_linux_tools_dir(monkeypatch, tools_dir)
+
+    assert darktable_search_paths() == [str(appimage)]
+
+
+def test_darktable_search_paths_linux_missing_dir_is_empty(tmp_path, monkeypatch):
+    """No install yet is the common case and must not raise."""
+    from develop import darktable_search_paths
+
+    _force_linux_tools_dir(monkeypatch, tmp_path / "never" / "created")
+
+    assert darktable_search_paths() == []
+
+
+def test_darktable_search_paths_linux_survives_vanishing_appimage(tmp_path, monkeypatch):
+    """A file removed between listdir and the mtime sort must not raise.
+
+    All callers are written against "returns paths or nothing, never raises":
+    an escaping OSError would 500 /api/darktable/status and fail a develop job
+    with a stack trace instead of a clean "darktable-cli not found".
+    """
+    import develop
+    from develop import darktable_search_paths
+
+    tools_dir = tmp_path / "tools" / "darktable"
+    tools_dir.mkdir(parents=True)
+    survivor = tools_dir / "darktable-5.0.AppImage"
+    vanished = tools_dir / "darktable-4.6.AppImage"
+    survivor.write_bytes(b"app")
+    vanished.write_bytes(b"doomed")
+
+    _force_linux_tools_dir(monkeypatch, tools_dir)
+
+    real_getmtime = os.path.getmtime
+
+    def racing_getmtime(path):
+        if path == str(vanished):
+            raise FileNotFoundError(2, "No such file or directory", path)
+        return real_getmtime(path)
+
+    monkeypatch.setattr(develop.os.path, "getmtime", racing_getmtime)
+
+    paths = darktable_search_paths()
+    assert str(survivor) in paths
+    assert paths[0] == str(survivor)

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -697,6 +697,7 @@ def test_develop_photo_appimage_direct_first_when_fuse_works(tmp_path, monkeypat
     import develop
 
     develop._APPIMAGE_MODE_CACHE.clear()
+    develop._APPIMAGE_APPRUN_CACHE.clear()
 
     raw = tmp_path / "bird.NEF"
     raw.touch()
@@ -728,34 +729,125 @@ def test_develop_photo_appimage_direct_first_when_fuse_works(tmp_path, monkeypat
     assert develop._APPIMAGE_MODE_CACHE[str(fake_bin)] == "direct"
 
 
-def test_develop_photo_appimage_falls_back_to_extract_on_fuse_failure(tmp_path, monkeypatch):
-    """When the AppImage runtime fails with a FUSE error, retry once with
-    APPIMAGE_EXTRACT_AND_RUN=1 and cache the answer so subsequent photos skip
-    the probe. Without the cache, every photo in a batch would pay the retry.
+def test_develop_photo_appimage_falls_back_to_persistent_extraction_on_fuse_failure(tmp_path, monkeypatch):
+    """When the AppImage runtime fails with a FUSE error, extract the bundle
+    once to a persistent tree and route every following photo through the
+    extracted AppRun — never APPIMAGE_EXTRACT_AND_RUN. Setting that flag
+    would make the runtime unpack the whole ~178 MB squashfs into a temp dir
+    for every photo in the batch, which is exactly the cost the persistent
+    extraction is here to avoid.
     """
     import subprocess
 
     import develop
 
     develop._APPIMAGE_MODE_CACHE.clear()
+    develop._APPIMAGE_APPRUN_CACHE.clear()
 
     raw = tmp_path / "bird.NEF"
     raw.touch()
     fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
     out = tmp_path / "out" / "bird.jpg"
 
-    calls = []
     fuse_stderr = (
         "AppImages require FUSE to run.\n"
         "You might still be able to extract the contents of this AppImage "
         "if you run it with the --appimage-extract option.\n"
     )
+    expected_apprun = os.path.join(
+        str(fake_bin) + ".extracted", "squashfs-root", "AppRun",
+    )
+
+    calls = []
 
     def fake_run(cmd, **kwargs):
         env = kwargs.get("env") or {}
-        calls.append(env.get("APPIMAGE_EXTRACT_AND_RUN"))
-        if env.get("APPIMAGE_EXTRACT_AND_RUN") != "1":
+        calls.append({
+            "argv0": cmd[0],
+            "argv": list(cmd),
+            "extract_flag": env.get("APPIMAGE_EXTRACT_AND_RUN"),
+            "cwd": kwargs.get("cwd"),
+        })
+        if cmd == [str(fake_bin), "--appimage-extract"]:
+            # Simulate the AppImage runtime's --appimage-extract producing
+            # squashfs-root/AppRun in the current working directory.
+            root = os.path.join(kwargs["cwd"], "squashfs-root")
+            os.makedirs(root, exist_ok=True)
+            apprun = os.path.join(root, "AppRun")
+            with open(apprun, "w") as f:
+                f.write("#!/bin/sh\nexec /usr/bin/darktable-cli \"$@\"\n")
+            os.chmod(apprun, 0o755)
+            return _fake_completed(0)
+        if cmd[0] == str(fake_bin):
             # First call: simulate the runtime's FUSE failure.
+            return _fake_completed(1, stdout="", stderr=fuse_stderr)
+        # Extracted AppRun run: write the output and succeed.
+        os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
+        with open(cmd[-1], "w") as f:
+            f.write("jpg")
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert result["success"] is True
+    # 1) probe against the AppImage, 2) --appimage-extract, 3) AppRun run.
+    assert [c["argv0"] for c in calls] == [
+        str(fake_bin), str(fake_bin), expected_apprun,
+    ]
+    assert calls[1]["argv"] == [str(fake_bin), "--appimage-extract"]
+    # APPIMAGE_EXTRACT_AND_RUN must NEVER get set on this path — the point of
+    # persistent extraction is to avoid the AppImage runtime unpacking again.
+    assert all(c["extract_flag"] is None for c in calls)
+    assert develop._APPIMAGE_MODE_CACHE[str(fake_bin)] == "extracted"
+    assert develop._APPIMAGE_APPRUN_CACHE[str(fake_bin)] == expected_apprun
+
+    # Second call for the same binary skips both the FUSE probe and the
+    # extract subprocess: only the extracted AppRun is invoked. Anything
+    # else would still be paying per-photo cost.
+    calls.clear()
+    out2 = tmp_path / "out" / "bird2.jpg"
+    result2 = develop.develop_photo(str(fake_bin), str(raw), str(out2))
+    assert result2["success"] is True
+    assert [c["argv0"] for c in calls] == [expected_apprun]
+    assert calls[0]["extract_flag"] is None
+
+
+def test_develop_photo_appimage_extract_failure_falls_back_to_per_run_flag(tmp_path, monkeypatch):
+    """If the one-time --appimage-extract cannot produce a usable AppRun
+    (unwritable dir, subprocess failure, truncated output), develop must
+    still succeed by setting APPIMAGE_EXTRACT_AND_RUN=1 on every call. The
+    fallback is slower per-photo, but shipping a broken FUSE-less path when
+    a working one exists would be worse.
+    """
+    import subprocess
+
+    import develop
+
+    develop._APPIMAGE_MODE_CACHE.clear()
+    develop._APPIMAGE_APPRUN_CACHE.clear()
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+    out = tmp_path / "out" / "bird.jpg"
+
+    fuse_stderr = "AppImages require FUSE to run.\n"
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        env = kwargs.get("env") or {}
+        calls.append({
+            "argv": list(cmd),
+            "extract_flag": env.get("APPIMAGE_EXTRACT_AND_RUN"),
+        })
+        if cmd == [str(fake_bin), "--appimage-extract"]:
+            # Extraction subprocess "runs" but leaves no AppRun on disk —
+            # simulates a truncated / corrupted download or a permission
+            # error surfaced only inside the runtime.
+            return _fake_completed(1, stdout="", stderr="extract failed")
+        if env.get("APPIMAGE_EXTRACT_AND_RUN") != "1":
             return _fake_completed(1, stdout="", stderr=fuse_stderr)
         os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
         with open(cmd[-1], "w") as f:
@@ -766,16 +858,69 @@ def test_develop_photo_appimage_falls_back_to_extract_on_fuse_failure(tmp_path, 
 
     result = develop.develop_photo(str(fake_bin), str(raw), str(out))
     assert result["success"] is True
-    assert calls == [None, "1"], "expected one probe then one fallback"
-    assert develop._APPIMAGE_MODE_CACHE[str(fake_bin)] == "extract"
+    # probe → extract (fails) → per-run flag fallback
+    assert calls[0]["extract_flag"] is None
+    assert calls[1]["argv"] == [str(fake_bin), "--appimage-extract"]
+    assert calls[2]["extract_flag"] == "1"
+    assert develop._APPIMAGE_MODE_CACHE[str(fake_bin)] == "extract-per-run"
+    assert str(fake_bin) not in develop._APPIMAGE_APPRUN_CACHE
 
-    # Second call for the same binary skips the probe and goes straight to
-    # extract mode — no more wasted probe subprocess per photo.
+    # Second call takes the cached fallback path: no re-probe, no re-extract,
+    # just the flagged call. Still costs an unpack per photo, but that is
+    # explicitly the last-resort cache value.
     calls.clear()
     out2 = tmp_path / "out" / "bird2.jpg"
     result2 = develop.develop_photo(str(fake_bin), str(raw), str(out2))
     assert result2["success"] is True
-    assert calls == ["1"]
+    assert len(calls) == 1
+    assert calls[0]["extract_flag"] == "1"
+
+
+def test_develop_photo_appimage_extracted_cache_recovers_from_deleted_tree(tmp_path, monkeypatch):
+    """If the persistent extraction disappears between photos (user cleared
+    tmp, reinstall, etc.), the develop must re-probe rather than silently
+    invoking a stale path — pointing subprocess at a missing AppRun would
+    surface as a confusing FileNotFoundError instead of a fresh, successful
+    extraction.
+    """
+    import subprocess
+
+    import develop
+
+    develop._APPIMAGE_MODE_CACHE.clear()
+    develop._APPIMAGE_APPRUN_CACHE.clear()
+
+    raw = tmp_path / "bird.NEF"
+    raw.touch()
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+    out = tmp_path / "out" / "bird.jpg"
+
+    # Pre-seed the cache with a path that does not exist on disk.
+    ghost_apprun = str(tmp_path / "ghosts" / "squashfs-root" / "AppRun")
+    develop._APPIMAGE_MODE_CACHE[str(fake_bin)] = "extracted"
+    develop._APPIMAGE_APPRUN_CACHE[str(fake_bin)] = ghost_apprun
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        # Whatever runs now must not be the ghost path.
+        assert cmd[0] != ghost_apprun
+        # Direct-run probe path succeeds so we finish the first develop
+        # without touching FUSE at all.
+        os.makedirs(os.path.dirname(cmd[-1]), exist_ok=True)
+        with open(cmd[-1], "w") as f:
+            f.write("jpg")
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = develop.develop_photo(str(fake_bin), str(raw), str(out))
+    assert result["success"] is True
+    # Stale cache entries were purged: mode reset to "direct" after the
+    # fresh probe, AppRun path evicted entirely.
+    assert develop._APPIMAGE_MODE_CACHE[str(fake_bin)] == "direct"
+    assert str(fake_bin) not in develop._APPIMAGE_APPRUN_CACHE
 
 
 def test_develop_photo_appimage_non_fuse_failure_is_not_retried(tmp_path, monkeypatch):
@@ -788,6 +933,7 @@ def test_develop_photo_appimage_non_fuse_failure_is_not_retried(tmp_path, monkey
     import develop
 
     develop._APPIMAGE_MODE_CACHE.clear()
+    develop._APPIMAGE_APPRUN_CACHE.clear()
 
     raw = tmp_path / "bird.NEF"
     raw.touch()
@@ -811,6 +957,103 @@ def test_develop_photo_appimage_non_fuse_failure_is_not_retried(tmp_path, monkey
     assert calls == [None], "must not retry when the failure is not FUSE-shaped"
     # Nothing cached — a transient darktable error should not lock the mode.
     assert str(fake_bin) not in develop._APPIMAGE_MODE_CACHE
+    assert str(fake_bin) not in develop._APPIMAGE_APPRUN_CACHE
+
+
+def test_extract_appimage_once_reuses_existing_apprun(tmp_path, monkeypatch):
+    """Second call for the same AppImage must NOT re-run the extract
+    subprocess: the whole point of the persistent extraction is to make the
+    ~178 MB unpack happen exactly once per install.
+    """
+    import subprocess
+
+    import develop
+
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        root = os.path.join(kwargs["cwd"], "squashfs-root")
+        os.makedirs(root, exist_ok=True)
+        apprun = os.path.join(root, "AppRun")
+        with open(apprun, "w") as f:
+            f.write("#!/bin/sh\nexec /usr/bin/darktable-cli \"$@\"\n")
+        os.chmod(apprun, 0o755)
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    first = develop._extract_appimage_once(str(fake_bin))
+    assert first is not None
+    assert os.path.isfile(first)
+    assert len(calls) == 1
+
+    # Second call: same AppRun, no new subprocess. The extraction on disk
+    # already satisfies the freshness check (mtime >= source), so no work.
+    second = develop._extract_appimage_once(str(fake_bin))
+    assert second == first
+    assert len(calls) == 1, "must not re-extract when a valid tree is present"
+
+
+def test_extract_appimage_once_re_extracts_when_source_is_newer(tmp_path, monkeypatch):
+    """When the AppImage is replaced (Vireo installs a newer build), the
+    stale extracted tree must be discarded and rebuilt — otherwise a batch
+    keeps invoking the old darktable version even after the user upgraded.
+    """
+    import subprocess
+
+    import develop
+
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        root = os.path.join(kwargs["cwd"], "squashfs-root")
+        os.makedirs(root, exist_ok=True)
+        apprun = os.path.join(root, "AppRun")
+        with open(apprun, "w") as f:
+            f.write("#!/bin/sh\nexec /usr/bin/darktable-cli \"$@\"\n")
+        os.chmod(apprun, 0o755)
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    first = develop._extract_appimage_once(str(fake_bin))
+    assert first is not None
+
+    # Make the source AppImage newer than its extraction.
+    future = os.path.getmtime(first) + 10
+    os.utime(str(fake_bin), (future, future))
+
+    second = develop._extract_appimage_once(str(fake_bin))
+    assert second == first  # same target dir
+    assert len(calls) == 2, "newer source must trigger a re-extract"
+
+
+def test_extract_appimage_once_returns_none_when_subprocess_fails(tmp_path, monkeypatch):
+    """A subprocess failure or missing AppRun after --appimage-extract must
+    surface as None so the caller can pick the APPIMAGE_EXTRACT_AND_RUN
+    fallback, not confidently return a broken path.
+    """
+    import subprocess
+
+    import develop
+
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+
+    def fake_run(cmd, **kwargs):
+        return _fake_completed(1, stdout="", stderr="oh no")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert develop._extract_appimage_once(str(fake_bin)) is None
+    # The failed extraction dir must be cleaned up so a later successful
+    # run does not find half-written state.
+    assert not os.path.exists(str(fake_bin) + ".extracted")
 
 
 def test_develop_photo_omits_appimage_extract_and_run_for_plain_binary(tmp_path, monkeypatch):
@@ -821,6 +1064,7 @@ def test_develop_photo_omits_appimage_extract_and_run_for_plain_binary(tmp_path,
     import develop
 
     develop._APPIMAGE_MODE_CACHE.clear()
+    develop._APPIMAGE_APPRUN_CACHE.clear()
 
     raw = tmp_path / "bird.NEF"
     raw.touch()
@@ -846,3 +1090,4 @@ def test_develop_photo_omits_appimage_extract_and_run_for_plain_binary(tmp_path,
     assert "APPIMAGE_EXTRACT_AND_RUN" not in captured["env"]
     assert set(os.environ) <= set(captured["env"])
     assert str(plain_bin) not in develop._APPIMAGE_MODE_CACHE
+    assert str(plain_bin) not in develop._APPIMAGE_APPRUN_CACHE

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -928,8 +928,8 @@ def test_develop_photo_appimage_extracted_cache_reprobes_when_source_is_newer(tm
     manual overwrite), the cached extraction points at the OLD darktable
     version. Reusing it silently would keep running the old build until the
     process restarts — same failure mode _extract_appimage_once already
-    guards against with the mtime check. Verify the develop_photo cache
-    branch checks it too.
+    guards against with its source-fingerprint marker. Verify the
+    develop_photo cache branch checks that marker too.
     """
     import subprocess
 
@@ -943,16 +943,24 @@ def test_develop_photo_appimage_extracted_cache_reprobes_when_source_is_newer(tm
     fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
     out = tmp_path / "out" / "bird.jpg"
 
-    # Pre-seed the cache with a real, executable AppRun. The mtime check is
-    # what should invalidate it, not the exec/exists check.
+    # Pre-seed the cache with a real, executable AppRun alongside a
+    # source-fingerprint marker recording the CURRENT source. That means
+    # only a follow-up change to the source can invalidate the tree — the
+    # exists/exec checks all pass, so any eviction has to come from the
+    # marker no longer matching.
     stale_apprun_dir = tmp_path / "old_extraction" / "squashfs-root"
     stale_apprun_dir.mkdir(parents=True)
     stale_apprun = stale_apprun_dir / "AppRun"
     stale_apprun.write_text("#!/bin/sh\nexec /old/darktable-cli \"$@\"\n")
     stale_apprun.chmod(0o755)
-    # Make the AppRun clearly older than the source.
-    ancient = os.path.getmtime(str(fake_bin)) - 3600
-    os.utime(str(stale_apprun), (ancient, ancient))
+    marker = stale_apprun_dir.parent / develop._APPIMAGE_SOURCE_MARKER
+    marker.write_text(develop._source_fingerprint(str(fake_bin)))
+
+    # Now simulate the in-place replacement — bump the source's mtime past
+    # what the marker recorded. The marker no longer matches the source,
+    # and the cached tree must be evicted.
+    future = os.path.getmtime(str(fake_bin)) + 3600
+    os.utime(str(fake_bin), (future, future))
 
     develop._APPIMAGE_MODE_CACHE[str(fake_bin)] = "extracted"
     develop._APPIMAGE_APPRUN_CACHE[str(fake_bin)] = str(stale_apprun)
@@ -1045,11 +1053,56 @@ def test_extract_appimage_once_reuses_existing_apprun(tmp_path, monkeypatch):
     assert os.path.isfile(first)
     assert len(calls) == 1
 
-    # Second call: same AppRun, no new subprocess. The extraction on disk
-    # already satisfies the freshness check (mtime >= source), so no work.
+    # Second call: same AppRun, no new subprocess. The source-fingerprint
+    # marker written by the first call still matches the source, so the
+    # extraction on disk satisfies the reuse check.
     second = develop._extract_appimage_once(str(fake_bin))
     assert second == first
     assert len(calls) == 1, "must not re-extract when a valid tree is present"
+
+
+def test_extract_appimage_once_reuses_when_apprun_older_than_source(tmp_path, monkeypatch):
+    """--appimage-extract preserves AppRun's embedded build timestamp, so on
+    a real download AppRun is OLDER than the freshly downloaded source
+    AppImage. Reuse must not depend on AppRun's mtime — the whole batch
+    would otherwise re-unpack ~500 MB per photo, defeating the persistent
+    extraction. As long as the source-fingerprint marker still matches,
+    an older AppRun is reused as-is.
+    """
+    import subprocess
+
+    import develop
+
+    fake_bin = _write_appimage(tmp_path / "Darktable-5.6.0-x86_64.AppImage")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        root = os.path.join(kwargs["cwd"], "squashfs-root")
+        os.makedirs(root, exist_ok=True)
+        apprun = os.path.join(root, "AppRun")
+        with open(apprun, "w") as f:
+            f.write("#!/bin/sh\nexec /usr/bin/darktable-cli \"$@\"\n")
+        os.chmod(apprun, 0o755)
+        return _fake_completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    first = develop._extract_appimage_once(str(fake_bin))
+    assert first is not None
+
+    # Simulate the real world: AppRun carries darktable's embedded build
+    # timestamp (weeks/months old), the source has a fresh download mtime.
+    long_ago = os.path.getmtime(str(fake_bin)) - 90 * 86400
+    os.utime(first, (long_ago, long_ago))
+
+    second = develop._extract_appimage_once(str(fake_bin))
+    assert second == first
+    assert len(calls) == 1, (
+        "AppRun older than source must NOT trigger a re-extract — the "
+        "source-fingerprint marker is what decides reuse"
+    )
 
 
 def test_extract_appimage_once_re_extracts_when_source_is_newer(tmp_path, monkeypatch):

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -520,6 +520,176 @@ def test_job_runner_list_jobs():
     assert len(jobs) >= 2
 
 
+def test_start_singleton_returns_existing_when_active():
+    """A second start_singleton for the same (type, key) while the first
+    is running must NOT create a second worker — that is the whole point
+    of the guard."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+    release = threading.Event()
+    workers = []
+
+    def work(job):
+        workers.append(job['id'])
+        assert release.wait(timeout=5), "worker never released"
+        return {'ok': True}
+
+    first_id, first_joined, first_snap = runner.start_singleton(
+        'download-x', work, singleton_key='k',
+        config={'note': 'first'},
+    )
+    assert first_joined is False
+    assert first_snap is None
+
+    second_id, second_joined, second_snap = runner.start_singleton(
+        'download-x', work, singleton_key='k',
+        config={'note': 'second-should-be-ignored'},
+    )
+    assert second_joined is True
+    assert second_id == first_id
+    # The snapshot must reflect the ORIGINAL registration's config,
+    # not the caller's — otherwise the artifact-identity check the
+    # endpoint layers on top of this would see whichever caller ran
+    # last and could not detect a mismatched join.
+    assert second_snap['config'] == {'note': 'first'}
+
+    release.set()
+    wait_for_job_via_runner(runner, first_id)
+    assert len(workers) == 1, (
+        f"exactly one worker must run, got {len(workers)}"
+    )
+
+
+def test_start_singleton_starts_a_fresh_job_once_the_first_finishes():
+    """The singleton is per-active-run, not forever: a completed job
+    releases the slot so retry from Settings can start a new download."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+
+    def quick(job):
+        return {'ok': True}
+
+    first_id, first_joined, _ = runner.start_singleton(
+        'download-x', quick, singleton_key='k',
+    )
+    assert first_joined is False
+    wait_for_job_via_runner(runner, first_id)
+
+    second_id, second_joined, second_snap = runner.start_singleton(
+        'download-x', quick, singleton_key='k',
+    )
+    assert second_joined is False, (
+        "a completed job must not pin the singleton — otherwise Retry stays broken"
+    )
+    assert second_snap is None
+    assert second_id != first_id
+    wait_for_job_via_runner(runner, second_id)
+
+
+def test_start_singleton_check_and_start_are_atomic_under_thread_pressure():
+    """Fire many concurrent start_singleton calls at once and confirm only
+    ONE worker was ever created. This is the specific race the earlier
+    list_jobs()+start() pattern had: two callers could both see "no
+    existing" and both start a worker."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+    release = threading.Event()
+    workers = []
+    workers_lock = threading.Lock()
+
+    def work(job):
+        with workers_lock:
+            workers.append(job['id'])
+        assert release.wait(timeout=10), "worker never released"
+        return {'ok': True}
+
+    ids = []
+    ids_lock = threading.Lock()
+    barrier = threading.Barrier(16)
+
+    def fire():
+        barrier.wait()
+        jid, _joined, _snap = runner.start_singleton(
+            'download-x', work, singleton_key='k',
+        )
+        with ids_lock:
+            ids.append(jid)
+
+    threads = [threading.Thread(target=fire) for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(ids)) == 1, (
+        f"all callers must converge on one id, got {set(ids)}"
+    )
+    release.set()
+    wait_for_job_via_runner(runner, ids[0])
+    assert len(workers) == 1, (
+        f"exactly one worker may run for a singleton, got {len(workers)}"
+    )
+
+
+def test_start_singleton_isolates_different_keys():
+    """Two singletons with different keys must coexist — the guard is
+    per-(type, key), not per-type. Otherwise unrelated singleton flows
+    would starve each other."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+    release = threading.Event()
+
+    def hold(job):
+        assert release.wait(timeout=5)
+        return {'ok': True}
+
+    a_id, a_joined, _ = runner.start_singleton(
+        'download-x', hold, singleton_key='alpha',
+    )
+    b_id, b_joined, _ = runner.start_singleton(
+        'download-x', hold, singleton_key='beta',
+    )
+    assert a_joined is False
+    assert b_joined is False
+    assert a_id != b_id
+
+    release.set()
+    wait_for_job_via_runner(runner, a_id)
+    wait_for_job_via_runner(runner, b_id)
+
+
+def test_start_singleton_does_not_match_plain_start_jobs_without_a_key():
+    """A regular start() call stores singleton_key=None; a start_singleton
+    lookup for the SAME job_type with any real key must NOT match it —
+    otherwise the guard would incorrectly join arbitrary jobs of the
+    same type that were never opting into singleton behavior."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+    release = threading.Event()
+
+    def hold(job):
+        assert release.wait(timeout=5)
+        return {'ok': True}
+
+    plain_id = runner.start('download-x', hold)
+    sing_id, joined, _ = runner.start_singleton(
+        'download-x', hold, singleton_key='k',
+    )
+    assert joined is False, (
+        "start_singleton must not join a plain start() job with key=None"
+    )
+    assert sing_id != plain_id
+
+    release.set()
+    wait_for_job_via_runner(runner, plain_id)
+    wait_for_job_via_runner(runner, sing_id)
+
+
 def test_job_progress_events():
     """Job progress updates are captured in the events queue."""
     from jobs import JobRunner

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -1234,6 +1234,97 @@ def test_download_with_resume_throttle_interval_gates_emits(tmp_path):
     )
 
 
+def test_download_with_resume_promotes_complete_partial_on_416(tmp_path):
+    """Cancellation between writing the final chunk and the empty-read break
+    leaves a ``.partial`` at exactly the full asset size.  The next attempt
+    sends ``Range: bytes=<total>-`` and gets 416; without promotion the retry
+    loop would burn through ``max_stalled`` attempts against a permanent 416
+    despite the UI promising "try again and the download will resume".
+    """
+    import http.server
+
+    from taxonomy import _download_with_resume
+
+    content = b"y" * 4096
+    call_count = [0]
+
+    # Pre-seed the .partial so the first attempt sends Range: bytes=<total>-.
+    dest = tmp_path / "out.bin"
+    partial = tmp_path / "out.bin.partial"
+    partial.write_bytes(content)
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            call_count[0] += 1
+            self.send_response(416)
+            self.send_header(
+                "Content-Range", f"bytes */{len(content)}",
+            )
+            self.end_headers()
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    try:
+        _download_with_resume(f"http://127.0.0.1:{port}/x", str(dest))
+    finally:
+        server.shutdown()
+
+    # Partial was promoted to the final path with the correct bytes; the
+    # download did not retry into a stall.
+    assert dest.exists()
+    assert not partial.exists()
+    assert dest.read_bytes() == content
+    assert call_count[0] == 1
+
+
+def test_download_with_resume_restarts_when_416_total_mismatches(tmp_path):
+    """A rebuilt release changes the asset size, so a 416 whose Content-Range
+    total does not match the partial means the partial is stale — delete it
+    and restart from scratch instead of promoting bytes of the wrong artifact.
+    """
+    import http.server
+
+    from taxonomy import _download_with_resume
+
+    fresh = b"Z" * 3000
+    partial = tmp_path / "out.bin.partial"
+    partial.write_bytes(b"X" * 2000)  # stale bytes from a previous release
+    call_count = [0]
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            call_count[0] += 1
+            range_header = self.headers.get("Range")
+            if range_header:
+                # First call: reject the stale-partial resume with 416,
+                # advertising the true total.
+                self.send_response(416)
+                self.send_header("Content-Range", f"bytes */{len(fresh)}")
+                self.end_headers()
+                return
+            # Second call: no Range header (partial was deleted); serve the
+            # fresh release from scratch.
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(fresh)))
+            self.end_headers()
+            self.wfile.write(fresh)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    try:
+        dest = tmp_path / "out.bin"
+        _download_with_resume(f"http://127.0.0.1:{port}/x", str(dest))
+    finally:
+        server.shutdown()
+
+    assert dest.read_bytes() == fresh
+    assert call_count[0] >= 2
+
+
 # ---------------------------------------------------------------------------
 # classify_to_keypoint_group — taxonomy routing for eye-focus detection
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -901,6 +901,16 @@ def test_download_with_resume_cancels_midstream(tmp_path):
     assert requests["n"] == 1, f"expected a single request, got {requests['n']}"
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason=(
+        "socket.shutdown(SHUT_RDWR) from another thread does not reliably "
+        "unblock a Python recv() on Windows — the blocked read only surfaces "
+        "once the peer actually closes, so this timing assertion is not a "
+        "meaningful check of the watcher there.  The mechanism still runs "
+        "in production; only the sub-5s timing property is Linux/macOS-only."
+    ),
+)
 def test_download_with_resume_cancel_interrupts_stalled_read(tmp_path):
     """A Stop press during a stalled resp.read must not wait for the socket timeout.
 

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -805,9 +805,11 @@ def test_download_with_resume_no_range_stalls_correctly(tmp_path):
     finally:
         server.shutdown()
 
+
 def test_download_with_resume_reports_bytes(tmp_path):
     """byte_callback gets real byte counts — this is what the progress bar reads."""
     import http.server
+
     from taxonomy import _download_with_resume
 
     payload = b"x" * 500_000
@@ -841,14 +843,23 @@ def test_download_with_resume_reports_bytes(tmp_path):
 
 
 def test_download_with_resume_cancels_midstream(tmp_path):
-    """should_cancel aborts and keeps a non-empty .partial for resume."""
+    """should_cancel aborts, keeps a non-empty .partial, and does not retry.
+
+    Cancellation must escape the retry machinery, not fall into it.  If the
+    DownloadCancelled re-raise is removed the generic handler treats a cancel
+    as a dropped connection: the user is told "Connection lost ... retrying"
+    right after pressing Cancel, and the download is re-requested.
+    """
     import http.server
+
     from taxonomy import DownloadCancelled, _download_with_resume
 
     payload = b"x" * 500_000
+    requests = {"n": 0}
 
     class Handler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
+            requests["n"] += 1
             self.send_response(200)
             self.send_header("Content-Length", str(len(payload)))
             self.end_headers()
@@ -859,6 +870,7 @@ def test_download_with_resume_cancels_midstream(tmp_path):
 
     server, port = _start_test_server(Handler)
     calls = {"n": 0}
+    messages = []
 
     def cancel_after_two_chunks():
         calls["n"] += 1
@@ -869,6 +881,7 @@ def test_download_with_resume_cancels_midstream(tmp_path):
         with pytest.raises(DownloadCancelled):
             _download_with_resume(
                 f"http://127.0.0.1:{port}/x", str(dest), chunk_size=4096,
+                progress_callback=messages.append,
                 should_cancel=cancel_after_two_chunks,
             )
     finally:
@@ -880,6 +893,61 @@ def test_download_with_resume_cancels_midstream(tmp_path):
     # Non-empty proves we cancelled mid-stream, not before the first read —
     # open(..., "wb") would create a 0-byte file either way.
     assert partial.stat().st_size > 0
+    # A cancel is not a network error: the user must never be told the
+    # connection dropped or that we are retrying.
+    assert not [m for m in messages if "retrying" in m], messages
+    assert not [m for m in messages if "Connection lost" in m], messages
+    # And we really stopped — no second attempt was made against the server.
+    assert requests["n"] == 1, f"expected a single request, got {requests['n']}"
+
+
+def test_download_with_resume_cancels_during_retry_backoff(tmp_path):
+    """A cancel that lands during the retry wait aborts instead of sleeping it out.
+
+    The backoff is polled in short slices so Cancel feels immediate.  With a
+    single time.sleep(3) the user would wait out the full backoff and the
+    download would be re-requested before anyone noticed the cancel.
+    """
+    import http.server
+    import time
+
+    from taxonomy import DownloadCancelled, _download_with_resume
+
+    requests = {"n": 0}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            requests["n"] += 1
+            self.send_response(500)
+            self.end_headers()
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+
+    # should_cancel is only consulted inside the read loop (never reached on a
+    # 500) and inside the backoff, so this is False for the whole first attempt
+    # and True from the moment the backoff starts.
+    def cancel_once_the_first_attempt_failed():
+        return requests["n"] >= 1
+
+    try:
+        dest = tmp_path / "out.bin"
+        started = time.monotonic()
+        with pytest.raises(DownloadCancelled):
+            _download_with_resume(
+                f"http://127.0.0.1:{port}/x", str(dest), max_stalled=2,
+                should_cancel=cancel_once_the_first_attempt_failed,
+            )
+        elapsed = time.monotonic() - started
+    finally:
+        server.shutdown()
+
+    # Well under the 3 s backoff: we noticed the cancel, we did not sleep it off.
+    assert elapsed < 1.5, f"cancel took {elapsed:.2f}s — backoff was not polled"
+    # And the retry never went out.
+    assert requests["n"] == 1, f"expected a single request, got {requests['n']}"
 
 
 def test_download_with_resume_bytes_include_resume_offset(tmp_path):
@@ -891,6 +959,7 @@ def test_download_with_resume_bytes_include_resume_offset(tmp_path):
     finishing at less than the real file size.
     """
     import http.server
+
     from taxonomy import _download_with_resume
 
     payload = b"C" * 300_000
@@ -955,6 +1024,7 @@ def test_download_with_resume_bytes_reset_when_server_ignores_range(tmp_path):
     would double-count the discarded bytes.
     """
     import http.server
+
     from taxonomy import _download_with_resume
 
     payload = b"E" * 200_000
@@ -1002,6 +1072,7 @@ def test_download_with_resume_throttles_byte_callback(tmp_path):
     must not emit ~700 events (and at 4 KB chunks, ~45000).
     """
     import http.server
+
     from taxonomy import _download_with_resume
 
     payload = b"y" * 500_000
@@ -1037,6 +1108,64 @@ def test_download_with_resume_throttles_byte_callback(tmp_path):
     assert len(seen) <= 20, f"expected throttled events, got {len(seen)}"
     # Still ends on an exact final count.
     assert seen[-1] == len(payload)
+
+
+def test_download_with_resume_throttle_interval_gates_emits(tmp_path):
+    """The emit interval is what paces the bar — pin both ends of it.
+
+    The unconditional final emit alone satisfies "the callback fired", so a
+    throttle window stretched to effectively-infinite still looks healthy from
+    the outside while the real 178 MB download shows a bar frozen at 0% until
+    the very last byte.  Driving the interval to 0 and to a huge value proves
+    the comparison actually gates each chunk.
+    """
+    import http.server
+
+    from taxonomy import _download_with_resume
+
+    payload = b"z" * 500_000
+    chunk_size = 4096
+    chunk_count = len(payload) // chunk_size  # 122
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *a):
+            pass
+
+    def run(interval, out_name):
+        server, port = _start_test_server(Handler)
+        seen = []
+        try:
+            _download_with_resume(
+                f"http://127.0.0.1:{port}/x", str(tmp_path / out_name),
+                chunk_size=chunk_size,
+                byte_callback=lambda done, total: seen.append(done),
+                _emit_interval=interval,
+            )
+        finally:
+            server.shutdown()
+        assert seen[-1] == len(payload)
+        return seen
+
+    # No throttle: every chunk emits.  A read may return short, so the loop
+    # runs at least chunk_count times — the count tracks chunks, not a
+    # hard-coded 1 or 2.
+    ungated = run(0, "ungated.bin")
+    assert len(ungated) >= chunk_count, (
+        f"with _emit_interval=0 expected ~{chunk_count} emits, got {len(ungated)}"
+    )
+
+    # Throttle wider than any plausible download: only the final unconditional
+    # emit survives.
+    gated = run(1e9, "gated.bin")
+    assert len(gated) == 1, (
+        f"with a huge _emit_interval only the final emit should fire, got {len(gated)}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -901,6 +901,72 @@ def test_download_with_resume_cancels_midstream(tmp_path):
     assert requests["n"] == 1, f"expected a single request, got {requests['n']}"
 
 
+def test_download_with_resume_cancel_interrupts_stalled_read(tmp_path):
+    """A Stop press during a stalled resp.read must not wait for the socket timeout.
+
+    Before the watcher thread, cancellation was polled only between reads, so a
+    stalled connection let the flag sit unnoticed until the 120 s urlopen timeout
+    expired — the Settings progress UI stayed running for two minutes on the
+    exact unreliable-network scenario cancellation is for.  The watcher now
+    closes resp when should_cancel goes true, unblocking the read immediately.
+    """
+    import http.server
+    import threading
+    import time
+
+    from taxonomy import DownloadCancelled, _download_with_resume
+
+    # Promise 8 MB in Content-Length but only send 1 KB and hang.  resp.read
+    # of 8 MB has to keep reading until it gets Content-Length bytes or the
+    # connection closes — after the 1 KB flush the read blocks on the socket.
+    stop_hanging = threading.Event()
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(8 * 1024 * 1024))
+            self.end_headers()
+            self.wfile.write(b"x" * 1024)
+            self.wfile.flush()
+            # Hold the connection open until the test releases it — this is
+            # what makes resp.read block on the client side.
+            stop_hanging.wait(timeout=30)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    cancel_flag = threading.Event()
+
+    def fire_cancel_after_read_starts():
+        # A short wait so we are already inside the blocked resp.read when
+        # the flag flips: much longer than the initial header exchange, much
+        # shorter than the socket timeout.
+        time.sleep(0.5)
+        cancel_flag.set()
+    threading.Thread(target=fire_cancel_after_read_starts, daemon=True).start()
+
+    try:
+        dest = tmp_path / "out.bin"
+        started = time.monotonic()
+        with pytest.raises(DownloadCancelled):
+            _download_with_resume(
+                f"http://127.0.0.1:{port}/x", str(dest),
+                chunk_size=8 * 1024 * 1024,  # bigger than the server ever sends
+                should_cancel=cancel_flag.is_set,
+            )
+        elapsed = time.monotonic() - started
+    finally:
+        stop_hanging.set()
+        server.shutdown()
+
+    # Well under the 120 s socket timeout — the watcher closed resp within
+    # its poll interval and the read exited immediately after.
+    assert elapsed < 5, (
+        f"cancel took {elapsed:.2f}s — the watcher did not close a stalled read"
+    )
+
+
 def test_download_with_resume_cancels_during_retry_backoff(tmp_path):
     """A cancel that lands during the retry wait aborts instead of sleeping it out.
 

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -5,6 +5,8 @@ import os
 import sys
 import tempfile
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from db import Database
@@ -802,6 +804,239 @@ def test_download_with_resume_no_range_stalls_correctly(tmp_path):
             )
     finally:
         server.shutdown()
+
+def test_download_with_resume_reports_bytes(tmp_path):
+    """byte_callback gets real byte counts — this is what the progress bar reads."""
+    import http.server
+    from taxonomy import _download_with_resume
+
+    payload = b"x" * 500_000
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    try:
+        seen = []
+        dest = tmp_path / "out.bin"
+        # chunk_size small enough to force several loop iterations
+        _download_with_resume(
+            f"http://127.0.0.1:{port}/x", str(dest), chunk_size=4096,
+            byte_callback=lambda done, total: seen.append((done, total)),
+        )
+    finally:
+        server.shutdown()
+
+    assert seen, "byte_callback was never called"
+    assert seen[-1][0] == len(payload)
+    assert seen[-1][1] == len(payload)          # from Content-Length
+    assert [d for d, _ in seen] == sorted(d for d, _ in seen)
+
+
+def test_download_with_resume_cancels_midstream(tmp_path):
+    """should_cancel aborts and keeps a non-empty .partial for resume."""
+    import http.server
+    from taxonomy import DownloadCancelled, _download_with_resume
+
+    payload = b"x" * 500_000
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    calls = {"n": 0}
+
+    def cancel_after_two_chunks():
+        calls["n"] += 1
+        return calls["n"] > 2
+
+    try:
+        dest = tmp_path / "out.bin"
+        with pytest.raises(DownloadCancelled):
+            _download_with_resume(
+                f"http://127.0.0.1:{port}/x", str(dest), chunk_size=4096,
+                should_cancel=cancel_after_two_chunks,
+            )
+    finally:
+        server.shutdown()
+
+    assert not dest.exists()
+    partial = tmp_path / "out.bin.partial"
+    assert partial.exists()
+    # Non-empty proves we cancelled mid-stream, not before the first read —
+    # open(..., "wb") would create a 0-byte file either way.
+    assert partial.stat().st_size > 0
+
+
+def test_download_with_resume_bytes_include_resume_offset(tmp_path):
+    """On a 206 resume, progress counts bytes already on disk and totals the full file.
+
+    Content-Length on a 206 is only the *remaining* length, so the implementation
+    has to add the resume offset back to both the running count and the total.
+    Without that, a resumed download would show the bar restarting at zero and
+    finishing at less than the real file size.
+    """
+    import http.server
+    from taxonomy import _download_with_resume
+
+    payload = b"C" * 300_000
+    first_chunk = 100_000
+    call_count = [0]
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # Promise the whole file but hang up after first_chunk bytes.
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload[:first_chunk])
+                return
+
+            # Later attempts honour Range with a real 206.
+            range_header = self.headers.get("Range", "")
+            assert range_header.startswith("bytes="), "expected a Range request"
+            start = int(range_header.split("=")[1].split("-")[0])
+            remaining = payload[start:]
+            self.send_response(206)
+            self.send_header("Content-Length", str(len(remaining)))
+            self.send_header("Content-Range",
+                             f"bytes {start}-{len(payload) - 1}/{len(payload)}")
+            self.end_headers()
+            self.wfile.write(remaining)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    seen = []
+    try:
+        dest = tmp_path / "out.bin"
+        _download_with_resume(
+            f"http://127.0.0.1:{port}/x", str(dest), chunk_size=4096,
+            byte_callback=lambda done, total: seen.append((call_count[0], done, total)),
+        )
+    finally:
+        server.shutdown()
+
+    assert open(dest, "rb").read() == payload
+
+    resumed = [e for e in seen if e[0] >= 2]
+    assert resumed, "no byte_callback events during the resumed attempt"
+    # Every event on the resumed attempt reports the FULL file size, never the
+    # 200_000-byte remainder from Content-Length.
+    assert {total for _, _, total in resumed} == {len(payload)}
+    # Progress picks up from the resume offset instead of restarting at zero.
+    assert resumed[0][1] >= first_chunk
+    assert all(done <= len(payload) for _, done, _ in seen)
+    assert seen[-1][1] == len(payload)
+
+
+def test_download_with_resume_bytes_reset_when_server_ignores_range(tmp_path):
+    """A 200 after a partial write restarts the count — the bar must not exceed 100%.
+
+    mode == "wb" truncates the partial in this branch, but downloaded_before is
+    deliberately kept as the stall baseline.  Reusing it as the display base
+    would double-count the discarded bytes.
+    """
+    import http.server
+    from taxonomy import _download_with_resume
+
+    payload = b"E" * 200_000
+    first_chunk = 50_000
+    call_count = [0]
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            call_count[0] += 1
+            self.send_response(200)  # never 206: this server ignores Range
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            if call_count[0] == 1:
+                self.wfile.write(payload[:first_chunk])
+                return
+            self.wfile.write(payload)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    seen = []
+    try:
+        dest = tmp_path / "out.bin"
+        _download_with_resume(
+            f"http://127.0.0.1:{port}/x", str(dest), chunk_size=4096,
+            byte_callback=lambda done, total: seen.append((done, total)),
+        )
+    finally:
+        server.shutdown()
+
+    assert open(dest, "rb").read() == payload
+    assert seen, "byte_callback was never called"
+    # The reported total is always the real file size, never inflated by the
+    # bytes that were thrown away.
+    assert {total for _, total in seen} == {len(payload)}
+    assert all(done <= len(payload) for done, _ in seen)
+    assert seen[-1] == (len(payload), len(payload))
+
+
+def test_download_with_resume_throttles_byte_callback(tmp_path):
+    """byte_callback is rate-limited, not fired once per chunk.
+
+    The SSE subscriber queue is bounded, so a 178 MB download at 256 KB chunks
+    must not emit ~700 events (and at 4 KB chunks, ~45000).
+    """
+    import http.server
+    from taxonomy import _download_with_resume
+
+    payload = b"y" * 500_000
+    chunk_size = 4096
+    chunk_count = len(payload) // chunk_size  # 122
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *a):
+            pass
+
+    server, port = _start_test_server(Handler)
+    seen = []
+    try:
+        dest = tmp_path / "out.bin"
+        _download_with_resume(
+            f"http://127.0.0.1:{port}/x", str(dest), chunk_size=chunk_size,
+            byte_callback=lambda done, total: seen.append(done),
+        )
+    finally:
+        server.shutdown()
+
+    # At ~4 Hz this loop would have to take 5+ seconds on localhost to reach 20
+    # events; one-per-chunk would be 120+.  Deliberately loose so it can't go
+    # flaky on a slow machine, while still failing outright if the throttle is
+    # removed.
+    assert chunk_count > 100, "payload/chunk_size no longer forces many iterations"
+    assert len(seen) <= 20, f"expected throttled events, got {len(seen)}"
+    # Still ends on an exact final count.
+    assert seen[-1] == len(payload)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The "RAW Development (darktable)" panel in Settings was a dead end — it told you darktable was missing and left you to find it yourself. This makes it actionable: resolve the right build for your platform, download it with real byte progress, verify it, and hand off to the OS installer.

Design: `docs/superpowers/specs/2026-07-26-darktable-download-design.md`
Plan: `docs/superpowers/plans/2026-07-26-darktable-download.md`

## Key decisions

- **darktable only.** Adobe DNG Converter is proprietary and EULA-gated with no URL we can legitimately hotlink, so that row gets a "Get it from Adobe ↗" link and nothing more.
- **Latest release resolved from the GitHub API at click time**, not a pinned version — a pinned build goes stale between Vireo releases and a pinned URL 404s if an asset is renamed.
- **Integrity comes from the API's own SHA256 `digest`**, not a code-signature check. darktable does not successfully notarize its macOS builds ([upstream #19295](https://github.com/darktable-org/darktable/issues/19295), closed as not-planned; Homebrew disabled the cask over it) and its Windows installer is unsigned — a fail-closed `spctl`/Authenticode check would have deleted **every legitimate download**.
- **The Gatekeeper warning is conditional** on `com.apple.quarantine` actually being present. Measured: urllib downloads are not quarantined (LaunchServices applies that, not urllib), so it normally stays hidden rather than warning about a dialog you will never see.
- **Per-platform honesty.** macOS/Windows say "Download installer" because you finish the install; Linux says "Download and set up" because there we complete it.

## Bugs found and fixed along the way

- `find_darktable` never probed `/Applications/darktable.app`, so a normal macOS `.dmg` install reported "not found" — while `find_dng_converter` already probed its Adobe equivalent. Without this, a successful download still ended in ✗.
- **Asset matching is exact-suffix.** The release ships ~300 KB `.zsync` delta manifests whose names contain "AppImage"; a substring matcher would have "successfully installed" one of those instead of darktable.
- **`resolve_release` now returns `(release, reason)`.** A bare `None` conflated network failure with "no build for your platform", so a user behind a proxy or over GitHub's 60/hr rate limit was told their platform was unsupported — which is false.
- **`_url_is_trusted` had a path-traversal bypass** (`.../releases/download/../../../../attacker/x.dmg`), and `asset["name"]` was `os.path.join`ed unchecked so `../evil-x86_64.AppImage` could write outside the tools directory.
- **`APPIMAGE_EXTRACT_AND_RUN` was unconditional.** That flag makes the runtime skip the FUSE probe and *always* unpack the full ~178 MB squashfs, and the develop job loops per photo. Now gated on an actual AppImage, detected by magic bytes rather than filename (a renamed AppImage silently launched the GUI and hung for the full 120 s timeout).

## Testing

```
CLAUDE.md required suite:  1 failed, 1972 passed, 14 skipped
Suites touched here:       202 passed
ruff check vireo/ tests/:  All checks passed
```

The single failure is `test_api_exiftool_status_reports_missing`, confirmed failing on `origin/main` as well — pre-existing and unrelated.

Every task was mutation-verified. That caught three tests that passed under the exact bug they were written to catch, plus a `verify_digest` gap where a `blake2s` digest shaped identically to a SHA256 could only be rejected by algorithm name. The Settings panel was driven end-to-end in a real browser across the full completion matrix (success, no-digest, quarantined, Linux config-write, digest mismatch, cancelled, expired, connection loss).

## Known limitation

On Linux the AppImage still extracts once per photo during a develop job. The fix — `--appimage-extract` once at install time — is unverified because darktable's `AppRun` sets `CAMLIBS`, `IOLIBS`, `GIO_EXTRA_MODULES` and sources a GTK hook before exec'ing, so the extracted binary may not run without that environment. It needs testing on real Linux and is recorded as an open question in Task 7 of the plan rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Get darktable” installation/download flow in Settings with availability pre-checks, streamed progress, resume/cancel handling, and platform-specific completion guidance (including macOS quarantine messaging).
  * Added API endpoints for darktable status diagnostics, install availability, and background download jobs with integrity verification.
* **Bug Fixes**
  * Hardened darktable detection and download safety (platform asset selection, path traversal protection, SHA256 verification), plus improved HTTP range resume correctness and robust cancellation.
* **Tests**
  * Expanded contract and unit/integration coverage for byte-accurate progress, cancellation, resumable/reuse behavior, and singleton job orchestration/asset-change handling.
* **Documentation**
  * Added new darktable download plan/specification documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->