### PR TITLE
Refresh Browse when folders reconnect

### DIFF
--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -526,6 +526,81 @@ def test_bootstrap_seeds_missing_snapshot_from_init_response(
     expect(page.locator(".grid-card")).to_have_count(5)
 
 
+def test_bootstrap_adopts_init_when_poll_baseline_is_known_older(
+    live_server, page, tmp_path
+):
+    """A poll completed before init starts must not override the newer init."""
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        (str(tmp_path / "gone-park"), folder_ids[0]),
+    )
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(yard), folder_ids[1]),
+    )
+    db.conn.commit()
+
+    # Hold the config promise so the navbar's initial missing-folder poll can
+    # finish before bootstrap issues /api/browse/init.
+    held_cfg = []
+
+    def _hold_all_cfg(route):
+        if route.request.method == "GET":
+            held_cfg.append(route)
+        else:
+            route.continue_()
+
+    page.route("**/api/config", _hold_all_cfg)
+    page.goto(f"{live_server['url']}/browse")
+    for _ in range(50):
+        if held_cfg:
+            break
+        page.wait_for_timeout(100)
+    assert held_cfg, "/api/config was never requested"
+    page.wait_for_function(
+        f"_missingFoldersLastIds !== null && "
+        f"_missingFoldersLastIds.length === 1 && "
+        f"_missingFoldersLastIds[0] === {folder_ids[0]}"
+    )
+    poll_version = page.evaluate("_missingFoldersSnapshotVersion")
+    page.evaluate(
+        "window._folderHealthEvents = [];"
+        "document.addEventListener('vireo:folder-health-changed', "
+        "function(e) { window._folderHealthEvents.push(e.detail.source); });"
+    )
+
+    # Restore park after the poll observation but before init starts. Init is
+    # now the known-newer snapshot and should be adopted directly, not treated
+    # as stale and reconciled backwards to the old poll baseline.
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(park), folder_ids[0]),
+    )
+    db.conn.commit()
+    page.unroute("**/api/config", _hold_all_cfg)
+
+    page.wait_for_function("browseDatasetReady", timeout=10000)
+    state = page.evaluate(
+        "({photoCount: photos.length, missingIds: _missingFoldersLastIds, "
+        "events: window._folderHealthEvents, "
+        "snapshotVersion: _missingFoldersSnapshotVersion})"
+    )
+    assert state["photoCount"] == 5, state
+    assert state["missingIds"] == [], state
+    assert page.evaluate("_missingFoldersSnapshotVersion") > poll_version
+    assert state["events"] == []
+    assert page.locator("#missingFoldersBanner").evaluate(
+        "(el) => getComputedStyle(el).display"
+    ) == "none"
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+
 def test_bootstrap_defers_lock_release_when_init_rejects(
     live_server, page, tmp_path
 ):
@@ -896,6 +971,58 @@ def test_load_folders_generation_guard_prevents_stale_render(
     )
 
 
+def test_load_folders_renders_older_success_after_newer_failure(
+    live_server, page
+):
+    """A failed superseder must not suppress the newest successful tree."""
+    db = live_server["db"]
+    folder_ids = live_server["data"]["folders"]
+    page.goto(f"{live_server['url']}/browse")
+    expect(page.locator("#folderTree .tree-item")).to_have_count(2)
+
+    held = []
+    request_count = 0
+
+    def _hold_success_then_fail(route):
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            held.append(route)
+        elif request_count == 2:
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
+
+    page.route("**/api/folders", _hold_success_then_fail)
+    page.evaluate(
+        "() => { window._olderSuccessfulFolderLoad = "
+        "loadFolders({ shouldRender: () => true }); }"
+    )
+    for _ in range(50):
+        if held:
+            break
+        page.wait_for_timeout(100)
+    assert held, "older folder-tree request was never issued"
+
+    # The held request will read the new tree when released. Start a newer
+    # request first and make that superseder fail.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?",
+        (folder_ids[0],),
+    )
+    db.conn.commit()
+    page.evaluate("() => { window._failedFolderLoad = loadFolders(); }")
+    page.wait_for_timeout(200)
+    held[0].continue_()
+
+    page.wait_for_function(
+        f"!document.querySelector("
+        f"'#folderTree .tree-item[data-folder-id=\"{folder_ids[0]}\"]')",
+        timeout=5000,
+    )
+    expect(page.locator("#folderTree .tree-item")).to_have_count(1)
+
+
 def test_health_refresh_awaits_config_before_loading_photos(
     live_server, page, tmp_path
 ):
@@ -1263,6 +1390,31 @@ def test_health_refresh_retry_preserves_unrelated_transition_ids(
         "document.getElementById('detailContent').classList.contains('visible')"
     )
     expect(page.locator(".grid-card")).to_have_count(3)
+
+
+def test_health_refresh_stops_after_bounded_folder_retries(live_server, page):
+    """A persistent folder endpoint failure must not retry forever."""
+    page.goto(f"{live_server['url']}/browse")
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+    folder_requests = []
+
+    def _fail_folders(route):
+        folder_requests.append(route.request.url)
+        route.fulfill(status=500, body="fail")
+
+    page.route("**/api/folders", _fail_folders)
+    page.evaluate(
+        "document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {"
+        "detail: {restored: [], wentMissing: [], source: 'test', "
+        "refreshRetryAttempt: 3}}))"
+    )
+    page.evaluate("() => window._activeFolderHealthRefresh")
+
+    # Attempt 3 is the cap: no fourth event should be scheduled two seconds
+    # later, and therefore no second folder-tree request should appear.
+    page.wait_for_timeout(2300)
+    assert len(folder_requests) == 1
 
 
 def test_missing_folders_recovery_skips_check_when_mutations_hang(

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -1046,6 +1046,104 @@ def test_unrelated_folder_health_change_preserves_leaf_selection(
     expect(page.locator(".grid-card")).to_have_count(3)
 
 
+def test_health_refresh_skips_stale_reset_when_load_folders_fails(
+    live_server, page, tmp_path
+):
+    """A transient ``/api/folders`` failure during a folder-health refresh
+    must NOT commit to a stale-DOM membership decision, and Browse must
+    recover automatically without waiting for the ten-minute background
+    poll.
+
+    Regression (Codex review r3687062925): ``loadFolders()`` swallowed its
+    exception and resolved, so the refresh's ``Promise.all`` looked
+    successful. The subsequent DOM check for ``activeFolderId`` then read
+    the pre-transition tree, retained the just-missing folder scope, and
+    reloaded that unavailable scope into an empty grid. Because the navbar
+    advances ``_missingFoldersLastIds`` before dispatching the event, no
+    later poll saw a transition to repair the view.
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(park), folder_ids[0]),
+    )
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(yard), folder_ids[1]),
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible", timeout=5000)
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+    # Select park so the health refresh has a folder scope to potentially
+    # mis-preserve. Once selected, only park's 3 photos are visible.
+    page.evaluate(f"filterByFolder({folder_ids[0]})")
+    expect(page.locator(".grid-card")).to_have_count(3)
+
+    # Ensure the initial /api/folders/missing poll seeded the baseline so
+    # the retry dispatched by the fix doesn't merely resurrect a null-diff.
+    page.wait_for_function(
+        "typeof _missingFoldersLastIds !== 'undefined' && "
+        "_missingFoldersLastIds !== null"
+    )
+
+    # Server-side: park just went missing. The navbar's next check-health
+    # POST will observe the transition and dispatch vireo:folder-health-
+    # changed. Route /api/folders to fail ONCE so the first refresh has to
+    # decide whether to reset the grid without fresh folder data.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?", (folder_ids[0],)
+    )
+    db.conn.commit()
+
+    fail_state = {"fired": False}
+
+    def _fail_first_folders(route):
+        if route.request.method == "GET" and not fail_state["fired"]:
+            fail_state["fired"] = True
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
+
+    page.route("**/api/folders", _fail_first_folders)
+
+    # Trigger the health refresh directly. Using the event bypasses the
+    # navbar poll timing so the test is deterministic; the fix under test
+    # lives entirely on the browse.html listener side.
+    page.evaluate(
+        "document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {"
+        " detail: { source: 'test' } }))"
+    )
+
+    # The first refresh must NOT run resetAndLoad against the stale park
+    # scope. Old behavior: the grid drops to 0 cards (park is missing).
+    # New behavior: skip the reset entirely, so the grid stays populated
+    # from the pre-event state until the retry fires.
+    page.wait_for_timeout(500)
+    interim_count = page.locator(".grid-card").count()
+    assert interim_count > 0, (
+        "health refresh reset the grid using stale folder data after "
+        "loadFolders() failed (activeFolderId was preserved from the "
+        "pre-transition DOM)"
+    )
+
+    # The scheduled retry (2s) re-dispatches the event; loadFolders now
+    # succeeds against a park-less tree, membership check clears
+    # activeFolderId, and the workspace-scoped reset lands on yard.
+    page.wait_for_function(
+        "activeFolderId === null",
+        timeout=5000,
+    )
+    expect(page.locator(".grid-card")).to_have_count(2)
+
+
 def test_missing_folders_recovery_skips_check_when_mutations_hang(
     live_server, page
 ):

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -1,4 +1,78 @@
+import json
+
 from playwright.sync_api import expect
+
+
+def test_folder_health_refresh_preserves_active_collection(live_server, page, tmp_path):
+    """A folder-health refresh must not kick the user out of a collection scope.
+
+    Regression: ``resetAndLoad()``'s default clears ``activeCollectionId``
+    for non-dashboard scopes, and the previous refresh path also bumped
+    ``browseScopeGen``. Both would combine to drop the user back to the
+    unscoped workspace grid when a drive or share reconnected while they
+    were viewing a normal collection — either during the brief
+    bootstrap window before ``filterByCollection`` swallows the id into
+    filter chips, or via the chip path being wiped by the reset
+    (CodeRabbit review r3684913393, Codex review r3684907518).
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    # park is repointed to a real path so the health check confirms it's
+    # ok (no status change); yard is marked missing so the check flips it
+    # back to ok and broadcasts vireo:folder-health-changed exactly once.
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(park), folder_ids[0]),
+    )
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        (str(yard), folder_ids[1]),
+    )
+    db.conn.commit()
+
+    rules = json.dumps([{"field": "extension", "op": "is", "value": ".jpg"}])
+    collection_id = db.add_collection("All JPGs", rules)
+
+    # Deep-link into the collection so bootstrap scopes the first paint
+    # through ``activeCollectionId`` and then loads the saved expression
+    # into the filter bar. yard is still missing, so only park's 3 hawks
+    # show.
+    page.goto(f"{live_server['url']}/browse?collection_id={collection_id}")
+    page.wait_for_function("window.VireoFilter && VireoFilter.isReady()")
+    page.wait_for_function(
+        "document.querySelector('.vf-chips') && "
+        "document.querySelector('.vf-chips').textContent.includes('File extension')",
+        timeout=4000,
+    )
+    expect(page.locator(".grid-card")).to_have_count(3)
+
+    # Health-refresh path must call resetAndLoad with preserveCollection so
+    # the option's short-circuit is exercised directly. If a future refactor
+    # drops the flag, this asserts the option is still honored.
+    result = page.evaluate(
+        f"(async () => {{"
+        f"  activeCollectionId = {collection_id};"
+        f"  await resetAndLoad({{ preserveCollection: true }});"
+        f"  return activeCollectionId;"
+        f"}})()"
+    )
+    assert result == collection_id
+
+    with page.expect_response(
+        lambda response: response.url.endswith("/api/folders/check-health")
+    ) as health_response:
+        page.evaluate("openMissingFoldersModal()")
+    assert health_response.value.json()["changed"] == 1
+
+    # The collection scope must survive the refresh: the collection's
+    # rules stay in the filter bar and the grid now includes yard's
+    # photos because the collection matches every .jpg.
+    expect(page.locator(".grid-card")).to_have_count(5)
+    expect(page.locator(".vf-chips")).to_contain_text("File extension")
 
 
 def test_reconnected_folders_refresh_empty_browse(live_server, page, tmp_path):

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -299,6 +299,231 @@ def test_check_health_dispatch_ignores_cross_workspace_flips(
     expect(page.locator(".grid-card")).to_have_count(5)
 
 
+def test_bootstrap_defers_load_lock_release_during_health_refresh(
+    live_server, page, tmp_path
+):
+    """Bootstrap must not release the load lock owned by a concurrent
+    health refresh.
+
+    Regression (Codex review r3685627307): if a folder-health event
+    fires while ``/api/browse/init`` is in flight, the health-refresh
+    handler runs ``resetAndLoad()`` → ``loadPhotos()`` which owns the
+    ``loading`` mutex. When init later returns, bootstrap already
+    guarded the render block on ``healthChangedDuringInit`` — but its
+    finally-region still unconditionally cleared ``loading`` and rearmed
+    the intersection observer. That released the mutex the concurrent
+    ``loadPhotos`` still held, letting the observer fire a duplicate
+    page-1 request against the same ``loadEpoch`` and appending the same
+    photos twice.
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    # Both folders missing initially so bootstrap's /api/browse/init
+    # returns an empty grid; the simulated health event then restores
+    # them and triggers the refresh path.
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        [
+            (str(tmp_path / "gone-park"), folder_ids[0]),
+            (str(tmp_path / "gone-yard"), folder_ids[1]),
+        ],
+    )
+    db.conn.commit()
+
+    # Hold /api/browse/init so the health event fires strictly during
+    # its in-flight window. Only intercept the FIRST init request —
+    # bootstrap re-issues nothing, but we don't want to catch anything
+    # else if the router matches loosely.
+    held_init = []
+
+    def _hold_first_init(route):
+        if not held_init:
+            held_init.append(route)
+        else:
+            route.continue_()
+
+    page.route("**/api/browse/init**", _hold_first_init)
+
+    page.goto(f"{live_server['url']}/browse")
+    for _ in range(50):
+        if held_init:
+            break
+        page.wait_for_timeout(100)
+    assert held_init, "init request was never issued"
+
+    # Restore the folders in the DB, then dispatch the event exactly the
+    # way loadMissingFolders/checkMissingFolders would. The refresh
+    # handler will reload folders/keywords/collections and then call
+    # resetAndLoad → loadPhotos.
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+    page.evaluate(
+        "document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', "
+        "{detail: {restored: [], wentMissing: [], source: 'test'}}))"
+    )
+
+    # Wait for the health-refresh chain's loadPhotos to populate the
+    # grid. The 5 photos come from the two restored folders.
+    page.wait_for_function("photos.length === 5", timeout=15000)
+
+    # Now release init. Bootstrap sees healthChangedDuringInit=true and
+    # must skip both the render block AND the load-lock release; the
+    # health refresh's own loadPhotos finally will clear ``loading``.
+    held_init[0].continue_()
+
+    # Give bootstrap's remaining code (VireoFilter.init promise chain +
+    # finally region) a chance to run so any load-lock release would land
+    # before we assert.
+    page.wait_for_timeout(400)
+
+    # The grid must show exactly 5 photos with no duplicates. If bootstrap
+    # had released the mutex, the observer could have double-fetched page 1
+    # and produced 10 (or 5 with duplicates in ``photos``).
+    expect(page.locator(".grid-card")).to_have_count(5)
+    unique_photos = page.evaluate("new Set(photos.map(p => p.id)).size")
+    assert unique_photos == page.evaluate("photos.length"), (
+        "duplicate photos in grid — bootstrap released the load lock and "
+        "the intersection observer double-fetched page 1"
+    )
+
+
+def test_poll_defers_snapshot_update_to_in_flight_check_health_post(
+    live_server, page, tmp_path
+):
+    """A GET /api/folders/missing whose response arrives while a
+    check-health POST is in flight must not update the snapshot or
+    dispatch vireo:folder-health-changed — the POST is the freshness
+    authority for the post-mutation state.
+
+    Regression (Codex review r3685627312): the previous fix used a
+    single shared ``_missingFoldersObservationGen`` bumped by both GET
+    and POST. A GET fired by ``closeMissingFoldersModal()`` after the
+    modal's POST was still running would bump the gen, and the POST's
+    equality check would then fail on completion — dropping the POST's
+    result even though it's the request that actually mutated folder
+    status. Give the POST its own mutation gen and an in-flight counter
+    so GETs defer to it and only POSTs supersede POSTs.
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        (str(tmp_path / "gone-park"), folder_ids[0]),
+    )
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(yard), folder_ids[1]),
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+    # Wait for the initial /api/folders/missing poll to seed the snapshot
+    # with park's id.
+    page.wait_for_function(
+        f"typeof _missingFoldersLastIds !== 'undefined' && "
+        f"_missingFoldersLastIds !== null && "
+        f"_missingFoldersLastIds.length === 1 && "
+        f"_missingFoldersLastIds[0] === {folder_ids[0]}"
+    )
+    # Instrument event dispatches so we can count them.
+    page.evaluate(
+        "window._folderHealthEvents = [];"
+        "document.addEventListener('vireo:folder-health-changed', "
+        "  function(e) { window._folderHealthEvents.push(e.detail.source); });"
+    )
+
+    # Hold the check-health POST so a subsequent GET can race ahead.
+    held_post = []
+
+    def _hold_post(route):
+        if route.request.method == "POST":
+            held_post.append(route)
+        else:
+            route.continue_()
+
+    page.route("**/api/folders/check-health", _hold_post)
+
+    # Kick off the POST (loadMissingFolders → POST /api/folders/check-health).
+    # Fire-and-forget: page.evaluate awaits any returned promise, and the
+    # held POST would never resolve — so wrap the call so evaluate returns
+    # undefined synchronously and lets us drive the release manually below.
+    page.evaluate(
+        "() => { window._pendingLoadMissing = loadMissingFolders(); }"
+    )
+    for _ in range(50):
+        if held_post:
+            break
+        page.wait_for_timeout(100)
+    assert held_post, "check-health POST was never issued"
+    # In-flight counter must reflect the held POST.
+    assert page.evaluate("_missingFoldersMutationInFlight") == 1
+
+    # Restore park in the DB now, so the GET (issued next) observes the
+    # post-restore state — worse than the pre-fix bug's exact ordering
+    # but simpler to set up: even with a "fresher-looking" GET result,
+    # the POST must still be applied as the authority. Under the old
+    # single-gen scheme the GET would bump the gen and the POST's
+    # completion check would fail, so the POST's dispatch would never
+    # fire. With the fix, the GET is skipped while the POST is in flight.
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(park), folder_ids[0]),
+    )
+    db.conn.commit()
+
+    events_before_get = page.evaluate("window._folderHealthEvents.length")
+    snapshot_before_get = page.evaluate("[..._missingFoldersLastIds]")
+
+    # Fire the racing GET and await its completion in-page — the GET's
+    # URL (/api/folders/missing) isn't intercepted, so it returns fast.
+    # By the time this evaluate resolves, the GET's response handler
+    # has run and either updated state (bug) or deferred to the POST (fix).
+    page.evaluate(
+        "(async () => { await checkMissingFolders(); })()"
+    )
+    # Belt-and-suspenders: give any microtasks a chance to settle.
+    page.wait_for_timeout(200)
+
+    # The GET's response landed while the POST is still in flight — it
+    # must have skipped snapshot update AND dispatch.
+    assert (
+        page.evaluate("[..._missingFoldersLastIds]") == snapshot_before_get
+    ), "racing GET updated snapshot while POST was in flight"
+    assert (
+        page.evaluate("window._folderHealthEvents.length") == events_before_get
+    ), "racing GET dispatched folder-health-changed while POST was in flight"
+    # In-flight counter still shows the held POST.
+    assert page.evaluate("_missingFoldersMutationInFlight") == 1
+
+    # Now release the POST. It observes park as ok → dispatches
+    # 'check-health' and updates the snapshot to [].
+    held_post[0].continue_()
+    page.wait_for_function(
+        f"window._folderHealthEvents.length > {events_before_get}",
+        timeout=10000,
+    )
+    events_after = page.evaluate("window._folderHealthEvents")
+    assert "check-health" in events_after[events_before_get:], (
+        "POST's dispatch was dropped even though it's the freshness authority"
+    )
+    assert page.evaluate("_missingFoldersLastIds") == [], (
+        "POST's snapshot update was dropped even though it's the freshness authority"
+    )
+    # In-flight counter drops back to zero after POST settles.
+    page.wait_for_function("_missingFoldersMutationInFlight === 0", timeout=5000)
+
+
 def test_keyword_search_empty_state_and_clear(live_server, page):
     """A zero-result keyword search must not look like an empty library."""
     url = live_server["url"]

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -394,6 +394,236 @@ def test_bootstrap_defers_load_lock_release_during_health_refresh(
     )
 
 
+def test_bootstrap_seeds_missing_snapshot_from_init_response(
+    live_server, page, tmp_path
+):
+    """/api/browse/init must seed ``_missingFoldersLastIds`` so the first
+    /api/folders/missing observation has a baseline to diff against.
+
+    Regression (Codex review r3686191141): if the background
+    ``_folder_health_loop`` flips folders in the active workspace
+    between ``/api/browse/init`` and the first ``/api/folders/missing``
+    poll, the poll used to return with ``_missingFoldersLastIds ===
+    null`` and its null-baseline early-return silently swallowed the
+    transition. Later polls then saw the post-flip IDs equal to the
+    baseline set by that first poll and never dispatched, leaving the
+    just-rendered Browse grid stuck showing pre-flip state until another
+    transition or a reload. Seeding the baseline from init closes the
+    window.
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    # park is missing at init time; the init response's
+    # ``missing_folder_ids`` must include park's id so the client seeds
+    # its snapshot with [park].
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        (str(tmp_path / "gone-park"), folder_ids[0]),
+    )
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(yard), folder_ids[1]),
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+
+    # After bootstrap settles, the snapshot must equal init's
+    # workspace-scoped missing set — [park] — regardless of whether the
+    # navbar's own initial poll landed first or the init response did.
+    page.wait_for_function(
+        f"typeof _missingFoldersLastIds !== 'undefined' && "
+        f"_missingFoldersLastIds !== null && "
+        f"_missingFoldersLastIds.length === 1 && "
+        f"_missingFoldersLastIds[0] === {folder_ids[0]}"
+    )
+
+    # Instrument dispatches so we can verify the next poll transitions
+    # the seeded [park] → [] state into a folder-health-changed event.
+    page.evaluate(
+        "window._folderHealthEvents = [];"
+        "document.addEventListener('vireo:folder-health-changed', "
+        "  function(e) { window._folderHealthEvents.push(e.detail.source); });"
+    )
+
+    # Server-side background loop restores park (no client involvement,
+    # no /api/folders/check-health POST). The next poll must diff the
+    # seeded [park] against the newly-observed [] and dispatch, so
+    # Browse repopulates with park's photos.
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(park), folder_ids[0]),
+    )
+    db.conn.commit()
+
+    page.evaluate("checkMissingFolders()")
+
+    page.wait_for_function(
+        "window._folderHealthEvents.length > 0", timeout=5000
+    )
+    assert page.evaluate("_missingFoldersLastIds") == []
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+
+def test_bootstrap_defers_lock_release_when_init_rejects(
+    live_server, page, tmp_path
+):
+    """Bootstrap must not release the load lock when /api/browse/init
+    rejects while a concurrent health refresh owns it.
+
+    Regression (Codex review r3686191138): the finally-region guard on
+    ``healthChangedDuringInit`` used to be assigned only in the try's
+    success path (after the init await). If a folder-health event fired
+    during init AND init then rejected, the assignment was skipped and
+    the guard treated the flag as false — clearing ``loading`` even
+    though the health refresh's ``loadPhotos`` still held the mutex,
+    letting the intersection observer fire a duplicate page-1 request
+    against the same ``loadEpoch``.
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        [
+            (str(tmp_path / "gone-park"), folder_ids[0]),
+            (str(tmp_path / "gone-yard"), folder_ids[1]),
+        ],
+    )
+    db.conn.commit()
+
+    # Fail the first init request with a 500 so bootstrap's catch runs;
+    # allow subsequent /api/browse/init requests (there are none in normal
+    # bootstrap flow, but keeps the route robust).
+    aborted_init = []
+
+    def _fail_first_init(route):
+        if not aborted_init:
+            aborted_init.append(route)
+            route.fulfill(status=500, body='{"error": "simulated"}',
+                          content_type="application/json")
+        else:
+            route.continue_()
+
+    page.route("**/api/browse/init**", _fail_first_init)
+
+    page.goto(f"{live_server['url']}/browse")
+    for _ in range(50):
+        if aborted_init:
+            break
+        page.wait_for_timeout(100)
+    assert aborted_init, "init request was never issued"
+
+    # Now restore the folders and dispatch the health-change event.
+    # refreshBrowseAfterFolderHealthChange bumps folderHealthRefreshSeq,
+    # reloads the sidebars, and runs resetAndLoad → loadPhotos.
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+    page.evaluate(
+        "document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', "
+        "{detail: {restored: [], wentMissing: [], source: 'test'}}))"
+    )
+
+    # Wait for the health refresh's loadPhotos to populate the grid.
+    page.wait_for_function("photos.length === 5", timeout=15000)
+
+    # Bootstrap's catch has already run (init rejected synchronously via
+    # the 500). Its finally-region MUST have deferred to the concurrent
+    # refresh — no duplicate cards, no double-fetch.
+    expect(page.locator(".grid-card")).to_have_count(5)
+    unique_photos = page.evaluate("new Set(photos.map(p => p.id)).size")
+    assert unique_photos == page.evaluate("photos.length"), (
+        "duplicate photos in grid — bootstrap's catch released the load "
+        "lock even though the concurrent health refresh owned it"
+    )
+
+
+def test_check_health_null_baseline_ignores_cross_workspace_flip(
+    live_server, page, tmp_path
+):
+    """The null-baseline fallback in loadMissingFolders() must gate on
+    ``workspace_changed``, not on the global ``changed`` count.
+
+    Regression (Codex review r3686191131): when the user opened the
+    missing-folders modal before any /api/folders/missing poll or
+    /api/browse/init seeded ``_missingFoldersLastIds``, the modal POST
+    ran with ``prevIds === null`` and dispatched
+    ``vireo:folder-health-changed`` whenever ``data.changed > 0`` — even
+    when the transition was in another workspace. That would reset the
+    active Browse grid, selection, and detail panel for a change that
+    never touched the active dataset.
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(park), folder_ids[0]),
+    )
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(yard), folder_ids[1]),
+    )
+
+    # A folder linked only to Field Work whose disk path is gone — the
+    # check-health scan will flip it to ``missing`` and bump the global
+    # ``changed`` count without changing the active workspace's set.
+    field_ws = db.conn.execute(
+        "SELECT id FROM workspaces WHERE name = 'Field Work'"
+    ).fetchone()["id"]
+    other_folder_id = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(tmp_path / "gone-field-folder"), "field"),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id, is_root) "
+        "VALUES (?, ?, 1)",
+        (field_ws, other_folder_id),
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+    # Wait for the grid to fully render.
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+    # Force null-baseline: reset the snapshot AFTER load so the modal
+    # POST hits the fallback branch. Then instrument the dispatch.
+    page.evaluate(
+        "_missingFoldersLastIds = null;"
+        "window._folderHealthEvents = 0;"
+        "document.addEventListener('vireo:folder-health-changed', "
+        "  function() { window._folderHealthEvents++; });"
+    )
+
+    with page.expect_response(
+        lambda response: response.url.endswith("/api/folders/check-health")
+    ) as health_response:
+        page.evaluate("openMissingFoldersModal()")
+
+    # The server reports a global change (Field Work's folder flipped)
+    # but the workspace-scoped diff is empty.
+    body = health_response.value.json()
+    assert body["changed"] == 1
+    assert body["workspace_changed"] is False
+    # The null-baseline fallback saw workspace_changed=false and did not
+    # dispatch. The grid stays as-is; no reset, no scope loss.
+    assert page.evaluate("window._folderHealthEvents") == 0
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+
 def test_poll_defers_snapshot_update_to_in_flight_check_health_post(
     live_server, page, tmp_path
 ):

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -1,6 +1,35 @@
 from playwright.sync_api import expect
 
 
+def test_reconnected_folders_refresh_empty_browse(live_server, page, tmp_path):
+    """A health check that restores folders must repopulate an open Browse."""
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+    expect(page.locator("#welcomeState")).to_be_visible()
+    expect(page.locator(".grid-card")).to_have_count(0)
+
+    with page.expect_response(
+        lambda response: response.url.endswith("/api/folders/check-health")
+    ) as health_response:
+        page.evaluate("openMissingFoldersModal()")
+
+    assert health_response.value.json()["changed"] == 2
+    expect(page.locator(".grid-card")).to_have_count(5)
+    expect(page.locator("#welcomeState")).to_be_hidden()
+    expect(page.locator("#filterSummary")).to_contain_text("of 5")
+
+
 def test_keyword_search_empty_state_and_clear(live_server, page):
     """A zero-result keyword search must not look like an empty library."""
     url = live_server["url"]

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -824,6 +824,33 @@ def test_newer_init_server_snapshot_supersedes_delivered_old_poll(
     expect(page.locator(".grid-card")).to_have_count(2)
 
 
+def test_older_init_version_reconciles_when_missing_ids_match(live_server, page):
+    """A stale init version must refresh even when both missing sets are []."""
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function("browseDatasetReady", timeout=5000)
+
+    result = page.evaluate(
+        "() => {"
+        "  window._folderHealthEvents = [];"
+        "  document.addEventListener('vireo:folder-health-changed', "
+        "    function(e) { window._folderHealthEvents.push(e.detail.source); }, "
+        "    {once: true});"
+        "  _missingFoldersLastIds = [];"
+        "  _missingFoldersServerVersion = 12;"
+        "  const startVersion = _missingFoldersSnapshotVersion;"
+        "  const stale = _reconcileMissingFoldersInitSnapshot("
+        "    [], startVersion, 'same-ids-version-reconcile', 11);"
+        "  return {stale: stale, events: window._folderHealthEvents.slice()};"
+        "}"
+    )
+
+    assert result == {
+        "stale": True,
+        "events": ["same-ids-version-reconcile"],
+    }
+    page.evaluate("() => window._activeFolderHealthRefresh")
+
+
 def test_bootstrap_defers_lock_release_when_init_rejects(
     live_server, page, tmp_path
 ):
@@ -1868,6 +1895,33 @@ def test_failed_health_grid_reload_reconciles_on_next_normal_poll(
     expect(page.locator(".grid-card")).to_have_count(5)
     assert len(photo_requests) == 2
     assert page.evaluate("_missingFoldersReconciliationPending") is False
+
+
+def test_wait_for_folder_health_refreshes_drains_replacements(live_server, page):
+    """A deep-link waiter must not resume between refresh A and refresh B."""
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function("browseDatasetReady", timeout=5000)
+
+    page.evaluate(
+        "() => {"
+        "  window._refreshWaitDone = false;"
+        "  _activeFolderHealthRefresh = new Promise(resolve => {"
+        "    window._resolveRefreshA = resolve;"
+        "  });"
+        "  window._refreshWait = waitForFolderHealthRefreshesToSettle().then(() => {"
+        "    window._refreshWaitDone = true;"
+        "  });"
+        "  _activeFolderHealthRefresh = new Promise(resolve => {"
+        "    window._resolveRefreshB = resolve;"
+        "  });"
+        "  window._resolveRefreshA();"
+        "}"
+    )
+    page.wait_for_timeout(100)
+    assert page.evaluate("window._refreshWaitDone") is False
+
+    page.evaluate("window._resolveRefreshB()")
+    page.wait_for_function("window._refreshWaitDone === true", timeout=3000)
 
 
 def test_missing_folders_recovery_skips_check_when_mutations_hang(

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -834,6 +834,111 @@ def test_load_folders_generation_guard_prevents_stale_render(
     )
 
 
+def test_health_refresh_awaits_config_before_loading_photos(
+    live_server, page, tmp_path
+):
+    """A health event fired while /api/config is pending must not load
+    photos with the hard-coded default ``perPage``.
+
+    Regression (Codex review r3686912883): the health-refresh handler used
+    to call ``resetAndLoad({ preserveCollection: true })`` unconditionally,
+    which calls ``loadPhotos()`` against ``perPage = 50`` (the JS default).
+    Bootstrap later applies the configured page size via
+    ``applyBrowseConfig(await _cfgPromise)`` — its own init render is
+    dropped by the health-generation guard, but the ``perPage`` variable
+    it wrote is not. Subsequent pagination then computes offsets against
+    the new size while page 1 was loaded with 50, silently skipping or
+    duplicating photos across the boundary.
+    """
+    import config as cfg
+
+    # Configure a non-default page size. Tiny value so the mismatch would
+    # be dramatic if the fix regressed.
+    saved = cfg.load()
+    saved["photos_per_page"] = 3
+    cfg.save(saved)
+
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    # Hold /api/config so bootstrap and refreshBrowseAfterFolderHealthChange
+    # are both stuck awaiting ``_cfgPromise`` when the health event fires.
+    held_cfg = []
+
+    def _hold_first_cfg(route):
+        if route.request.method == "GET" and not held_cfg:
+            held_cfg.append(route)
+        else:
+            route.continue_()
+
+    page.route("**/api/config", _hold_first_cfg)
+
+    # Capture every /api/photos request the client issues so we can inspect
+    # the per_page value the health refresh's loadPhotos ended up sending.
+    photos_requests = []
+    page.on(
+        "request",
+        lambda req: (
+            photos_requests.append(req.url)
+            if "/api/photos" in req.url and "per_page=" in req.url
+            else None
+        ),
+    )
+
+    page.goto(f"{live_server['url']}/browse")
+    for _ in range(50):
+        if held_cfg:
+            break
+        page.wait_for_timeout(100)
+    assert held_cfg, "/api/config was never requested"
+
+    # Restore folders on disk and dispatch the health event while /api/config
+    # is still pending. Under the pre-fix code, refreshBrowseAfterFolderHealthChange
+    # would immediately call resetAndLoad → loadPhotos using perPage=50.
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+    page.evaluate(
+        "document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', "
+        "{detail: {restored: [], wentMissing: [], source: 'test'}}))"
+    )
+
+    # Give the refresh handler a chance to reach its first await. With the
+    # fix in place it awaits _cfgPromise; without the fix it would already
+    # have fired /api/photos with per_page=50.
+    page.wait_for_timeout(300)
+
+    # Release /api/config so bootstrap and the refresh handler resume with
+    # the configured perPage=3 applied.
+    held_cfg[0].continue_()
+
+    # Wait for the refresh to complete (page 1 fetched from restored folders).
+    page.wait_for_function("photos.length > 0", timeout=10000)
+
+    # Any /api/photos request issued by the health refresh must have used
+    # the configured per_page=3, never the hard-coded 50 that used to leak
+    # through when the event fired before config resolved.
+    assert photos_requests, "health refresh never fetched /api/photos"
+    for url in photos_requests:
+        assert "per_page=3" in url, (
+            f"health-refresh loadPhotos used unconfigured perPage: {url}"
+        )
+        assert "per_page=50" not in url, (
+            f"health-refresh loadPhotos leaked the hard-coded 50: {url}"
+        )
+
+
 def test_missing_folders_recovery_skips_check_when_mutations_hang(
     live_server, page
 ):

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -1378,6 +1378,47 @@ def test_load_summary_renders_older_success_after_newer_failure(
     expect(page.locator("#summaryPhotoCount")).to_have_text("5", timeout=5000)
 
 
+def test_load_calendar_renders_older_success_after_newer_failure(
+    live_server, page
+):
+    """An identical-scope failed superseder must retain a usable calendar."""
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function("browseDatasetReady", timeout=5000)
+    expected_year = str(page.evaluate("calendarYear"))
+
+    held = []
+    request_count = 0
+
+    def _hold_success_then_fail(route):
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            held.append(route)
+        elif request_count == 2:
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
+
+    page.route("**/api/photos/calendar**", _hold_success_then_fail)
+    page.evaluate(
+        "() => {"
+        "  document.getElementById('calYearLabel').textContent = 'stale';"
+        "  window._olderSuccessfulCalendarLoad = loadCalendarData();"
+        "}"
+    )
+    for _ in range(50):
+        if held:
+            break
+        page.wait_for_timeout(100)
+    assert held, "older calendar request was never issued"
+
+    page.evaluate("() => { window._failedCalendarLoad = loadCalendarData(); }")
+    page.wait_for_timeout(200)
+    held[0].continue_()
+
+    expect(page.locator("#calYearLabel")).to_have_text(expected_year, timeout=5000)
+
+
 def test_health_refresh_awaits_config_before_loading_photos(
     live_server, page, tmp_path
 ):

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -1070,6 +1070,50 @@ def test_load_collections_renders_older_success_after_newer_failure(
     ).to_have_count(1, timeout=5000)
 
 
+def test_load_keywords_renders_older_success_after_newer_failure(
+    live_server, page
+):
+    """A failed superseder must not suppress the newest successful tree."""
+    db = live_server["db"]
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function("!loading", timeout=5000)
+
+    held = []
+    request_count = 0
+
+    def _hold_success_then_fail(route):
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            held.append(route)
+        elif request_count == 2:
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
+
+    page.route("**/api/keywords", _hold_success_then_fail)
+    page.evaluate(
+        "() => { window._olderSuccessfulKeywordLoad = "
+        "loadKeywords({ shouldRender: () => true }); }"
+    )
+    for _ in range(50):
+        if held:
+            break
+        page.wait_for_timeout(100)
+    assert held, "older keyword-tree request was never issued"
+
+    keyword_name = "Fallback keyword"
+    keyword_id = db.add_keyword(keyword_name)
+    db.tag_photo(live_server["data"]["photos"][0], keyword_id)
+    page.evaluate("() => { window._failedKeywordLoad = loadKeywords(); }")
+    page.wait_for_timeout(200)
+    held[0].continue_()
+
+    expect(
+        page.locator(f'#keywordTree .tree-item[data-keyword="{keyword_name}"]')
+    ).to_have_count(1, timeout=5000)
+
+
 def test_health_refresh_awaits_config_before_loading_photos(
     live_server, page, tmp_path
 ):
@@ -1476,6 +1520,49 @@ def test_bounded_folder_retries_reconcile_on_next_normal_poll(live_server, page)
     page.evaluate("() => window._activeFolderHealthRefresh")
     assert page.evaluate("_missingFoldersReconciliationPending") is False
     assert len(folder_requests) == 2
+
+
+def test_failed_health_grid_reload_reconciles_on_next_normal_poll(
+    live_server, page
+):
+    """A transient first-page failure must remain pending for reconciliation."""
+    page.goto(f"{live_server['url']}/browse")
+    expect(page.locator(".grid-card")).to_have_count(5)
+    page.wait_for_function(
+        "typeof _missingFoldersLastIds !== 'undefined' && "
+        "_missingFoldersLastIds !== null"
+    )
+
+    photo_requests = []
+    fail_photos = {"value": True}
+
+    def _fail_photos(route):
+        photo_requests.append(route.request.url)
+        if fail_photos["value"]:
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
+
+    page.route("**/api/photos/query", _fail_photos)
+    page.evaluate(
+        "document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {"
+        "detail: {restored: [], wentMissing: [], source: 'test'}}))"
+    )
+    page.evaluate("() => window._activeFolderHealthRefresh")
+
+    expect(page.locator(".grid-card")).to_have_count(0)
+    assert len(photo_requests) == 1
+    assert page.evaluate("_missingFoldersReconciliationPending") is True
+
+    # The missing-folder IDs are unchanged, but the pending marker forces a
+    # synthetic health event and retries the failed page-one grid load.
+    fail_photos["value"] = False
+    page.evaluate("checkMissingFolders()")
+    page.evaluate("() => window._activeFolderHealthRefresh")
+
+    expect(page.locator(".grid-card")).to_have_count(5)
+    assert len(photo_requests) == 2
+    assert page.evaluate("_missingFoldersReconciliationPending") is False
 
 
 def test_missing_folders_recovery_skips_check_when_mutations_hang(

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -1023,6 +1023,53 @@ def test_load_folders_renders_older_success_after_newer_failure(
     expect(page.locator("#folderTree .tree-item")).to_have_count(1)
 
 
+def test_load_collections_renders_older_success_after_newer_failure(
+    live_server, page
+):
+    """A failed superseder must not suppress the newest successful list."""
+    db = live_server["db"]
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function("!loading", timeout=5000)
+
+    held = []
+    request_count = 0
+
+    def _hold_success_then_fail(route):
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            held.append(route)
+        elif request_count == 2:
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
+
+    page.route("**/api/collections", _hold_success_then_fail)
+    page.evaluate(
+        "() => { window._olderSuccessfulCollectionLoad = "
+        "loadCollections({ shouldRender: () => true }); }"
+    )
+    for _ in range(50):
+        if held:
+            break
+        page.wait_for_timeout(100)
+    assert held, "older collection-list request was never issued"
+
+    # The held request reaches the server only after release, so it observes
+    # this new collection. A later request starts first but fails; the older
+    # success is therefore the newest usable response and must be rendered.
+    collection_id = db.add_collection("Fallback collection", "[]")
+    page.evaluate("() => { window._failedCollectionLoad = loadCollections(); }")
+    page.wait_for_timeout(200)
+    held[0].continue_()
+
+    expect(
+        page.locator(
+            f'#collectionList .tree-item[data-collection-id="{collection_id}"]'
+        )
+    ).to_have_count(1, timeout=5000)
+
+
 def test_health_refresh_awaits_config_before_loading_photos(
     live_server, page, tmp_path
 ):
@@ -1392,16 +1439,20 @@ def test_health_refresh_retry_preserves_unrelated_transition_ids(
     expect(page.locator(".grid-card")).to_have_count(3)
 
 
-def test_health_refresh_stops_after_bounded_folder_retries(live_server, page):
-    """A persistent folder endpoint failure must not retry forever."""
+def test_bounded_folder_retries_reconcile_on_next_normal_poll(live_server, page):
+    """A capped retry burst stays dirty for the next normal health poll."""
     page.goto(f"{live_server['url']}/browse")
     expect(page.locator(".grid-card")).to_have_count(5)
 
     folder_requests = []
+    fail_folders = {"value": True}
 
     def _fail_folders(route):
         folder_requests.append(route.request.url)
-        route.fulfill(status=500, body="fail")
+        if fail_folders["value"]:
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
 
     page.route("**/api/folders", _fail_folders)
     page.evaluate(
@@ -1415,6 +1466,16 @@ def test_health_refresh_stops_after_bounded_folder_retries(live_server, page):
     # later, and therefore no second folder-tree request should appear.
     page.wait_for_timeout(2300)
     assert len(folder_requests) == 1
+    assert page.evaluate("_missingFoldersReconciliationPending") is True
+
+    # The navbar snapshot already advanced before the original transition,
+    # so this poll sees unchanged missing-folder ids. It must still consume
+    # the persistent dirty marker and refresh the folder tree successfully.
+    fail_folders["value"] = False
+    page.evaluate("checkMissingFolders()")
+    page.evaluate("() => window._activeFolderHealthRefresh")
+    assert page.evaluate("_missingFoldersReconciliationPending") is False
+    assert len(folder_requests) == 2
 
 
 def test_missing_folders_recovery_skips_check_when_mutations_hang(

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -754,6 +754,138 @@ def test_poll_defers_snapshot_update_to_in_flight_check_health_post(
     page.wait_for_function("_missingFoldersMutationInFlight === 0", timeout=5000)
 
 
+def test_load_folders_generation_guard_prevents_stale_render(
+    live_server, page, tmp_path
+):
+    """Two overlapping ``loadFolders()`` calls: the later one's response must
+    win the folder-tree render even if the earlier one arrives last.
+
+    Regression (Codex review r3686842772): ``refreshBrowseSidebarCounts()``
+    and every mutation-triggered ``loadFolders()`` fire without any
+    ``shouldRender`` guard. Without an internal generation counter shared
+    across every caller, a slow pre-transition response can arrive after a
+    guarded ``refreshBrowseAfterFolderHealthChange()`` has already
+    repainted the tree with the freshly-restored folders — putting the
+    just-cleared missing folder back into the sidebar and letting the user
+    click it into an empty stale scope.
+    """
+    db = live_server["db"]
+    folder_ids = live_server["data"]["folders"]
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible", timeout=5000)
+    initial_count = page.evaluate(
+        "document.querySelectorAll('#folderTree .tree-item').length"
+    )
+    assert initial_count >= 2, "test fixture must ship at least two folders"
+
+    # Hold the FIRST post-bootstrap /api/folders response so we can fire a
+    # newer loadFolders() while the older one is still in flight, then let
+    # the older response come back last.
+    held = []
+
+    def _hold_first_folders(route):
+        if route.request.method == "GET" and not held:
+            held.append(route)
+        else:
+            route.continue_()
+
+    page.route("**/api/folders", _hold_first_folders)
+
+    # Kick off the older ("stale") call. Do NOT await the returned promise —
+    # ``page.evaluate`` would otherwise block until the held response returns.
+    page.evaluate("() => { window._staleLoad = loadFolders(); }")
+    for _ in range(50):
+        if held:
+            break
+        page.wait_for_timeout(100)
+    assert held, "older /api/folders request was never issued"
+
+    # Meanwhile, drop one folder in the DB so the second (newer) call reads
+    # a shorter tree. The newer call is unrouted, so its response returns
+    # immediately with the mutated data.
+    db.conn.execute("DELETE FROM folders WHERE id = ?", (folder_ids[-1],))
+    db.conn.commit()
+
+    page.evaluate("() => { window._freshLoad = loadFolders(); }")
+    # Wait for the newer render to repaint the tree with the shorter list.
+    page.wait_for_function(
+        f"document.querySelectorAll('#folderTree .tree-item').length "
+        f"=== {initial_count - 1}",
+        timeout=10000,
+    )
+    fresh_count = page.evaluate(
+        "document.querySelectorAll('#folderTree .tree-item').length"
+    )
+
+    # Release the older, stale response. Under the pre-fix code the older
+    # ``renderFolderTree(data)`` would clobber the tree back to its
+    # pre-mutation shape; the generation guard must drop it silently.
+    held[0].continue_()
+    # Belt-and-suspenders: give the older response's handler a chance to run.
+    page.wait_for_timeout(300)
+
+    final_count = page.evaluate(
+        "document.querySelectorAll('#folderTree .tree-item').length"
+    )
+    assert final_count == fresh_count, (
+        f"stale loadFolders response repainted the tree "
+        f"(expected {fresh_count} items, got {final_count})"
+    )
+
+
+def test_missing_folders_recovery_skips_check_when_mutations_hang(
+    live_server, page
+):
+    """When the mutation counter never returns to zero (a hung POST), the
+    recovery poll must NOT fire ``checkMissingFolders()`` — its own
+    in-flight guard would reject the GET, wasting a round-trip and
+    masking the drop.
+
+    Regression (Codex review r3686842771): the previous escape hatch
+    (``attempts >= 100``) issued a stale ``checkMissingFolders()`` call
+    anyway, guaranteed to be rejected by its ``_missingFoldersMutationInFlight
+    > 0`` guard. The 10-minute background poll is the only remaining
+    fallback for a genuinely hung POST; fire-and-drop instead of
+    fire-and-be-rejected.
+    """
+    page.goto(f"{live_server['url']}/browse")
+    # Wait for the initial poll to settle so the counter is at rest.
+    page.wait_for_function("_missingFoldersMutationInFlight === 0", timeout=10000)
+
+    # Count subsequent /api/folders/missing requests so we can prove none
+    # were issued by the recovery timer.
+    page.evaluate(
+        "window._missingRequestCount = 0;"
+        "const _origFetch = window.fetch;"
+        "window.fetch = function(url, opts) {"
+        "  if (typeof url === 'string' && url.indexOf('/api/folders/missing') !== -1) {"
+        "    window._missingRequestCount++;"
+        "  }"
+        "  return _origFetch.apply(this, arguments);"
+        "};"
+    )
+
+    # Pin the mutation counter above zero to simulate a POST that never
+    # resolves. The recovery timer wakes up every 50ms for 100 attempts.
+    page.evaluate("_missingFoldersMutationInFlight = 5;")
+    page.evaluate("_scheduleMissingFoldersRecovery();")
+
+    # Sleep past the escape-hatch window (100 × 50ms = 5s) with headroom
+    # for scheduler jitter.
+    page.wait_for_timeout(6500)
+
+    # Escape hatch must have released the scheduled flag without firing a
+    # request the mutation guard would immediately reject.
+    assert page.evaluate("_missingFoldersRecoveryScheduled") is False, (
+        "recovery flag was not cleared after escape-hatch window elapsed"
+    )
+    assert page.evaluate("window._missingRequestCount") == 0, (
+        "recovery fired a stale /api/folders/missing GET the mutation guard "
+        "would have rejected"
+    )
+
+
 def test_bootstrap_renders_grid_from_init_on_plain_load(live_server, page):
     """A plain /browse load must render grid cards from init's response.
 

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -1201,6 +1201,70 @@ def test_health_refresh_skips_stale_reset_when_load_folders_fails(
     expect(page.locator(".grid-card")).to_have_count(2)
 
 
+def test_health_refresh_retry_preserves_unrelated_transition_ids(
+    live_server, page, tmp_path
+):
+    """A folder-tree retry must not reset an unaffected leaf-folder grid."""
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse?folder_id={folder_ids[0]}")
+    expect(page.locator(".grid-card")).to_have_count(3)
+    page.locator(".grid-card").first.click()
+    page.wait_for_function(
+        "document.getElementById('detailContent').classList.contains('visible')",
+        timeout=3000,
+    )
+    selected_id = page.evaluate("selectedPhotoId")
+    load_epoch = page.evaluate("loadEpoch")
+
+    fail_state = {"fired": False}
+
+    def _fail_first_folders(route):
+        if route.request.method == "GET" and not fail_state["fired"]:
+            fail_state["fired"] = True
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
+
+    page.route("**/api/folders", _fail_first_folders)
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?",
+        (folder_ids[1],),
+    )
+    db.conn.commit()
+    page.evaluate(
+        "document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', "
+        f"{{detail: {{restored: [], wentMissing: [{folder_ids[1]}], "
+        "source: 'test'}}))"
+    )
+
+    # The first folder load fails; the scheduled retry succeeds and removes
+    # yard from the tree. It must carry the original wentMissing id so park
+    # remains recognized as unaffected and its grid is not reset.
+    page.wait_for_function(
+        f"!document.querySelector("
+        f"'#folderTree .tree-item[data-folder-id=\"{folder_ids[1]}\"]')",
+        timeout=5000,
+    )
+    assert fail_state["fired"], "the first folder-tree request did not fail"
+    assert page.evaluate("loadEpoch") == load_epoch
+    assert page.evaluate("selectedPhotoId") == selected_id
+    assert page.evaluate(
+        "document.getElementById('detailContent').classList.contains('visible')"
+    )
+    expect(page.locator(".grid-card")).to_have_count(3)
+
+
 def test_missing_folders_recovery_skips_check_when_mutations_hang(
     live_server, page
 ):

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -754,6 +754,28 @@ def test_poll_defers_snapshot_update_to_in_flight_check_health_post(
     page.wait_for_function("_missingFoldersMutationInFlight === 0", timeout=5000)
 
 
+def test_bootstrap_renders_grid_from_init_on_plain_load(live_server, page):
+    """A plain /browse load must render grid cards from init's response.
+
+    Regression: ``bootstrapBrowse()`` synchronously reads
+    ``folderHealthRefreshSeq`` into ``bootstrapHealthSeq`` before its first
+    await. When the paired ``var folderHealthRefreshSeq = 0;`` initialization
+    lived further down the script (past the bootstrapBrowse() invocation),
+    hoisting made the snapshot ``undefined``; the outer script's ``= 0``
+    assignment then ran while bootstrap was awaiting /api/browse/init, and
+    the post-await ``folderHealthRefreshSeq !== bootstrapHealthSeq`` check
+    became ``0 !== undefined`` = true on every normal load. That skipped
+    bootstrap's render block, leaving Browse empty until VireoFilter.init
+    happened to trigger its own reload — which, without an active filter,
+    it does not (Codex review r3686317674).
+    """
+    page.goto(f"{live_server['url']}/browse")
+    # Bootstrap's own render must populate the grid — plain /browse has no
+    # filter/collection deep-link fallback to hide the regression.
+    page.locator(".grid-card").first.wait_for(state="visible", timeout=5000)
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+
 def test_keyword_search_empty_state_and_clear(live_server, page):
     """A zero-result keyword search must not look like an empty library."""
     url = live_server["url"]

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -394,6 +394,63 @@ def test_bootstrap_defers_load_lock_release_during_health_refresh(
     )
 
 
+def test_unrelated_health_event_initializes_pending_folder_bootstrap(
+    live_server, page, tmp_path
+):
+    """An unrelated health transition must not preserve an unpainted grid."""
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    held_init = []
+
+    def _hold_first_init(route):
+        if not held_init:
+            held_init.append(route)
+        else:
+            route.continue_()
+
+    page.route("**/api/browse/init**", _hold_first_init)
+    page.goto(f"{live_server['url']}/browse?folder_id={folder_ids[0]}")
+    for _ in range(50):
+        if held_init:
+            break
+        page.wait_for_timeout(100)
+    assert held_init, "folder-scoped init request was never issued"
+    assert page.evaluate("browseDatasetReady") is False
+
+    # Yard changes while park's first paint is still held. The park scope is
+    # unaffected, but there is no initialized grid to preserve: the health
+    # refresh must take over the initial park-scoped load.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?",
+        (folder_ids[1],),
+    )
+    db.conn.commit()
+    page.evaluate(
+        "document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', "
+        f"{{detail: {{restored: [], wentMissing: [{folder_ids[1]}], "
+        "source: 'test'}}))"
+    )
+    page.evaluate("() => window._activeFolderHealthRefresh")
+
+    held_init[0].continue_()
+    page.wait_for_function(
+        "browseDatasetReady && !loading && photos.length === 3",
+        timeout=10000,
+    )
+    assert page.evaluate("activeFolderId") == folder_ids[0]
+    expect(page.locator(".grid-card")).to_have_count(3)
+
+
 def test_bootstrap_seeds_missing_snapshot_from_init_response(
     live_server, page, tmp_path
 ):

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -721,6 +721,109 @@ def test_bootstrap_snapshot_invalidates_older_inflight_poll(
     expect(page.locator(".grid-card")).to_have_count(2)
 
 
+def test_newer_init_server_snapshot_supersedes_delivered_old_poll(
+    live_server, page, tmp_path
+):
+    """Server observation order wins when the old poll is delivered first."""
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    # Hold real fetch responses in page JavaScript. Playwright route handlers
+    # are serialized, so trying to hold both responses at that layer deadlocks
+    # the second request instead of producing the intended delivery ordering.
+    page.add_init_script(
+        """
+        (() => {
+          const originalFetch = window.fetch.bind(window);
+          const controls = {
+            configs: [],
+            configsReleased: false,
+            missing: null,
+            init: null,
+          };
+          window._snapshotFetchControls = controls;
+          window.fetch = function(input, options) {
+            const url = typeof input === 'string' ? input : input.url;
+            let kind = null;
+            if (url.indexOf('/api/config') !== -1) kind = 'config';
+            else if (url.indexOf('/api/folders/missing') !== -1) kind = 'missing';
+            else if (url.indexOf('/api/browse/init') !== -1) kind = 'init';
+            if (!kind) return originalFetch(input, options);
+            return new Promise((resolve, reject) => {
+              originalFetch(input, options).then(response => {
+                const held = {response: response, release: () => resolve(response)};
+                if (kind === 'config') {
+                  if (controls.configsReleased) held.release();
+                  else controls.configs.push(held);
+                } else {
+                  controls[kind] = held;
+                }
+              }, reject);
+            });
+          };
+        })();
+        """
+    )
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function(
+        "_snapshotFetchControls.configs.length > 0 && "
+        "_snapshotFetchControls.missing !== null",
+        timeout=5000,
+    )
+
+    # The poll has already observed version N with no missing folders. Move
+    # the server to N+1, then let init read and hold that newer response.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?", (folder_ids[0],)
+    )
+    db.conn.commit()
+    page.evaluate(
+        "_snapshotFetchControls.configsReleased = true;"
+        "_snapshotFetchControls.configs.splice(0).forEach(item => item.release());"
+    )
+    page.wait_for_function(
+        "_snapshotFetchControls.init !== null", timeout=5000
+    )
+
+    # Deliver the old poll before applying the already-read newer init. A
+    # client-only request-generation scheme accepts this [] baseline; the
+    # init response must still supersede it via its higher server version.
+    page.evaluate("_snapshotFetchControls.missing.release()")
+    page.wait_for_function(
+        "_missingFoldersLastIds !== null && "
+        "_missingFoldersLastIds.length === 0"
+    )
+    old_server_version = page.evaluate("_missingFoldersServerVersion")
+
+    page.evaluate(
+        "window._folderHealthEvents = [];"
+        "document.addEventListener('vireo:folder-health-changed', "
+        "function(e) { window._folderHealthEvents.push(e.detail.source); });"
+    )
+    page.evaluate("_snapshotFetchControls.init.release()")
+    page.wait_for_function(
+        f"browseDatasetReady && _missingFoldersLastIds.length === 1 && "
+        f"_missingFoldersLastIds[0] === {folder_ids[0]}",
+        timeout=10000,
+    )
+
+    assert page.evaluate("_missingFoldersServerVersion") > old_server_version
+    assert page.evaluate("window._folderHealthEvents") == []
+    assert page.locator("#missingFoldersBanner").evaluate(
+        "(el) => getComputedStyle(el).display"
+    ) == "flex"
+    expect(page.locator(".grid-card")).to_have_count(2)
+
+
 def test_bootstrap_defers_lock_release_when_init_rejects(
     live_server, page, tmp_path
 ):
@@ -1232,6 +1335,47 @@ def test_load_keywords_renders_older_success_after_newer_failure(
     expect(
         page.locator(f'#keywordTree .tree-item[data-keyword="{keyword_name}"]')
     ).to_have_count(1, timeout=5000)
+
+
+def test_load_summary_renders_older_success_after_newer_failure(
+    live_server, page
+):
+    """An identical-scope failed superseder must retain a usable summary."""
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function("browseDatasetReady", timeout=5000)
+    expect(page.locator("#summaryPhotoCount")).to_have_text("5", timeout=5000)
+
+    held = []
+    request_count = 0
+
+    def _hold_success_then_fail(route):
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            held.append(route)
+        elif request_count == 2:
+            route.fulfill(status=500, body="fail")
+        else:
+            route.continue_()
+
+    page.route("**/api/browse/summary**", _hold_success_then_fail)
+    page.evaluate(
+        "() => {"
+        "  document.getElementById('summaryPhotoCount').textContent = 'stale';"
+        "  window._olderSuccessfulSummaryLoad = loadSummary();"
+        "}"
+    )
+    for _ in range(50):
+        if held:
+            break
+        page.wait_for_timeout(100)
+    assert held, "older summary request was never issued"
+
+    page.evaluate("() => { window._failedSummaryLoad = loadSummary(); }")
+    page.wait_for_timeout(200)
+    held[0].continue_()
+
+    expect(page.locator("#summaryPhotoCount")).to_have_text("5", timeout=5000)
 
 
 def test_health_refresh_awaits_config_before_loading_photos(

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -158,6 +158,147 @@ def test_background_health_recovery_refreshes_browse(live_server, page, tmp_path
     expect(page.locator("#filterSummary")).to_contain_text("of 5")
 
 
+def test_relocation_refreshes_browse_when_check_health_reports_no_change(
+    live_server, page, tmp_path
+):
+    """Relocating a missing folder via the modal must refresh Browse even
+    though ``/api/folders/check-health`` reports ``changed=0``.
+
+    ``/api/folders/<id>/relocate`` flips the folder's status to ``ok``
+    before ``loadMissingFolders()`` runs its check-health POST, so the
+    server sees no transition and ``data.changed`` is zero. The
+    workspace's missing set still shrank, and Browse must repopulate —
+    otherwise the just-relocated folder's photos stay hidden until the
+    next 10-minute poll or a manual reload (Codex review r3685295405).
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    # park is missing (pointed at a non-existent path); yard is ok and
+    # anchors its 2 photos in the initial grid so the reappearance of
+    # park's 3 photos is visible in the count.
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        (str(tmp_path / "gone-park"), folder_ids[0]),
+    )
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(yard), folder_ids[1]),
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+    # Wait for the initial /api/folders/missing poll so
+    # _missingFoldersLastIds has park's id as its baseline; otherwise the
+    # workspace-scoped ID diff has nothing to compare against and the
+    # post-relocate check-health response would be treated as first-load
+    # (no dispatch).
+    page.wait_for_function(
+        f"typeof _missingFoldersLastIds !== 'undefined' && "
+        f"_missingFoldersLastIds !== null && "
+        f"_missingFoldersLastIds.length === 1 && "
+        f"_missingFoldersLastIds[0] === {folder_ids[0]}"
+    )
+    expect(page.locator(".grid-card")).to_have_count(2)
+
+    # Simulate what /api/folders/<id>/relocate does server-side: flip
+    # park's status back to ``ok``. The real endpoint uses ``let``-scoped
+    # module state that page.evaluate cannot reach; the post-relocate
+    # UI path (confirmRelocate → loadMissingFolders) is what matters
+    # for this regression, so re-enter it directly below.
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(park), folder_ids[0]),
+    )
+    db.conn.commit()
+
+    with page.expect_response(
+        lambda response: response.url.endswith("/api/folders/check-health")
+    ) as health_response:
+        page.evaluate("loadMissingFolders()")
+
+    # check-health sees no transition — park is already ``ok`` from the
+    # (simulated) relocate. Without the workspace-scoped ID-diff dispatch
+    # this would leave Browse showing only yard's 2 photos.
+    assert health_response.value.json()["changed"] == 0
+    expect(page.locator(".grid-card")).to_have_count(5)
+    expect(page.locator("#filterSummary")).to_contain_text("of 5")
+
+
+def test_check_health_dispatch_ignores_cross_workspace_flips(
+    live_server, page, tmp_path
+):
+    """A folder flip in another workspace must not reset the active Browse.
+
+    ``db.check_folder_health()`` scans every folder in the database and
+    returns a global change count, while ``data.missing`` and Browse are
+    scoped to the active workspace. Dispatching on ``data.changed`` would
+    then blow away the active selection whenever a folder in an
+    unrelated workspace transitioned (Codex review r3685295409).
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(park), folder_ids[0]),
+    )
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        (str(yard), folder_ids[1]),
+    )
+
+    # Add a folder linked only to Field Work whose disk path is already
+    # gone — the next check_folder_health() will flip its status to
+    # ``missing`` and bump the global change count without affecting the
+    # active Default workspace's missing set.
+    field_ws = db.conn.execute(
+        "SELECT id FROM workspaces WHERE name = 'Field Work'"
+    ).fetchone()["id"]
+    other_folder_id = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(tmp_path / "gone-field-folder"), "field"),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id, is_root) "
+        "VALUES (?, ?, 1)",
+        (field_ws, other_folder_id),
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+    page.wait_for_function(
+        "typeof _missingFoldersLastIds !== 'undefined' && "
+        "_missingFoldersLastIds !== null && _missingFoldersLastIds.length === 0"
+    )
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+    # Instrument the dispatch: the event must NOT fire, since only the
+    # Field Work folder transitioned and the active workspace's missing
+    # set is still empty.
+    page.evaluate(
+        "window._folderHealthEvents = 0;"
+        "document.addEventListener('vireo:folder-health-changed', "
+        "  function() { window._folderHealthEvents++; });"
+    )
+
+    with page.expect_response(
+        lambda response: response.url.endswith("/api/folders/check-health")
+    ) as health_response:
+        page.evaluate("openMissingFoldersModal()")
+
+    assert health_response.value.json()["changed"] == 1
+    assert page.evaluate("window._folderHealthEvents") == 0
+    # And the grid stays exactly as it was — no reset, no scope loss.
+    expect(page.locator(".grid-card")).to_have_count(5)
+
+
 def test_keyword_search_empty_state_and_clear(live_server, page):
     """A zero-result keyword search must not look like an empty library."""
     url = live_server["url"]

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -801,10 +801,15 @@ def test_load_folders_generation_guard_prevents_stale_render(
         page.wait_for_timeout(100)
     assert held, "older /api/folders request was never issued"
 
-    # Meanwhile, drop one folder in the DB so the second (newer) call reads
-    # a shorter tree. The newer call is unrouted, so its response returns
-    # immediately with the mutated data.
-    db.conn.execute("DELETE FROM folders WHERE id = ?", (folder_ids[-1],))
+    # Meanwhile, mark one folder missing so the second (newer) call reads a
+    # shorter visible tree. Do not delete the row: fixture photos still
+    # reference it and production health transitions preserve folder rows.
+    # The newer call is unrouted, so its response returns immediately with
+    # the mutated data.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?",
+        (folder_ids[-1],),
+    )
     db.conn.commit()
 
     page.evaluate("() => { window._freshLoad = loadFolders(); }")
@@ -882,17 +887,16 @@ def test_health_refresh_awaits_config_before_loading_photos(
 
     page.route("**/api/config", _hold_first_cfg)
 
-    # Capture every /api/photos request the client issues so we can inspect
+    # Capture every photo-query request the client issues so we can inspect
     # the per_page value the health refresh's loadPhotos ended up sending.
-    photos_requests = []
-    page.on(
-        "request",
-        lambda req: (
-            photos_requests.append(req.url)
-            if "/api/photos" in req.url and "per_page=" in req.url
-            else None
-        ),
-    )
+    # The current Browse API sends pagination in a JSON POST body.
+    photo_query_page_sizes = []
+
+    def _capture_photo_query(req):
+        if req.method == "POST" and req.url.endswith("/api/photos/query"):
+            photo_query_page_sizes.append(req.post_data_json.get("per_page"))
+
+    page.on("request", _capture_photo_query)
 
     page.goto(f"{live_server['url']}/browse")
     for _ in range(50):
@@ -926,17 +930,120 @@ def test_health_refresh_awaits_config_before_loading_photos(
     # Wait for the refresh to complete (page 1 fetched from restored folders).
     page.wait_for_function("photos.length > 0", timeout=10000)
 
-    # Any /api/photos request issued by the health refresh must have used
+    # Any photo-query request issued by the health refresh must have used
     # the configured per_page=3, never the hard-coded 50 that used to leak
     # through when the event fired before config resolved.
-    assert photos_requests, "health refresh never fetched /api/photos"
-    for url in photos_requests:
-        assert "per_page=3" in url, (
-            f"health-refresh loadPhotos used unconfigured perPage: {url}"
-        )
-        assert "per_page=50" not in url, (
-            f"health-refresh loadPhotos leaked the hard-coded 50: {url}"
-        )
+    assert photo_query_page_sizes, "health refresh never queried photos"
+    assert all(size == 3 for size in photo_query_page_sizes), (
+        "health-refresh loadPhotos used unconfigured perPage: "
+        f"{photo_query_page_sizes}"
+    )
+
+
+def test_health_refresh_uses_its_folder_response_when_render_is_superseded(
+    live_server, page, tmp_path
+):
+    """A superseded health-owned folder render must still clear a dead scope."""
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse?folder_id={folder_ids[0]}")
+    expect(page.locator(".grid-card")).to_have_count(3)
+
+    held = []
+
+    def _hold_folder_loads(route):
+        held.append(route)
+
+    page.route("**/api/folders", _hold_folder_loads)
+    park.rmdir()
+
+    with page.expect_response(
+        lambda response: response.url.endswith("/api/folders/check-health")
+    ):
+        page.evaluate("openMissingFoldersModal()")
+
+    # The health event owns the first folder load. Start a second caller so
+    # the shared generation suppresses the first load's DOM render.
+    for _ in range(50):
+        if held:
+            break
+        page.wait_for_timeout(100)
+    assert len(held) == 1, "health refresh did not request the folder tree"
+    page.evaluate("() => { window._winningFolderLoad = loadFolders(); }")
+    for _ in range(50):
+        if len(held) == 2:
+            break
+        page.wait_for_timeout(100)
+    assert len(held) == 2, "competing folder load was not issued"
+
+    # Release only the suppressed health-owned response. The competing render
+    # is still pending, so the DOM remains stale; the refresh must use the
+    # returned rows themselves to see that the active folder disappeared.
+    held[0].continue_()
+    page.wait_for_function("activeFolderId === null", timeout=10000)
+    expect(page.locator(".grid-card")).to_have_count(2)
+
+    held[1].continue_()
+    page.wait_for_function(
+        f"!document.querySelector("
+        f"'#folderTree .tree-item[data-folder-id=\"{folder_ids[0]}\"]')",
+        timeout=5000,
+    )
+
+
+def test_unrelated_folder_health_change_preserves_leaf_selection(
+    live_server, page, tmp_path
+):
+    """A sibling folder transition must not reset a leaf-folder Browse view."""
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse?folder_id={folder_ids[0]}")
+    expect(page.locator(".grid-card")).to_have_count(3)
+    first = page.locator(".grid-card").first
+    first.click()
+    page.wait_for_function(
+        "document.getElementById('detailContent').classList.contains('visible')",
+        timeout=3000,
+    )
+    selected_id = page.evaluate("selectedPhotoId")
+    load_epoch = page.evaluate("loadEpoch")
+
+    # Only the unrelated yard folder changes health. The park-scoped grid is
+    # identical, so the health refresh should update sidebars/counts without
+    # rebuilding the grid or discarding the focused photo and detail panel.
+    yard.rmdir()
+    with page.expect_response(
+        lambda response: response.url.endswith("/api/folders/check-health")
+    ):
+        page.evaluate("openMissingFoldersModal()")
+    page.evaluate("() => window._activeFolderHealthRefresh")
+
+    assert page.evaluate("loadEpoch") == load_epoch
+    assert page.evaluate("selectedPhotoId") == selected_id
+    assert page.evaluate(
+        "document.getElementById('detailContent').classList.contains('visible')"
+    )
+    expect(page.locator(".grid-card")).to_have_count(3)
 
 
 def test_missing_folders_recovery_skips_check_when_mutations_hang(

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -104,6 +104,60 @@ def test_reconnected_folders_refresh_empty_browse(live_server, page, tmp_path):
     expect(page.locator("#filterSummary")).to_contain_text("of 5")
 
 
+def test_background_health_recovery_refreshes_browse(live_server, page, tmp_path):
+    """The 10-minute /api/folders/missing poll must refresh Browse when a
+    server-side background reconnect flips a folder missing→ok.
+
+    Regression: the folder-health event only fired from the modal's
+    /api/folders/check-health POST. The server's own _folder_health_loop
+    runs independently every 10 minutes and can restore a folder with no
+    client involvement; without a diff in the periodic
+    ``checkMissingFolders()`` poll a long-lived Browse view kept its
+    pre-flip empty grid until the user reopened the modal or reloaded
+    (Codex review r3685083009).
+    """
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'missing' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/browse")
+    expect(page.locator("#welcomeState")).to_be_visible()
+    expect(page.locator(".grid-card")).to_have_count(0)
+
+    # Wait for the initial poll snapshot to be recorded — otherwise the
+    # next checkMissingFolders() would see _missingFoldersLastIds === null
+    # and treat the first-since-load state as "no change".
+    page.wait_for_function(
+        "typeof _missingFoldersLastIds !== 'undefined' && "
+        "_missingFoldersLastIds !== null && _missingFoldersLastIds.length === 2"
+    )
+
+    # Simulate the server-side _folder_health_loop restoring both folders.
+    # This mutates DB state without ever touching /api/folders/check-health.
+    db.conn.execute(
+        "UPDATE folders SET status = 'ok' WHERE id IN (?, ?)",
+        (folder_ids[0], folder_ids[1]),
+    )
+    db.conn.commit()
+
+    # Fire the periodic poll manually (the real code runs it on a 10-minute
+    # interval). It must diff the missing set, detect the missing→ok
+    # transition, and dispatch vireo:folder-health-changed.
+    page.evaluate("checkMissingFolders()")
+
+    expect(page.locator(".grid-card")).to_have_count(5)
+    expect(page.locator("#welcomeState")).to_be_hidden()
+    expect(page.locator("#filterSummary")).to_contain_text("of 5")
+
+
 def test_keyword_search_empty_state_and_clear(live_server, page):
     """A zero-result keyword search must not look like an empty library."""
     url = live_server["url"]

--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -1,6 +1,56 @@
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from urllib.request import urlopen
 
 from playwright.sync_api import expect
+
+
+def test_browse_init_reads_folder_health_from_single_snapshot(
+    live_server, monkeypatch
+):
+    """Every health-sensitive init read must share one SQLite snapshot."""
+    from db import Database
+
+    reached_photo_query = threading.Event()
+    release_photo_query = threading.Event()
+    original_get_photos = Database.get_photos
+
+    def _hold_after_photos_read(self, *args, **kwargs):
+        rows = original_get_photos(self, *args, **kwargs)
+        reached_photo_query.set()
+        assert release_photo_query.wait(timeout=5)
+        return rows
+
+    monkeypatch.setattr(Database, "get_photos", _hold_after_photos_read)
+
+    def _request_init():
+        with urlopen(
+            f"{live_server['url']}/api/browse/init?per_page=50", timeout=10
+        ) as response:
+            return json.loads(response.read())
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_request_init)
+        assert reached_photo_query.wait(timeout=5), "init never read its photo page"
+
+        # Commit a health transition after the missing-id/photo reads but
+        # before the endpoint continues to get_folder_tree(). Without the
+        # explicit read transaction the response mixes five old-snapshot
+        # photos and [] missing IDs with a post-transition one-folder tree.
+        missing_id = live_server["data"]["folders"][0]
+        live_server["db"].conn.execute(
+            "UPDATE folders SET status = 'missing' WHERE id = ?", (missing_id,)
+        )
+        live_server["db"].conn.commit()
+        release_photo_query.set()
+        payload = future.result(timeout=10)
+
+    assert payload["missing_folder_ids"] == []
+    assert len(payload["photos"]) == 5
+    assert {row["id"] for row in payload["folders"]} == set(
+        live_server["data"]["folders"]
+    )
 
 
 def test_folder_health_refresh_preserves_active_collection(live_server, page, tmp_path):
@@ -599,6 +649,76 @@ def test_bootstrap_adopts_init_when_poll_baseline_is_known_older(
         "(el) => getComputedStyle(el).display"
     ) == "none"
     expect(page.locator(".grid-card")).to_have_count(5)
+
+
+def test_bootstrap_snapshot_invalidates_older_inflight_poll(
+    live_server, page, tmp_path
+):
+    """A poll response read before init must not overwrite init's baseline."""
+    db = live_server["db"]
+    park = tmp_path / "park"
+    yard = tmp_path / "yard"
+    park.mkdir()
+    yard.mkdir()
+    folder_ids = live_server["data"]["folders"]
+    db.conn.executemany(
+        "UPDATE folders SET path = ?, status = 'ok' WHERE id = ?",
+        [(str(park), folder_ids[0]), (str(yard), folder_ids[1])],
+    )
+    db.conn.commit()
+
+    # Hold config so the navbar poll can read the old [] state before init
+    # starts. route.fetch() captures that response now; delaying fulfill
+    # simulates a slow delivery after the newer init snapshot is applied.
+    held_cfg = []
+    held_missing = []
+
+    def _hold_all_cfg(route):
+        held_cfg.append(route)
+
+    def _capture_then_hold_missing(route):
+        held_missing.append((route, route.fetch()))
+
+    page.route("**/api/config", _hold_all_cfg)
+    page.route("**/api/folders/missing", _capture_then_hold_missing)
+    page.goto(f"{live_server['url']}/browse")
+    for _ in range(50):
+        if held_cfg and held_missing:
+            break
+        page.wait_for_timeout(100)
+    assert held_cfg, "/api/config was never requested"
+    assert held_missing, "/api/folders/missing was never requested"
+
+    # Init begins after the transition and installs [park] as the newer
+    # baseline while the old poll response remains undelivered.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?", (folder_ids[0],)
+    )
+    db.conn.commit()
+    for route in held_cfg:
+        route.continue_()
+    page.unroute("**/api/config", _hold_all_cfg)
+    page.wait_for_function(
+        f"browseDatasetReady && _missingFoldersLastIds.length === 1 && "
+        f"_missingFoldersLastIds[0] === {folder_ids[0]}",
+        timeout=10000,
+    )
+    expect(page.locator(".grid-card")).to_have_count(2)
+
+    page.evaluate(
+        "window._folderHealthEvents = [];"
+        "document.addEventListener('vireo:folder-health-changed', "
+        "function(e) { window._folderHealthEvents.push(e.detail.source); });"
+    )
+    held_missing[0][0].fulfill(response=held_missing[0][1])
+    page.wait_for_timeout(300)
+
+    assert page.evaluate("_missingFoldersLastIds") == [folder_ids[0]]
+    assert page.evaluate("window._folderHealthEvents") == []
+    assert page.locator("#missingFoldersBanner").evaluate(
+        "(el) => getComputedStyle(el).display"
+    ) == "flex"
+    expect(page.locator(".grid-card")).to_have_count(2)
 
 
 def test_bootstrap_defers_lock_release_when_init_rejects(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4807,6 +4807,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # remains to repair the mixed response (Codex reviews r3686317681 and
         # r3687501744).
         missing_folder_ids = [f["id"] for f in db.get_missing_folders()]
+        folder_health_version = db.get_folder_health_version()
 
         # First paint is scope-only (folder / collection / sort); metadata
         # filter deep links compile into the filter bar client-side, which
@@ -4896,6 +4897,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "keywords": [dict(k) for k in keywords],
                 "collections": collection_dicts,
                 "missing_folder_ids": missing_folder_ids,
+                "folder_health_version": folder_health_version,
             }
         )
         # End the read transaction after every value in the response has been
@@ -5322,8 +5324,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/folders/missing")
     def api_folders_missing():
         db = _get_db()
+        # Keep the rows and their monotonic observation marker on one read
+        # snapshot so clients can compare this response with /api/browse/init
+        # independent of network delivery order.
+        db.conn.execute("BEGIN")
         missing = db.get_missing_folders()
-        return jsonify([dict(f) for f in missing])
+        health_version = db.get_folder_health_version()
+        response = jsonify([dict(f) for f in missing])
+        response.headers["X-Vireo-Folder-Health-Version"] = str(health_version)
+        db.conn.rollback()
+        return response
 
     _MISSING_ORIGINALS_STALE_SECONDS = 30 * 60
     _MISSING_ORIGINALS_BACKOFF_SECONDS = 30 * 60
@@ -5867,13 +5877,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # next full scan.
         if changed:
             _invalidate_missing_originals_cache()
+        db.conn.execute("BEGIN")
         missing = db.get_missing_folders()
         ws_missing_after = {f["id"] for f in missing}
-        return jsonify({
+        health_version = db.get_folder_health_version()
+        response = jsonify({
             "changed": changed,
             "workspace_changed": ws_missing_before != ws_missing_after,
             "missing": [dict(f) for f in missing],
+            "folder_health_version": health_version,
         })
+        db.conn.rollback()
+        return response
 
     @app.route("/api/photos/missing/delete-sidecars", methods=["POST"])
     def api_photos_missing_delete_sidecars():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4783,6 +4783,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if coll_row is not None and coll_row["visual_json"] is not None:
                 visual_first_paint = True
 
+        # Snapshot the active workspace's missing-folder IDs so the client's
+        # navbar can seed ``_missingFoldersLastIds`` from this init response.
+        # Without a baseline, the first /api/folders/missing observation
+        # returns false when a background _folder_health_loop flip runs
+        # between init and the poll — later polls then see the same IDs and
+        # never dispatch, leaving Browse stuck showing the pre-flip state
+        # (Codex review r3686191141).
+        #
+        # Take this snapshot BEFORE the photo / folder / keyword / collection
+        # reads. Each SELECT reads its own committed snapshot (no explicit
+        # transaction here), so ``_folder_health_loop`` committing between
+        # the folder read and the missing-folder read used to produce a
+        # split-snapshot response: folders reflected the pre-flip state
+        # while ``missing_folder_ids`` reflected the post-flip state. When
+        # the client seeded ``_missingFoldersLastIds`` from that fresher
+        # baseline, the subsequent /api/folders/missing polls saw no diff
+        # and never dispatched vireo:folder-health-changed, so Browse's
+        # sidebar/grid stayed stuck showing the pre-flip folders until
+        # another health transition or a reload (Codex review r3686317681).
+        # Taking the baseline first guarantees it is at least as OLD as the
+        # folder data — any inconsistency now points the "wrong" way, so
+        # the very next poll finds a diff and drives a refresh.
+        missing_folder_ids = [f["id"] for f in db.get_missing_folders()]
+
         # First paint is scope-only (folder / collection / sort); metadata
         # filter deep links compile into the filter bar client-side, which
         # reloads through /api/photos/query once initialized (Phase 5 —
@@ -4814,14 +4838,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         folders = db.get_folder_tree()
         keywords = db.get_keyword_tree()
         collections = db.get_collections()
-        # Snapshot the active workspace's missing-folder IDs so the client's
-        # navbar can seed ``_missingFoldersLastIds`` from this init response.
-        # Without a baseline, the first /api/folders/missing observation
-        # returns false when a background _folder_health_loop flip runs
-        # between init and the poll — later polls then see the same IDs and
-        # never dispatch, leaving Browse stuck showing the pre-flip state
-        # (Codex review r3686191141).
-        missing_folder_ids = [f["id"] for f in db.get_missing_folders()]
 
         photo_dicts = [dict(p) for p in photos]
         _attach_location_statuses(db, photo_dicts)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4760,6 +4760,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         folder_id = request.args.get("folder_id", None, type=int)
         collection_id = request.args.get("collection_id", None, type=int)
 
+        # Keep the combined first-paint payload on one SQLite read snapshot.
+        # Independent SELECT snapshots can straddle a background folder-health
+        # commit and combine pre-transition photos/missing IDs with a
+        # post-transition folder tree. Since the navbar poll may already have
+        # completed, there is no guaranteed immediate observation to repair
+        # that split response.
+        db.conn.execute("BEGIN")
+
         # ``db.get_photos(collection_id=...)`` / ``count_filtered_photos`` both
         # expand only ``collections.rules`` — the same rules-only path guarded
         # elsewhere by ``_reject_visual_collection``. A visual-only collection
@@ -4791,20 +4799,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # never dispatch, leaving Browse stuck showing the pre-flip state
         # (Codex review r3686191141).
         #
-        # Take this snapshot BEFORE the photo / folder / keyword / collection
-        # reads. Each SELECT reads its own committed snapshot (no explicit
-        # transaction here), so ``_folder_health_loop`` committing between
-        # the folder read and the missing-folder read used to produce a
-        # split-snapshot response: folders reflected the pre-flip state
-        # while ``missing_folder_ids`` reflected the post-flip state. When
-        # the client seeded ``_missingFoldersLastIds`` from that fresher
-        # baseline, the subsequent /api/folders/missing polls saw no diff
-        # and never dispatched vireo:folder-health-changed, so Browse's
-        # sidebar/grid stayed stuck showing the pre-flip folders until
-        # another health transition or a reload (Codex review r3686317681).
-        # Taking the baseline first guarantees it is at least as OLD as the
-        # folder data — any inconsistency now points the "wrong" way, so
-        # the very next poll finds a diff and drives a refresh.
+        # This is the first read in the explicit transaction above, so every
+        # photo / folder / keyword / collection read below shares the same
+        # health snapshot. Ordering alone is insufficient: if the background
+        # health loop commits after this query but before get_folder_tree(),
+        # and the navbar's initial poll already finished, no immediate poll
+        # remains to repair the mixed response (Codex reviews r3686317681 and
+        # r3687501744).
         missing_folder_ids = [f["id"] for f in db.get_missing_folders()]
 
         # First paint is scope-only (folder / collection / sort); metadata
@@ -4824,6 +4825,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     sort=sort,
                 )
             except ValueError as exc:
+                db.conn.rollback()
                 return json_error(str(exc), 400)
             if not any([folder_id, collection_id]):
                 total = db.count_photos()
@@ -4834,6 +4836,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         collection_id=collection_id,
                     )
                 except ValueError as exc:
+                    db.conn.rollback()
                     return json_error(str(exc), 400)
         folders = db.get_folder_tree()
         keywords = db.get_keyword_tree()
@@ -4883,7 +4886,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
             collection_dicts.append(d)
 
-        return jsonify(
+        response = jsonify(
             {
                 "photos": photo_dicts,
                 "total": total,
@@ -4895,6 +4898,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "missing_folder_ids": missing_folder_ids,
             }
         )
+        # End the read transaction after every value in the response has been
+        # materialized. rollback() is intentional: this endpoint is read-only
+        # and it releases the snapshot without implying a write commit.
+        db.conn.rollback()
+        return response
 
     @app.route("/api/pipeline/slots")
     def api_pipeline_slots():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4814,6 +4814,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         folders = db.get_folder_tree()
         keywords = db.get_keyword_tree()
         collections = db.get_collections()
+        # Snapshot the active workspace's missing-folder IDs so the client's
+        # navbar can seed ``_missingFoldersLastIds`` from this init response.
+        # Without a baseline, the first /api/folders/missing observation
+        # returns false when a background _folder_health_loop flip runs
+        # between init and the poll — later polls then see the same IDs and
+        # never dispatch, leaving Browse stuck showing the pre-flip state
+        # (Codex review r3686191141).
+        missing_folder_ids = [f["id"] for f in db.get_missing_folders()]
 
         photo_dicts = [dict(p) for p in photos]
         _attach_location_statuses(db, photo_dicts)
@@ -4868,6 +4876,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "folders": [dict(f) for f in folders],
                 "keywords": [dict(k) for k in keywords],
                 "collections": collection_dicts,
+                "missing_folder_ids": missing_folder_ids,
             }
         )
 
@@ -5817,6 +5826,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/folders/check-health", methods=["POST"])
     def api_folders_check_health():
         db = _get_db()
+        # ``check_folder_health()`` scans every folder in the DB and returns a
+        # global change count, but the client needs to know whether the
+        # ACTIVE workspace's missing set changed. Snapshot the workspace-
+        # scoped missing IDs before and after so the client's null-baseline
+        # fallback in loadMissingFolders() (fired when the modal opens before
+        # any poll seeds the snapshot) can distinguish a cross-workspace
+        # flip — which must NOT reset the active Browse — from a real
+        # active-workspace transition that still needs to notify Browse
+        # (Codex review r3686191131).
+        ws_missing_before = {f["id"] for f in db.get_missing_folders()}
         changed = db.check_folder_health()
         # A folder flipping ok→missing turns every one of its photos into a
         # ghost, and missing→ok resurrects them. Either transition would
@@ -5825,8 +5844,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if changed:
             _invalidate_missing_originals_cache()
         missing = db.get_missing_folders()
+        ws_missing_after = {f["id"] for f in missing}
         return jsonify({
             "changed": changed,
+            "workspace_changed": ws_missing_before != ws_missing_after,
             "missing": [dict(f) for f in missing],
         })
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1175,6 +1175,48 @@ class Database:
                 ON collections(workspace_id);
             CREATE INDEX IF NOT EXISTS idx_pending_workspace
                 ON pending_changes(workspace_id);
+
+            -- Monotonic observation marker shared by folder-health endpoints.
+            -- Clients use it to order responses by the SQLite snapshot they
+            -- observed rather than by request start or network delivery.
+            INSERT OR IGNORE INTO db_meta(key, value)
+                VALUES ('folder_health_version', '0');
+            CREATE TRIGGER IF NOT EXISTS trg_folder_health_version_insert
+            AFTER INSERT ON folders
+            BEGIN
+                UPDATE db_meta
+                SET value = CAST(value AS INTEGER) + 1
+                WHERE key = 'folder_health_version';
+            END;
+            CREATE TRIGGER IF NOT EXISTS trg_folder_health_version_delete
+            AFTER DELETE ON folders
+            BEGIN
+                UPDATE db_meta
+                SET value = CAST(value AS INTEGER) + 1
+                WHERE key = 'folder_health_version';
+            END;
+            CREATE TRIGGER IF NOT EXISTS trg_folder_health_version_status
+            AFTER UPDATE OF status ON folders
+            WHEN OLD.status IS NOT NEW.status
+            BEGIN
+                UPDATE db_meta
+                SET value = CAST(value AS INTEGER) + 1
+                WHERE key = 'folder_health_version';
+            END;
+            CREATE TRIGGER IF NOT EXISTS trg_folder_health_version_ws_insert
+            AFTER INSERT ON workspace_folders
+            BEGIN
+                UPDATE db_meta
+                SET value = CAST(value AS INTEGER) + 1
+                WHERE key = 'folder_health_version';
+            END;
+            CREATE TRIGGER IF NOT EXISTS trg_folder_health_version_ws_delete
+            AFTER DELETE ON workspace_folders
+            BEGIN
+                UPDATE db_meta
+                SET value = CAST(value AS INTEGER) + 1
+                WHERE key = 'folder_health_version';
+            END;
         """
         )
         cur = self.conn.cursor()
@@ -3532,6 +3574,11 @@ class Database:
                ORDER BY f.path""",
             (self._ws_id(),),
         ).fetchall()
+
+    def get_folder_health_version(self):
+        """Return the monotonic version for folder-health-visible changes."""
+        value = self.get_meta("folder_health_version")
+        return int(value or 0)
 
     def get_missing_photos(
         self,

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11142,18 +11142,35 @@ let _missingBannerDismissedCount = 0;
 // reloaded \u2014 the background reconnect that just restored the folder would
 // never reach the page (Codex review r3685083009).
 let _missingFoldersLastIds = null;
-// Monotonic id shared by every observation of the missing-folder set —
-// the GET poll (checkMissingFolders) and the modal's check-health POST
-// (loadMissingFolders). A caller captures the id before its fetch and
-// checks it after awaiting; only the newest-issued observation may
-// update the snapshot or dispatch. Without this, an older GET whose
-// response lands after a newer POST could unconditionally replace
-// ``_missingFoldersLastIds`` with its stale result — e.g. a GET that
-// observed folder A as missing before a POST restored it can return
-// after the POST stored ``[]``, causing a false ``wentMissing`` event
-// and restoring the missing-folder banner until the next 10-minute
-// poll (Codex review r3685515796).
+// Race guards for the two paths that observe the missing-folder set —
+// the GET poll (checkMissingFolders) and the modal's mutating check-
+// health POST (loadMissingFolders). Issuance order alone is not a
+// freshness guarantee across them: the POST commits DB updates a
+// concurrent GET can't yet see, so a GET started after the POST can
+// still return an older snapshot than what the POST will observe once
+// its filesystem check finishes. Semantics:
+//   * ``_missingFoldersObservationGen`` bumps on every GET only, for
+//     GET-vs-GET supersession.
+//   * ``_missingFoldersMutationGen`` bumps on every POST only, for
+//     POST-vs-POST supersession (a modal reopen while an earlier POST
+//     is still in flight; the newest post-mutation observation wins).
+//   * ``_missingFoldersMutationInFlight`` counts running POSTs. A GET
+//     whose response arrives while > 0 has observed pre-mutation state
+//     and must skip its snapshot update / dispatch — the POST is the
+//     freshness authority and will fire the event itself
+//     (Codex review r3685627312).
+//   * ``_missingFoldersMutationEpoch`` bumps when a POST finishes. A
+//     GET snapshots it at start and skips if it changed by completion —
+//     catches the case where a POST started AFTER the GET and completed
+//     BEFORE it (also stale for the GET).
+// Together, these preserve r3685515796's guarantee — a stale GET can
+// never overwrite a fresher POST — while also giving the POST
+// precedence over GETs that happen to start after it
+// (Codex review r3685627312).
 let _missingFoldersObservationGen = 0;
+let _missingFoldersMutationGen = 0;
+let _missingFoldersMutationInFlight = 0;
+let _missingFoldersMutationEpoch = 0;
 
 function _missingFolderIdsDiffer(prev, curr) {
   if (prev.length !== curr.length) return true;
@@ -11183,16 +11200,29 @@ function _dispatchFolderHealthChangeFromIds(prevIds, currentIds, source) {
 
 async function checkMissingFolders() {
   const myGen = ++_missingFoldersObservationGen;
+  const mutationEpochAtStart = _missingFoldersMutationEpoch;
   try {
     const resp = await fetch('/api/folders/missing');
     if (!resp.ok) return;
     const folders = await resp.json();
-    // A newer observation (another GET, or the modal's check-health POST)
-    // started while this fetch was pending \u2014 its result supersedes ours.
-    // Skip the snapshot update and dispatch so a stale GET response can't
-    // repaint the banner or fire a false ``wentMissing`` event
-    // (Codex review r3685515796).
+    // A newer GET started while this fetch was pending \u2014 its result
+    // supersedes ours (Codex review r3685515796). Skip the whole
+    // response: banner too, since a stale banner update would just
+    // paint a false state that the newer GET is about to overwrite
+    // anyway.
     if (myGen !== _missingFoldersObservationGen) return;
+    // A mutating /api/folders/check-health POST is either in flight or
+    // completed during our await; its post-mutation observation is the
+    // freshness authority and this GET may only reflect pre-mutation
+    // truth. Skip snapshot + dispatch + banner so a pre-commit read
+    // can't paint the banner ahead of the POST or fire a false
+    // ``wentMissing`` for a transition the POST will handle
+    // (Codex review r3685627312). The POST refreshes the banner via
+    // its own tail call to checkMissingFolders() when it settles the
+    // list to empty; the periodic 10-minute poll picks up any
+    // remaining drift.
+    if (_missingFoldersMutationInFlight > 0 ||
+        mutationEpochAtStart !== _missingFoldersMutationEpoch) return;
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     _dispatchFolderHealthChangeFromIds(_missingFoldersLastIds, currentIds, 'poll');
     _missingFoldersLastIds = currentIds;
@@ -11619,7 +11649,14 @@ function closeMissingFoldersModal() {
 async function loadMissingFolders() {
   const container = document.getElementById('missingFoldersList');
   container.innerHTML = '<p style="color:var(--text-secondary);">Checking folders…</p>';
-  const myGen = ++_missingFoldersObservationGen;
+  // Own mutation gen (POST-vs-POST supersession) and in-flight counter —
+  // the shared observation gen the GET poll uses is deliberately NOT
+  // bumped here: a POST that started earlier must not be discarded just
+  // because a later GET (e.g. from closeMissingFoldersModal) bumped it
+  // (Codex review r3685627312). GET-vs-POST supersession is handled
+  // instead via ``_missingFoldersMutationInFlight`` + ``…MutationEpoch``.
+  const myMutationGen = ++_missingFoldersMutationGen;
+  _missingFoldersMutationInFlight++;
   try {
     const resp = await fetch('/api/folders/check-health', { method: 'POST' });
     if (!resp.ok) throw new Error('check failed');
@@ -11642,14 +11679,11 @@ async function loadMissingFolders() {
     //     folder to ``ok`` by the time this POST runs, so ``data.changed``
     //     is zero — but the workspace's missing set did change and Browse
     //     still needs to repopulate (r3685295405).
-    // A newer observation started while this POST was pending — its
-    // result supersedes ours. Skip snapshot update and dispatch so a
-    // stale check-health response cannot overwrite fresher state or
-    // fire a duplicate ``vireo:folder-health-changed`` for a transition
-    // the newer observation will handle (Codex review r3685515796).
-    // We still render the modal rows below so the user sees what this
-    // POST returned — that's what they were waiting on.
-    if (myGen === _missingFoldersObservationGen) {
+    // A newer POST superseded this one (rare — modal reopened before this
+    // POST finished). Skip snapshot + dispatch so its result becomes the
+    // authority. The modal rows below still render, because the user
+    // opened this modal and is waiting on this POST's data.
+    if (myMutationGen === _missingFoldersMutationGen) {
       const prevIds = _missingFoldersLastIds;
       const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
       // Keep the poll snapshot in sync with what this POST just observed
@@ -11713,6 +11747,12 @@ async function loadMissingFolders() {
     });
   } catch (e) {
     container.innerHTML = '<p style="color:var(--text-secondary);">Failed to check folders.</p>';
+  } finally {
+    // Decrement + bump epoch in the finally so any GET whose ``await``
+    // straddled this POST — start OR end — sees the change and defers
+    // (Codex review r3685627312).
+    _missingFoldersMutationInFlight--;
+    _missingFoldersMutationEpoch++;
   }
 }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11280,8 +11280,21 @@ function _reconcileMissingFoldersInitSnapshot(
     _updateMissingFoldersBanner(currentIds.map(id => ({ id })));
     return false;
   }
-  return _dispatchFolderHealthChangeFromIds(
+  const dispatched = _dispatchFolderHealthChangeFromIds(
     currentIds, _missingFoldersLastIds, source);
+  if (dispatched) return true;
+  // A higher server version proves the init payload is stale even when the
+  // missing-ID set is unchanged (for example a healthy folder was linked,
+  // unlinked, inserted, or deleted). Force the conservative no-ID refresh so
+  // bootstrap does not render the obsolete folder tree/photo grid.
+  if (serverVersion !== null && _missingFoldersServerVersion !== null &&
+      serverVersion < _missingFoldersServerVersion) {
+    document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+      detail: { restored: [], wentMissing: [], source },
+    }));
+    return true;
+  }
+  return false;
 }
 
 // Wait for every in-flight POST mutation to settle, then run one

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11143,14 +11143,30 @@ let _missingBannerDismissedCount = 0;
 // never reach the page (Codex review r3685083009).
 let _missingFoldersLastIds = null;
 
-function _missingFolderIdsChanged(currentIds) {
-  if (_missingFoldersLastIds === null) return false;
-  const prev = _missingFoldersLastIds;
-  if (prev.length !== currentIds.length) return true;
+function _missingFolderIdsDiffer(prev, curr) {
+  if (prev.length !== curr.length) return true;
   for (let i = 0; i < prev.length; i++) {
-    if (prev[i] !== currentIds[i]) return true;
+    if (prev[i] !== curr[i]) return true;
   }
   return false;
+}
+
+// Fire vireo:folder-health-changed based on the transition of the
+// workspace-scoped missing-folder ID set — not on the modal POST's
+// ``changed`` count, which reflects a global scan and would trigger a
+// spurious Browse reset when a folder in another workspace flipped
+// (Codex review r3685295409). Returns whether an event was dispatched.
+function _dispatchFolderHealthChangeFromIds(prevIds, currentIds, source) {
+  if (prevIds === null) return false;
+  if (!_missingFolderIdsDiffer(prevIds, currentIds)) return false;
+  const prevSet = new Set(prevIds);
+  const currSet = new Set(currentIds);
+  const restored = prevIds.filter(id => !currSet.has(id));
+  const wentMissing = currentIds.filter(id => !prevSet.has(id));
+  document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+    detail: { restored, wentMissing, source },
+  }));
+  return true;
 }
 
 async function checkMissingFolders() {
@@ -11159,15 +11175,7 @@ async function checkMissingFolders() {
     if (!resp.ok) return;
     const folders = await resp.json();
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
-    if (_missingFolderIdsChanged(currentIds)) {
-      const prevSet = new Set(_missingFoldersLastIds);
-      const currSet = new Set(currentIds);
-      const restored = _missingFoldersLastIds.filter(id => !currSet.has(id));
-      const wentMissing = currentIds.filter(id => !prevSet.has(id));
-      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
-        detail: { restored, wentMissing, source: 'poll' },
-      }));
-    }
+    _dispatchFolderHealthChangeFromIds(_missingFoldersLastIds, currentIds, 'poll');
     _missingFoldersLastIds = currentIds;
     const banner = document.getElementById('missingFoldersBanner');
     const msg = document.getElementById('missingFoldersMsg');
@@ -11596,22 +11604,44 @@ async function loadMissingFolders() {
     const resp = await fetch('/api/folders/check-health', { method: 'POST' });
     if (!resp.ok) throw new Error('check failed');
     const data = await resp.json();
+    const folders = data.missing;
     // Folder health is part of the effective photo dataset: ok→missing hides
     // a folder's photos, while missing→ok makes them available again. Notify
     // the current page so a long-lived Browse view does not keep showing the
     // pre-check empty grid after a drive or network share reconnects.
-    if (data.changed) {
-      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
-        detail: { changed: data.changed, source: 'check-health' },
-      }));
-    }
-    const folders = data.missing;
+    //
+    // Dispatch on the workspace-scoped missing-ID transition rather than
+    // ``data.changed``. Two motivations, both from Codex review of 31acc79:
+    //   * ``check_folder_health()`` scans every folder in the database and
+    //     returns a global change count, so a flip in another workspace's
+    //     folder would trigger a needless Browse reset here — clearing the
+    //     user's active selection and detail view even though the active
+    //     dataset did not change (r3685295409).
+    //   * When the modal is used to relocate a missing folder, the
+    //     ``/api/folders/<id>/relocate`` endpoint has already flipped the
+    //     folder to ``ok`` by the time this POST runs, so ``data.changed``
+    //     is zero — but the workspace's missing set did change and Browse
+    //     still needs to repopulate (r3685295405).
+    const prevIds = _missingFoldersLastIds;
+    const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     // Keep the poll snapshot in sync with what this POST just observed on
     // the server — closeMissingFoldersModal() and the 10-minute interval
     // both call checkMissingFolders() next, and without this the poll
     // would see (last-poll ≠ post-POST) and fire a second redundant
     // vireo:folder-health-changed for the same transition.
-    _missingFoldersLastIds = folders.map(f => f.id).sort((a, b) => a - b);
+    _missingFoldersLastIds = currentIds;
+    const dispatched = _dispatchFolderHealthChangeFromIds(
+      prevIds, currentIds, 'check-health');
+    // Narrow initial-load race: the user opened this modal before the
+    // page-load ``checkMissingFolders()`` finished, so no ID baseline
+    // exists yet. Preserve the pre-fix behavior in that window — a
+    // status flip in the active workspace still needs to reach Browse.
+    // Cross-workspace flips remain filtered as soon as any poll runs.
+    if (!dispatched && prevIds === null && data.changed) {
+      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+        detail: { restored: [], wentMissing: [], source: 'check-health' },
+      }));
+    }
     if (folders.length === 0) {
       container.textContent = '';
       const ok = document.createElement('p');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11566,6 +11566,15 @@ async function loadMissingFolders() {
     const resp = await fetch('/api/folders/check-health', { method: 'POST' });
     if (!resp.ok) throw new Error('check failed');
     const data = await resp.json();
+    // Folder health is part of the effective photo dataset: ok→missing hides
+    // a folder's photos, while missing→ok makes them available again. Notify
+    // the current page so a long-lived Browse view does not keep showing the
+    // pre-check empty grid after a drive or network share reconnects.
+    if (data.changed) {
+      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+        detail: { changed: data.changed },
+      }));
+    }
     const folders = data.missing;
     if (folders.length === 0) {
       container.textContent = '';

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11171,6 +11171,12 @@ let _missingFoldersObservationGen = 0;
 let _missingFoldersMutationGen = 0;
 let _missingFoldersMutationInFlight = 0;
 let _missingFoldersMutationEpoch = 0;
+// Incremented whenever a GET, POST, or Browse init snapshot becomes the
+// client-side baseline. Browse captures this immediately before requesting
+// /api/browse/init, which lets it distinguish a baseline that was already
+// applied (init is newer) from one that landed while init was in flight
+// (the later observation remains authoritative).
+let _missingFoldersSnapshotVersion = 0;
 
 function _missingFolderIdsDiffer(prev, curr) {
   if (prev.length !== curr.length) return true;
@@ -11221,6 +11227,28 @@ function _updateMissingFoldersBanner(folders) {
     banner.style.display = 'none';
     _missingBannerDismissedCount = 0;
   }
+}
+
+// Reconcile the missing-folder IDs bundled into /api/browse/init with the
+// navbar poll/POST baseline. If the baseline version has not changed since
+// the init request began, init is known to be the newer observation: adopt
+// it and update the banner without dispatching a backwards transition. If
+// the version changed in flight, keep that later observation and dispatch
+// init→current so Browse discards its stale init payload.
+function _reconcileMissingFoldersInitSnapshot(
+  initIds, snapshotVersionAtStart, source
+) {
+  const currentIds = initIds.slice().sort((a, b) => a - b);
+  const initIsNewer = _missingFoldersLastIds === null ||
+    snapshotVersionAtStart === _missingFoldersSnapshotVersion;
+  if (initIsNewer) {
+    _missingFoldersLastIds = currentIds;
+    _missingFoldersSnapshotVersion++;
+    _updateMissingFoldersBanner(currentIds.map(id => ({ id })));
+    return false;
+  }
+  return _dispatchFolderHealthChangeFromIds(
+    currentIds, _missingFoldersLastIds, source);
 }
 
 // Wait for every in-flight POST mutation to settle, then run one
@@ -11285,6 +11313,7 @@ async function checkMissingFolders() {
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     _dispatchFolderHealthChangeFromIds(_missingFoldersLastIds, currentIds, 'poll');
     _missingFoldersLastIds = currentIds;
+    _missingFoldersSnapshotVersion++;
     _updateMissingFoldersBanner(folders);
   } catch (e) { /* ignore */ }
 }
@@ -11761,6 +11790,7 @@ async function loadMissingFolders() {
     // the poll would see (last-poll ≠ post-POST) and fire a second
     // redundant vireo:folder-health-changed for the same transition.
     _missingFoldersLastIds = currentIds;
+    _missingFoldersSnapshotVersion++;
     const dispatched = _dispatchFolderHealthChangeFromIds(
       prevIds, currentIds, 'check-health');
     // Narrow initial-load race: the user opened this modal before the

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11198,6 +11198,31 @@ function _dispatchFolderHealthChangeFromIds(prevIds, currentIds, source) {
   return true;
 }
 
+// Shared banner-update helper used by both the GET poll
+// (checkMissingFolders) and the modal POST (loadMissingFolders). The POST
+// must NOT delegate to checkMissingFolders here: if the user closes the
+// modal while its POST is still pending, closeMissingFoldersModal fires a
+// GET that our own _missingFoldersMutationInFlight guard rejects, and a
+// tail-call checkMissingFolders() from the POST body is rejected too —
+// its GET starts while the in-flight counter is still > 0, then finishes
+// after our finally bumps the mutation epoch (stale by both checks). The
+// banner would then keep showing the pre-check state until the next
+// 10-minute poll (Codex review r3686095481). Updating from the POST's
+// authoritative response bypasses the guards entirely.
+function _updateMissingFoldersBanner(folders) {
+  const banner = document.getElementById('missingFoldersBanner');
+  const msg = document.getElementById('missingFoldersMsg');
+  if (!banner || !msg) return;
+  if (folders.length > 0 && folders.length !== _missingBannerDismissedCount) {
+    const s = folders.length === 1 ? '' : 's';
+    msg.textContent = `${folders.length} folder${s} can’t be found on disk.`;
+    banner.style.display = 'flex';
+  } else if (folders.length === 0) {
+    banner.style.display = 'none';
+    _missingBannerDismissedCount = 0;
+  }
+}
+
 async function checkMissingFolders() {
   const myGen = ++_missingFoldersObservationGen;
   const mutationEpochAtStart = _missingFoldersMutationEpoch;
@@ -11217,25 +11242,15 @@ async function checkMissingFolders() {
     // truth. Skip snapshot + dispatch + banner so a pre-commit read
     // can't paint the banner ahead of the POST or fire a false
     // ``wentMissing`` for a transition the POST will handle
-    // (Codex review r3685627312). The POST refreshes the banner via
-    // its own tail call to checkMissingFolders() when it settles the
-    // list to empty; the periodic 10-minute poll picks up any
-    // remaining drift.
+    // (Codex review r3685627312). The POST paints the banner directly
+    // from its own authoritative response via _updateMissingFoldersBanner
+    // — see r3686095481 for why it can't safely delegate back here.
     if (_missingFoldersMutationInFlight > 0 ||
         mutationEpochAtStart !== _missingFoldersMutationEpoch) return;
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     _dispatchFolderHealthChangeFromIds(_missingFoldersLastIds, currentIds, 'poll');
     _missingFoldersLastIds = currentIds;
-    const banner = document.getElementById('missingFoldersBanner');
-    const msg = document.getElementById('missingFoldersMsg');
-    if (folders.length > 0 && folders.length !== _missingBannerDismissedCount) {
-      const s = folders.length === 1 ? '' : 's';
-      msg.textContent = `${folders.length} folder${s} can\u2019t be found on disk.`;
-      banner.style.display = 'flex';
-    } else if (folders.length === 0) {
-      banner.style.display = 'none';
-      _missingBannerDismissedCount = 0;
-    }
+    _updateMissingFoldersBanner(folders);
   } catch (e) { /* ignore */ }
 }
 
@@ -11680,31 +11695,41 @@ async function loadMissingFolders() {
     //     is zero — but the workspace's missing set did change and Browse
     //     still needs to repopulate (r3685295405).
     // A newer POST superseded this one (rare — modal reopened before this
-    // POST finished). Skip snapshot + dispatch so its result becomes the
-    // authority. The modal rows below still render, because the user
-    // opened this modal and is waiting on this POST's data.
-    if (myMutationGen === _missingFoldersMutationGen) {
-      const prevIds = _missingFoldersLastIds;
-      const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
-      // Keep the poll snapshot in sync with what this POST just observed
-      // on the server — closeMissingFoldersModal() and the 10-minute
-      // interval both call checkMissingFolders() next, and without this
-      // the poll would see (last-poll ≠ post-POST) and fire a second
-      // redundant vireo:folder-health-changed for the same transition.
-      _missingFoldersLastIds = currentIds;
-      const dispatched = _dispatchFolderHealthChangeFromIds(
-        prevIds, currentIds, 'check-health');
-      // Narrow initial-load race: the user opened this modal before the
-      // page-load ``checkMissingFolders()`` finished, so no ID baseline
-      // exists yet. Preserve the pre-fix behavior in that window — a
-      // status flip in the active workspace still needs to reach Browse.
-      // Cross-workspace flips remain filtered as soon as any poll runs.
-      if (!dispatched && prevIds === null && data.changed) {
-        document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
-          detail: { restored: [], wentMissing: [], source: 'check-health' },
-        }));
-      }
+    // POST finished). Skip *everything* below — snapshot, dispatch,
+    // banner, modal rendering. The newer POST is the freshness authority
+    // and will paint the correct rows/error when it settles; letting a
+    // stale POST run past its guard used to overwrite the newer POST's
+    // "Checking folders…" placeholder with pre-mutation rows or a false
+    // failure message (Codex review r3686095489).
+    if (myMutationGen !== _missingFoldersMutationGen) return;
+    const prevIds = _missingFoldersLastIds;
+    const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
+    // Keep the poll snapshot in sync with what this POST just observed
+    // on the server — closeMissingFoldersModal() and the 10-minute
+    // interval both call checkMissingFolders() next, and without this
+    // the poll would see (last-poll ≠ post-POST) and fire a second
+    // redundant vireo:folder-health-changed for the same transition.
+    _missingFoldersLastIds = currentIds;
+    const dispatched = _dispatchFolderHealthChangeFromIds(
+      prevIds, currentIds, 'check-health');
+    // Narrow initial-load race: the user opened this modal before the
+    // page-load ``checkMissingFolders()`` finished, so no ID baseline
+    // exists yet. Preserve the pre-fix behavior in that window — a
+    // status flip in the active workspace still needs to reach Browse.
+    // Cross-workspace flips remain filtered as soon as any poll runs.
+    if (!dispatched && prevIds === null && data.changed) {
+      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+        detail: { restored: [], wentMissing: [], source: 'check-health' },
+      }));
     }
+    // Update the banner directly from this POST's authoritative response
+    // rather than tail-calling checkMissingFolders(). See the helper's
+    // comment for the race that made the delegation unrecoverable when
+    // the modal was closed mid-POST (Codex review r3686095481). Runs for
+    // both empty and non-empty results so the banner is right regardless
+    // of whether closeMissingFoldersModal's own GET was rejected by our
+    // in-flight guard.
+    _updateMissingFoldersBanner(folders);
     if (folders.length === 0) {
       container.textContent = '';
       const ok = document.createElement('p');
@@ -11714,7 +11739,6 @@ async function loadMissingFolders() {
       check.style.cssText = 'font-size:18px;line-height:1;';
       ok.append(check, document.createTextNode('All folders are accounted for.'));
       container.appendChild(ok);
-      checkMissingFolders();  // update banner
       return;
     }
     // Paths are user-controlled: build rows with DOM methods instead of
@@ -11746,7 +11770,12 @@ async function loadMissingFolders() {
       container.appendChild(row);
     });
   } catch (e) {
-    container.innerHTML = '<p style="color:var(--text-secondary);">Failed to check folders.</p>';
+    // Same stale guard as the success path — a superseded POST must not
+    // overwrite the newer POST's in-flight "Checking folders…" placeholder
+    // with a false failure message (Codex review r3686095489).
+    if (myMutationGen === _missingFoldersMutationGen) {
+      container.innerHTML = '<p style="color:var(--text-secondary);">Failed to check folders.</p>';
+    }
   } finally {
     // Decrement + bump epoch in the finally so any GET whose ``await``
     // straddled this POST — start OR end — sees the change and defers

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11142,6 +11142,18 @@ let _missingBannerDismissedCount = 0;
 // reloaded \u2014 the background reconnect that just restored the folder would
 // never reach the page (Codex review r3685083009).
 let _missingFoldersLastIds = null;
+// Monotonic id shared by every observation of the missing-folder set —
+// the GET poll (checkMissingFolders) and the modal's check-health POST
+// (loadMissingFolders). A caller captures the id before its fetch and
+// checks it after awaiting; only the newest-issued observation may
+// update the snapshot or dispatch. Without this, an older GET whose
+// response lands after a newer POST could unconditionally replace
+// ``_missingFoldersLastIds`` with its stale result — e.g. a GET that
+// observed folder A as missing before a POST restored it can return
+// after the POST stored ``[]``, causing a false ``wentMissing`` event
+// and restoring the missing-folder banner until the next 10-minute
+// poll (Codex review r3685515796).
+let _missingFoldersObservationGen = 0;
 
 function _missingFolderIdsDiffer(prev, curr) {
   if (prev.length !== curr.length) return true;
@@ -11170,10 +11182,17 @@ function _dispatchFolderHealthChangeFromIds(prevIds, currentIds, source) {
 }
 
 async function checkMissingFolders() {
+  const myGen = ++_missingFoldersObservationGen;
   try {
     const resp = await fetch('/api/folders/missing');
     if (!resp.ok) return;
     const folders = await resp.json();
+    // A newer observation (another GET, or the modal's check-health POST)
+    // started while this fetch was pending \u2014 its result supersedes ours.
+    // Skip the snapshot update and dispatch so a stale GET response can't
+    // repaint the banner or fire a false ``wentMissing`` event
+    // (Codex review r3685515796).
+    if (myGen !== _missingFoldersObservationGen) return;
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     _dispatchFolderHealthChangeFromIds(_missingFoldersLastIds, currentIds, 'poll');
     _missingFoldersLastIds = currentIds;
@@ -11600,6 +11619,7 @@ function closeMissingFoldersModal() {
 async function loadMissingFolders() {
   const container = document.getElementById('missingFoldersList');
   container.innerHTML = '<p style="color:var(--text-secondary);">Checking folders…</p>';
+  const myGen = ++_missingFoldersObservationGen;
   try {
     const resp = await fetch('/api/folders/check-health', { method: 'POST' });
     if (!resp.ok) throw new Error('check failed');
@@ -11622,25 +11642,34 @@ async function loadMissingFolders() {
     //     folder to ``ok`` by the time this POST runs, so ``data.changed``
     //     is zero — but the workspace's missing set did change and Browse
     //     still needs to repopulate (r3685295405).
-    const prevIds = _missingFoldersLastIds;
-    const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
-    // Keep the poll snapshot in sync with what this POST just observed on
-    // the server — closeMissingFoldersModal() and the 10-minute interval
-    // both call checkMissingFolders() next, and without this the poll
-    // would see (last-poll ≠ post-POST) and fire a second redundant
-    // vireo:folder-health-changed for the same transition.
-    _missingFoldersLastIds = currentIds;
-    const dispatched = _dispatchFolderHealthChangeFromIds(
-      prevIds, currentIds, 'check-health');
-    // Narrow initial-load race: the user opened this modal before the
-    // page-load ``checkMissingFolders()`` finished, so no ID baseline
-    // exists yet. Preserve the pre-fix behavior in that window — a
-    // status flip in the active workspace still needs to reach Browse.
-    // Cross-workspace flips remain filtered as soon as any poll runs.
-    if (!dispatched && prevIds === null && data.changed) {
-      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
-        detail: { restored: [], wentMissing: [], source: 'check-health' },
-      }));
+    // A newer observation started while this POST was pending — its
+    // result supersedes ours. Skip snapshot update and dispatch so a
+    // stale check-health response cannot overwrite fresher state or
+    // fire a duplicate ``vireo:folder-health-changed`` for a transition
+    // the newer observation will handle (Codex review r3685515796).
+    // We still render the modal rows below so the user sees what this
+    // POST returned — that's what they were waiting on.
+    if (myGen === _missingFoldersObservationGen) {
+      const prevIds = _missingFoldersLastIds;
+      const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
+      // Keep the poll snapshot in sync with what this POST just observed
+      // on the server — closeMissingFoldersModal() and the 10-minute
+      // interval both call checkMissingFolders() next, and without this
+      // the poll would see (last-poll ≠ post-POST) and fire a second
+      // redundant vireo:folder-health-changed for the same transition.
+      _missingFoldersLastIds = currentIds;
+      const dispatched = _dispatchFolderHealthChangeFromIds(
+        prevIds, currentIds, 'check-health');
+      // Narrow initial-load race: the user opened this modal before the
+      // page-load ``checkMissingFolders()`` finished, so no ID baseline
+      // exists yet. Preserve the pre-fix behavior in that window — a
+      // status flip in the active workspace still needs to reach Browse.
+      // Cross-workspace flips remain filtered as soon as any poll runs.
+      if (!dispatched && prevIds === null && data.changed) {
+        document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+          detail: { restored: [], wentMissing: [], source: 'check-health' },
+        }));
+      }
     }
     if (folders.length === 0) {
       container.textContent = '';

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11223,6 +11223,30 @@ function _updateMissingFoldersBanner(folders) {
   }
 }
 
+// Wait for every in-flight POST mutation to settle, then run one
+// ``checkMissingFolders()``. Used by loadMissingFolders's catch block
+// to guarantee its recovery poll isn't swallowed by its own in-flight
+// counter — which would happen when two POSTs overlap and the newer
+// one fails while the older one is still pending. A firehose safety
+// bound (100 × 50ms = 5s) keeps this from spinning forever if a hung
+// fetch somehow leaves the counter stuck (Codex review r3686778064).
+let _missingFoldersRecoveryScheduled = false;
+function _scheduleMissingFoldersRecovery() {
+  if (_missingFoldersRecoveryScheduled) return;
+  _missingFoldersRecoveryScheduled = true;
+  let attempts = 0;
+  const tick = function() {
+    if (_missingFoldersMutationInFlight === 0 || attempts >= 100) {
+      _missingFoldersRecoveryScheduled = false;
+      checkMissingFolders();
+      return;
+    }
+    attempts++;
+    setTimeout(tick, 50);
+  };
+  setTimeout(tick, 0);
+}
+
 async function checkMissingFolders() {
   const myGen = ++_missingFoldersObservationGen;
   const mutationEpochAtStart = _missingFoldersMutationEpoch;
@@ -11791,7 +11815,15 @@ async function loadMissingFolders() {
     // once ``_missingFoldersMutationInFlight`` has been decremented (and
     // ``_missingFoldersMutationEpoch`` bumped) — otherwise its own
     // in-flight guard rejects it (Codex review r3686605299).
-    setTimeout(checkMissingFolders, 0);
+    //
+    // Additionally, wait for *every* overlapping POST to settle before
+    // running the poll: if a newer POST failed while an older POST is
+    // still pending, decrementing our own counter only takes it from
+    // 2→1, checkMissingFolders still sees ``> 0`` and rejects, and the
+    // older POST is later discarded by its mutation-gen guard — leaving
+    // no request to update the snapshot until the ten-minute interval
+    // (Codex review r3686778064).
+    _scheduleMissingFoldersRecovery();
   } finally {
     // Decrement + bump epoch in the finally so any GET whose ``await``
     // straddled this POST — start OR end — sees the change and defers

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11302,6 +11302,7 @@ function _scheduleMissingFoldersRecovery() {
 async function checkMissingFolders() {
   const myGen = ++_missingFoldersObservationGen;
   const mutationEpochAtStart = _missingFoldersMutationEpoch;
+  const snapshotVersionAtStart = _missingFoldersSnapshotVersion;
   try {
     const resp = await fetch('/api/folders/missing');
     if (!resp.ok) return;
@@ -11323,6 +11324,11 @@ async function checkMissingFolders() {
     // — see r3686095481 for why it can't safely delegate back here.
     if (_missingFoldersMutationInFlight > 0 ||
         mutationEpochAtStart !== _missingFoldersMutationEpoch) return;
+    // /api/browse/init can install a newer workspace snapshot while this
+    // GET is in flight even when no newer GET/POST exists. Do not let the
+    // pre-init poll overwrite that baseline, repaint the banner backwards,
+    // or dispatch a reverse health transition.
+    if (snapshotVersionAtStart !== _missingFoldersSnapshotVersion) return;
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     const dispatched = _dispatchFolderHealthChangeFromIds(
       _missingFoldersLastIds, currentIds, 'poll');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11782,6 +11782,16 @@ async function loadMissingFolders() {
     if (myMutationGen === _missingFoldersMutationGen) {
       container.innerHTML = '<p style="color:var(--text-secondary);">Failed to check folders.</p>';
     }
+    // When the POST fails (network drop, lost response) the server may have
+    // still committed the folder-status flip before the connection died —
+    // and page-load / modal-close GETs that started while we were in flight
+    // were discarded by our mutation guard. Without a follow-up poll the
+    // banner and Browse grid stay stuck on the pre-POST snapshot until the
+    // ten-minute interval. Schedule a poll AFTER the finally so it runs
+    // once ``_missingFoldersMutationInFlight`` has been decremented (and
+    // ``_missingFoldersMutationEpoch`` bumped) — otherwise its own
+    // in-flight guard rejects it (Codex review r3686605299).
+    setTimeout(checkMissingFolders, 0);
   } finally {
     // Decrement + bump epoch in the finally so any GET whose ``await``
     // straddled this POST — start OR end — sees the change and defers

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11230,15 +11230,26 @@ function _updateMissingFoldersBanner(folders) {
 // one fails while the older one is still pending. A firehose safety
 // bound (100 × 50ms = 5s) keeps this from spinning forever if a hung
 // fetch somehow leaves the counter stuck (Codex review r3686778064).
+//
+// If the counter never reaches zero within 5s we drop the recovery
+// entirely instead of firing ``checkMissingFolders()`` anyway: its
+// own in-flight guard would reject the GET, wasting a round-trip and
+// giving the false impression that recovery ran. The 10-minute
+// background poll is the only remaining fallback for a genuinely
+// hung POST (Codex review r3686842771).
 let _missingFoldersRecoveryScheduled = false;
 function _scheduleMissingFoldersRecovery() {
   if (_missingFoldersRecoveryScheduled) return;
   _missingFoldersRecoveryScheduled = true;
   let attempts = 0;
   const tick = function() {
-    if (_missingFoldersMutationInFlight === 0 || attempts >= 100) {
+    if (_missingFoldersMutationInFlight === 0) {
       _missingFoldersRecoveryScheduled = false;
       checkMissingFolders();
+      return;
+    }
+    if (attempts >= 100) {
+      _missingFoldersRecoveryScheduled = false;
       return;
     }
     attempts++;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11713,11 +11713,17 @@ async function loadMissingFolders() {
     const dispatched = _dispatchFolderHealthChangeFromIds(
       prevIds, currentIds, 'check-health');
     // Narrow initial-load race: the user opened this modal before the
-    // page-load ``checkMissingFolders()`` finished, so no ID baseline
-    // exists yet. Preserve the pre-fix behavior in that window — a
-    // status flip in the active workspace still needs to reach Browse.
-    // Cross-workspace flips remain filtered as soon as any poll runs.
-    if (!dispatched && prevIds === null && data.changed) {
+    // page-load ``checkMissingFolders()`` finished AND before /api/browse/init
+    // seeded the snapshot, so no ID baseline exists yet. Preserve the pre-fix
+    // behavior in that window — a status flip in the active workspace still
+    // needs to reach Browse — but gate on ``workspace_changed`` (server-side
+    // computed pre-vs-post-check diff of THIS workspace's missing set)
+    // instead of ``data.changed`` (a global count across all workspaces).
+    // Without the workspace-scoped gate this fallback would fire for a
+    // cross-workspace flip and blow away the active selection / detail view
+    // for a transition that never touched the active dataset
+    // (Codex review r3686191131).
+    if (!dispatched && prevIds === null && data.workspace_changed) {
       document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
         detail: { restored: [], wentMissing: [], source: 'check-health' },
       }));

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11133,12 +11133,42 @@ function formatDuration(seconds) {
 <script>
 /* ---------- Missing Folders Banner ---------- */
 let _missingBannerDismissedCount = 0;
+// Snapshot of missing-folder ids from the last /api/folders/missing poll.
+// The server's own _folder_health_loop (app.py) flips folders ok\u2194missing on
+// its 10-minute cadence with no client involvement, so the modal's
+// /api/folders/check-health POST is only one of two paths that mutate this
+// set. Without a diff here a long-lived Browse view would keep serving its
+// pre-flip photo grid until the user manually reopened the modal or
+// reloaded \u2014 the background reconnect that just restored the folder would
+// never reach the page (Codex review r3685083009).
+let _missingFoldersLastIds = null;
+
+function _missingFolderIdsChanged(currentIds) {
+  if (_missingFoldersLastIds === null) return false;
+  const prev = _missingFoldersLastIds;
+  if (prev.length !== currentIds.length) return true;
+  for (let i = 0; i < prev.length; i++) {
+    if (prev[i] !== currentIds[i]) return true;
+  }
+  return false;
+}
 
 async function checkMissingFolders() {
   try {
     const resp = await fetch('/api/folders/missing');
     if (!resp.ok) return;
     const folders = await resp.json();
+    const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
+    if (_missingFolderIdsChanged(currentIds)) {
+      const prevSet = new Set(_missingFoldersLastIds);
+      const currSet = new Set(currentIds);
+      const restored = _missingFoldersLastIds.filter(id => !currSet.has(id));
+      const wentMissing = currentIds.filter(id => !prevSet.has(id));
+      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+        detail: { restored, wentMissing, source: 'poll' },
+      }));
+    }
+    _missingFoldersLastIds = currentIds;
     const banner = document.getElementById('missingFoldersBanner');
     const msg = document.getElementById('missingFoldersMsg');
     if (folders.length > 0 && folders.length !== _missingBannerDismissedCount) {
@@ -11572,10 +11602,16 @@ async function loadMissingFolders() {
     // pre-check empty grid after a drive or network share reconnects.
     if (data.changed) {
       document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
-        detail: { changed: data.changed },
+        detail: { changed: data.changed, source: 'check-health' },
       }));
     }
     const folders = data.missing;
+    // Keep the poll snapshot in sync with what this POST just observed on
+    // the server — closeMissingFoldersModal() and the 10-minute interval
+    // both call checkMissingFolders() next, and without this the poll
+    // would see (last-poll ≠ post-POST) and fire a second redundant
+    // vireo:folder-health-changed for the same transition.
+    _missingFoldersLastIds = folders.map(f => f.id).sort((a, b) => a - b);
     if (folders.length === 0) {
       container.textContent = '';
       const ok = document.createElement('p');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11171,6 +11171,19 @@ let _missingFoldersObservationGen = 0;
 let _missingFoldersMutationGen = 0;
 let _missingFoldersMutationInFlight = 0;
 let _missingFoldersMutationEpoch = 0;
+// When Browse abandons its short-term retry loop after a folder-health event
+// (``/api/folders`` stayed down through every retry), the pre-transition
+// grid/tree is still on screen but ``_missingFoldersLastIds`` has already
+// advanced to the post-transition IDs. The normal 10-minute poll then sees
+// unchanged IDs and never re-emits, so the page stays stale until an
+// unrelated health flip or a reload (Codex review r3687331927). This flag
+// tells the next successful poll to dispatch a synthetic reconciliation
+// event regardless of the ID diff, so Browse can retry the refresh once the
+// endpoint recovers.
+let _missingFoldersReconciliationPending = false;
+window.markMissingFoldersReconciliationPending = function() {
+  _missingFoldersReconciliationPending = true;
+};
 // Incremented whenever a GET, POST, or Browse init snapshot becomes the
 // client-side baseline. Browse captures this immediately before requesting
 // /api/browse/init, which lets it distinguish a baseline that was already
@@ -11311,7 +11324,22 @@ async function checkMissingFolders() {
     if (_missingFoldersMutationInFlight > 0 ||
         mutationEpochAtStart !== _missingFoldersMutationEpoch) return;
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
-    _dispatchFolderHealthChangeFromIds(_missingFoldersLastIds, currentIds, 'poll');
+    const dispatched = _dispatchFolderHealthChangeFromIds(
+      _missingFoldersLastIds, currentIds, 'poll');
+    // Browse abandoned an earlier refresh because ``/api/folders`` stayed
+    // down through every retry; ``_missingFoldersLastIds`` was already
+    // advanced then, so this poll's diff can be empty even though the page
+    // is still on pre-transition data. Force a synthetic reconciliation so
+    // Browse re-attempts the refresh now that the endpoint is answering
+    // again. Empty restored/wentMissing routes through the conservative
+    // reload path in ``folderHealthTouchesActiveScope`` (Codex review
+    // r3687331927).
+    if (!dispatched && _missingFoldersReconciliationPending) {
+      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+        detail: { restored: [], wentMissing: [], source: 'poll-reconcile' },
+      }));
+    }
+    _missingFoldersReconciliationPending = false;
     _missingFoldersLastIds = currentIds;
     _missingFoldersSnapshotVersion++;
     _updateMissingFoldersBanner(folders);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11736,7 +11736,23 @@ async function loadMissingFolders() {
     // stale POST run past its guard used to overwrite the newer POST's
     // "Checking folders…" placeholder with pre-mutation rows or a false
     // failure message (Codex review r3686095489).
-    if (myMutationGen !== _missingFoldersMutationGen) return;
+    //
+    // But *client-side* issuance order isn't a freshness guarantee for
+    // /api/folders/check-health, which mutates the DB and then reads the
+    // post-mutation missing set: if the filesystem changed between the
+    // two server-side scans, the discarded response can represent the
+    // final committed state while the newer-issued POST's already-
+    // dispatched result is now stale. Successful superseded requests
+    // scheduled no reconciliation, leaving the snapshot, banner, and
+    // Browse grid wrong until the ten-minute poll. Schedule a poll to
+    // fire once every in-flight POST has settled — the same wait-for-
+    // settle helper the catch path uses — so one GET reconciles with
+    // whatever the server actually committed last (Codex review
+    // r3686912886).
+    if (myMutationGen !== _missingFoldersMutationGen) {
+      _scheduleMissingFoldersRecovery();
+      return;
+    }
     const prevIds = _missingFoldersLastIds;
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     // Keep the poll snapshot in sync with what this POST just observed

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -11190,6 +11190,16 @@ window.markMissingFoldersReconciliationPending = function() {
 // applied (init is newer) from one that landed while init was in flight
 // (the later observation remains authoritative).
 let _missingFoldersSnapshotVersion = 0;
+// Monotonic SQLite-backed observation marker returned by every server
+// endpoint that can establish the missing-folder baseline. Unlike client
+// request generations, this orders responses even when an older server read
+// is delivered before a newer init response is applied.
+let _missingFoldersServerVersion = null;
+
+function _parseFolderHealthVersion(value) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
 
 function _missingFolderIdsDiffer(prev, curr) {
   if (prev.length !== curr.length) return true;
@@ -11249,13 +11259,23 @@ function _updateMissingFoldersBanner(folders) {
 // the version changed in flight, keep that later observation and dispatch
 // init→current so Browse discards its stale init payload.
 function _reconcileMissingFoldersInitSnapshot(
-  initIds, snapshotVersionAtStart, source
+  initIds, snapshotVersionAtStart, source, initServerVersion
 ) {
   const currentIds = initIds.slice().sort((a, b) => a - b);
-  const initIsNewer = _missingFoldersLastIds === null ||
-    snapshotVersionAtStart === _missingFoldersSnapshotVersion;
+  const serverVersion = _parseFolderHealthVersion(initServerVersion);
+  let initIsNewer;
+  if (_missingFoldersServerVersion === null || serverVersion === null) {
+    initIsNewer = _missingFoldersLastIds === null ||
+      snapshotVersionAtStart === _missingFoldersSnapshotVersion;
+  } else if (serverVersion !== _missingFoldersServerVersion) {
+    initIsNewer = serverVersion > _missingFoldersServerVersion;
+  } else {
+    initIsNewer = _missingFoldersLastIds === null ||
+      snapshotVersionAtStart === _missingFoldersSnapshotVersion;
+  }
   if (initIsNewer) {
     _missingFoldersLastIds = currentIds;
+    if (serverVersion !== null) _missingFoldersServerVersion = serverVersion;
     _missingFoldersSnapshotVersion++;
     _updateMissingFoldersBanner(currentIds.map(id => ({ id })));
     return false;
@@ -11306,6 +11326,8 @@ async function checkMissingFolders() {
   try {
     const resp = await fetch('/api/folders/missing');
     if (!resp.ok) return;
+    const serverVersion = _parseFolderHealthVersion(
+      resp.headers.get('X-Vireo-Folder-Health-Version'));
     const folders = await resp.json();
     // A newer GET started while this fetch was pending \u2014 its result
     // supersedes ours (Codex review r3685515796). Skip the whole
@@ -11324,11 +11346,16 @@ async function checkMissingFolders() {
     // — see r3686095481 for why it can't safely delegate back here.
     if (_missingFoldersMutationInFlight > 0 ||
         mutationEpochAtStart !== _missingFoldersMutationEpoch) return;
-    // /api/browse/init can install a newer workspace snapshot while this
-    // GET is in flight even when no newer GET/POST exists. Do not let the
-    // pre-init poll overwrite that baseline, repaint the banner backwards,
-    // or dispatch a reverse health transition.
-    if (snapshotVersionAtStart !== _missingFoldersSnapshotVersion) return;
+    // Prefer the server's monotonic observation ordering. The client version
+    // remains the compatibility/tie-break guard when the response lacks the
+    // marker or observed the same SQLite health version.
+    if (_missingFoldersServerVersion !== null && serverVersion !== null) {
+      if (serverVersion < _missingFoldersServerVersion) return;
+      if (serverVersion === _missingFoldersServerVersion &&
+          snapshotVersionAtStart !== _missingFoldersSnapshotVersion) return;
+    } else if (snapshotVersionAtStart !== _missingFoldersSnapshotVersion) {
+      return;
+    }
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     const dispatched = _dispatchFolderHealthChangeFromIds(
       _missingFoldersLastIds, currentIds, 'poll');
@@ -11347,6 +11374,7 @@ async function checkMissingFolders() {
     }
     _missingFoldersReconciliationPending = false;
     _missingFoldersLastIds = currentIds;
+    if (serverVersion !== null) _missingFoldersServerVersion = serverVersion;
     _missingFoldersSnapshotVersion++;
     _updateMissingFoldersBanner(folders);
   } catch (e) { /* ignore */ }
@@ -11775,6 +11803,8 @@ async function loadMissingFolders() {
     if (!resp.ok) throw new Error('check failed');
     const data = await resp.json();
     const folders = data.missing;
+    const serverVersion = _parseFolderHealthVersion(
+      data.folder_health_version);
     // Folder health is part of the effective photo dataset: ok→missing hides
     // a folder's photos, while missing→ok makes them available again. Notify
     // the current page so a long-lived Browse view does not keep showing the
@@ -11816,6 +11846,11 @@ async function loadMissingFolders() {
       _scheduleMissingFoldersRecovery();
       return;
     }
+    if (_missingFoldersServerVersion !== null && serverVersion !== null &&
+        serverVersion < _missingFoldersServerVersion) {
+      _scheduleMissingFoldersRecovery();
+      return;
+    }
     const prevIds = _missingFoldersLastIds;
     const currentIds = folders.map(f => f.id).sort((a, b) => a - b);
     // Keep the poll snapshot in sync with what this POST just observed
@@ -11824,6 +11859,7 @@ async function loadMissingFolders() {
     // the poll would see (last-poll ≠ post-POST) and fire a second
     // redundant vireo:folder-health-changed for the same transition.
     _missingFoldersLastIds = currentIds;
+    if (serverVersion !== null) _missingFoldersServerVersion = serverVersion;
     _missingFoldersSnapshotVersion++;
     const dispatched = _dispatchFolderHealthChangeFromIds(
       prevIds, currentIds, 'check-health');

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2054,6 +2054,8 @@ var folderLoadGen = 0;
 var folderLoadStates = {};
 var folderRenderDecisionGen = 0;
 var keywordLoadGen = 0;
+var keywordLoadStates = {};
+var keywordRenderDecisionGen = 0;
 var collectionLoadGen = 0;
 var collectionLoadStates = {};
 var collectionRenderDecisionGen = 0;
@@ -3399,17 +3401,50 @@ function filterByFolder(folderId) {
 }
 
 /* ---------- Keyword Tree ---------- */
+function reconcileKeywordLoadRenders() {
+  // Do not discard the newest usable keyword response merely because a
+  // later request started. Pending newer generations still block it, while
+  // failed newer generations fall back to the newest success just like the
+  // folder and collection loaders.
+  var gen = keywordLoadGen;
+  while (gen > keywordRenderDecisionGen) {
+    var state = keywordLoadStates[gen];
+    if (!state || state.status === 'pending') return;
+    if (state.status === 'success') {
+      var shouldRender = !state.shouldRender || state.shouldRender();
+      keywordRenderDecisionGen = gen;
+      if (shouldRender) renderKeywordTree(state.data);
+      Object.keys(keywordLoadStates).forEach(function(key) {
+        if (Number(key) <= keywordLoadGen) delete keywordLoadStates[key];
+      });
+      return;
+    }
+    gen--;
+  }
+}
+
 async function loadKeywords(opts) {
   var myGen = ++keywordLoadGen;
+  keywordLoadStates[myGen] = {
+    status: 'pending',
+    shouldRender: opts && opts.shouldRender
+  };
   try {
     var data = await safeFetch('/api/keywords', {}, { toast: false });
-    // See loadFolders — same shared-generation freshness guard so an older
-    // response cannot overwrite the keyword tree that a newer caller has
-    // already repainted.
-    if (myGen !== keywordLoadGen) return;
-    if (opts && opts.shouldRender && !opts.shouldRender()) return;
-    renderKeywordTree(data);
-  } catch(e) {}
+    var state = keywordLoadStates[myGen];
+    if (!state) return data;
+    state.status = 'success';
+    state.data = data;
+    reconcileKeywordLoadRenders();
+    return data;
+  } catch(e) {
+    var failedState = keywordLoadStates[myGen];
+    if (failedState) {
+      failedState.status = 'failure';
+      reconcileKeywordLoadRenders();
+    }
+    return null;
+  }
 }
 
 function renderKeywordTree(keywords) {
@@ -3837,8 +3872,21 @@ async function refreshBrowseAfterFolderHealthChange(detail) {
   // ``activeCollectionId`` for non-dashboard scopes, which would kick a user
   // viewing a normal collection back to the unscoped workspace grid whenever
   // folder health changes (CodeRabbit review r3684913393).
-  await resetAndLoad({ preserveCollection: true, preserveAnchor: true });
+  var gridReloadStatus = await resetAndLoad({
+    preserveCollection: true,
+    preserveAnchor: true
+  });
   if (!isCurrent()) return;
+  if (gridReloadStatus === false) {
+    // resetAndLoad has already cleared the pre-transition grid. Keep the
+    // navbar reconciliation marker set so an unchanged normal poll retries
+    // after a transient first-page query/collection failure instead of
+    // leaving Browse empty indefinitely.
+    if (typeof window.markMissingFoldersReconciliationPending === 'function') {
+      window.markMissingFoldersReconciliationPending();
+    }
+    return;
+  }
   loadCollectionCounts();
   loadSummary();
   if (timelineMode) loadCalendarData();
@@ -4526,15 +4574,17 @@ async function resetAndLoad(options) {
 
   if (anchor) anchorScanDepth++;
   try {
-    await loadPhotos();
-    if (!resetRequestIsCurrent() || !anchor) return;
+    var initialLoadStatus = await loadPhotos();
+    if (initialLoadStatus !== true) return initialLoadStatus;
+    if (!resetRequestIsCurrent()) return null;
+    if (!anchor) return true;
 
     var card = await loadUntilPhotoRendered(anchor.photoId, anchorScanShouldContinue);
-    if (!resetRequestIsCurrent()) return;
-    if (!anchorRestoreIsPending(anchor, restoreEpoch)) return;
+    if (!resetRequestIsCurrent()) return null;
+    if (!anchorRestoreIsPending(anchor, restoreEpoch)) return true;
     if (!card) {
       clearActiveSelectionAndDetail();
-      return;
+      return true;
     }
 
     selectedPhotoId = anchor.photoId;
@@ -4548,6 +4598,7 @@ async function resetAndLoad(options) {
       restorePhotoAnchor(anchor);
       updateScrollPosition();
     });
+    return true;
   } finally {
     if (anchor) {
       anchorScanDepth = Math.max(0, anchorScanDepth - 1);
@@ -4579,7 +4630,8 @@ function buildCurrentBrowseParams() {
 }
 
 async function loadPhotos(options) {
-  if (loading || allLoaded) return;
+  if (loading) return null;
+  if (allLoaded) return true;
   loading = true;
   var epoch = loadEpoch;
   var loadSucceeded = false;
@@ -4635,7 +4687,7 @@ async function loadPhotos(options) {
 
   try {
     var data = await safeFetch(url, fetchOptions);
-    if (epoch !== loadEpoch) return;  // grid was reset mid-flight; drop stale response
+    if (epoch !== loadEpoch) return null;  // grid was reset mid-flight; drop stale response
     totalPhotos = data.total;
     if (window.VireoFilter && VireoFilter.setResultTotal) VireoFilter.setResultTotal(totalPhotos);
     if (window.VireoFilter && VireoFilter.setVisualInfo) {
@@ -4674,7 +4726,7 @@ async function loadPhotos(options) {
     }
     loadSucceeded = true;
   } catch(e) {
-    if (epoch !== loadEpoch) return;
+    if (epoch !== loadEpoch) return null;
     if (showLoading && loadingState) {
       loadingState.textContent = 'Error loading photos.';
     }
@@ -4694,6 +4746,7 @@ async function loadPhotos(options) {
       }
     }
   }
+  return loadSucceeded;
 }
 
 /* ---------- Calendar Heatmap ---------- */

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3244,7 +3244,10 @@ async function loadFolders(opts) {
     var data = await safeFetch('/api/folders', {}, { toast: false });
     // Internal freshness guard: a later ``loadFolders()`` call — from any
     // site — has advanced the generation, so its response is the truth
-    // and ours would just overwrite it with stale data.
+    // and ours would just overwrite it with stale data. Still return the
+    // fetched data so callers that need it for membership checks (rather
+    // than the DOM) can use it without race-losing renders masking a
+    // successful fetch as a failure.
     if (myGen !== folderLoadGen) return data;
     // Callers that fire this alongside other refreshes can pass a
     // ``shouldRender`` guard so a slow response cannot overwrite a newer
@@ -3254,6 +3257,13 @@ async function loadFolders(opts) {
     renderFolderTree(data);
     return data;
   } catch(e) {
+    // Signal failure to callers that gate destructive decisions (e.g. the
+    // health refresh clearing ``activeFolderId``) on a successful fetch.
+    // A DOM/cache-based check after a swallowed failure sees the stale
+    // tree and preserves a folder that just went missing, then reloads
+    // its now-unavailable scope into an empty grid — the advanced navbar
+    // snapshot means later polls see no transition to repair it
+    // (Codex review r3687062925).
     return null;
   }
 }
@@ -3691,13 +3701,28 @@ async function refreshBrowseAfterFolderHealthChange(detail) {
     loadCollections({ shouldRender: isCurrent }),
   ]);
   if (!isCurrent()) return;
+  // If ``/api/folders`` failed transiently during this health transition,
+  // the folder tree DOM (and the cached ``browseFolderRows``) are still
+  // the pre-transition state — a membership check against either would
+  // preserve a folder that just went missing, and ``resetAndLoad`` would
+  // then reload an empty folder-scoped grid. Because the navbar has
+  // already advanced ``_missingFoldersLastIds`` before dispatching this
+  // event, later polls see no transition and never repair the view, so
+  // schedule a retry via the same event listener rather than committing
+  // to a decision from stale data (Codex review r3687062925).
+  if (loaded[0] === null) {
+    setTimeout(function() {
+      document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
+        detail: { source: 'refresh-retry' }
+      }));
+    }, 2000);
+    return;
+  }
   // Use the health-owned response rather than the DOM. A later unrelated
   // loadFolders() call may supersede this render while still being in flight;
   // in that window the DOM is intentionally old even though this response
   // already proves whether the selected folder is available.
-  var currentFolderRows = Array.isArray(loaded[0])
-    ? loaded[0]
-    : browseFolderRows.slice();
+  var currentFolderRows = loaded[0];
   var activeScopeWasAffected = folderHealthTouchesActiveScope(
     detail, beforeFolderRows, currentFolderRows);
   if (activeFolderId &&

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2048,6 +2048,7 @@ var calendarDataLoadGen = 0;
 var folderLoadGen = 0;
 var keywordLoadGen = 0;
 var collectionLoadGen = 0;
+var browseFolderRows = [];
 var collectionsById = {};
 var browseCompareIds = [];
 var browseCompareOffset = 0;
@@ -3244,17 +3245,21 @@ async function loadFolders(opts) {
     // Internal freshness guard: a later ``loadFolders()`` call — from any
     // site — has advanced the generation, so its response is the truth
     // and ours would just overwrite it with stale data.
-    if (myGen !== folderLoadGen) return;
+    if (myGen !== folderLoadGen) return data;
     // Callers that fire this alongside other refreshes can pass a
     // ``shouldRender`` guard so a slow response cannot overwrite a newer
     // render — see refreshBrowseAfterFolderHealthChange
     // (Codex review r3685193225).
-    if (opts && opts.shouldRender && !opts.shouldRender()) return;
+    if (opts && opts.shouldRender && !opts.shouldRender()) return data;
     renderFolderTree(data);
-  } catch(e) {}
+    return data;
+  } catch(e) {
+    return null;
+  }
 }
 
 function renderFolderTree(folders) {
+  browseFolderRows = folders.slice();
   var byParent = {};
   folders.forEach(function(f) {
     var pid = f.parent_id || 'root';
@@ -3616,7 +3621,35 @@ function refreshBrowseSidebarCounts() {
 // ``folderHealthRefreshSeq`` is initialized above the bootstrapBrowse()
 // invocation so the pre-await snapshot inside bootstrap reads ``0`` instead
 // of ``undefined`` (Codex review r3686317674).
-async function refreshBrowseAfterFolderHealthChange() {
+function folderRowsContainScope(rows, folderId, scopeId) {
+  var byId = {};
+  (rows || []).forEach(function(row) { byId[row.id] = row; });
+  var currentId = folderId;
+  var seen = {};
+  while (currentId != null && !seen[currentId]) {
+    if (currentId === scopeId) return true;
+    seen[currentId] = true;
+    var row = byId[currentId];
+    currentId = row ? row.parent_id : null;
+  }
+  return false;
+}
+
+function folderHealthTouchesActiveScope(detail, beforeRows, afterRows) {
+  if (!activeFolderId) return true;
+  var restored = detail && Array.isArray(detail.restored) ? detail.restored : [];
+  var wentMissing = detail && Array.isArray(detail.wentMissing) ? detail.wentMissing : [];
+  var changedIds = restored.concat(wentMissing);
+  // The null-baseline fallback intentionally carries no ids. Conservatively
+  // reload because the server only knows that this workspace changed.
+  if (!changedIds.length) return true;
+  return changedIds.some(function(folderId) {
+    return folderRowsContainScope(beforeRows, folderId, activeFolderId) ||
+      folderRowsContainScope(afterRows, folderId, activeFolderId);
+  });
+}
+
+async function refreshBrowseAfterFolderHealthChange(detail) {
   var seq = ++folderHealthRefreshSeq;
   // A health-driven dataset refresh is not a user scope change: bumping
   // browseScopeGen here would make any in-flight sidebar click
@@ -3651,22 +3684,43 @@ async function refreshBrowseAfterFolderHealthChange() {
   // *before* render means only the winning generation's data ever reaches
   // the tree (Codex review r3685193225).
   var isCurrent = function() { return seq === folderHealthRefreshSeq; };
-  await Promise.all([
+  var beforeFolderRows = browseFolderRows.slice();
+  var loaded = await Promise.all([
     loadFolders({ shouldRender: isCurrent }),
     loadKeywords({ shouldRender: isCurrent }),
     loadCollections({ shouldRender: isCurrent }),
   ]);
   if (!isCurrent()) return;
+  // Use the health-owned response rather than the DOM. A later unrelated
+  // loadFolders() call may supersede this render while still being in flight;
+  // in that window the DOM is intentionally old even though this response
+  // already proves whether the selected folder is available.
+  var currentFolderRows = Array.isArray(loaded[0])
+    ? loaded[0]
+    : browseFolderRows.slice();
+  var activeScopeWasAffected = folderHealthTouchesActiveScope(
+    detail, beforeFolderRows, currentFolderRows);
   if (activeFolderId &&
-      !document.querySelector('#folderTree .tree-item[data-folder-id="' + activeFolderId + '"]')) {
+      !currentFolderRows.some(function(folder) { return folder.id === activeFolderId; })) {
     activeFolderId = null;
+    activeScopeWasAffected = true;
+  }
+
+  // A transition in an unrelated folder cannot change a leaf-folder result
+  // set. Keep its selection, detail panel, and scroll position intact while
+  // still refreshing workspace-wide sidebar and summary counts.
+  if (!activeScopeWasAffected) {
+    loadCollectionCounts();
+    loadSummary();
+    if (timelineMode) loadCalendarData();
+    return;
   }
 
   // Preserve the active collection: resetAndLoad's default is to clear
   // ``activeCollectionId`` for non-dashboard scopes, which would kick a user
   // viewing a normal collection back to the unscoped workspace grid whenever
   // folder health changes (CodeRabbit review r3684913393).
-  await resetAndLoad({ preserveCollection: true });
+  await resetAndLoad({ preserveCollection: true, preserveAnchor: true });
   if (!isCurrent()) return;
   loadCollectionCounts();
   loadSummary();
@@ -3683,8 +3737,9 @@ async function refreshBrowseAfterFolderHealthChange() {
 // without scrolling to the requested photo (and VireoFilter was left
 // uninitialized) (Codex review r3686778061).
 var _activeFolderHealthRefresh = Promise.resolve();
-document.addEventListener('vireo:folder-health-changed', function() {
-  _activeFolderHealthRefresh = refreshBrowseAfterFolderHealthChange();
+document.addEventListener('vireo:folder-health-changed', function(event) {
+  _activeFolderHealthRefresh = refreshBrowseAfterFolderHealthChange(
+    event && event.detail);
 });
 
 async function filterByCollection(id, options) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2860,6 +2860,9 @@ async function bootstrapBrowse() {
   // Prevent the IntersectionObserver from triggering loadPhotos() while bootstrap is in flight
   loading = true;
   var bootstrapSucceeded = false;
+  // Declared out here so the finally-region guard below can read it even
+  // if /api/browse/init throws before the assignment inside the try.
+  var healthChangedDuringInit = false;
   try {
     applyBrowseConfig(await _cfgPromise);
     var pageParams = new URLSearchParams(window.location.search);
@@ -2893,7 +2896,7 @@ async function bootstrapBrowse() {
     // another event or a manual reload (Codex review r3685515800).
     var bootstrapHealthSeq = folderHealthRefreshSeq;
     var data = await safeFetch('/api/browse/init?' + initParams.toString());
-    var healthChangedDuringInit = folderHealthRefreshSeq !== bootstrapHealthSeq;
+    healthChangedDuringInit = folderHealthRefreshSeq !== bootstrapHealthSeq;
 
     if (!healthChangedDuringInit) {
       // Populate everything from a single response
@@ -3087,12 +3090,23 @@ async function bootstrapBrowse() {
   } catch(e) {
     document.getElementById('loadingState').textContent = 'Error loading.';
   }
-  loading = false;
-  if (bootstrapSucceeded) {
-    rearmInfiniteScrollObserver();
-    // Make sure a tall viewport still gets its second page even when the
-    // sentinel callback does not fire after the initial layout.
-    requestAnimationFrame(ensureViewportHydrated);
+  // If a folder-health event fired while /api/browse/init was in flight,
+  // refreshBrowseAfterFolderHealthChange() has already taken over the load
+  // state: its resetAndLoad() → loadPhotos() chain owns ``loading`` and
+  // rearms the intersection observer itself when it settles. Clearing
+  // ``loading`` here would release the mutex that concurrent loadPhotos
+  // still holds, letting the newly-rearmed observer fire a second page-1
+  // request against the same ``loadEpoch``; both responses append and the
+  // grid ends up with duplicated cards and off-by-one pagination
+  // (Codex review r3685627307).
+  if (!healthChangedDuringInit) {
+    loading = false;
+    if (bootstrapSucceeded) {
+      rearmInfiniteScrollObserver();
+      // Make sure a tall viewport still gets its second page even when the
+      // sentinel callback does not fire after the initial layout.
+      requestAnimationFrame(ensureViewportHydrated);
+    }
   }
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2852,6 +2852,20 @@ function clearActiveSelectionAndDetail() {
 }
 
 /* ---------- Bootstrap ---------- */
+// ``folderHealthRefreshSeq`` must be *initialized* before ``bootstrapBrowse()``
+// is invoked, not merely declared. ``var`` hoists the declaration to the top
+// of the script but leaves the value ``undefined`` until this line executes;
+// the paired assignment lives further down at the health-refresh helpers.
+// Bootstrap synchronously reads ``folderHealthRefreshSeq`` into
+// ``bootstrapHealthSeq`` before its first await, so with the initialization
+// happening later, the snapshot was ``undefined``, the outer script then
+// ran the ``= 0`` assignment while bootstrap was awaiting ``/api/browse/init``,
+// and the post-await comparison ``0 !== undefined`` was always true. That
+// made ``healthChangedDuringInit`` fire on every normal load, skipping the
+// render block and leaving Browse empty until VireoFilter.init happened to
+// re-fetch. Initialize here so the pre-await snapshot reads the same ``0``
+// the rest of the script sees (Codex review r3686317674).
+var folderHealthRefreshSeq = 0;
 bootstrapBrowse();
 
 async function bootstrapBrowse() {
@@ -3540,7 +3554,9 @@ function refreshBrowseSidebarCounts() {
   loadCollectionCounts();
 }
 
-var folderHealthRefreshSeq = 0;
+// ``folderHealthRefreshSeq`` is initialized above the bootstrapBrowse()
+// invocation so the pre-await snapshot inside bootstrap reads ``0`` instead
+// of ``undefined`` (Codex review r3686317674).
 async function refreshBrowseAfterFolderHealthChange() {
   var seq = ++folderHealthRefreshSeq;
   // A health-driven dataset refresh is not a user scope change: bumping

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2034,6 +2034,20 @@ var collectionCountLoadGen = 0;
 // (CodeRabbit review r3684913398).
 var summaryLoadGen = 0;
 var calendarDataLoadGen = 0;
+// Internal generation counters shared across every caller of the sidebar
+// loaders. Without these, ``refreshBrowseSidebarCounts()`` and the various
+// mutation-triggered ``loadKeywords()``/``loadCollections()`` calls fire
+// without any freshness guard, so a slow pre-transition response can arrive
+// after a guarded ``refreshBrowseAfterFolderHealthChange`` render and
+// repaint the sidebar with data that no longer reflects the current health
+// state — reintroducing the offline-folder-in-tree symptom the health
+// refresh was meant to fix (Codex review r3686842772). Every loader checks
+// its captured generation after ``await`` and skips ``render*`` when a
+// newer call has since started, so last-started always wins regardless of
+// which call site issued it.
+var folderLoadGen = 0;
+var keywordLoadGen = 0;
+var collectionLoadGen = 0;
 var collectionsById = {};
 var browseCompareIds = [];
 var browseCompareOffset = 0;
@@ -3224,8 +3238,13 @@ function renderCollectionList(collections) {
 
 /* ---------- Folder Tree ---------- */
 async function loadFolders(opts) {
+  var myGen = ++folderLoadGen;
   try {
     var data = await safeFetch('/api/folders', {}, { toast: false });
+    // Internal freshness guard: a later ``loadFolders()`` call — from any
+    // site — has advanced the generation, so its response is the truth
+    // and ours would just overwrite it with stale data.
+    if (myGen !== folderLoadGen) return;
     // Callers that fire this alongside other refreshes can pass a
     // ``shouldRender`` guard so a slow response cannot overwrite a newer
     // render — see refreshBrowseAfterFolderHealthChange
@@ -3336,8 +3355,13 @@ function filterByFolder(folderId) {
 
 /* ---------- Keyword Tree ---------- */
 async function loadKeywords(opts) {
+  var myGen = ++keywordLoadGen;
   try {
     var data = await safeFetch('/api/keywords', {}, { toast: false });
+    // See loadFolders — same shared-generation freshness guard so an older
+    // response cannot overwrite the keyword tree that a newer caller has
+    // already repainted.
+    if (myGen !== keywordLoadGen) return;
     if (opts && opts.shouldRender && !opts.shouldRender()) return;
     renderKeywordTree(data);
   } catch(e) {}
@@ -3430,8 +3454,13 @@ async function filterByKeyword(name) {
 
 /* ---------- Collections ---------- */
 async function loadCollections(opts) {
+  var myGen = ++collectionLoadGen;
   try {
     var data = await safeFetch('/api/collections', {}, { toast: false });
+    // See loadFolders — same shared-generation freshness guard so an older
+    // response cannot overwrite the collection list that a newer caller
+    // has already repainted.
+    if (myGen !== collectionLoadGen) return;
     if (opts && opts.shouldRender && !opts.shouldRender()) return;
     renderCollectionList(data);
   } catch(e) {}

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3626,6 +3626,19 @@ async function refreshBrowseAfterFolderHealthChange() {
   // grid instead of the user's newer selection (Codex review r3684907518).
   // folderHealthRefreshSeq below is the only counter this refresh needs.
 
+  // Apply the effective ``perPage`` (and other cfg values) before any
+  // loadPhotos call. Without this, a health event that fires while
+  // ``_cfgPromise`` is still pending calls resetAndLoad → loadPhotos with
+  // the hard-coded default (50), and bootstrap later applies the configured
+  // size — its own init response is discarded by the health-generation
+  // guard, but the perPage variable it wrote is not, so subsequent
+  // pagination computes offsets against the new size while the health
+  // refresh loaded page 1 with the old size: photos are silently skipped
+  // or duplicated across the boundary (Codex review r3686912883).
+  // applyBrowseConfig is idempotent — safe to call again after bootstrap.
+  try { applyBrowseConfig(await _cfgPromise); } catch (e) {}
+  if (seq !== folderHealthRefreshSeq) return;
+
   // Refresh the scope controls first. If the selected folder just went
   // offline it disappears from /api/folders; clear that stale scope before
   // reloading the grid so Browse falls back to the available workspace.

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2038,6 +2038,8 @@ var collectionCountLoadGen = 0;
 // after a newer scope selection triggered a fresh load
 // (CodeRabbit review r3684913398).
 var summaryLoadGen = 0;
+var summaryLoadStates = {};
+var summaryRenderDecisionGen = 0;
 var calendarDataLoadGen = 0;
 // Internal generation counters shared across every caller of the sidebar
 // loaders. Without these, ``refreshBrowseSidebarCounts()`` and the various
@@ -2983,7 +2985,8 @@ async function bootstrapBrowse() {
       var initWasStale = _reconcileMissingFoldersInitSnapshot(
         data.missing_folder_ids,
         missingSnapshotVersionAtInitStart,
-        'bootstrap-reconcile');
+        'bootstrap-reconcile',
+        data.folder_health_version);
       if (initWasStale) healthChangedDuringInit = true;
     }
 
@@ -7107,20 +7110,58 @@ function closeDetail() {
   loadSummary();
 }
 
-async function loadSummary() {
-  var gen = ++summaryLoadGen;
+function buildSummaryParams() {
   var params = new URLSearchParams();
   if (activeFolderId) params.set('folder_id', activeFolderId);
   var rules = getBrowseRules();
   if (rules) params.set('rules', JSON.stringify(rules));
   appendVisualScopeParams(params);
   if (activeCollectionId) params.set('collection_id', activeCollectionId);
+  return params;
+}
+
+function reconcileSummaryLoadRenders() {
+  var gen = summaryLoadGen;
+  while (gen > summaryRenderDecisionGen) {
+    var state = summaryLoadStates[gen];
+    if (!state || state.status === 'pending') return;
+    if (state.status === 'success') {
+      var currentKey = buildSummaryParams().toString();
+      summaryRenderDecisionGen = gen;
+      if (state.key === currentKey) renderSummary(state.data);
+      Object.keys(summaryLoadStates).forEach(function(key) {
+        if (Number(key) <= summaryLoadGen) delete summaryLoadStates[key];
+      });
+      return;
+    }
+    gen--;
+  }
+}
+
+async function loadSummary() {
+  var gen = ++summaryLoadGen;
+  var params = buildSummaryParams();
+  summaryLoadStates[gen] = {
+    status: 'pending',
+    key: params.toString()
+  };
 
   try {
     var data = await safeFetch('/api/browse/summary?' + params.toString(), {}, { toast: false });
-    if (gen !== summaryLoadGen) return;
-    renderSummary(data);
-  } catch(e) {}
+    var state = summaryLoadStates[gen];
+    if (!state) return data;
+    state.status = 'success';
+    state.data = data;
+    reconcileSummaryLoadRenders();
+    return data;
+  } catch(e) {
+    var failedState = summaryLoadStates[gen];
+    if (failedState) {
+      failedState.status = 'failure';
+      reconcileSummaryLoadRenders();
+    }
+    return null;
+  }
 }
 
 function renderSummary(data) {
@@ -8908,7 +8949,8 @@ async function _runPhotoDeepLink(photoId) {
         _reconcileMissingFoldersInitSnapshot(
           initData.missing_folder_ids,
           missingSnapshotVersionAtInitStart,
-          'deep-link-reconcile');
+          'deep-link-reconcile',
+          initData.folder_health_version);
         if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
       }
       renderFolderTree(initData.folders || []);

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2883,26 +2883,41 @@ async function bootstrapBrowse() {
     // in either case.
     if (activeCollectionId) initParams.set('collection_id', activeCollectionId);
     initParams.set('per_page', perPage);
+    // Snapshot the health-refresh generation before issuing /api/browse/init.
+    // If a vireo:folder-health-changed event fires while this request is in
+    // flight, refreshBrowseAfterFolderHealthChange() will have already
+    // reloaded folders/keywords/collections and the grid from the fresh
+    // post-flip state. Populating ``photos`` / rendering the sidebars from
+    // this pre-flip response afterwards would silently overwrite that
+    // fresher refresh with stale data — leaving the grid empty until
+    // another event or a manual reload (Codex review r3685515800).
+    var bootstrapHealthSeq = folderHealthRefreshSeq;
     var data = await safeFetch('/api/browse/init?' + initParams.toString());
+    var healthChangedDuringInit = folderHealthRefreshSeq !== bootstrapHealthSeq;
 
-    // Populate everything from a single response
-    photos = data.photos || [];
-    totalPhotos = data.total || 0;
-    currentPage = 2; // next page to load
-    if (photos.length >= totalPhotos) allLoaded = true;
+    if (!healthChangedDuringInit) {
+      // Populate everything from a single response
+      photos = data.photos || [];
+      totalPhotos = data.total || 0;
+      currentPage = 2; // next page to load
+      if (photos.length >= totalPhotos) allLoaded = true;
 
-    renderFolderTree(data.folders || []);
-    renderKeywordTree(data.keywords || []);
-    renderCollectionList(data.collections || []);
-    loadCollectionCounts();
-    renderGrid();
-    updateFilterSummary();
-    loadSummary();
+      renderFolderTree(data.folders || []);
+      renderKeywordTree(data.keywords || []);
+      renderCollectionList(data.collections || []);
+      loadCollectionCounts();
+      renderGrid();
+      updateFilterSummary();
+      loadSummary();
+    }
     refreshPendingSyncBanner();
 
     document.getElementById('loadingState').style.display = 'none';
-    // Lazy-load collection photo counts to avoid N+1 on init
-    loadCollectionCounts();
+    // Lazy-load collection photo counts to avoid N+1 on init. Skip this
+    // when the health refresh already ran — it issued its own
+    // loadCollectionCounts() and repeating the call here would just fire
+    // another round-trip for the same data.
+    if (!healthChangedDuringInit) loadCollectionCounts();
     bootstrapSucceeded = true;
 
     // Universal filter bar: registry + persisted/deep-linked state load

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3466,6 +3466,32 @@ function refreshBrowseSidebarCounts() {
   loadCollectionCounts();
 }
 
+var folderHealthRefreshSeq = 0;
+async function refreshBrowseAfterFolderHealthChange() {
+  var seq = ++folderHealthRefreshSeq;
+  browseScopeGen++;
+
+  // Refresh the scope controls first. If the selected folder just went
+  // offline it disappears from /api/folders; clear that stale scope before
+  // reloading the grid so Browse falls back to the available workspace.
+  await Promise.all([loadFolders(), loadKeywords(), loadCollections()]);
+  if (seq !== folderHealthRefreshSeq) return;
+  if (activeFolderId &&
+      !document.querySelector('#folderTree .tree-item[data-folder-id="' + activeFolderId + '"]')) {
+    activeFolderId = null;
+  }
+
+  await resetAndLoad();
+  if (seq !== folderHealthRefreshSeq) return;
+  loadCollectionCounts();
+  loadSummary();
+  if (timelineMode) loadCalendarData();
+}
+
+document.addEventListener('vireo:folder-health-changed', function() {
+  refreshBrowseAfterFolderHealthChange();
+});
+
 async function filterByCollection(id, options) {
   // The sidebar collection list is rendered from the initial /photos payload,
   // so a slow /api/filters/fields (or workspace) round-trip leaves clickable

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2863,6 +2863,21 @@ async function bootstrapBrowse() {
   // Declared out here so the finally-region guard below can read it even
   // if /api/browse/init throws before the assignment inside the try.
   var healthChangedDuringInit = false;
+  // Snapshot the health-refresh generation before any await so we can
+  // detect a concurrent refresh from BOTH the try's success path and
+  // its catch. If a vireo:folder-health-changed event fires while
+  // /api/browse/init is in flight, refreshBrowseAfterFolderHealthChange()
+  // will have already reloaded folders/keywords/collections and the grid
+  // from the fresh post-flip state. Populating ``photos`` / rendering the
+  // sidebars from this pre-flip response afterwards would silently
+  // overwrite that fresher refresh with stale data — leaving the grid
+  // empty until another event or a manual reload (Codex review
+  // r3685515800). Snapshotting here (outside the try) also lets the
+  // catch below recompute the flag when the init request rejects: the
+  // in-try assignment used to be skipped by the throw, leaving the
+  // finally-region guard to release the load lock the concurrent health
+  // refresh's ``loadPhotos`` still owned (Codex review r3686191138).
+  var bootstrapHealthSeq = folderHealthRefreshSeq;
   try {
     applyBrowseConfig(await _cfgPromise);
     var pageParams = new URLSearchParams(window.location.search);
@@ -2886,17 +2901,25 @@ async function bootstrapBrowse() {
     // in either case.
     if (activeCollectionId) initParams.set('collection_id', activeCollectionId);
     initParams.set('per_page', perPage);
-    // Snapshot the health-refresh generation before issuing /api/browse/init.
-    // If a vireo:folder-health-changed event fires while this request is in
-    // flight, refreshBrowseAfterFolderHealthChange() will have already
-    // reloaded folders/keywords/collections and the grid from the fresh
-    // post-flip state. Populating ``photos`` / rendering the sidebars from
-    // this pre-flip response afterwards would silently overwrite that
-    // fresher refresh with stale data — leaving the grid empty until
-    // another event or a manual reload (Codex review r3685515800).
-    var bootstrapHealthSeq = folderHealthRefreshSeq;
     var data = await safeFetch('/api/browse/init?' + initParams.toString());
     healthChangedDuringInit = folderHealthRefreshSeq !== bootstrapHealthSeq;
+
+    // Seed the navbar's missing-folder snapshot from init's workspace-scoped
+    // view so the first /api/folders/missing observation has a baseline to
+    // compare against. Without this, a background _folder_health_loop flip
+    // that runs between /api/browse/init and the first navbar poll leaves
+    // the poll's null-baseline branch returning false — later polls then
+    // see the same IDs and never dispatch, so Browse stays showing the
+    // pre-flip state until another transition or a reload (Codex review
+    // r3686191141). Only seed if still null — a poll (or modal POST) that
+    // already landed is a fresher source of truth than this init snapshot.
+    if (typeof _missingFoldersLastIds !== 'undefined' &&
+        _missingFoldersLastIds === null &&
+        Array.isArray(data.missing_folder_ids)) {
+      _missingFoldersLastIds = data.missing_folder_ids
+        .slice()
+        .sort(function(a, b) { return a - b; });
+    }
 
     if (!healthChangedDuringInit) {
       // Populate everything from a single response
@@ -2908,7 +2931,6 @@ async function bootstrapBrowse() {
       renderFolderTree(data.folders || []);
       renderKeywordTree(data.keywords || []);
       renderCollectionList(data.collections || []);
-      loadCollectionCounts();
       renderGrid();
       updateFilterSummary();
       loadSummary();
@@ -3088,6 +3110,15 @@ async function bootstrapBrowse() {
       }
     }).catch(function() {});
   } catch(e) {
+    // /api/browse/init rejected — recompute healthChangedDuringInit so the
+    // finally-region guard below correctly defers to a concurrent health
+    // refresh that owns the load lock. The assignment inside the try was
+    // skipped by the throw, and without recomputing here we would clear
+    // ``loading`` even though the health refresh's ``loadPhotos`` still
+    // holds the mutex, letting the intersection observer fire a duplicate
+    // page-1 request against the same ``loadEpoch``
+    // (Codex review r3686191138).
+    healthChangedDuringInit = folderHealthRefreshSeq !== bootstrapHealthSeq;
     document.getElementById('loadingState').textContent = 'Error loading.';
   }
   // If a folder-health event fired while /api/browse/init was in flight,

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2027,6 +2027,13 @@ var keywordAutocompletePromise = null;
 var keywordAutocompleteStates = {};
 var collectionCountRefreshTimer = null;
 var collectionCountLoadGen = 0;
+// Same superseded-response guard as loadCollectionCounts, extended to the
+// summary and calendar loaders so a slow /api/browse/summary or
+// /api/photos/calendar response cannot overwrite the panel or heatmap
+// after a newer scope selection triggered a fresh load
+// (CodeRabbit review r3684913398).
+var summaryLoadGen = 0;
+var calendarDataLoadGen = 0;
 var collectionsById = {};
 var browseCompareIds = [];
 var browseCompareOffset = 0;
@@ -3469,7 +3476,13 @@ function refreshBrowseSidebarCounts() {
 var folderHealthRefreshSeq = 0;
 async function refreshBrowseAfterFolderHealthChange() {
   var seq = ++folderHealthRefreshSeq;
-  browseScopeGen++;
+  // A health-driven dataset refresh is not a user scope change: bumping
+  // browseScopeGen here would make any in-flight sidebar click
+  // (filterByFolder/filterByKeyword/filterByCollection) or the initial
+  // collection deep-link replay look stale, and its own guard would then
+  // silently discard the requested scope — leaving Browse on the workspace
+  // grid instead of the user's newer selection (Codex review r3684907518).
+  // folderHealthRefreshSeq below is the only counter this refresh needs.
 
   // Refresh the scope controls first. If the selected folder just went
   // offline it disappears from /api/folders; clear that stale scope before
@@ -3481,7 +3494,11 @@ async function refreshBrowseAfterFolderHealthChange() {
     activeFolderId = null;
   }
 
-  await resetAndLoad();
+  // Preserve the active collection: resetAndLoad's default is to clear
+  // ``activeCollectionId`` for non-dashboard scopes, which would kick a user
+  // viewing a normal collection back to the unscoped workspace grid whenever
+  // folder health changes (CodeRabbit review r3684913393).
+  await resetAndLoad({ preserveCollection: true });
   if (seq !== folderHealthRefreshSeq) return;
   loadCollectionCounts();
   loadSummary();
@@ -4111,6 +4128,11 @@ async function saveCollection() {
 /* ---------- Photo Loading ---------- */
 async function resetAndLoad(options) {
   var preserveAnchor = !!(options && options.preserveAnchor);
+  // Callers that need the current collection scope to survive a reset
+  // (folder-health refresh) pass ``preserveCollection: true``. Without it
+  // the default clear below would drop a normal (non-dashboard) collection
+  // and send the user back to the unscoped workspace grid.
+  var preserveCollection = !!(options && options.preserveCollection);
   var anchor = preserveAnchor ? captureSelectedPhotoAnchor() : null;
   var restoreEpoch = anchor ? ++anchorRestoreEpoch : null;
   photos = [];
@@ -4131,15 +4153,21 @@ async function resetAndLoad(options) {
   // Dashboard-scoped collections are the exception: there the collection is an
   // explicit composable restriction that filters combine WITH, so it must
   // survive filter-driven reloads (dashboard drill-down deep links).
-  if (!dashboardCollectionScope) activeCollectionId = null;
+  if (!dashboardCollectionScope && !preserveCollection) activeCollectionId = null;
+  var preservedCollectionId = preserveCollection ? activeCollectionId : null;
   if (anchor) hideDetailPanel();
   else closeDetail();
   document.getElementById('grid').innerHTML = '';
   document.getElementById('gridContainer').scrollTop = 0;
 
   function resetRequestIsCurrent() {
-    return resetLoadEpoch === loadEpoch &&
-      (activeCollectionId == null || dashboardCollectionScope);
+    if (resetLoadEpoch !== loadEpoch) return false;
+    if (activeCollectionId == null) return true;
+    if (dashboardCollectionScope) return true;
+    // Explicitly preserved collection: the reset is still current as long as
+    // the caller-chosen scope hasn't been replaced by a newer sidebar click.
+    if (preserveCollection && activeCollectionId === preservedCollectionId) return true;
+    return false;
   }
   function anchorScanShouldContinue() {
     return resetRequestIsCurrent() && anchorRestoreEpoch === restoreEpoch;
@@ -4334,6 +4362,7 @@ function toggleTimelineMode() {
 }
 
 async function loadCalendarData() {
+  var gen = ++calendarDataLoadGen;
   var params = new URLSearchParams();
   params.set('year', calendarYear);
   if (activeFolderId) params.set('folder_id', activeFolderId);
@@ -4354,7 +4383,9 @@ async function loadCalendarData() {
   if (rules) params.set('rules', JSON.stringify(rules));
   appendVisualScopeParams(params);
 
-  calendarData = await safeFetch('/api/photos/calendar?' + params.toString());
+  var data = await safeFetch('/api/photos/calendar?' + params.toString());
+  if (gen !== calendarDataLoadGen) return;
+  calendarData = data;
   renderCalendar();
 }
 
@@ -6672,6 +6703,7 @@ function closeDetail() {
 }
 
 async function loadSummary() {
+  var gen = ++summaryLoadGen;
   var params = new URLSearchParams();
   if (activeFolderId) params.set('folder_id', activeFolderId);
   var rules = getBrowseRules();
@@ -6681,6 +6713,7 @@ async function loadSummary() {
 
   try {
     var data = await safeFetch('/api/browse/summary?' + params.toString(), {}, { toast: false });
+    if (gen !== summaryLoadGen) return;
     renderSummary(data);
   } catch(e) {}
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3717,9 +3717,16 @@ async function refreshBrowseAfterFolderHealthChange(detail) {
   // schedule a retry via the same event listener rather than committing
   // to a decision from stale data (Codex review r3687062925).
   if (loaded[0] === null) {
+    var retryDetail = Object.assign({}, detail || {}, {
+      source: 'refresh-retry'
+    });
     setTimeout(function() {
       document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
-        detail: { source: 'refresh-retry' }
+        // Preserve restored/wentMissing ids so the successful retry can still
+        // distinguish an unrelated sibling transition from one that affects
+        // the active folder scope. Dropping them makes the conservative
+        // no-id fallback reset an unaffected grid and selection.
+        detail: retryDetail
       }));
     }, 2000);
     return;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3119,9 +3119,14 @@ function renderCollectionList(collections) {
 }
 
 /* ---------- Folder Tree ---------- */
-async function loadFolders() {
+async function loadFolders(opts) {
   try {
     var data = await safeFetch('/api/folders', {}, { toast: false });
+    // Callers that fire this alongside other refreshes can pass a
+    // ``shouldRender`` guard so a slow response cannot overwrite a newer
+    // render — see refreshBrowseAfterFolderHealthChange
+    // (Codex review r3685193225).
+    if (opts && opts.shouldRender && !opts.shouldRender()) return;
     renderFolderTree(data);
   } catch(e) {}
 }
@@ -3226,9 +3231,10 @@ function filterByFolder(folderId) {
 }
 
 /* ---------- Keyword Tree ---------- */
-async function loadKeywords() {
+async function loadKeywords(opts) {
   try {
     var data = await safeFetch('/api/keywords', {}, { toast: false });
+    if (opts && opts.shouldRender && !opts.shouldRender()) return;
     renderKeywordTree(data);
   } catch(e) {}
 }
@@ -3319,9 +3325,10 @@ async function filterByKeyword(name) {
 }
 
 /* ---------- Collections ---------- */
-async function loadCollections() {
+async function loadCollections(opts) {
   try {
     var data = await safeFetch('/api/collections', {}, { toast: false });
+    if (opts && opts.shouldRender && !opts.shouldRender()) return;
     renderCollectionList(data);
   } catch(e) {}
 }
@@ -3487,8 +3494,21 @@ async function refreshBrowseAfterFolderHealthChange() {
   // Refresh the scope controls first. If the selected folder just went
   // offline it disappears from /api/folders; clear that stale scope before
   // reloading the grid so Browse falls back to the available workspace.
-  await Promise.all([loadFolders(), loadKeywords(), loadCollections()]);
-  if (seq !== folderHealthRefreshSeq) return;
+  //
+  // Pass ``shouldRender`` into each loader: without it, two overlapping
+  // health events (a folder flapping, or the modal check racing the
+  // ten-minute poll) can complete out of order — the older fetch's
+  // render*Tree call would clobber the newer render, and the post-await
+  // seq check would fire too late to undo the DOM mutation. Guarding
+  // *before* render means only the winning generation's data ever reaches
+  // the tree (Codex review r3685193225).
+  var isCurrent = function() { return seq === folderHealthRefreshSeq; };
+  await Promise.all([
+    loadFolders({ shouldRender: isCurrent }),
+    loadKeywords({ shouldRender: isCurrent }),
+    loadCollections({ shouldRender: isCurrent }),
+  ]);
+  if (!isCurrent()) return;
   if (activeFolderId &&
       !document.querySelector('#folderTree .tree-item[data-folder-id="' + activeFolderId + '"]')) {
     activeFolderId = null;
@@ -3499,7 +3519,7 @@ async function refreshBrowseAfterFolderHealthChange() {
   // viewing a normal collection back to the unscoped workspace grid whenever
   // folder health changes (CodeRabbit review r3684913393).
   await resetAndLoad({ preserveCollection: true });
-  if (seq !== folderHealthRefreshSeq) return;
+  if (!isCurrent()) return;
   loadCollectionCounts();
   loadSummary();
   if (timelineMode) loadCalendarData();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3631,8 +3631,18 @@ async function refreshBrowseAfterFolderHealthChange() {
   if (timelineMode) loadCalendarData();
 }
 
+// Track the currently-running refresh so awaiters (the photo deep-link
+// loader in particular) can wait for it to settle before re-snapshotting
+// their generation counter and retrying. Without this, a health event
+// that fires while ``?photo_id=…`` is awaiting ``_cfgPromise`` /
+// ``/api/photos/<id>`` / ``/api/browse/init`` used to cancel the deep
+// link permanently — the refresh has no idea what folder the target
+// photo lives in, so Browse fell back to the unscoped workspace grid
+// without scrolling to the requested photo (and VireoFilter was left
+// uninitialized) (Codex review r3686778061).
+var _activeFolderHealthRefresh = Promise.resolve();
 document.addEventListener('vireo:folder-health-changed', function() {
-  refreshBrowseAfterFolderHealthChange();
+  _activeFolderHealthRefresh = refreshBrowseAfterFolderHealthChange();
 });
 
 async function filterByCollection(id, options) {
@@ -8543,13 +8553,12 @@ document.addEventListener('contextmenu', function(e) {
 });
 
 /* ---------- Deep-link: scroll to photo_id if present in URL ---------- */
-(async function() {
-  var params = new URLSearchParams(window.location.search);
-  var photoId = params.get('photo_id');
-  if (!photoId) return;
-  photoId = parseInt(photoId, 10);
-  if (isNaN(photoId)) return;
-
+// Cap retry loops so a folder that keeps flapping (health event on every
+// interval) can't spin this indefinitely — after this many stale
+// interruptions, fall through to whatever refreshBrowseAfterFolderHealthChange
+// last rendered rather than deep-link forever (Codex review r3686778061).
+var _DEEP_LINK_MAX_RETRIES = 5;
+async function _runPhotoDeepLink(photoId) {
   // Snapshot the health-refresh generation BEFORE any await. If a
   // vireo:folder-health-changed event fires while this loader is awaiting
   // /api/photos/<id> or its folder-scoped /api/browse/init,
@@ -8563,22 +8572,28 @@ document.addEventListener('contextmenu', function(e) {
   var isDeepLinkHealthCurrent = function() {
     return folderHealthRefreshSeq === deepLinkHealthSeq;
   };
+  // Signal to the outer retry loop whether we bailed out due to a
+  // concurrent health refresh (retryable) versus completed / errored
+  // (terminal). Returning a boolean keeps the existing return-early
+  // pattern intact — every ``return`` inside the try body is a stale
+  // detection.
+  var wasSuperseded = false;
 
   // Prevent the IntersectionObserver from triggering loadPhotos() while deep-link is loading
   loading = true;
   var deepLinkLoaded = false;
   try {
     applyBrowseConfig(await _cfgPromise);
-    if (!isDeepLinkHealthCurrent()) return;
+    if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
     var photo = await safeFetch('/api/photos/' + photoId, {}, { toast: false });
-    if (!isDeepLinkHealthCurrent()) return;
+    if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
     if (!photo || !photo.folder_id) {
       // Don't release ``loading`` if a concurrent health refresh owns it
       // (its loadPhotos would then race the intersection observer). The
       // isDeepLinkHealthCurrent check above already returns early in that
       // case, so reaching here means it's safe to release.
       loading = false;
-      return;
+      return wasSuperseded;
     }
 
     // Navigate to the photo's folder
@@ -8599,7 +8614,7 @@ document.addEventListener('contextmenu', function(e) {
     // Load pages until the target photo is found or all pages exhausted
     // (bootstrapBrowse was skipped, so we also need folder/keyword trees)
     var initData = await safeFetch('/api/browse/init?folder_id=' + photo.folder_id + '&per_page=' + perPage + '&sort=' + document.getElementById('sortSelect').value, {}, { toast: false });
-    if (!isDeepLinkHealthCurrent()) return;
+    if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
     if (initData) {
       // Seed the navbar's missing-folder snapshot from init's workspace-scoped
       // view so the first /api/folders/missing observation has a baseline to
@@ -8625,7 +8640,7 @@ document.addEventListener('contextmenu', function(e) {
                    typeof _dispatchFolderHealthChangeFromIds === 'function') {
           _dispatchFolderHealthChangeFromIds(
             initMissingIds, _missingFoldersLastIds, 'deep-link-reconcile');
-          if (!isDeepLinkHealthCurrent()) return;
+          if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
         }
       }
       renderFolderTree(initData.folders || []);
@@ -8647,10 +8662,10 @@ document.addEventListener('contextmenu', function(e) {
     // or a target beyond the first page spins in a resolved Promise loop.
     // Same freshness guard as above — don't release ``loading`` if a health
     // refresh took ownership while init was in flight.
-    if (!isDeepLinkHealthCurrent()) return;
+    if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
     loading = false;
     var el = await loadUntilPhotoRendered(photoId);
-    if (!isDeepLinkHealthCurrent()) return;
+    if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
 
     // Update folder tree active state
     document.querySelectorAll('#folderTree .tree-item').forEach(function(el) {
@@ -8711,6 +8726,30 @@ document.addEventListener('contextmenu', function(e) {
       rearmInfiniteScrollObserver();
       requestAnimationFrame(ensureViewportHydrated);
     }
+  }
+  return wasSuperseded;
+}
+
+(async function() {
+  var params = new URLSearchParams(window.location.search);
+  var photoId = params.get('photo_id');
+  if (!photoId) return;
+  photoId = parseInt(photoId, 10);
+  if (isNaN(photoId)) return;
+
+  // If a folder-health refresh interrupts us, wait for it to finish and
+  // retry — otherwise the deep-link is silently abandoned and Browse is
+  // left on whatever the refresh happened to load (usually the unscoped
+  // workspace grid, with the target photo never scrolled into view and
+  // VireoFilter uninitialized) (Codex review r3686778061).
+  for (var attempt = 0; attempt < _DEEP_LINK_MAX_RETRIES; attempt++) {
+    var wasSuperseded = await _runPhotoDeepLink(photoId);
+    if (!wasSuperseded) return;
+    // Await the refresh that stole the load so the next attempt starts
+    // from a settled state and its pre-await snapshot is guaranteed to
+    // match the current generation (unless yet another refresh fires
+    // during the retry, which the loop handles).
+    try { await _activeFolderHealthRefresh; } catch (e) { /* ignore */ }
   }
 })();
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -8550,13 +8550,36 @@ document.addEventListener('contextmenu', function(e) {
   photoId = parseInt(photoId, 10);
   if (isNaN(photoId)) return;
 
+  // Snapshot the health-refresh generation BEFORE any await. If a
+  // vireo:folder-health-changed event fires while this loader is awaiting
+  // /api/photos/<id> or its folder-scoped /api/browse/init,
+  // refreshBrowseAfterFolderHealthChange() has already reloaded folders,
+  // keywords, collections, and the grid from the fresh post-flip state and
+  // owns the ``loading`` mutex. Rendering pre-flip data from initData or
+  // releasing ``loading`` here would either clobber that fresher refresh
+  // or let the intersection observer fire a duplicate page-1 request
+  // against the same loadEpoch (Codex review r3686696351).
+  var deepLinkHealthSeq = folderHealthRefreshSeq;
+  var isDeepLinkHealthCurrent = function() {
+    return folderHealthRefreshSeq === deepLinkHealthSeq;
+  };
+
   // Prevent the IntersectionObserver from triggering loadPhotos() while deep-link is loading
   loading = true;
   var deepLinkLoaded = false;
   try {
     applyBrowseConfig(await _cfgPromise);
+    if (!isDeepLinkHealthCurrent()) return;
     var photo = await safeFetch('/api/photos/' + photoId, {}, { toast: false });
-    if (!photo || !photo.folder_id) { loading = false; return; }
+    if (!isDeepLinkHealthCurrent()) return;
+    if (!photo || !photo.folder_id) {
+      // Don't release ``loading`` if a concurrent health refresh owns it
+      // (its loadPhotos would then race the intersection observer). The
+      // isDeepLinkHealthCurrent check above already returns early in that
+      // case, so reaching here means it's safe to release.
+      loading = false;
+      return;
+    }
 
     // Navigate to the photo's folder
     activeFolderId = photo.folder_id;
@@ -8576,7 +8599,35 @@ document.addEventListener('contextmenu', function(e) {
     // Load pages until the target photo is found or all pages exhausted
     // (bootstrapBrowse was skipped, so we also need folder/keyword trees)
     var initData = await safeFetch('/api/browse/init?folder_id=' + photo.folder_id + '&per_page=' + perPage + '&sort=' + document.getElementById('sortSelect').value, {}, { toast: false });
+    if (!isDeepLinkHealthCurrent()) return;
     if (initData) {
+      // Seed the navbar's missing-folder snapshot from init's workspace-scoped
+      // view so the first /api/folders/missing observation has a baseline to
+      // compare against. bootstrapBrowse() does the same seed but returns
+      // immediately for ?photo_id=..., so without this the deep-link path
+      // leaves _missingFoldersLastIds null: a background _folder_health_loop
+      // flip that runs between init and the first navbar poll then lands
+      // silently (null-baseline branch), later polls see the same IDs and
+      // never dispatch, and Browse stays stuck on the pre-flip state
+      // indefinitely. When a poll already landed with a differing baseline,
+      // dispatch the init→now transition so
+      // refreshBrowseAfterFolderHealthChange takes over — the subsequent
+      // isDeepLinkHealthCurrent check will then skip our stale render
+      // (Codex review r3686696347).
+      if (typeof _missingFoldersLastIds !== 'undefined' &&
+          Array.isArray(initData.missing_folder_ids)) {
+        var initMissingIds = initData.missing_folder_ids
+          .slice()
+          .sort(function(a, b) { return a - b; });
+        if (_missingFoldersLastIds === null) {
+          _missingFoldersLastIds = initMissingIds;
+        } else if (_missingFolderIdsDiffer(initMissingIds, _missingFoldersLastIds) &&
+                   typeof _dispatchFolderHealthChangeFromIds === 'function') {
+          _dispatchFolderHealthChangeFromIds(
+            initMissingIds, _missingFoldersLastIds, 'deep-link-reconcile');
+          if (!isDeepLinkHealthCurrent()) return;
+        }
+      }
       renderFolderTree(initData.folders || []);
       renderKeywordTree(initData.keywords || []);
       renderCollectionList(initData.collections || []);
@@ -8594,8 +8645,12 @@ document.addEventListener('contextmenu', function(e) {
     // above intentionally blocks IntersectionObserver-driven loads, but
     // loadPhotos() also honors it; clear it before this explicit paging pass
     // or a target beyond the first page spins in a resolved Promise loop.
+    // Same freshness guard as above — don't release ``loading`` if a health
+    // refresh took ownership while init was in flight.
+    if (!isDeepLinkHealthCurrent()) return;
     loading = false;
     var el = await loadUntilPhotoRendered(photoId);
+    if (!isDeepLinkHealthCurrent()) return;
 
     // Update folder tree active state
     document.querySelectorAll('#folderTree .tree-item').forEach(function(el) {
@@ -8645,10 +8700,17 @@ document.addEventListener('contextmenu', function(e) {
       }).catch(function() {});
     }
   } catch(e) { /* ignore deep-link errors silently */ }
-  loading = false;
-  if (deepLinkLoaded) {
-    rearmInfiniteScrollObserver();
-    requestAnimationFrame(ensureViewportHydrated);
+  // A concurrent refreshBrowseAfterFolderHealthChange() owns ``loading``
+  // and rearms the observer itself when its loadPhotos settles; releasing
+  // ``loading`` here would let a second page-1 request race against the
+  // same loadEpoch, producing duplicate cards and off-by-one pagination
+  // (Codex review r3686696351).
+  if (isDeepLinkHealthCurrent()) {
+    loading = false;
+    if (deepLinkLoaded) {
+      rearmInfiniteScrollObserver();
+      requestAnimationFrame(ensureViewportHydrated);
+    }
   }
 })();
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2892,16 +2892,27 @@ async function bootstrapBrowse() {
   // finally-region guard to release the load lock the concurrent health
   // refresh's ``loadPhotos`` still owned (Codex review r3686191138).
   var bootstrapHealthSeq = folderHealthRefreshSeq;
+  // Parse URL scope params BEFORE the first await. A folder-health event that
+  // fires while ``_cfgPromise`` is still pending runs
+  // refreshBrowseAfterFolderHealthChange(), which calls resetAndLoad() from
+  // the current ``activeFolderId`` / ``activeCollectionId``. If those were
+  // still null the refresh loads the unscoped workspace grid, and then this
+  // bootstrap's folder-scoped init response is thrown away by the
+  // healthChangedDuringInit guard below — for a plain collection deep link
+  // the browseFilterInitPromise.then replay reopens it, but a folder-only
+  // deep link has no such replay, so Browse would render unscoped despite
+  // ``?folder_id=N`` in the URL (Codex review r3686605296). Assigning here
+  // means any concurrent refresh sees the right scope.
+  var pageParams = new URLSearchParams(window.location.search);
+  var initialFolderId = parseInt(pageParams.get('folder_id'), 10);
+  if (!isNaN(initialFolderId)) activeFolderId = initialFolderId;
+  var initialCollectionId = parseInt(pageParams.get('collection_id'), 10);
+  if (!isNaN(initialCollectionId)) {
+    activeCollectionId = initialCollectionId;
+    dashboardCollectionScope = pageParams.get('dashboard_scope') === '1';
+  }
   try {
     applyBrowseConfig(await _cfgPromise);
-    var pageParams = new URLSearchParams(window.location.search);
-    var initialFolderId = parseInt(pageParams.get('folder_id'), 10);
-    if (!isNaN(initialFolderId)) activeFolderId = initialFolderId;
-    var initialCollectionId = parseInt(pageParams.get('collection_id'), 10);
-    if (!isNaN(initialCollectionId)) {
-      activeCollectionId = initialCollectionId;
-      dashboardCollectionScope = pageParams.get('dashboard_scope') === '1';
-    }
     // Legacy filter deep-link params (rating_min/flag/keyword/dates/…) are
     // compiled into an initial rule tree by VireoFilter.init below, which
     // reloads through /api/photos/query — the bootstrap endpoint is

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2927,12 +2927,31 @@ async function bootstrapBrowse() {
     // pre-flip state until another transition or a reload (Codex review
     // r3686191141). Only seed if still null — a poll (or modal POST) that
     // already landed is a fresher source of truth than this init snapshot.
+    //
+    // When a poll DID land first with a non-null baseline that differs
+    // from init's, the flip committed between init's baseline read and
+    // the poll's observation. The poll wrote its post-flip snapshot to
+    // ``_missingFoldersLastIds`` without dispatching (null prev), and
+    // init returned with pre-flip photos/folders that we're about to
+    // render below. Left alone, later polls see the same post-flip IDs
+    // and never dispatch — Browse would stay stuck on the stale init
+    // paint forever. Dispatch the init→now transition here so
+    // refreshBrowseAfterFolderHealthChange takes over, and mark the
+    // health-changed flag so the guarded render path skips init's data
+    // (Codex review r3686452019).
     if (typeof _missingFoldersLastIds !== 'undefined' &&
-        _missingFoldersLastIds === null &&
         Array.isArray(data.missing_folder_ids)) {
-      _missingFoldersLastIds = data.missing_folder_ids
+      var initMissingIds = data.missing_folder_ids
         .slice()
         .sort(function(a, b) { return a - b; });
+      if (_missingFoldersLastIds === null) {
+        _missingFoldersLastIds = initMissingIds;
+      } else if (_missingFolderIdsDiffer(initMissingIds, _missingFoldersLastIds) &&
+                 typeof _dispatchFolderHealthChangeFromIds === 'function') {
+        var dispatched = _dispatchFolderHealthChangeFromIds(
+          initMissingIds, _missingFoldersLastIds, 'bootstrap-reconcile');
+        if (dispatched) healthChangedDuringInit = true;
+      }
     }
 
     if (!healthChangedDuringInit) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3912,6 +3912,18 @@ document.addEventListener('vireo:folder-health-changed', function(event) {
     event && event.detail);
 });
 
+async function waitForFolderHealthRefreshesToSettle() {
+  // A second event can replace the active promise while an awaiter is still
+  // waiting on the first. Keep observing until the promise that just settled
+  // is still the active one, so photo deep-link retries cannot resume in the
+  // gap between overlapping refreshes.
+  while (true) {
+    var observed = _activeFolderHealthRefresh;
+    try { await observed; } catch (e) { /* keep draining newer refreshes */ }
+    if (observed === _activeFolderHealthRefresh) return;
+  }
+}
+
 async function filterByCollection(id, options) {
   // The sidebar collection list is rendered from the initial /photos payload,
   // so a slow /api/filters/fields (or workspace) round-trip leaves clickable
@@ -9104,7 +9116,7 @@ async function _runPhotoDeepLink(photoId) {
     // from a settled state and its pre-await snapshot is guaranteed to
     // match the current generation (unless yet another refresh fires
     // during the retry, which the loop handles).
-    try { await _activeFolderHealthRefresh; } catch (e) { /* ignore */ }
+    await waitForFolderHealthRefreshesToSettle();
   }
 })();
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1962,6 +1962,11 @@ var currentPage = 1;
 var perPage = 50;
 var loading = false;
 var allLoaded = false;
+// True only after an authoritative response has initialized the grid, even
+// when that response contains zero photos. Health events can arrive while
+// bootstrap or a deep link is still pending; an "unaffected scope" is only
+// safe to preserve once there is an initialized dataset to preserve.
+var browseDatasetReady = false;
 var selectedPhotoId = null;
 var selectedIndex = -1;
 var anchorRestoreEpoch = 0;
@@ -2991,6 +2996,7 @@ async function bootstrapBrowse() {
       renderKeywordTree(data.keywords || []);
       renderCollectionList(data.collections || []);
       renderGrid();
+      browseDatasetReady = true;
       updateFilterSummary();
       loadSummary();
     }
@@ -3734,7 +3740,7 @@ async function refreshBrowseAfterFolderHealthChange(detail) {
   // A transition in an unrelated folder cannot change a leaf-folder result
   // set. Keep its selection, detail panel, and scroll position intact while
   // still refreshing workspace-wide sidebar and summary counts.
-  if (!activeScopeWasAffected) {
+  if (!activeScopeWasAffected && browseDatasetReady) {
     loadCollectionCounts();
     loadSummary();
     if (timelineMode) loadCalendarData();
@@ -4393,6 +4399,7 @@ async function resetAndLoad(options) {
   var preserveCollection = !!(options && options.preserveCollection);
   var anchor = preserveAnchor ? captureSelectedPhotoAnchor() : null;
   var restoreEpoch = anchor ? ++anchorRestoreEpoch : null;
+  browseDatasetReady = false;
   photos = [];
   currentPage = 1;
   allLoaded = false;
@@ -4563,6 +4570,7 @@ async function loadPhotos(options) {
 
     if (firstNewIdx === 0) renderGrid();
     else appendGridPhotos(data.photos, firstNewIdx);
+    browseDatasetReady = true;
     updateGridTail();
     updateFilterSummary();
 
@@ -8722,6 +8730,7 @@ async function _runPhotoDeepLink(photoId) {
     activeFolderId = photo.folder_id;
     activeKeyword = null;
     activeCollectionId = null;
+    browseDatasetReady = false;
     photos = [];
     currentPage = 1;
     allLoaded = false;
@@ -8774,6 +8783,7 @@ async function _runPhotoDeepLink(photoId) {
       currentPage = 2;
       if (photos.length >= totalPhotos) allLoaded = true;
       renderGrid();
+      browseDatasetReady = true;
       document.getElementById('loadingState').style.display = 'none';
       deepLinkLoaded = true;
     }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2041,6 +2041,8 @@ var summaryLoadGen = 0;
 var summaryLoadStates = {};
 var summaryRenderDecisionGen = 0;
 var calendarDataLoadGen = 0;
+var calendarDataLoadStates = {};
+var calendarRenderDecisionGen = 0;
 // Internal generation counters shared across every caller of the sidebar
 // loaders. Without these, ``refreshBrowseSidebarCounts()`` and the various
 // mutation-triggered ``loadKeywords()``/``loadCollections()`` calls fire
@@ -4769,8 +4771,7 @@ function toggleTimelineMode() {
   }
 }
 
-async function loadCalendarData() {
-  var gen = ++calendarDataLoadGen;
+function buildCalendarParams() {
   var params = new URLSearchParams();
   params.set('year', calendarYear);
   if (activeFolderId) params.set('folder_id', activeFolderId);
@@ -4790,11 +4791,54 @@ async function loadCalendarData() {
   var rules = getBrowseRulesWithoutTimestamp();
   if (rules) params.set('rules', JSON.stringify(rules));
   appendVisualScopeParams(params);
+  return params;
+}
 
-  var data = await safeFetch('/api/photos/calendar?' + params.toString());
-  if (gen !== calendarDataLoadGen) return;
-  calendarData = data;
-  renderCalendar();
+function reconcileCalendarLoadRenders() {
+  var gen = calendarDataLoadGen;
+  while (gen > calendarRenderDecisionGen) {
+    var state = calendarDataLoadStates[gen];
+    if (!state || state.status === 'pending') return;
+    if (state.status === 'success') {
+      var currentKey = buildCalendarParams().toString();
+      calendarRenderDecisionGen = gen;
+      if (state.key === currentKey) {
+        calendarData = state.data;
+        renderCalendar();
+      }
+      Object.keys(calendarDataLoadStates).forEach(function(key) {
+        if (Number(key) <= calendarDataLoadGen) delete calendarDataLoadStates[key];
+      });
+      return;
+    }
+    gen--;
+  }
+}
+
+async function loadCalendarData() {
+  var gen = ++calendarDataLoadGen;
+  var params = buildCalendarParams();
+  calendarDataLoadStates[gen] = {
+    status: 'pending',
+    key: params.toString()
+  };
+
+  try {
+    var data = await safeFetch('/api/photos/calendar?' + params.toString());
+    var state = calendarDataLoadStates[gen];
+    if (!state) return data;
+    state.status = 'success';
+    state.data = data;
+    reconcileCalendarLoadRenders();
+    return data;
+  } catch(e) {
+    var failedState = calendarDataLoadStates[gen];
+    if (failedState) {
+      failedState.status = 'failure';
+      reconcileCalendarLoadRenders();
+    }
+    return null;
+  }
 }
 
 function getBrowseRulesWithoutTimestamp() {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2055,6 +2055,8 @@ var folderLoadStates = {};
 var folderRenderDecisionGen = 0;
 var keywordLoadGen = 0;
 var collectionLoadGen = 0;
+var collectionLoadStates = {};
+var collectionRenderDecisionGen = 0;
 var browseFolderRows = [];
 var collectionsById = {};
 var browseCompareIds = [];
@@ -3496,17 +3498,54 @@ async function filterByKeyword(name) {
 }
 
 /* ---------- Collections ---------- */
+function reconcileCollectionLoadRenders() {
+  // Mirror reconcileFolderLoadRenders: don't render an older successful
+  // response while a newer request is still pending, but if every newer
+  // request failed, fall back to the newest available success rather than
+  // leaving the collection list stale. Otherwise a health-owned request
+  // that observed a just-created collection could be silently dropped by
+  // a subsequent mutation-triggered reload that transiently fails, so the
+  // collection stays absent until the next explicit list refresh
+  // (Codex review r3687331931).
+  var gen = collectionLoadGen;
+  while (gen > collectionRenderDecisionGen) {
+    var state = collectionLoadStates[gen];
+    if (!state || state.status === 'pending') return;
+    if (state.status === 'success') {
+      var shouldRender = !state.shouldRender || state.shouldRender();
+      collectionRenderDecisionGen = gen;
+      if (shouldRender) renderCollectionList(state.data);
+      Object.keys(collectionLoadStates).forEach(function(key) {
+        if (Number(key) <= collectionLoadGen) delete collectionLoadStates[key];
+      });
+      return;
+    }
+    gen--;
+  }
+}
+
 async function loadCollections(opts) {
   var myGen = ++collectionLoadGen;
+  collectionLoadStates[myGen] = {
+    status: 'pending',
+    shouldRender: opts && opts.shouldRender
+  };
   try {
     var data = await safeFetch('/api/collections', {}, { toast: false });
-    // See loadFolders — same shared-generation freshness guard so an older
-    // response cannot overwrite the collection list that a newer caller
-    // has already repainted.
-    if (myGen !== collectionLoadGen) return;
-    if (opts && opts.shouldRender && !opts.shouldRender()) return;
-    renderCollectionList(data);
-  } catch(e) {}
+    var state = collectionLoadStates[myGen];
+    if (!state) return data;
+    state.status = 'success';
+    state.data = data;
+    reconcileCollectionLoadRenders();
+    return data;
+  } catch(e) {
+    var failedState = collectionLoadStates[myGen];
+    if (failedState) {
+      failedState.status = 'failure';
+      reconcileCollectionLoadRenders();
+    }
+    return null;
+  }
 }
 
 async function loadCollectionCounts() {
@@ -3743,7 +3782,19 @@ async function refreshBrowseAfterFolderHealthChange(detail) {
     // Bound the short-term recovery loop. A prolonged/permanent endpoint
     // outage must fall back to the normal ten-minute health poll instead of
     // issuing folder/keyword/collection requests forever.
-    if (retryAttempt >= 3) return;
+    if (retryAttempt >= 3) {
+      // The navbar advanced ``_missingFoldersLastIds`` before dispatching
+      // this event, so its 10-minute poll will see unchanged IDs once
+      // ``/api/folders`` recovers and by default emits nothing — the page
+      // would then remain on pre-transition data indefinitely. Flag the
+      // navbar so the next successful poll fires a synthetic reconciliation
+      // event regardless of the ID diff, letting this handler re-attempt
+      // the refresh with a healthy endpoint (Codex review r3687331927).
+      if (typeof window.markMissingFoldersReconciliationPending === 'function') {
+        window.markMissingFoldersReconciliationPending();
+      }
+      return;
+    }
     var retryDetail = Object.assign({}, detail || {}, {
       source: 'refresh-retry',
       refreshRetryAttempt: retryAttempt + 1

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2051,6 +2051,8 @@ var calendarDataLoadGen = 0;
 // newer call has since started, so last-started always wins regardless of
 // which call site issued it.
 var folderLoadGen = 0;
+var folderLoadStates = {};
+var folderRenderDecisionGen = 0;
 var keywordLoadGen = 0;
 var collectionLoadGen = 0;
 var browseFolderRows = [];
@@ -2946,6 +2948,10 @@ async function bootstrapBrowse() {
     // in either case.
     if (activeCollectionId) initParams.set('collection_id', activeCollectionId);
     initParams.set('per_page', perPage);
+    var missingSnapshotVersionAtInitStart =
+      typeof _missingFoldersSnapshotVersion !== 'undefined'
+        ? _missingFoldersSnapshotVersion
+        : null;
     var data = await safeFetch('/api/browse/init?' + initParams.toString());
     healthChangedDuringInit = folderHealthRefreshSeq !== bootstrapHealthSeq;
 
@@ -2956,33 +2962,25 @@ async function bootstrapBrowse() {
     // the poll's null-baseline branch returning false — later polls then
     // see the same IDs and never dispatch, so Browse stays showing the
     // pre-flip state until another transition or a reload (Codex review
-    // r3686191141). Only seed if still null — a poll (or modal POST) that
-    // already landed is a fresher source of truth than this init snapshot.
+    // r3686191141). The navbar helper compares its baseline version at init
+    // request start and completion: a poll/POST already applied before the
+    // request is older than init, while one applied during the request remains
+    // authoritative.
     //
-    // When a poll DID land first with a non-null baseline that differs
-    // from init's, the flip committed between init's baseline read and
-    // the poll's observation. The poll wrote its post-flip snapshot to
-    // ``_missingFoldersLastIds`` without dispatching (null prev), and
-    // init returned with pre-flip photos/folders that we're about to
-    // render below. Left alone, later polls see the same post-flip IDs
-    // and never dispatch — Browse would stay stuck on the stale init
-    // paint forever. Dispatch the init→now transition here so
+    // When a differing poll snapshot lands while init is in flight, init may
+    // contain pre-flip photos/folders. Dispatch the init→now transition so
     // refreshBrowseAfterFolderHealthChange takes over, and mark the
-    // health-changed flag so the guarded render path skips init's data
-    // (Codex review r3686452019).
-    if (typeof _missingFoldersLastIds !== 'undefined' &&
-        Array.isArray(data.missing_folder_ids)) {
-      var initMissingIds = data.missing_folder_ids
-        .slice()
-        .sort(function(a, b) { return a - b; });
-      if (_missingFoldersLastIds === null) {
-        _missingFoldersLastIds = initMissingIds;
-      } else if (_missingFolderIdsDiffer(initMissingIds, _missingFoldersLastIds) &&
-                 typeof _dispatchFolderHealthChangeFromIds === 'function') {
-        var dispatched = _dispatchFolderHealthChangeFromIds(
-          initMissingIds, _missingFoldersLastIds, 'bootstrap-reconcile');
-        if (dispatched) healthChangedDuringInit = true;
-      }
+    // health-changed flag so the guarded render path skips init's stale data
+    // (Codex review r3686452019). Conversely, a poll applied before this
+    // request is known older and the helper adopts init directly
+    // (Codex review r3687277899).
+    if (Array.isArray(data.missing_folder_ids) &&
+        typeof _reconcileMissingFoldersInitSnapshot === 'function') {
+      var initWasStale = _reconcileMissingFoldersInitSnapshot(
+        data.missing_folder_ids,
+        missingSnapshotVersionAtInitStart,
+        'bootstrap-reconcile');
+      if (initWasStale) healthChangedDuringInit = true;
     }
 
     if (!healthChangedDuringInit) {
@@ -3244,25 +3242,49 @@ function renderCollectionList(collections) {
 }
 
 /* ---------- Folder Tree ---------- */
+function reconcileFolderLoadRenders() {
+  // Do not render an older successful response while any newer request is
+  // still pending. Once every newer request has failed, fall back to the
+  // newest success instead of leaving the pre-transition tree in the DOM.
+  // This handles both completion orders: success-before-failure and
+  // failure-before-success.
+  var gen = folderLoadGen;
+  while (gen > folderRenderDecisionGen) {
+    var state = folderLoadStates[gen];
+    if (!state || state.status === 'pending') return;
+    if (state.status === 'success') {
+      var shouldRender = !state.shouldRender || state.shouldRender();
+      folderRenderDecisionGen = gen;
+      if (shouldRender) renderFolderTree(state.data);
+      Object.keys(folderLoadStates).forEach(function(key) {
+        if (Number(key) <= folderLoadGen) delete folderLoadStates[key];
+      });
+      return;
+    }
+    gen--;
+  }
+}
+
 async function loadFolders(opts) {
   var myGen = ++folderLoadGen;
+  folderLoadStates[myGen] = {
+    status: 'pending',
+    shouldRender: opts && opts.shouldRender
+  };
   try {
     var data = await safeFetch('/api/folders', {}, { toast: false });
-    // Internal freshness guard: a later ``loadFolders()`` call — from any
-    // site — has advanced the generation, so its response is the truth
-    // and ours would just overwrite it with stale data. Still return the
-    // fetched data so callers that need it for membership checks (rather
-    // than the DOM) can use it without race-losing renders masking a
-    // successful fetch as a failure.
-    if (myGen !== folderLoadGen) return data;
-    // Callers that fire this alongside other refreshes can pass a
-    // ``shouldRender`` guard so a slow response cannot overwrite a newer
-    // render — see refreshBrowseAfterFolderHealthChange
-    // (Codex review r3685193225).
-    if (opts && opts.shouldRender && !opts.shouldRender()) return data;
-    renderFolderTree(data);
+    var state = folderLoadStates[myGen];
+    if (!state) return data;
+    state.status = 'success';
+    state.data = data;
+    reconcileFolderLoadRenders();
     return data;
   } catch(e) {
+    var failedState = folderLoadStates[myGen];
+    if (failedState) {
+      failedState.status = 'failure';
+      reconcileFolderLoadRenders();
+    }
     // Signal failure to callers that gate destructive decisions (e.g. the
     // health refresh clearing ``activeFolderId``) on a successful fetch.
     // A DOM/cache-based check after a swallowed failure sees the stale
@@ -3717,8 +3739,14 @@ async function refreshBrowseAfterFolderHealthChange(detail) {
   // schedule a retry via the same event listener rather than committing
   // to a decision from stale data (Codex review r3687062925).
   if (loaded[0] === null) {
+    var retryAttempt = detail && Number(detail.refreshRetryAttempt) || 0;
+    // Bound the short-term recovery loop. A prolonged/permanent endpoint
+    // outage must fall back to the normal ten-minute health poll instead of
+    // issuing folder/keyword/collection requests forever.
+    if (retryAttempt >= 3) return;
     var retryDetail = Object.assign({}, detail || {}, {
-      source: 'refresh-retry'
+      source: 'refresh-retry',
+      refreshRetryAttempt: retryAttempt + 1
     });
     setTimeout(function() {
       document.dispatchEvent(new CustomEvent('vireo:folder-health-changed', {
@@ -3728,7 +3756,7 @@ async function refreshBrowseAfterFolderHealthChange(detail) {
         // no-id fallback reset an unaffected grid and selection.
         detail: retryDetail
       }));
-    }, 2000);
+    }, 2000 * Math.pow(2, retryAttempt));
     return;
   }
   // Use the health-owned response rather than the DOM. A later unrelated
@@ -8751,6 +8779,10 @@ async function _runPhotoDeepLink(photoId) {
 
     // Load pages until the target photo is found or all pages exhausted
     // (bootstrapBrowse was skipped, so we also need folder/keyword trees)
+    var missingSnapshotVersionAtInitStart =
+      typeof _missingFoldersSnapshotVersion !== 'undefined'
+        ? _missingFoldersSnapshotVersion
+        : null;
     var initData = await safeFetch('/api/browse/init?folder_id=' + photo.folder_id + '&per_page=' + perPage + '&sort=' + document.getElementById('sortSelect').value, {}, { toast: false });
     if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
     if (initData) {
@@ -8762,24 +8794,18 @@ async function _runPhotoDeepLink(photoId) {
       // flip that runs between init and the first navbar poll then lands
       // silently (null-baseline branch), later polls see the same IDs and
       // never dispatch, and Browse stays stuck on the pre-flip state
-      // indefinitely. When a poll already landed with a differing baseline,
-      // dispatch the init→now transition so
-      // refreshBrowseAfterFolderHealthChange takes over — the subsequent
-      // isDeepLinkHealthCurrent check will then skip our stale render
-      // (Codex review r3686696347).
-      if (typeof _missingFoldersLastIds !== 'undefined' &&
-          Array.isArray(initData.missing_folder_ids)) {
-        var initMissingIds = initData.missing_folder_ids
-          .slice()
-          .sort(function(a, b) { return a - b; });
-        if (_missingFoldersLastIds === null) {
-          _missingFoldersLastIds = initMissingIds;
-        } else if (_missingFolderIdsDiffer(initMissingIds, _missingFoldersLastIds) &&
-                   typeof _dispatchFolderHealthChangeFromIds === 'function') {
-          _dispatchFolderHealthChangeFromIds(
-            initMissingIds, _missingFoldersLastIds, 'deep-link-reconcile');
-          if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
-        }
+      // indefinitely. The shared snapshot-version helper adopts init when a
+      // baseline was already present before this request, but dispatches an
+      // init→current transition when a newer observation landed in flight;
+      // the subsequent isDeepLinkHealthCurrent check then skips stale render
+      // data (Codex reviews r3686696347 and r3687277899).
+      if (Array.isArray(initData.missing_folder_ids) &&
+          typeof _reconcileMissingFoldersInitSnapshot === 'function') {
+        _reconcileMissingFoldersInitSnapshot(
+          initData.missing_folder_ids,
+          missingSnapshotVersionAtInitStart,
+          'deep-link-reconcile');
+        if (!isDeepLinkHealthCurrent()) { wasSuperseded = true; return wasSuperseded; }
       }
       renderFolderTree(initData.folders || []);
       renderKeywordTree(initData.keywords || []);

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -200,21 +200,13 @@ def test_dashboard_and_browse_share_collection_date_scope(app_and_db):
 def test_browse_init_captures_missing_baseline_before_folder_tree(
     app_and_db, monkeypatch,
 ):
-    """/api/browse/init must snapshot missing-folder IDs BEFORE reading the
-    folder tree.
+    """/api/browse/init must establish its read snapshot from missing-folder
+    IDs before reading the folder tree.
 
-    Each SELECT here reads its own committed snapshot (no explicit read
-    transaction), so a ``_folder_health_loop`` commit landing between the
-    two used to produce a split-snapshot response: folders reflected the
-    pre-flip state while ``missing_folder_ids`` reflected the post-flip
-    state. The client seeded ``_missingFoldersLastIds`` from that fresher
-    baseline, so subsequent /api/folders/missing polls saw no diff and
-    never dispatched ``vireo:folder-health-changed`` — Browse stayed
-    stuck on the pre-flip folders and grid until another transition or a
-    reload (Codex review r3686317681). Taking the baseline first guarantees
-    it is at least as OLD as the folder data: any lingering inconsistency
-    now points the "wrong" way, so the very next poll finds a diff and
-    drives a refresh.
+    The endpoint now wraps every first-paint read in one transaction, so the
+    ordering establishes the shared snapshot rather than merely narrowing
+    the direction of a possible inconsistency (Codex reviews r3686317681 and
+    r3687501744).
     """
     from db import Database
 
@@ -243,8 +235,8 @@ def test_browse_init_captures_missing_baseline_before_folder_tree(
         f"expected both reads to run, got {call_order}"
     )
     assert call_order.index("missing") < call_order.index("tree"), (
-        "get_missing_folders must run before get_folder_tree so the client's "
-        f"baseline is never fresher than the folder data; call order was {call_order}"
+        "get_missing_folders must establish the transaction snapshot before "
+        f"get_folder_tree; call order was {call_order}"
     )
 
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -197,6 +197,57 @@ def test_dashboard_and_browse_share_collection_date_scope(app_and_db):
     assert query_resp.get_json()["ids"] == [photos[2]["id"]]
 
 
+def test_browse_init_captures_missing_baseline_before_folder_tree(
+    app_and_db, monkeypatch,
+):
+    """/api/browse/init must snapshot missing-folder IDs BEFORE reading the
+    folder tree.
+
+    Each SELECT here reads its own committed snapshot (no explicit read
+    transaction), so a ``_folder_health_loop`` commit landing between the
+    two used to produce a split-snapshot response: folders reflected the
+    pre-flip state while ``missing_folder_ids`` reflected the post-flip
+    state. The client seeded ``_missingFoldersLastIds`` from that fresher
+    baseline, so subsequent /api/folders/missing polls saw no diff and
+    never dispatched ``vireo:folder-health-changed`` — Browse stayed
+    stuck on the pre-flip folders and grid until another transition or a
+    reload (Codex review r3686317681). Taking the baseline first guarantees
+    it is at least as OLD as the folder data: any lingering inconsistency
+    now points the "wrong" way, so the very next poll finds a diff and
+    drives a refresh.
+    """
+    from db import Database
+
+    app, _ = app_and_db
+    client = app.test_client()
+
+    call_order = []
+    real_missing = Database.get_missing_folders
+    real_tree = Database.get_folder_tree
+
+    def spy_missing(self):
+        call_order.append("missing")
+        return real_missing(self)
+
+    def spy_tree(self):
+        call_order.append("tree")
+        return real_tree(self)
+
+    monkeypatch.setattr(Database, "get_missing_folders", spy_missing)
+    monkeypatch.setattr(Database, "get_folder_tree", spy_tree)
+
+    resp = client.get("/api/browse/init")
+    assert resp.status_code == 200
+
+    assert "missing" in call_order and "tree" in call_order, (
+        f"expected both reads to run, got {call_order}"
+    )
+    assert call_order.index("missing") < call_order.index("tree"), (
+        "get_missing_folders must run before get_folder_tree so the client's "
+        f"baseline is never fresher than the folder data; call order was {call_order}"
+    )
+
+
 def test_dashboard_options_flags_degraded_collections(app_and_db):
     """Collections whose rules can't compile are flagged so the scope
     picker can disable them instead of 400ing /api/stats and /api/coverage."""


### PR DESCRIPTION
Folder health checks now notify the active page when folders transition online or offline. Browse responds by refreshing its folder, keyword, collection, grid, summary, and calendar state, and drops a selected folder scope when that folder is no longer available. Adds an end-to-end regression covering an empty Browse view repopulating immediately after two folders reconnect.

Tested with `pytest -q tests/e2e/test_browse*.py` (116 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when folder-health refreshes occur during Browse startup/deep-link loads, preventing empty grids and stale renders.
  * Preserved active collection/selection across health-driven resets, with stronger safeguards against out-of-order responses.
  * Centralized missing-folders banner behavior so banner and modal states stay consistent and workspace-scoped, including cross-workspace transitions.
* **Tests**
  * Expanded e2e coverage for bootstrap/polling race conditions and empty-state restoration.
  * Added integration coverage ensuring the missing-folder baseline is captured before loading the folder tree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->