### PR TITLE
Stabilize map filter bar browser tests

### DIFF
--- a/tests/e2e/leaflet_stub.py
+++ b/tests/e2e/leaflet_stub.py
@@ -1,0 +1,113 @@
+"""Deterministic Leaflet replacement for map-page browser tests.
+
+The application intentionally loads Leaflet from unpkg, but E2E coverage
+should not depend on third-party network availability.
+"""
+
+LEAFLET_STUB = """
+window.L = {
+  tileLayer: function() {
+    return { addTo: function() { return this; } };
+  },
+  map: function() {
+    return {
+      setView: function(latlng, zoom) {
+        window.__lastMapSetView = { latlng: latlng, zoom: zoom };
+        return this;
+      },
+      addLayer: function() { return this; },
+      fitBounds: function(bounds) {
+        window.__lastFitBounds = bounds;
+        return this;
+      },
+      getZoom: function() { return 2; }
+    };
+  },
+  control: {
+    layers: function() {
+      return { addTo: function() { return this; } };
+    }
+  },
+  markerClusterGroup: function() {
+    var layers = [];
+    window.__mapMarkerBatchSizes = [];
+    return {
+      addLayer: function(marker) {
+        layers.push(marker);
+        window.__mapMarkerCount = layers.length;
+        return this;
+      },
+      addLayers: function(markers) {
+        window.__mapMarkerBatchSizes.push(markers.length);
+        layers = layers.concat(markers);
+        window.__mapMarkerCount = layers.length;
+        return this;
+      },
+      clearLayers: function() {
+        layers = [];
+        window.__mapMarkerCount = 0;
+        return this;
+      },
+      getBounds: function() { return [[0, 0], [1, 1]]; },
+      zoomToShowLayer: function(marker, cb) {
+        window.__zoomedToMarker = marker.getLatLng();
+        if (cb) cb();
+      },
+      on: function() { return this; }
+    };
+  },
+  divIcon: function(opts) { return opts; },
+  marker: function(latlng) {
+    return {
+      _latlng: latlng,
+      bindPopup: function(popup) { this._popup = popup; return this; },
+      on: function(name, handler) {
+        this._handlers = this._handlers || {};
+        this._handlers[name] = handler;
+        return this;
+      },
+      getLatLng: function() { return this._latlng; },
+      openPopup: function() {
+        window.__openedPopup = this._popup;
+        return this;
+      }
+    };
+  },
+  Control: {
+    extend: function(definition) {
+      function Control() {}
+      Control.prototype.addTo = function(map) {
+        this._div = definition.onAdd.call(this, map);
+        return this;
+      };
+      Object.keys(definition).forEach(function(key) {
+        if (key !== "onAdd") Control.prototype[key] = definition[key];
+      });
+      return Control;
+    }
+  },
+  DomUtil: {
+    create: function(tag, className) {
+      var el = document.createElement(tag);
+      el.className = className;
+      return el;
+    }
+  },
+  DomEvent: {
+    disableClickPropagation: function() {},
+    disableScrollPropagation: function() {}
+  }
+};
+"""
+
+
+def stub_leaflet(route):
+    """Fulfill unpkg Leaflet JS/CSS requests without external network."""
+    if route.request.url.endswith(".css"):
+        route.fulfill(status=200, content_type="text/css", body="")
+        return
+    route.fulfill(
+        status=200,
+        content_type="application/javascript",
+        body=LEAFLET_STUB,
+    )

--- a/tests/e2e/test_filterbar_pages.py
+++ b/tests/e2e/test_filterbar_pages.py
@@ -8,6 +8,8 @@ photo has a pending prediction.
 
 import pytest
 
+from e2e.leaflet_stub import stub_leaflet
+
 
 def _wait_bar(page):
     page.wait_for_selector("#vireoFilterBar", timeout=15000)
@@ -30,6 +32,7 @@ def test_map_page_uses_filter_bar(live_server, page):
             "UPDATE photos SET latitude=37.7, longitude=-122.4 WHERE id IN (?, ?)",
             (photos["hawk1.jpg"], photos["robin1.jpg"]))
 
+    page.route("https://unpkg.com/**", stub_leaflet)
     page.goto(live_server["url"] + "/map")
     _wait_bar(page)
     assert _total(page) == 2
@@ -190,6 +193,7 @@ def test_handoff_carries_expression_to_map(live_server, page):
             "UPDATE photos SET latitude=37.7, longitude=-122.4 WHERE id = ?",
             (photos["hawk1.jpg"],))
 
+    page.route("https://unpkg.com/**", stub_leaflet)
     page.goto(live_server["url"] + "/browse")
     _wait_bar(page)
     search = page.locator(".vf-search input")

--- a/tests/e2e/test_map_deep_link.py
+++ b/tests/e2e/test_map_deep_link.py
@@ -1,108 +1,6 @@
 from playwright.sync_api import expect
 
-LEAFLET_STUB = """
-window.L = {
-  tileLayer: function() {
-    return { addTo: function() { return this; } };
-  },
-  map: function() {
-    return {
-      setView: function(latlng, zoom) {
-        window.__lastMapSetView = { latlng: latlng, zoom: zoom };
-        return this;
-      },
-      addLayer: function() { return this; },
-      fitBounds: function(bounds) {
-        window.__lastFitBounds = bounds;
-        return this;
-      },
-      getZoom: function() { return 2; }
-    };
-  },
-  control: {
-    layers: function() {
-      return { addTo: function() { return this; } };
-    }
-  },
-  markerClusterGroup: function() {
-    var layers = [];
-    window.__mapMarkerBatchSizes = [];
-    return {
-      addLayer: function(marker) {
-        layers.push(marker);
-        window.__mapMarkerCount = layers.length;
-        return this;
-      },
-      addLayers: function(markers) {
-        window.__mapMarkerBatchSizes.push(markers.length);
-        layers = layers.concat(markers);
-        window.__mapMarkerCount = layers.length;
-        return this;
-      },
-      clearLayers: function() {
-        layers = [];
-        window.__mapMarkerCount = 0;
-        return this;
-      },
-      getBounds: function() { return [[0, 0], [1, 1]]; },
-      zoomToShowLayer: function(marker, cb) {
-        window.__zoomedToMarker = marker.getLatLng();
-        if (cb) cb();
-      },
-      on: function() { return this; }
-    };
-  },
-  divIcon: function(opts) { return opts; },
-  marker: function(latlng) {
-    return {
-      _latlng: latlng,
-      bindPopup: function(popup) { this._popup = popup; return this; },
-      on: function(name, handler) {
-        this._handlers = this._handlers || {};
-        this._handlers[name] = handler;
-        return this;
-      },
-      getLatLng: function() { return this._latlng; },
-      openPopup: function() {
-        window.__openedPopup = this._popup;
-        return this;
-      }
-    };
-  },
-  Control: {
-    extend: function(definition) {
-      function Control() {}
-      Control.prototype.addTo = function(map) {
-        this._div = definition.onAdd.call(this, map);
-        return this;
-      };
-      Object.keys(definition).forEach(function(key) {
-        if (key !== "onAdd") Control.prototype[key] = definition[key];
-      });
-      return Control;
-    }
-  },
-  DomUtil: {
-    create: function(tag, className) {
-      var el = document.createElement(tag);
-      el.className = className;
-      return el;
-    }
-  },
-  DomEvent: {
-    disableClickPropagation: function() {},
-    disableScrollPropagation: function() {}
-  }
-};
-"""
-
-
-def _stub_leaflet(route):
-    url = route.request.url
-    if url.endswith(".css"):
-        route.fulfill(status=200, content_type="text/css", body="")
-        return
-    route.fulfill(status=200, content_type="application/javascript", body=LEAFLET_STUB)
+from e2e.leaflet_stub import stub_leaflet
 
 
 def test_map_photo_id_deep_link_focuses_marker(live_server, page):
@@ -114,7 +12,7 @@ def test_map_photo_id_deep_link_focuses_marker(live_server, page):
     )
     live_server["db"].conn.commit()
 
-    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.route("https://unpkg.com/**", stub_leaflet)
     page.goto(f"{live_server['url']}/map?photo_id={pid}")
 
     page.wait_for_function(
@@ -135,7 +33,7 @@ def test_map_photo_id_deep_link_reports_missing_location(live_server, page):
     """A map deep link to an unplottable photo gives a targeted status."""
     pid = live_server["data"]["photos"][0]
 
-    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.route("https://unpkg.com/**", stub_leaflet)
     page.goto(f"{live_server['url']}/map?photo_id={pid}")
 
     expect(page.locator("#mapStatus")).to_contain_text("No map location found for this photo.")
@@ -143,7 +41,7 @@ def test_map_photo_id_deep_link_reports_missing_location(live_server, page):
 
 def test_empty_map_links_to_photos_without_coordinates(live_server, page):
     """An all-empty map gives users a working path to the affected photos."""
-    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.route("https://unpkg.com/**", stub_leaflet)
     page.goto(f"{live_server['url']}/map")
 
     expect(page.locator("#mapStatus")).to_contain_text("No geolocated photos")
@@ -166,7 +64,7 @@ def test_map_photo_id_deep_link_is_one_shot_for_later_filters(live_server, page)
     )
     live_server["db"].conn.commit()
 
-    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.route("https://unpkg.com/**", stub_leaflet)
     page.goto(f"{live_server['url']}/map?photo_id={linked_pid}")
     page.wait_for_function(
         "pid => window.activePhotoId === pid && !!window.__openedPopup",
@@ -218,7 +116,7 @@ def test_large_map_renders_in_bounded_batches_and_virtualizes_sidebar(
         "total_without_coordinates": 0,
     }
 
-    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.route("https://unpkg.com/**", stub_leaflet)
     page.route("**/api/photos/geo**", lambda route: route.fulfill(json=payload))
     page.goto(f"{live_server['url']}/map")
 


### PR DESCRIPTION
Stabilizes Map browser tests by intercepting Leaflet and MarkerCluster CDN requests with a shared deterministic stub.
The filter-bar and Map handoff tests now reuse the same helper as the deep-link tests, preventing transient `unpkg.com` availability from blocking Map initialization and causing unrelated assertions to time out.
Validation: `pytest -q tests/e2e/test_filterbar_pages.py --browser chromium` (18 passed), the five Map deep-link tests, Ruff, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for map and filter-bar workflows.
  * Added deterministic Leaflet behavior for map loading, markers, popups, clustering, and navigation.
  * Prevented tests from depending on third-party Leaflet assets or network availability.
  * Standardized map deep-link and missing-location test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->