### PR TITLE
Cache the parsed taxonomy instead of re-reading it per request

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -127,6 +127,23 @@ def live_server(tmp_path, monkeypatch):
     monkeypatch.setattr(
         models, "DEFAULT_MODELS_DIR", str(tmp_path / ".vireo" / "models"),
     )
+
+    # Pin the taxonomy candidates to tmp_path too. Both resolve at import
+    # time, so patching HOME does not move them: a developer with a real
+    # ~/.vireo/taxonomy.json or an in-checkout vireo/taxonomy.json (a full
+    # iNaturalist dump is ~500MB) has every compare/review request parse it,
+    # which changes both request timing and the categories those pages
+    # render. CI has no such file, so without this the browser suite passes
+    # there and fails on a working machine.
+    import taxonomy as tax_mod
+    monkeypatch.setattr(
+        tax_mod, "TAXONOMY_JSON_PATH",
+        str(tmp_path / ".vireo" / "taxonomy.json"),
+    )
+    monkeypatch.setattr(
+        tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(tmp_path / "taxonomy.json"),
+    )
+
     _seed_classifier_model(str(tmp_path))
 
     db_path = str(tmp_path / "test.db")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18506,7 +18506,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # new one and could OOM. It also seeds the cache, so the
                 # next compare/accept request reuses this parse instead of
                 # paying for its own.
-                tax = load_local_taxonomy()
+                #
+                # Pin it to the file we just downloaded. Without path=, a
+                # transient failure parsing the new file would fall back to
+                # a legacy copy, and we would retype keywords from the old
+                # taxonomy while the taxa tables hold the new one — mixing
+                # versions and reporting success.
+                tax = load_local_taxonomy(path=TAXONOMY_JSON_PATH)
                 if tax is None:
                     raise RuntimeError(
                         f"taxonomy unreadable after download: {TAXONOMY_JSON_PATH}"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18446,8 +18446,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         def work(job):
             from taxonomy import (
                 TAXONOMY_JSON_PATH,
-                Taxonomy,
                 download_taxonomy,
+                load_local_taxonomy,
                 populate_taxa_db_from_json,
                 seed_informal_groups,
             )
@@ -18499,7 +18499,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # retype for free (it's idempotent).
             progress_cb("Retyping existing keywords...")
             try:
-                tax = Taxonomy(TAXONOMY_JSON_PATH)
+                # Go through load_local_taxonomy() rather than constructing
+                # Taxonomy directly: it drops the cached instance before
+                # parsing the replacement. Constructing here bypassed that,
+                # so a refresh held the old ~2.8GB parse alive alongside the
+                # new one and could OOM. It also seeds the cache, so the
+                # next compare/accept request reuses this parse instead of
+                # paying for its own.
+                tax = load_local_taxonomy()
+                if tax is None:
+                    raise RuntimeError(
+                        f"taxonomy unreadable after download: {TAXONOMY_JSON_PATH}"
+                    )
                 updated = bg_db.mark_species_keywords(tax)
                 bg_db.repair_duplicate_photo_species()
                 log.info("Retyped %d existing keywords as taxonomy after download", updated)

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -537,6 +537,22 @@ def _load_taxonomy_cached(path):
                 # failure that the very next call could succeed at, and
                 # load_local_taxonomy() would silently fall through to
                 # a stale or nonexistent alternate candidate instead.
+                #
+                # Only retry when the file actually moved, though. A file
+                # that is simply corrupt fails identically every time, and
+                # retrying re-reads most of ~500MB two more times on every
+                # request — reinstating the latency and allocation pressure
+                # this cache exists to remove, for a read that cannot
+                # succeed. Truncated JSON only raises at the end of the
+                # parse, so this is the expensive case, not the cheap one.
+                try:
+                    file_moved = _taxonomy_stat_key(path) != pre_stat
+                except OSError:
+                    # Cannot even stat it now; a re-read will not fare
+                    # better, so report the parse failure we already have.
+                    file_moved = False
+                if not file_moved:
+                    raise
                 continue
             post_stat = _taxonomy_stat_key(path)
             if pre_stat == post_stat:

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -486,20 +486,30 @@ def _load_taxonomy_cached(path):
     instead of one waiting for the other's result.
     """
     global _taxonomy_cache
-    stat_key = _taxonomy_stat_key(path)
     with _taxonomy_cache_lock:
+        # Stat inside the lock. Read before it, a caller that then waits on
+        # the lock compares a pre-wait stat against an entry another caller
+        # refreshed while it waited, decides that entry is stale, evicts it
+        # and re-parses ~2.8GB for nothing.
+        stat_key = _taxonomy_stat_key(path)
         cached = _taxonomy_cache
         if cached is not None and cached[0] == path and cached[1] == stat_key:
             return cached[2]
-        # A cache miss means the previous entry is stale. A parsed
-        # iNaturalist taxonomy is ~2.8GB, so if we let the old instance
-        # stay reachable through _taxonomy_cache (or the local ``cached``
-        # tuple) while Taxonomy(path) allocates its replacement, peak
-        # RSS doubles — and a rewrite mid-parse would stack another live
-        # copy on top of that per retry. Drop every reference we hold
-        # before entering the parse loop so the old instance can be
-        # collected before the new one is built.
-        _taxonomy_cache = None
+        # An entry for this same path is now outdated. A parsed iNaturalist
+        # taxonomy is ~2.8GB, so if we let the old instance stay reachable
+        # through _taxonomy_cache (or the local ``cached`` tuple) while
+        # Taxonomy(path) allocates its replacement, peak RSS doubles — and a
+        # rewrite mid-parse would stack another live copy on top of that per
+        # retry. Drop every reference we hold before entering the parse loop.
+        #
+        # An entry for a *different* path is not stale and must survive: when
+        # the preferred candidate exists but is corrupt, load_local_taxonomy()
+        # parses it, fails, and falls back to the legacy one. Evicting the
+        # legacy entry here would make that fallback re-parse a multi-GB file
+        # on every single compare/accept request — exactly the cost this cache
+        # exists to remove.
+        if cached is not None and cached[0] == path:
+            _taxonomy_cache = None
         cached = None
         # Bracket the parse with a pre- and post-stat: if a background
         # download rewrites the file while Taxonomy(path) is reading it,
@@ -520,7 +530,9 @@ def _load_taxonomy_cached(path):
             if pre_stat == post_stat:
                 _taxonomy_cache = (path, post_stat, taxonomy)
                 return taxonomy
-        _taxonomy_cache = None
+        # Retries exhausted. Nothing was cached for this path above, so
+        # there is no stale entry left to clear — and clearing here would
+        # evict a different path's still-valid entry.
         return taxonomy
 
 
@@ -746,11 +758,18 @@ class Taxonomy:
         # is atomic within a filesystem, so a reader sees either the whole old
         # file or the whole new one, and an interrupted save leaves the
         # existing taxonomy intact rather than a half-written stub.
-        tmp_path = f"{self._path}.tmp"
+        # Rename onto the resolved target, not the path we were handed:
+        # os.replace() would swap a symlink for a regular file, silently
+        # detaching a taxonomy that was linked in from elsewhere and leaving
+        # a duplicate ~500MB copy behind. open(path, "w") wrote through the
+        # link. Keeping the temp file beside the resolved target also keeps
+        # the rename within one filesystem, which is what makes it atomic.
+        target = os.path.realpath(self._path)
+        tmp_path = f"{target}.tmp"
         try:
             with open(tmp_path, "w") as f:
                 json.dump(data, f)
-            os.replace(tmp_path, self._path)
+            os.replace(tmp_path, target)
         except BaseException:
             with contextlib.suppress(OSError):
                 os.remove(tmp_path)

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -739,8 +739,22 @@ class Taxonomy:
             data = json.load(f)
         data["taxa_by_common"] = self._by_common
         data["api_misses"] = sorted(self._api_misses)
-        with open(self._path, "w") as f:
-            json.dump(data, f)
+        # Write a sibling and rename over the target instead of truncating it
+        # in place. `open(path, "w")` empties the file for as long as it takes
+        # to serialize ~500MB, and anything reading it in that window — now
+        # including _load_taxonomy_cached — gets a truncated document. Rename
+        # is atomic within a filesystem, so a reader sees either the whole old
+        # file or the whole new one, and an interrupted save leaves the
+        # existing taxonomy intact rather than a half-written stub.
+        tmp_path = f"{self._path}.tmp"
+        try:
+            with open(tmp_path, "w") as f:
+                json.dump(data, f)
+            os.replace(tmp_path, self._path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
+            raise
         self._dirty = False
         # This instance is the one the cache hands out, and it already holds
         # everything we just wrote. Re-stamp the cache key so the rewrite

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -500,6 +500,46 @@ def clear_taxonomy_cache():
         _taxonomy_failed_stats.clear()
 
 
+def _write_taxonomy_json_atomically(path, data):
+    """Serialize ``data`` to ``path`` via a temp sibling and an atomic rename.
+
+    Both taxonomy writers use this. `open(path, "w")` truncates the target
+    for as long as it takes to serialize ~500MB, and anything reading it in
+    that window — including _load_taxonomy_cached from a concurrent request
+    — gets a partial document that will not parse; its retry loop is bounded
+    and cannot wait out an in-place write. Rename is atomic within a
+    filesystem, so a reader sees the whole old file or the whole new one,
+    and an interrupted write leaves the previous taxonomy intact.
+
+    Renames onto the *resolved* target: os.replace() would otherwise swap a
+    symlink for a regular file, detaching a taxonomy linked in from
+    elsewhere and leaving a duplicate ~500MB copy. Keeping the temp file
+    beside the resolved target also keeps the rename within one filesystem,
+    which is what makes it atomic.
+    """
+    target = os.path.realpath(path)
+    tmp_path = f"{target}.tmp"
+    try:
+        with open(tmp_path, "w") as f:
+            json.dump(data, f)
+            # Closing only hands the bytes to the page cache. Without fsync,
+            # a crash just after the rename can expose the target with
+            # unflushed content — the half-written taxonomy this whole dance
+            # exists to prevent.
+            f.flush()
+            os.fsync(f.fileno())
+        # A fresh temp file gets umask permissions; open(path, "w") kept the
+        # target's mode. Carry it over when there is a target to copy from,
+        # so writing cannot silently loosen or tighten access.
+        with contextlib.suppress(OSError):
+            os.chmod(tmp_path, stat_module.S_IMODE(os.stat(target).st_mode))
+        os.replace(tmp_path, target)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
+        raise
+
+
 def _taxonomy_stat_key(path):
     st = os.stat(path)
     return (st.st_mtime_ns, st.st_size)
@@ -848,40 +888,7 @@ class Taxonomy:
             data = json.load(f)
         data["taxa_by_common"] = self._by_common
         data["api_misses"] = sorted(self._api_misses)
-        # Write a sibling and rename over the target instead of truncating it
-        # in place. `open(path, "w")` empties the file for as long as it takes
-        # to serialize ~500MB, and anything reading it in that window — now
-        # including _load_taxonomy_cached — gets a truncated document. Rename
-        # is atomic within a filesystem, so a reader sees either the whole old
-        # file or the whole new one, and an interrupted save leaves the
-        # existing taxonomy intact rather than a half-written stub.
-        # Rename onto the resolved target, not the path we were handed:
-        # os.replace() would swap a symlink for a regular file, silently
-        # detaching a taxonomy that was linked in from elsewhere and leaving
-        # a duplicate ~500MB copy behind. open(path, "w") wrote through the
-        # link. Keeping the temp file beside the resolved target also keeps
-        # the rename within one filesystem, which is what makes it atomic.
-        target = os.path.realpath(self._path)
-        tmp_path = f"{target}.tmp"
-        try:
-            with open(tmp_path, "w") as f:
-                json.dump(data, f)
-                # Closing only hands the bytes to the page cache. Without
-                # fsync, a crash just after the rename can expose the target
-                # with unflushed content — the half-written taxonomy this
-                # whole dance exists to prevent.
-                f.flush()
-                os.fsync(f.fileno())
-            # A fresh temp file gets umask permissions; open(path, "w") kept
-            # the target's mode. Carry it over so saving cannot silently
-            # loosen or tighten access to the taxonomy.
-            with contextlib.suppress(OSError):
-                os.chmod(tmp_path, stat_module.S_IMODE(os.stat(target).st_mode))
-            os.replace(tmp_path, target)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.remove(tmp_path)
-            raise
+        _write_taxonomy_json_atomically(self._path, data)
         self._dirty = False
         # This instance is the one the cache hands out, and it already holds
         # everything we just wrote. Re-stamp the cache key so the rewrite
@@ -1600,26 +1607,7 @@ def download_taxonomy(output_path, progress_callback=None):
         _status(
             f"Writing taxonomy ({len(taxa_by_common):,} common + {len(taxa_by_scientific):,} scientific names)..."
         )
-        # Write to a sibling and rename over the target rather than
-        # truncating in place. `open(output_path, "w")` empties the file
-        # for as long as it takes to serialize ~500MB, and anything
-        # reading it in that window — including _load_taxonomy_cached from
-        # a concurrent /api/predictions/compare request — sees a partial
-        # JSON document that fails to parse. The bounded retry loop over
-        # there can't wait out a multi-second in-place write. Rename onto
-        # the resolved target so we replace the file the symlink points
-        # to, matching Taxonomy.save() and keeping the rename within one
-        # filesystem (which is what makes it atomic).
-        target = os.path.realpath(output_path)
-        tmp_path = f"{target}.tmp"
-        try:
-            with open(tmp_path, "w") as f:
-                json.dump(result, f)
-            os.replace(tmp_path, target)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.remove(tmp_path)
-            raise
+        _write_taxonomy_json_atomically(output_path, result)
         _status(
             f"Taxonomy complete: {len(taxa_by_common):,} common names, {len(taxa_by_scientific):,} scientific names"
         )

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -588,7 +588,18 @@ def _load_taxonomy_cached(path):
                     # requests short-circuit before hitting the parse and,
                     # crucially, before the eviction above would drop a
                     # still-valid fallback in a corrupt-preferred scenario.
-                    _taxonomy_failed_stats[path] = pre_stat
+                    #
+                    # Only memoize a *content* failure, though. An OSError
+                    # can be transient — a read permission bit, a momentary
+                    # fd exhaustion — and the usual repair (chmod, or the
+                    # fd pressure passing) changes ctime at most, not mtime
+                    # or size. Memoizing it would key the record to a stat
+                    # that never changes, leaving taxonomy features off
+                    # until the contents happen to change or the process
+                    # restarts. A ValueError is the file's own content and
+                    # cannot fix itself without a rewrite.
+                    if isinstance(parse_error, ValueError):
+                        _taxonomy_failed_stats[path] = pre_stat
                     raise
                 continue
             post_stat = _taxonomy_stat_key(path)

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -457,6 +457,20 @@ def find_taxonomy_json():
 _taxonomy_cache_lock = threading.Lock()
 _taxonomy_cache = None  # (path, stat_key, Taxonomy)
 
+# Per-path record of parses that failed (e.g., corrupt JSON). Keyed by path
+# and validated against the current stat key on lookup, so a repaired or
+# re-downloaded file automatically drops its old failure record. Without
+# this, a corrupt preferred candidate would be re-parsed on every request
+# — expensive on its own, and the trigger for a worse problem: it prevents
+# us from evicting the fallback cache before parsing, because the corrupt
+# case would otherwise re-parse the multi-GB fallback each time.
+_taxonomy_failed_stats = {}  # {path: stat_key}
+
+
+class _KnownCorruptTaxonomy(Exception):
+    """Raised when a path is known to have failed to parse at its current stat."""
+
+
 # Cap on how many times _load_taxonomy_cached will re-parse a file that
 # keeps changing mid-read. A rewrite during parse means the parsed object
 # does not correspond to the post-parse stat, so caching that pair would
@@ -471,6 +485,7 @@ def clear_taxonomy_cache():
     global _taxonomy_cache
     with _taxonomy_cache_lock:
         _taxonomy_cache = None
+        _taxonomy_failed_stats.clear()
 
 
 def _taxonomy_stat_key(path):
@@ -492,24 +507,38 @@ def _load_taxonomy_cached(path):
         # refreshed while it waited, decides that entry is stale, evicts it
         # and re-parses ~2.8GB for nothing.
         stat_key = _taxonomy_stat_key(path)
+
+        # Short-circuit a path we've already established is corrupt at this
+        # stat. Without this, load_local_taxonomy() would attempt the parse
+        # (and log a warning) on every request for as long as the file stays
+        # broken. This also lets the eviction below evict cross-path fallback
+        # entries safely: even if the current parse fails, a subsequent call
+        # skips it here instead of re-parsing the multi-GB fallback to
+        # rediscover it's still broken.
+        failed_stat = _taxonomy_failed_stats.get(path)
+        if failed_stat == stat_key:
+            raise _KnownCorruptTaxonomy(path)
+        if failed_stat is not None:
+            # File has changed since it last failed; give it another chance.
+            _taxonomy_failed_stats.pop(path, None)
+
         cached = _taxonomy_cache
         if cached is not None and cached[0] == path and cached[1] == stat_key:
             return cached[2]
-        # An entry for this same path is now outdated. A parsed iNaturalist
-        # taxonomy is ~2.8GB, so if we let the old instance stay reachable
-        # through _taxonomy_cache (or the local ``cached`` tuple) while
-        # Taxonomy(path) allocates its replacement, peak RSS doubles — and a
-        # rewrite mid-parse would stack another live copy on top of that per
-        # retry. Drop every reference we hold before entering the parse loop.
+        # We're about to parse. A parsed iNaturalist taxonomy is ~2.8GB, so
+        # letting any prior instance stay reachable through _taxonomy_cache
+        # (or the local ``cached`` tuple) while Taxonomy(path) allocates its
+        # replacement doubles peak RSS — and a rewrite mid-parse stacks
+        # another live copy on top of that per retry.
         #
-        # An entry for a *different* path is not stale and must survive: when
-        # the preferred candidate exists but is corrupt, load_local_taxonomy()
-        # parses it, fails, and falls back to the legacy one. Evicting the
-        # legacy entry here would make that fallback re-parse a multi-GB file
-        # on every single compare/accept request — exactly the cost this cache
-        # exists to remove.
-        if cached is not None and cached[0] == path:
-            _taxonomy_cache = None
+        # Evict cross-path entries too (e.g. a cached legacy fallback when
+        # we're now parsing the preferred file that just appeared): holding
+        # both live during the parse can OOM during a normal migration. This
+        # is safe because the failure cache above prevents a corrupt preferred
+        # file from triggering a re-parse of the fallback on every request —
+        # once the corrupt parse fails, subsequent calls short-circuit before
+        # they ever touch the fallback slot.
+        _taxonomy_cache = None
         cached = None
         # Bracket the parse with a pre- and post-stat: if a background
         # download rewrites the file while Taxonomy(path) is reading it,
@@ -552,6 +581,11 @@ def _load_taxonomy_cached(path):
                     # better, so report the parse failure we already have.
                     file_moved = False
                 if not file_moved:
+                    # Durable failure at this stat. Record it so subsequent
+                    # requests short-circuit before hitting the parse and,
+                    # crucially, before the eviction above would drop a
+                    # still-valid fallback in a corrupt-preferred scenario.
+                    _taxonomy_failed_stats[path] = pre_stat
                     raise
                 continue
             post_stat = _taxonomy_stat_key(path)
@@ -603,6 +637,11 @@ def load_local_taxonomy():
             continue
         try:
             return _load_taxonomy_cached(path)
+        except _KnownCorruptTaxonomy:
+            # We've already logged the real error for this stat; skip
+            # quietly on subsequent requests so a persistently-broken
+            # preferred file doesn't flood the log.
+            continue
         except Exception as e:
             log.warning(
                 "Failed to load taxonomy from %s: %s — trying next candidate",

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -1600,8 +1600,26 @@ def download_taxonomy(output_path, progress_callback=None):
         _status(
             f"Writing taxonomy ({len(taxa_by_common):,} common + {len(taxa_by_scientific):,} scientific names)..."
         )
-        with open(output_path, "w") as f:
-            json.dump(result, f)
+        # Write to a sibling and rename over the target rather than
+        # truncating in place. `open(output_path, "w")` empties the file
+        # for as long as it takes to serialize ~500MB, and anything
+        # reading it in that window — including _load_taxonomy_cached from
+        # a concurrent /api/predictions/compare request — sees a partial
+        # JSON document that fails to parse. The bounded retry loop over
+        # there can't wait out a multi-second in-place write. Rename onto
+        # the resolved target so we replace the file the symlink points
+        # to, matching Taxonomy.save() and keeping the rename within one
+        # filesystem (which is what makes it atomic).
+        target = os.path.realpath(output_path)
+        tmp_path = f"{target}.tmp"
+        try:
+            with open(tmp_path, "w") as f:
+                json.dump(result, f)
+            os.replace(tmp_path, target)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
+            raise
         _status(
             f"Taxonomy complete: {len(taxa_by_common):,} common names, {len(taxa_by_scientific):,} scientific names"
         )

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -491,6 +491,16 @@ def _load_taxonomy_cached(path):
         cached = _taxonomy_cache
         if cached is not None and cached[0] == path and cached[1] == stat_key:
             return cached[2]
+        # A cache miss means the previous entry is stale. A parsed
+        # iNaturalist taxonomy is ~2.8GB, so if we let the old instance
+        # stay reachable through _taxonomy_cache (or the local ``cached``
+        # tuple) while Taxonomy(path) allocates its replacement, peak
+        # RSS doubles — and a rewrite mid-parse would stack another live
+        # copy on top of that per retry. Drop every reference we hold
+        # before entering the parse loop so the old instance can be
+        # collected before the new one is built.
+        _taxonomy_cache = None
+        cached = None
         # Bracket the parse with a pre- and post-stat: if a background
         # download rewrites the file while Taxonomy(path) is reading it,
         # the parsed data is a stale snapshot even though a fresh
@@ -500,6 +510,10 @@ def _load_taxonomy_cached(path):
         # latest parse but skip the cache so the next call re-checks.
         taxonomy = None
         for _ in range(_TAXONOMY_PARSE_RETRY_LIMIT):
+            # Same peak-RSS reason: release the previous retry's
+            # instance before Taxonomy(path) builds the next one, so a
+            # file that keeps changing does not pile up N live copies.
+            taxonomy = None
             pre_stat = _taxonomy_stat_key(path)
             taxonomy = Taxonomy(path)
             post_stat = _taxonomy_stat_key(path)

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -613,7 +613,13 @@ def _load_taxonomy_cached(path):
         # to get a stable read; if the file keeps changing, return the
         # latest parse but skip the cache so the next call re-checks.
         taxonomy = None
-        last_error = None
+        # Keep only the *text* of a failed parse, never the exception. Its
+        # traceback holds the Taxonomy.__init__ frame, which still
+        # references the multi-GB dict json.load() just decoded — so
+        # retaining it across the loop would keep a failed attempt alive
+        # through the next allocation, defeating the between-retry release
+        # right below.
+        last_error_text = None
         for _ in range(_TAXONOMY_PARSE_RETRY_LIMIT):
             # Same peak-RSS reason: release the previous retry's
             # instance before Taxonomy(path) builds the next one, so a
@@ -623,7 +629,7 @@ def _load_taxonomy_cached(path):
             try:
                 taxonomy = Taxonomy(path)
             except Exception as parse_error:
-                last_error = parse_error
+                last_error_text = f"{type(parse_error).__name__}: {parse_error}"
                 # A rewrite caught mid-stream — from an atomic-save gap
                 # on another platform, an interrupted download, or an
                 # external tool — leaves a partial JSON document that
@@ -672,12 +678,14 @@ def _load_taxonomy_cached(path):
         # raised, surface a clean error rather than returning None and
         # letting the caller misread it as "file was fine but empty".
         if taxonomy is None:
-            # Chain the last parse failure: load_local_taxonomy() logs this,
-            # and "file kept changing" alone doesn't tell you which byte of
-            # which file was malformed.
+            # Carry the last parse failure's message: load_local_taxonomy()
+            # logs this, and "file kept changing" alone doesn't tell you
+            # which byte of which file was malformed. The message rather
+            # than the exception, so no traceback pins the decoded document.
+            detail = f" (last error: {last_error_text})" if last_error_text else ""
             raise ValueError(
-                f"Unable to parse {path}: file kept changing during read"
-            ) from last_error
+                f"Unable to parse {path}: file kept changing during read{detail}"
+            )
         return taxonomy
 
 

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -555,7 +555,16 @@ def _write_taxonomy_json_atomically(path, data):
 
 def _taxonomy_stat_key(path):
     st = os.stat(path)
-    return (st.st_mtime_ns, st.st_size)
+    # Identity and ctime, not just (mtime, size). A metadata-preserving
+    # install — shutil.copy2, rsync -t, a restore from backup — can land
+    # different content at the same size and mtime, and we would serve the
+    # stale parse forever (and keep rejecting a repaired file as corrupt,
+    # since _taxonomy_failed_stats uses the same key). The inode and device
+    # change under an atomic rename; ctime changes on an in-place rewrite or
+    # a permission repair.
+    return (
+        st.st_mtime_ns, st.st_size, st.st_dev, st.st_ino, st.st_ctime_ns,
+    )
 
 
 def _load_taxonomy_cached(path):
@@ -596,14 +605,23 @@ def _load_taxonomy_cached(path):
         # replacement doubles peak RSS — and a rewrite mid-parse stacks
         # another live copy on top of that per retry.
         #
-        # Evict cross-path entries too (e.g. a cached legacy fallback when
-        # we're now parsing the preferred file that just appeared): holding
-        # both live during the parse can OOM during a normal migration. This
-        # is safe because the failure cache above prevents a corrupt preferred
-        # file from triggering a re-parse of the fallback on every request —
-        # once the corrupt parse fails, subsequent calls short-circuit before
-        # they ever touch the fallback slot.
-        _taxonomy_cache = None
+        # Only evict an entry for *this* path. A cross-path entry is a live
+        # fallback, not a stale copy, and dropping it here is not safe: the
+        # failure memo covers content failures, but deliberately does not
+        # cover transient ones (see _TRANSIENT_TAXONOMY_ERRORS). So a
+        # preferred file that keeps raising OSError — wrong permissions, say
+        # — is re-attempted on every request, and an unconditional evict
+        # would drop the cached legacy taxonomy each time and re-parse
+        # ~500MB of fallback per compare or accept.
+        #
+        # The migration case that motivated evicting cross-path (a cached
+        # legacy still live while the newly-appeared preferred file parses)
+        # is already covered: download_taxonomy() clears the cache before it
+        # builds a replacement, so the normal path never holds both. A manual
+        # drop-in can still hold two instances for one parse; that is a
+        # one-off, where the fallback re-parse would be per-request forever.
+        if cached is not None and cached[0] == path:
+            _taxonomy_cache = None
         cached = None
         # Bracket the parse with a pre- and post-stat: if a background
         # download rewrites the file while Taxonomy(path) is reading it,

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -472,6 +472,17 @@ class _KnownCorruptTaxonomy(Exception):
     """Raised when a path is known to have failed to parse at its current stat."""
 
 
+# Parse failures that are environmental rather than the file's fault, so a
+# later attempt at the same bytes can legitimately succeed: a read permission
+# bit, momentary fd exhaustion, an allocation failure on a ~2.8GB parse. These
+# must stay retryable — memoizing them against (mtime_ns, size) would key the
+# record to a stat the repair does not change. Everything else (malformed JSON
+# raising ValueError, or valid JSON in the wrong shape raising AttributeError
+# or TypeError as the parser walks it) is the content itself and cannot fix
+# itself without a rewrite, which does change the stat.
+_TRANSIENT_TAXONOMY_ERRORS = (OSError, MemoryError)
+
+
 # Cap on how many times _load_taxonomy_cached will re-parse a file that
 # keeps changing mid-read. A rewrite during parse means the parsed object
 # does not correspond to the post-parse stat, so caching that pair would
@@ -558,7 +569,7 @@ def _load_taxonomy_cached(path):
             pre_stat = _taxonomy_stat_key(path)
             try:
                 taxonomy = Taxonomy(path)
-            except (ValueError, OSError) as parse_error:
+            except Exception as parse_error:
                 last_error = parse_error
                 # A rewrite caught mid-stream — from an atomic-save gap
                 # on another platform, an interrupted download, or an
@@ -589,16 +600,12 @@ def _load_taxonomy_cached(path):
                     # crucially, before the eviction above would drop a
                     # still-valid fallback in a corrupt-preferred scenario.
                     #
-                    # Only memoize a *content* failure, though. An OSError
-                    # can be transient — a read permission bit, a momentary
-                    # fd exhaustion — and the usual repair (chmod, or the
-                    # fd pressure passing) changes ctime at most, not mtime
-                    # or size. Memoizing it would key the record to a stat
-                    # that never changes, leaving taxonomy features off
-                    # until the contents happen to change or the process
-                    # restarts. A ValueError is the file's own content and
-                    # cannot fix itself without a rewrite.
-                    if isinstance(parse_error, ValueError):
+                    # Only memoize a *content* failure, though — see
+                    # _TRANSIENT_TAXONOMY_ERRORS. Memoizing an environmental
+                    # failure would key the record to a stat its repair does
+                    # not change, leaving taxonomy features off until the
+                    # contents happen to change or the process restarts.
+                    if not isinstance(parse_error, _TRANSIENT_TAXONOMY_ERRORS):
                         _taxonomy_failed_stats[path] = pre_stat
                     raise
                 continue

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -25,6 +25,7 @@ import re
 import socket
 import ssl
 import stat as stat_module
+import tempfile
 import threading
 import time
 import unicodedata
@@ -518,9 +519,19 @@ def _write_taxonomy_json_atomically(path, data):
     which is what makes it atomic.
     """
     target = os.path.realpath(path)
-    tmp_path = f"{target}.tmp"
+    # A unique temp name per write, not a fixed "<target>.tmp". Two writes
+    # can overlap — POSTing the download endpoint twice starts two workers,
+    # since it uses runner.start() rather than start_singleton() — and a
+    # shared name lets one writer rename its inode out from under the other,
+    # exposing a partial target and then failing the second writer when its
+    # pathname has vanished.
+    fd, tmp_path = tempfile.mkstemp(
+        dir=os.path.dirname(target) or ".",
+        prefix=f"{os.path.basename(target)}.",
+        suffix=".tmp",
+    )
     try:
-        with open(tmp_path, "w") as f:
+        with os.fdopen(fd, "w") as f:
             json.dump(data, f)
             # Closing only hands the bytes to the page cache. Without fsync,
             # a crash just after the rename can expose the target with
@@ -528,9 +539,11 @@ def _write_taxonomy_json_atomically(path, data):
             # exists to prevent.
             f.flush()
             os.fsync(f.fileno())
-        # A fresh temp file gets umask permissions; open(path, "w") kept the
-        # target's mode. Carry it over when there is a target to copy from,
-        # so writing cannot silently loosen or tighten access.
+        # mkstemp creates 0600; open(path, "w") kept the target's mode.
+        # Carry it over when there is a target to copy from, so writing
+        # cannot silently loosen or tighten access. With no existing target
+        # (a first download) the file stays 0600 — ~/.vireo is single-user
+        # data, so private is the right default there.
         with contextlib.suppress(OSError):
             os.chmod(tmp_path, stat_module.S_IMODE(os.stat(target).st_mode))
         os.replace(tmp_path, target)

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -24,6 +24,7 @@ import os
 import re
 import socket
 import ssl
+import stat as stat_module
 import threading
 import time
 import unicodedata
@@ -548,6 +549,7 @@ def _load_taxonomy_cached(path):
         # to get a stable read; if the file keeps changing, return the
         # latest parse but skip the cache so the next call re-checks.
         taxonomy = None
+        last_error = None
         for _ in range(_TAXONOMY_PARSE_RETRY_LIMIT):
             # Same peak-RSS reason: release the previous retry's
             # instance before Taxonomy(path) builds the next one, so a
@@ -556,7 +558,8 @@ def _load_taxonomy_cached(path):
             pre_stat = _taxonomy_stat_key(path)
             try:
                 taxonomy = Taxonomy(path)
-            except (ValueError, OSError):
+            except (ValueError, OSError) as parse_error:
+                last_error = parse_error
                 # A rewrite caught mid-stream — from an atomic-save gap
                 # on another platform, an interrupted download, or an
                 # external tool — leaves a partial JSON document that
@@ -598,9 +601,12 @@ def _load_taxonomy_cached(path):
         # raised, surface a clean error rather than returning None and
         # letting the caller misread it as "file was fine but empty".
         if taxonomy is None:
+            # Chain the last parse failure: load_local_taxonomy() logs this,
+            # and "file kept changing" alone doesn't tell you which byte of
+            # which file was malformed.
             raise ValueError(
                 f"Unable to parse {path}: file kept changing during read"
-            )
+            ) from last_error
         return taxonomy
 
 
@@ -842,6 +848,17 @@ class Taxonomy:
         try:
             with open(tmp_path, "w") as f:
                 json.dump(data, f)
+                # Closing only hands the bytes to the page cache. Without
+                # fsync, a crash just after the rename can expose the target
+                # with unflushed content — the half-written taxonomy this
+                # whole dance exists to prevent.
+                f.flush()
+                os.fsync(f.fileno())
+            # A fresh temp file gets umask permissions; open(path, "w") kept
+            # the target's mode. Carry it over so saving cannot silently
+            # loosen or tighten access to the taxonomy.
+            with contextlib.suppress(OSError):
+                os.chmod(tmp_path, stat_module.S_IMODE(os.stat(target).st_mode))
             os.replace(tmp_path, target)
         except BaseException:
             with contextlib.suppress(OSError):

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -1472,6 +1472,17 @@ def download_taxonomy(output_path, progress_callback=None):
         if progress_callback:
             progress_callback(msg)
 
+    # Drop the cache's own reference to the old parse before we start
+    # building the replacement. A cached iNat dump is ~2.8GB, so letting
+    # it stay strongly reachable through _taxonomy_cache while this
+    # function also holds the ~2.8GB dict it is about to write can double
+    # peak RSS. The post-download retype already routes through
+    # load_local_taxonomy() (which re-evicts on parse), but that runs
+    # *after* the build. Evicting here covers the overlap. Concurrent
+    # requests that borrowed the taxonomy still keep it alive until they
+    # return; this only releases the cache's own reference.
+    clear_taxonomy_cache()
+
     # Download zip to a file (resumable) instead of holding in memory
     zip_dir = os.path.dirname(output_path) or "."
     os.makedirs(zip_dir, exist_ok=True)

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -696,7 +696,7 @@ def _restamp_taxonomy_cache(taxonomy):
             _taxonomy_cache = None
 
 
-def load_local_taxonomy():
+def load_local_taxonomy(path=None):
     """Load a Taxonomy from disk, falling back across known paths.
 
     Tries ~/.vireo/taxonomy.json first, then the package-dir legacy path.
@@ -707,8 +707,15 @@ def load_local_taxonomy():
 
     The returned instance is shared across callers and cached until the
     file on disk changes — treat it as read-mostly.
+
+    Args:
+        path: load only this file, with no fallback. Use it when a
+            specific artifact has to be the one loaded: the post-download
+            retype must fail loudly if the file it just wrote won't parse,
+            rather than quietly retyping keywords from a stale legacy copy
+            while the taxa tables hold the new download's data.
     """
-    candidates = [TAXONOMY_JSON_PATH, LEGACY_TAXONOMY_JSON_PATH]
+    candidates = [path] if path else [TAXONOMY_JSON_PATH, LEGACY_TAXONOMY_JSON_PATH]
     for path in candidates:
         if not os.path.exists(path):
             continue

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -525,14 +525,32 @@ def _load_taxonomy_cached(path):
             # file that keeps changing does not pile up N live copies.
             taxonomy = None
             pre_stat = _taxonomy_stat_key(path)
-            taxonomy = Taxonomy(path)
+            try:
+                taxonomy = Taxonomy(path)
+            except (ValueError, OSError):
+                # A rewrite caught mid-stream — from an atomic-save gap
+                # on another platform, an interrupted download, or an
+                # external tool — leaves a partial JSON document that
+                # Taxonomy() cannot parse. That is the same kind of
+                # transient instability the stat-drift check retries
+                # against; propagating here would surface as a spurious
+                # failure that the very next call could succeed at, and
+                # load_local_taxonomy() would silently fall through to
+                # a stale or nonexistent alternate candidate instead.
+                continue
             post_stat = _taxonomy_stat_key(path)
             if pre_stat == post_stat:
                 _taxonomy_cache = (path, post_stat, taxonomy)
                 return taxonomy
         # Retries exhausted. Nothing was cached for this path above, so
         # there is no stale entry left to clear — and clearing here would
-        # evict a different path's still-valid entry.
+        # evict a different path's still-valid entry. If every attempt
+        # raised, surface a clean error rather than returning None and
+        # letting the caller misread it as "file was fine but empty".
+        if taxonomy is None:
+            raise ValueError(
+                f"Unable to parse {path}: file kept changing during read"
+            )
         return taxonomy
 
 

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -421,6 +421,12 @@ DWCA_URL = "https://www.inaturalist.org/taxa/inaturalist-taxonomy.dwca.zip"
 # directory is an ephemeral _MEI* extraction dir that's rebuilt per run.
 TAXONOMY_JSON_PATH = os.path.expanduser("~/.vireo/taxonomy.json")
 
+# Fallback for dev checkouts that downloaded a taxonomy.json next to this
+# module before the persistent path existed. Named so tests (and the browser
+# suite, which must not pick up a developer's ~500MB local copy) can
+# monkeypatch it instead of patching os.path.dirname globally.
+LEGACY_TAXONOMY_JSON_PATH = os.path.join(os.path.dirname(__file__), "taxonomy.json")
+
 
 def find_taxonomy_json():
     """Return the first existing taxonomy.json path, or the persistent path.
@@ -435,10 +441,66 @@ def find_taxonomy_json():
     """
     if os.path.exists(TAXONOMY_JSON_PATH):
         return TAXONOMY_JSON_PATH
-    legacy_path = os.path.join(os.path.dirname(__file__), "taxonomy.json")
-    if os.path.exists(legacy_path):
-        return legacy_path
+    if os.path.exists(LEGACY_TAXONOMY_JSON_PATH):
+        return LEGACY_TAXONOMY_JSON_PATH
     return TAXONOMY_JSON_PATH
+
+
+# Process-wide cache for the parsed taxonomy. A full iNaturalist
+# taxonomy.json is ~500MB of JSON that expands to a couple of GB of dicts
+# and takes seconds to parse, and request handlers (notably
+# /api/predictions/compare) plus accept/replace call load_local_taxonomy()
+# on every invocation. Re-parsing per call made those requests take
+# seconds-to-minutes and let concurrent requests each allocate their own
+# copy. Keyed by (path, mtime_ns, size) so a re-downloaded taxonomy is
+# still picked up without restarting the app.
+_taxonomy_cache_lock = threading.Lock()
+_taxonomy_cache = None  # (path, stat_key, Taxonomy)
+
+
+def clear_taxonomy_cache():
+    """Drop the cached Taxonomy so the next load re-reads from disk."""
+    global _taxonomy_cache
+    with _taxonomy_cache_lock:
+        _taxonomy_cache = None
+
+
+def _taxonomy_stat_key(path):
+    st = os.stat(path)
+    return (st.st_mtime_ns, st.st_size)
+
+
+def _load_taxonomy_cached(path):
+    """Return the parsed Taxonomy for ``path``, reusing the cached instance.
+
+    The parse happens under the lock on purpose: without it, two requests
+    arriving together would each build a multi-GB structure and thrash swap
+    instead of one waiting for the other's result.
+    """
+    global _taxonomy_cache
+    stat_key = _taxonomy_stat_key(path)
+    with _taxonomy_cache_lock:
+        cached = _taxonomy_cache
+        if cached is not None and cached[0] == path and cached[1] == stat_key:
+            return cached[2]
+        taxonomy = Taxonomy(path)
+        _taxonomy_cache = (path, _taxonomy_stat_key(path), taxonomy)
+        return taxonomy
+
+
+def _restamp_taxonomy_cache(taxonomy):
+    """Refresh the cache key after ``taxonomy`` rewrote its own file."""
+    global _taxonomy_cache
+    with _taxonomy_cache_lock:
+        cached = _taxonomy_cache
+        if cached is None or cached[2] is not taxonomy:
+            return
+        try:
+            _taxonomy_cache = (
+                cached[0], _taxonomy_stat_key(cached[0]), taxonomy,
+            )
+        except OSError:
+            _taxonomy_cache = None
 
 
 def load_local_taxonomy():
@@ -449,16 +511,16 @@ def load_local_taxonomy():
     write) no longer disables taxonomy features if a valid legacy file
     is present. Returns a Taxonomy instance on success, or None if no
     readable taxonomy file exists.
+
+    The returned instance is shared across callers and cached until the
+    file on disk changes — treat it as read-mostly.
     """
-    candidates = [
-        TAXONOMY_JSON_PATH,
-        os.path.join(os.path.dirname(__file__), "taxonomy.json"),
-    ]
+    candidates = [TAXONOMY_JSON_PATH, LEGACY_TAXONOMY_JSON_PATH]
     for path in candidates:
         if not os.path.exists(path):
             continue
         try:
-            return Taxonomy(path)
+            return _load_taxonomy_cached(path)
         except Exception as e:
             log.warning(
                 "Failed to load taxonomy from %s: %s — trying next candidate",
@@ -644,6 +706,11 @@ class Taxonomy:
         with open(self._path, "w") as f:
             json.dump(data, f)
         self._dirty = False
+        # This instance is the one the cache hands out, and it already holds
+        # everything we just wrote. Re-stamp the cache key so the rewrite
+        # doesn't look like an external change and force a needless re-parse
+        # of the file we authored.
+        _restamp_taxonomy_cache(self)
         log.info("Saved updated taxonomy with new alternate names")
 
     def get_hierarchy(self, name):

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -707,6 +707,20 @@ def _load_taxonomy_cached(path):
         return taxonomy
 
 
+def _drop_cached_taxonomy_path(path):
+    """Release the cached parse for ``path`` (and its failure memo, if any).
+
+    Used when the file has gone away: the entry can never be served again,
+    and a full taxonomy is ~2.8GB of otherwise unreachable memory.
+    """
+    global _taxonomy_cache
+    with _taxonomy_cache_lock:
+        _taxonomy_failed_stats.pop(path, None)
+        cached = _taxonomy_cache
+        if cached is not None and cached[0] == path:
+            _taxonomy_cache = None
+
+
 def _restamp_taxonomy_cache(taxonomy):
     """Refresh the cache key after ``taxonomy`` rewrote its own file."""
     global _taxonomy_cache
@@ -744,6 +758,14 @@ def load_local_taxonomy(path=None):
     candidates = [path] if path else [TAXONOMY_JSON_PATH, LEGACY_TAXONOMY_JSON_PATH]
     for path in candidates:
         if not os.path.exists(path):
+            # The file backing a cached parse is gone, so that ~2.8GB object
+            # can never be served again. Release it here: _load_taxonomy_cached
+            # deliberately keeps cross-path entries (a live fallback is not
+            # stale), so a rollback to the legacy file would otherwise hold the
+            # deleted file's parse alive while allocating the legacy one — and
+            # with no fallback at all it would stay resident for the life of
+            # the process.
+            _drop_cached_taxonomy_path(path)
             continue
         try:
             return _load_taxonomy_cached(path)

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -457,6 +457,14 @@ def find_taxonomy_json():
 _taxonomy_cache_lock = threading.Lock()
 _taxonomy_cache = None  # (path, stat_key, Taxonomy)
 
+# Cap on how many times _load_taxonomy_cached will re-parse a file that
+# keeps changing mid-read. A rewrite during parse means the parsed object
+# does not correspond to the post-parse stat, so caching that pair would
+# serve stale data forever. If the file is still moving after this many
+# tries, we return the last parse without caching it and let the next
+# call try again.
+_TAXONOMY_PARSE_RETRY_LIMIT = 3
+
 
 def clear_taxonomy_cache():
     """Drop the cached Taxonomy so the next load re-reads from disk."""
@@ -483,8 +491,22 @@ def _load_taxonomy_cached(path):
         cached = _taxonomy_cache
         if cached is not None and cached[0] == path and cached[1] == stat_key:
             return cached[2]
-        taxonomy = Taxonomy(path)
-        _taxonomy_cache = (path, _taxonomy_stat_key(path), taxonomy)
+        # Bracket the parse with a pre- and post-stat: if a background
+        # download rewrites the file while Taxonomy(path) is reading it,
+        # the parsed data is a stale snapshot even though a fresh
+        # post-parse stat would look current. Caching that pair would
+        # keep serving the old taxonomy indefinitely. Retry a few times
+        # to get a stable read; if the file keeps changing, return the
+        # latest parse but skip the cache so the next call re-checks.
+        taxonomy = None
+        for _ in range(_TAXONOMY_PARSE_RETRY_LIMIT):
+            pre_stat = _taxonomy_stat_key(path)
+            taxonomy = Taxonomy(path)
+            post_stat = _taxonomy_stat_key(path)
+            if pre_stat == post_stat:
+                _taxonomy_cache = (path, post_stat, taxonomy)
+                return taxonomy
+        _taxonomy_cache = None
         return taxonomy
 
 

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2105,6 +2105,77 @@ def test_load_local_taxonomy_cache_is_keyed_by_path(tmp_path, monkeypatch):
     assert tax_mod.load_local_taxonomy().is_taxon("second species")
 
 
+def test_load_local_taxonomy_retries_when_file_changes_during_parse(tmp_path, monkeypatch):
+    """A rewrite mid-parse must not cache stale content under the new stat key.
+
+    Without a retry, the post-parse stat would record the new file's metadata
+    while the parsed object still holds the old snapshot. Future calls with a
+    stat that matches the cached key would then keep returning the stale
+    taxonomy indefinitely.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "first species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    real_init = tax_mod.Taxonomy.__init__
+    call_count = {"n": 0}
+
+    def racing_init(self, path):
+        call_count["n"] += 1
+        real_init(self, path)
+        # Race only the first parse; the retry then reads a stable file.
+        if call_count["n"] == 1:
+            _write_taxonomy_json(persistent, "second species that is longer")
+            os.utime(persistent, (2e9, 2e9))
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", racing_init)
+
+    result = tax_mod.load_local_taxonomy()
+
+    assert result is not None
+    assert result.is_taxon("second species that is longer")
+    assert call_count["n"] == 2
+
+    again = tax_mod.load_local_taxonomy()
+    assert again is result
+    assert call_count["n"] == 2
+
+
+def test_load_local_taxonomy_skips_cache_when_file_keeps_changing(tmp_path, monkeypatch):
+    """A file that keeps moving must not be cached under a mismatched stat.
+
+    When retries exhaust, the parse still returns so the caller sees fresh
+    data, but the cache stays empty so the next call re-checks instead of
+    stranding the process on a stale snapshot.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    real_init = tax_mod.Taxonomy.__init__
+    counter = {"n": 0}
+
+    def always_racing_init(self, path):
+        counter["n"] += 1
+        real_init(self, path)
+        os.utime(persistent, (counter["n"] + 1e9, counter["n"] + 1e9))
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", always_racing_init)
+
+    result = tax_mod.load_local_taxonomy()
+
+    assert result is not None
+    assert counter["n"] == tax_mod._TAXONOMY_PARSE_RETRY_LIMIT
+    with tax_mod._taxonomy_cache_lock:
+        assert tax_mod._taxonomy_cache is None
+
+
 def test_taxonomy_save_keeps_cached_instance_current(tmp_path, monkeypatch):
     """save() rewrites the file; the cache must not serve a pre-save copy.
 

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2969,3 +2969,56 @@ def test_download_taxonomy_writes_atomically(tmp_path, monkeypatch):
     written = json.loads(output_path.read_text())
     assert written["taxa_by_common"] == result["taxa_by_common"]
     assert not (tmp_path / "taxonomy.json.tmp").exists()
+
+
+def test_atomic_write_creates_a_new_target_without_a_mode_to_copy(tmp_path):
+    """A first-time write has no existing file to copy permissions from.
+
+    download_taxonomy() hits this on a fresh install; the mode copy must
+    degrade quietly rather than fail the write.
+    """
+    import taxonomy as tax_mod
+
+    target = tmp_path / "brand-new.json"
+    assert not target.exists()
+
+    tax_mod._write_taxonomy_json_atomically(str(target), {"taxa_by_common": {}})
+
+    assert json.loads(target.read_text()) == {"taxa_by_common": {}}
+    assert not (tmp_path / "brand-new.json.tmp").exists()
+
+
+def test_atomic_write_is_shared_by_both_taxonomy_writers(tmp_path, monkeypatch):
+    """save() and download_taxonomy() must not drift apart again.
+
+    They had two separate temp-file-and-rename implementations that differed
+    on fsync and permission handling; both now route through one helper.
+    """
+    import taxonomy as tax_mod
+
+    calls = []
+    real_writer = tax_mod._write_taxonomy_json_atomically
+
+    def recording_writer(path, data):
+        calls.append(path)
+        return real_writer(path, data)
+
+    monkeypatch.setattr(
+        tax_mod, "_write_taxonomy_json_atomically", recording_writer,
+    )
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    tax = tax_mod.load_local_taxonomy()
+    tax._api_misses.add("nothing here")
+    tax._dirty = True
+    tax.save()
+
+    assert calls == [str(persistent)]
+    import inspect
+    download_src = inspect.getsource(tax_mod.download_taxonomy)
+    assert "_write_taxonomy_json_atomically(output_path, result)" in download_src
+    assert 'open(output_path, "w")' not in download_src

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -3307,3 +3307,65 @@ def test_download_taxonomy_evicts_cache_before_rebuilding(tmp_path, monkeypatch)
         "cache must be evicted BEFORE download_taxonomy() begins building "
         "its ~2.8GB replacement, otherwise both are live at once"
     )
+
+
+def test_deleted_preferred_file_releases_its_cached_parse(tmp_path, monkeypatch):
+    """A cached parse whose file is gone must not stay resident.
+
+    _load_taxonomy_cached keeps cross-path entries on purpose — a live
+    fallback is not stale — so nothing else would drop this one. A full
+    taxonomy is ~2.8GB, and rolling back to the legacy file would otherwise
+    hold the deleted file's parse alive while allocating the legacy one.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    preferred = tmp_path / "persistent.json"
+    _write_taxonomy_json(preferred, "preferred species")
+    legacy = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(legacy, "legacy species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
+    monkeypatch.setattr(tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(legacy))
+
+    first = tax_mod.load_local_taxonomy()
+    assert first.is_taxon("preferred species")
+
+    cache_during_legacy_parse = []
+    real_init = tax_mod.Taxonomy.__init__
+
+    def observing_init(self, path):
+        if path == str(legacy):
+            cache_during_legacy_parse.append(tax_mod._taxonomy_cache)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", observing_init)
+
+    preferred.unlink()
+    second = tax_mod.load_local_taxonomy()
+
+    assert second.is_taxon("legacy species")
+    assert cache_during_legacy_parse == [None], (
+        "the deleted file's parse must be released before the fallback loads"
+    )
+
+
+def test_deleted_taxonomy_with_no_fallback_releases_the_cache(tmp_path, monkeypatch):
+    """With nothing to fall back to, the dead entry still has to go."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    preferred = tmp_path / "persistent.json"
+    _write_taxonomy_json(preferred, "preferred species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
+
+    assert tax_mod.load_local_taxonomy().is_taxon("preferred species")
+    with tax_mod._taxonomy_cache_lock:
+        assert tax_mod._taxonomy_cache is not None
+
+    preferred.unlink()
+
+    assert tax_mod.load_local_taxonomy() is None
+    with tax_mod._taxonomy_cache_lock:
+        assert tax_mod._taxonomy_cache is None, (
+            "an unservable taxonomy must not stay resident for the process"
+        )

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2317,7 +2317,7 @@ def test_taxonomy_save_leaves_original_intact_when_write_fails(tmp_path, monkeyp
         tax.save()
 
     assert persistent.read_text() == original
-    assert not (tmp_path / "persistent.json.tmp").exists()
+    assert not list(tmp_path.glob("*.tmp")), "no temp file may survive"
     tax_mod.clear_taxonomy_cache()
     assert tax_mod.load_local_taxonomy().is_taxon("test species")
 
@@ -2477,7 +2477,7 @@ def test_taxonomy_save_writes_through_a_symlinked_path(tmp_path, monkeypatch):
     assert link.is_symlink(), "os.replace must not swap the link for a file"
     assert os.readlink(link) == str(real)
     assert json.loads(real.read_text())["api_misses"] == ["nothing here"]
-    assert not (tmp_path / "real-taxonomy.json.tmp").exists()
+    assert not list(tmp_path.glob("*.tmp")), "no temp file may survive"
 
 
 def test_load_local_taxonomy_retries_parse_exception_from_mid_write(
@@ -2957,7 +2957,7 @@ def test_download_taxonomy_writes_atomically(tmp_path, monkeypatch):
     assert output_path.read_text() == original_text, (
         "interrupted download must not clobber the existing taxonomy"
     )
-    assert not (tmp_path / "taxonomy.json.tmp").exists(), (
+    assert not list(tmp_path.glob("*.tmp")), (
         "failed atomic write must clean up its sibling temp file"
     )
 
@@ -2968,7 +2968,7 @@ def test_download_taxonomy_writes_atomically(tmp_path, monkeypatch):
     assert result["taxa_by_common"], "the successful write should produce content"
     written = json.loads(output_path.read_text())
     assert written["taxa_by_common"] == result["taxa_by_common"]
-    assert not (tmp_path / "taxonomy.json.tmp").exists()
+    assert not list(tmp_path.glob("*.tmp"))
 
 
 def test_atomic_write_creates_a_new_target_without_a_mode_to_copy(tmp_path):
@@ -2985,7 +2985,7 @@ def test_atomic_write_creates_a_new_target_without_a_mode_to_copy(tmp_path):
     tax_mod._write_taxonomy_json_atomically(str(target), {"taxa_by_common": {}})
 
     assert json.loads(target.read_text()) == {"taxa_by_common": {}}
-    assert not (tmp_path / "brand-new.json.tmp").exists()
+    assert not list(tmp_path.glob("*.tmp")), "no temp file may survive"
 
 
 def test_atomic_write_is_shared_by_both_taxonomy_writers(tmp_path, monkeypatch):
@@ -3022,3 +3022,46 @@ def test_atomic_write_is_shared_by_both_taxonomy_writers(tmp_path, monkeypatch):
     download_src = inspect.getsource(tax_mod.download_taxonomy)
     assert "_write_taxonomy_json_atomically(output_path, result)" in download_src
     assert 'open(output_path, "w")' not in download_src
+
+
+def test_overlapping_atomic_writes_do_not_share_a_temp_file(tmp_path):
+    """Concurrent writers must not collide on one temp path.
+
+    Two POSTs to the download endpoint start two workers — it uses
+    runner.start(), not start_singleton() — so both can be serializing at
+    once. With a fixed "<target>.tmp" one writer renames the inode out from
+    under the other, exposing a partial target and then failing the second
+    when its pathname has vanished.
+    """
+    import taxonomy as tax_mod
+
+    target = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(target, "original species")
+
+    seen_temp_names = []
+    real_dump = tax_mod.json.dump
+    barrier = {"inner_done": False}
+
+    def dump_and_reenter(data, fp, *args, **kwargs):
+        seen_temp_names.append(fp.name)
+        if not barrier["inner_done"]:
+            # Start a second write while this one still holds its fd open.
+            barrier["inner_done"] = True
+            tax_mod._write_taxonomy_json_atomically(
+                str(target), {"taxa_by_common": {"inner species": {}}},
+            )
+        return real_dump(data, fp, *args, **kwargs)
+
+    import unittest.mock as mock
+    with mock.patch.object(tax_mod.json, "dump", dump_and_reenter):
+        tax_mod._write_taxonomy_json_atomically(
+            str(target), {"taxa_by_common": {"outer species": {}}},
+        )
+
+    assert len(seen_temp_names) == 2
+    assert seen_temp_names[0] != seen_temp_names[1], (
+        "each write needs its own temp file"
+    )
+    # The outer write renamed last, so it wins — and the target is whole.
+    assert json.loads(target.read_text())["taxa_by_common"] == {"outer species": {}}
+    assert not list(tmp_path.glob("*.tmp"))

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2153,6 +2153,84 @@ def test_load_local_taxonomy_cache_is_keyed_by_path(tmp_path, monkeypatch):
     assert tax_mod.load_local_taxonomy().is_taxon("second species")
 
 
+def test_load_local_taxonomy_detects_metadata_preserving_replacement(
+    tmp_path, monkeypatch,
+):
+    """A ``cp -p`` / ``rsync -t`` style swap with the old mtime and matching
+    size must still invalidate the cache.
+
+    An external updater can atomically install a taxonomy while preserving
+    the previous mtime and hitting the same byte length; without file
+    identity in the cache key the pair ``(mtime_ns, size)`` matches and
+    ``_load_taxonomy_cached()`` keeps handing back the old snapshot forever.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    # Common names padded to the same length so the two taxonomy files
+    # serialize to the same byte count — that is the exact case where
+    # (mtime_ns, size) alone cannot tell them apart.
+    old_common = "a" * 30
+    new_common = "b" * 30
+    _write_taxonomy_json(persistent, old_common)
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    first = tax_mod.load_local_taxonomy()
+    assert first.is_taxon(old_common)
+    old_stat = os.stat(persistent)
+
+    # Atomically replace via rename onto the target — new inode, but stamp
+    # the old mtime back so mtime and size match the pre-replacement values.
+    replacement = tmp_path / "replacement.json"
+    _write_taxonomy_json(replacement, new_common)
+    assert os.stat(replacement).st_size == old_stat.st_size, (
+        "test setup: the padded names must yield equal-size JSON files"
+    )
+    os.replace(str(replacement), str(persistent))
+    os.utime(persistent, ns=(old_stat.st_mtime_ns, old_stat.st_mtime_ns))
+    new_stat = os.stat(persistent)
+    assert new_stat.st_mtime_ns == old_stat.st_mtime_ns
+    assert new_stat.st_size == old_stat.st_size
+
+    second = tax_mod.load_local_taxonomy()
+    assert second is not first
+    assert second.is_taxon(new_common)
+    assert not second.is_taxon(old_common)
+
+
+def test_taxonomy_stat_key_includes_file_identity(tmp_path):
+    """The stat key must change when the file is atomically replaced,
+    even if mtime and size are preserved.
+
+    Direct guard on ``_taxonomy_stat_key`` for the metadata-preserving
+    replacement case — the integration test above depends on this
+    property, and asserting it in isolation makes a future regression
+    fail here first with an obvious diff.
+    """
+    import taxonomy as tax_mod
+
+    target = tmp_path / "taxonomy.json"
+    target.write_text("x" * 128)
+    before_stat = os.stat(target)
+    before_key = tax_mod._taxonomy_stat_key(str(target))
+
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text("y" * 128)
+    os.replace(str(replacement), str(target))
+    os.utime(target, ns=(before_stat.st_mtime_ns, before_stat.st_mtime_ns))
+    after_stat = os.stat(target)
+    after_key = tax_mod._taxonomy_stat_key(str(target))
+
+    # Preconditions: mtime and size did not move, so a key made of just
+    # (mtime_ns, size) would compare equal.
+    assert after_stat.st_mtime_ns == before_stat.st_mtime_ns
+    assert after_stat.st_size == before_stat.st_size
+    # The key must still change — that is what makes the cache pick up
+    # the replacement.
+    assert after_key != before_key
+
+
 def test_load_local_taxonomy_retries_when_file_changes_during_parse(tmp_path, monkeypatch):
     """A rewrite mid-parse must not cache stale content under the new stat key.
 

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2842,3 +2842,69 @@ def test_content_failure_is_still_memoized(tmp_path, monkeypatch):
     assert len(parses) == 1
     with tax_mod._taxonomy_cache_lock:
         assert str(persistent) in tax_mod._taxonomy_failed_stats
+
+
+def test_schema_invalid_preferred_file_is_memoized(tmp_path, monkeypatch):
+    """Valid JSON in the wrong shape must be remembered like malformed JSON.
+
+    Taxonomy() walks the decoded document, so a top-level list raises
+    AttributeError rather than ValueError. Left unmemoized, every request
+    would evict the cached fallback, re-attempt the preferred file, and
+    re-parse the multi-GB legacy one to rediscover the same failure.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    preferred = tmp_path / "persistent.json"
+    preferred.write_text("[1, 2, 3]")  # parses as JSON, wrong shape
+    legacy = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(legacy, "legacy species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
+    monkeypatch.setattr(tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(legacy))
+
+    parses = []
+    real_init = tax_mod.Taxonomy.__init__
+
+    def counting_init(self, path):
+        parses.append(path)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", counting_init)
+
+    for _ in range(3):
+        assert tax_mod.load_local_taxonomy().is_taxon("legacy species")
+
+    assert parses.count(str(preferred)) == 1, "schema failure must be memoized"
+    assert parses.count(str(legacy)) == 1, "the fallback must survive"
+    with tax_mod._taxonomy_cache_lock:
+        assert str(preferred) in tax_mod._taxonomy_failed_stats
+
+
+def test_memory_error_during_parse_is_not_memoized(tmp_path, monkeypatch):
+    """Running out of memory on a ~2.8GB parse is environmental, not corruption."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    real_init = tax_mod.Taxonomy.__init__
+    calls = {"n": 0}
+
+    def oom_once(self, path):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise MemoryError("cannot allocate taxonomy")
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", oom_once)
+
+    assert tax_mod.load_local_taxonomy() is None
+    with tax_mod._taxonomy_cache_lock:
+        assert str(persistent) not in tax_mod._taxonomy_failed_stats
+
+    result = tax_mod.load_local_taxonomy()
+    assert result is not None
+    assert result.is_taxon("test species")
+    assert calls["n"] == 2

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -1511,15 +1511,10 @@ def test_load_local_taxonomy_falls_back_when_persistent_corrupt(tmp_path, monkey
 
     monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(corrupt))
     # Redirect the "package-dir legacy" candidate path to our tmp fixture.
-    orig_dirname = tax_mod.os.path.dirname
-
-    def fake_dirname(p):
-        if p == tax_mod.__file__:
-            return str(tmp_path)
-        return orig_dirname(p)
-
     legacy.rename(tmp_path / "taxonomy.json")
-    monkeypatch.setattr(tax_mod.os.path, "dirname", fake_dirname)
+    monkeypatch.setattr(
+        tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(tmp_path / "taxonomy.json"),
+    )
 
     result = tax_mod.load_local_taxonomy()
     assert result is not None, "should fall back to legacy copy on corrupt persistent"
@@ -1533,14 +1528,9 @@ def test_load_local_taxonomy_returns_none_when_no_file(tmp_path, monkeypatch):
     monkeypatch.setattr(
         tax_mod, "TAXONOMY_JSON_PATH", str(tmp_path / "nonexistent.json"),
     )
-    orig_dirname = tax_mod.os.path.dirname
-
-    def fake_dirname(p):
-        if p == tax_mod.__file__:
-            return str(tmp_path)
-        return orig_dirname(p)
-
-    monkeypatch.setattr(tax_mod.os.path, "dirname", fake_dirname)
+    monkeypatch.setattr(
+        tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(tmp_path / "taxonomy.json"),
+    )
     assert tax_mod.load_local_taxonomy() is None
 
 
@@ -2031,3 +2021,107 @@ def test_populate_taxa_db_from_json_enables_auto_detect(tmp_path):
         "SELECT type FROM keywords WHERE id = ?", (kid,)
     ).fetchone()
     assert row["type"] == "taxonomy"
+
+
+def _write_taxonomy_json(path, common_name):
+    """Write a minimal but valid taxonomy.json containing one species."""
+    path.write_text(
+        '{"last_updated":"2026-07-30","source":"test",'
+        '"taxa_by_common":{"' + common_name + '":{"taxon_id":1,'
+        '"scientific_name":"Test species","common_name":"Test",'
+        '"rank":"species","lineage_names":["Animalia","Test species"],'
+        '"lineage_ranks":["kingdom","species"]}},'
+        '"taxa_by_scientific":{}}'
+    )
+
+
+def test_load_local_taxonomy_reuses_parsed_instance(tmp_path, monkeypatch):
+    """Repeated loads reuse the parsed taxonomy instead of re-parsing the file.
+
+    A real iNaturalist taxonomy.json is ~500MB, and ``/api/predictions/compare``
+    calls load_local_taxonomy() on every request. Re-parsing per request made
+    the Compare page take seconds-to-minutes and allocated a fresh multi-GB
+    structure each time.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    parses = []
+    real_init = tax_mod.Taxonomy.__init__
+
+    def counting_init(self, path):
+        parses.append(path)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", counting_init)
+
+    first = tax_mod.load_local_taxonomy()
+    second = tax_mod.load_local_taxonomy()
+
+    assert first is not None
+    assert second is first
+    assert len(parses) == 1
+
+
+def test_load_local_taxonomy_reloads_after_file_changes(tmp_path, monkeypatch):
+    """A re-downloaded taxonomy.json is picked up without restarting."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "old species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    first = tax_mod.load_local_taxonomy()
+    assert first.is_taxon("old species")
+
+    _write_taxonomy_json(persistent, "new species that is much longer")
+    os.utime(persistent, (1e9, 1e9))
+
+    second = tax_mod.load_local_taxonomy()
+    assert second is not first
+    assert second.is_taxon("new species that is much longer")
+    assert not second.is_taxon("old species")
+
+
+def test_load_local_taxonomy_cache_is_keyed_by_path(tmp_path, monkeypatch):
+    """Switching to a different taxonomy file does not serve the stale one."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+    _write_taxonomy_json(first_path, "first species")
+    _write_taxonomy_json(second_path, "second species")
+
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(first_path))
+    assert tax_mod.load_local_taxonomy().is_taxon("first species")
+
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(second_path))
+    assert tax_mod.load_local_taxonomy().is_taxon("second species")
+
+
+def test_taxonomy_save_keeps_cached_instance_current(tmp_path, monkeypatch):
+    """save() rewrites the file; the cache must not serve a pre-save copy.
+
+    The instance mutated by api_lookup() is the cached one, so after it
+    persists itself the next load should keep returning that same object
+    rather than re-parsing the file it just wrote.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    tax = tax_mod.load_local_taxonomy()
+    tax._api_misses.add("nothing here")
+    tax._dirty = True
+    tax.save()
+
+    assert tax_mod.load_local_taxonomy() is tax

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -3065,3 +3065,55 @@ def test_overlapping_atomic_writes_do_not_share_a_temp_file(tmp_path):
     # The outer write renamed last, so it wins — and the target is whole.
     assert json.loads(target.read_text())["taxa_by_common"] == {"outer species": {}}
     assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_load_local_taxonomy_with_explicit_path_does_not_fall_back(
+    tmp_path, monkeypatch,
+):
+    """path= pins the load to one artifact, with no legacy fallback.
+
+    The post-download retype must fail loudly when the file it just wrote
+    won't parse. Falling back would retype keywords from a stale legacy
+    copy while the taxa tables hold the new download's data — two taxonomy
+    versions mixed, reported as success.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    preferred = tmp_path / "persistent.json"
+    preferred.write_text("{ not valid json")
+    legacy = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(legacy, "legacy species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
+    monkeypatch.setattr(tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(legacy))
+
+    # Default behaviour still falls back — other callers rely on it.
+    assert tax_mod.load_local_taxonomy().is_taxon("legacy species")
+
+    # Pinned to the broken artifact, it reports failure instead.
+    assert tax_mod.load_local_taxonomy(path=str(preferred)) is None
+
+
+def test_load_local_taxonomy_with_explicit_path_still_caches(tmp_path, monkeypatch):
+    """A pinned load shares the same cache as the default path."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    preferred = tmp_path / "persistent.json"
+    _write_taxonomy_json(preferred, "preferred species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
+
+    parses = []
+    real_init = tax_mod.Taxonomy.__init__
+
+    def counting_init(self, path):
+        parses.append(path)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", counting_init)
+
+    pinned = tax_mod.load_local_taxonomy(path=str(preferred))
+    default = tax_mod.load_local_taxonomy()
+
+    assert pinned is default
+    assert len(parses) == 1

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2908,3 +2908,64 @@ def test_memory_error_during_parse_is_not_memoized(tmp_path, monkeypatch):
     assert result is not None
     assert result.is_taxon("test species")
     assert calls["n"] == 2
+
+
+def test_download_taxonomy_writes_atomically(tmp_path, monkeypatch):
+    """A concurrent reader never sees a half-written taxonomy.json.
+
+    ``download_taxonomy()`` used to serialize ~500MB straight into the
+    output path with ``open(path, "w")``, exposing a partial JSON document
+    to any request that read the file during the write window. That
+    window is longer than ``_load_taxonomy_cached``'s bounded retry loop
+    can wait out. Verify that an interrupted write leaves the pre-existing
+    file intact and that no ``.tmp`` sibling is left behind.
+    """
+    import taxonomy as tax_mod
+
+    output_path = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(output_path, "pre-existing species")
+    original_text = output_path.read_text()
+
+    def fake_download(url, path, progress_callback=None):
+        # Build a minimal but valid DWCA archive with one taxon so the
+        # parse steps run to completion and we reach the write block.
+        import zipfile as _zf
+        with _zf.ZipFile(path, "w") as zf:
+            zf.writestr(
+                "taxa.csv",
+                "id,parentNameUsageID,scientificName,taxonRank\n"
+                "1,,Test species,species\n",
+            )
+            zf.writestr(
+                "VernacularNames-english.csv",
+                "id,vernacularName,language\n"
+                "1,Test,en\n",
+            )
+
+    monkeypatch.setattr(tax_mod, "_download_with_resume", fake_download)
+
+    real_dump = tax_mod.json.dump
+
+    def exploding_dump(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(tax_mod.json, "dump", exploding_dump)
+
+    with pytest.raises(OSError):
+        tax_mod.download_taxonomy(str(output_path))
+
+    assert output_path.read_text() == original_text, (
+        "interrupted download must not clobber the existing taxonomy"
+    )
+    assert not (tmp_path / "taxonomy.json.tmp").exists(), (
+        "failed atomic write must clean up its sibling temp file"
+    )
+
+    # Now let the write succeed and verify the target ends up updated
+    # through the .tmp -> os.replace path.
+    monkeypatch.setattr(tax_mod.json, "dump", real_dump)
+    result = tax_mod.download_taxonomy(str(output_path))
+    assert result["taxa_by_common"], "the successful write should produce content"
+    written = json.loads(output_path.read_text())
+    assert written["taxa_by_common"] == result["taxa_by_common"]
+    assert not (tmp_path / "taxonomy.json.tmp").exists()

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2505,6 +2505,11 @@ def test_load_local_taxonomy_retries_parse_exception_from_mid_write(
     def flaky_init(self, path):
         attempts["n"] += 1
         if attempts["n"] == 1:
+            # A partial read means the writer was mid-rewrite, so the file
+            # has moved. That drift is what makes the retry worth doing —
+            # see the stably-corrupt test for the case that must not retry.
+            _write_taxonomy_json(persistent, "test species")
+            os.utime(persistent, (5e9, 5e9))
             raise ValueError("simulated mid-write JSONDecodeError")
         real_init(self, path)
 
@@ -2549,3 +2554,69 @@ def test_load_local_taxonomy_raises_when_every_parse_attempt_fails(
     # And the outer function still returns None cleanly, so callers that
     # tolerate no taxonomy at all keep working.
     assert tax_mod.load_local_taxonomy() is None
+
+
+def test_load_local_taxonomy_does_not_retry_a_stably_corrupt_file(
+    tmp_path, monkeypatch,
+):
+    """A file that is simply corrupt is read once, not once per retry.
+
+    Truncated JSON only raises at the *end* of the parse, so each retry
+    reads most of a ~500MB file. Retrying a read that cannot succeed puts
+    that cost back on every compare/accept request — the exact latency this
+    cache exists to remove. Only a file that demonstrably moved between
+    attempts is worth re-reading.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    attempts = {"n": 0}
+
+    def always_raising_init(self, path):
+        attempts["n"] += 1
+        raise ValueError("persistent corruption")
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", always_raising_init)
+
+    with pytest.raises(ValueError, match="persistent corruption"):
+        tax_mod._load_taxonomy_cached(str(persistent))
+
+    assert attempts["n"] == 1, "an unchanged corrupt file must be read once"
+
+
+def test_corrupt_preferred_file_costs_one_parse_attempt_per_call(
+    tmp_path, monkeypatch,
+):
+    """The corrupt-preferred fallback stays cheap on every request.
+
+    The preferred candidate is attempted once (not once per retry) and the
+    legacy fallback is parsed once for the whole process.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    corrupt = tmp_path / "persistent.json"
+    corrupt.write_text("{ not valid json")
+    legacy = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(legacy, "legacy species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(corrupt))
+    monkeypatch.setattr(tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(legacy))
+
+    parses = []
+    real_init = tax_mod.Taxonomy.__init__
+
+    def counting_init(self, path):
+        parses.append(path)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", counting_init)
+
+    for _ in range(3):
+        assert tax_mod.load_local_taxonomy().is_taxon("legacy species")
+
+    assert parses.count(str(corrupt)) == 3, "one attempt per call, not per retry"
+    assert parses.count(str(legacy)) == 1, "the fallback is parsed once"

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2286,3 +2286,66 @@ def test_taxonomy_save_keeps_cached_instance_current(tmp_path, monkeypatch):
     tax.save()
 
     assert tax_mod.load_local_taxonomy() is tax
+
+
+def test_taxonomy_save_leaves_original_intact_when_write_fails(tmp_path, monkeypatch):
+    """An interrupted save must not destroy the existing taxonomy.
+
+    save() used to truncate the target with open(path, "w") before
+    serializing ~500MB into it, so a crash — or any concurrent reader,
+    now including _load_taxonomy_cached — saw a half-written file.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+    original = persistent.read_text()
+
+    tax = tax_mod.load_local_taxonomy()
+    tax._api_misses.add("nothing here")
+    tax._dirty = True
+
+    def exploding_dump(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(tax_mod.json, "dump", exploding_dump)
+
+    with pytest.raises(OSError):
+        tax.save()
+
+    assert persistent.read_text() == original
+    assert not (tmp_path / "persistent.json.tmp").exists()
+    tax_mod.clear_taxonomy_cache()
+    assert tax_mod.load_local_taxonomy().is_taxon("test species")
+
+
+def test_taxonomy_save_replaces_file_without_truncating_it(tmp_path, monkeypatch):
+    """The target is never observed empty: the new bytes land via rename."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    tax = tax_mod.load_local_taxonomy()
+    tax._api_misses.add("nothing here")
+    tax._dirty = True
+
+    real_dump = tax_mod.json.dump
+    target_during_write = []
+
+    def observing_dump(data, fp, *args, **kwargs):
+        # Mid-serialize, the file callers read must still parse.
+        with open(persistent) as f:
+            target_during_write.append(json.load(f))
+        return real_dump(data, fp, *args, **kwargs)
+
+    monkeypatch.setattr(tax_mod.json, "dump", observing_dump)
+    tax.save()
+
+    assert len(target_during_write) == 1
+    assert "test species" in target_during_write[0]["taxa_by_common"]
+    assert json.loads(persistent.read_text())["api_misses"] == ["nothing here"]

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2779,3 +2779,66 @@ def test_taxonomy_save_preserves_target_permissions(tmp_path, monkeypatch):
 
     assert stat.S_IMODE(os.stat(persistent).st_mode) == 0o640
     assert json.loads(persistent.read_text())["api_misses"] == ["nothing here"]
+
+
+def test_transient_open_failure_is_not_memoized_as_corruption(tmp_path, monkeypatch):
+    """A read that fails on OS grounds must get another chance.
+
+    The usual repairs for an unreadable file — restoring a permission bit,
+    fd pressure passing — change ctime at most, not mtime or size. Keying a
+    failure record to that stat would leave taxonomy features off until the
+    contents changed or the process restarted.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    real_init = tax_mod.Taxonomy.__init__
+    calls = {"n": 0}
+
+    def unreadable_once(self, path):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError(13, "Permission denied", path)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", unreadable_once)
+
+    # First call fails and must not be remembered as corruption.
+    assert tax_mod.load_local_taxonomy() is None
+    with tax_mod._taxonomy_cache_lock:
+        assert str(persistent) not in tax_mod._taxonomy_failed_stats
+
+    # Access restored, file untouched: the next call reopens it.
+    result = tax_mod.load_local_taxonomy()
+    assert result is not None
+    assert result.is_taxon("test species")
+    assert calls["n"] == 2
+
+
+def test_content_failure_is_still_memoized(tmp_path, monkeypatch):
+    """A malformed file is remembered, so it isn't re-read every request."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    persistent.write_text("{ not valid json")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    parses = []
+    real_init = tax_mod.Taxonomy.__init__
+
+    def counting_init(self, path):
+        parses.append(path)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", counting_init)
+
+    assert tax_mod.load_local_taxonomy() is None
+    assert tax_mod.load_local_taxonomy() is None
+    assert len(parses) == 1
+    with tax_mod._taxonomy_cache_lock:
+        assert str(persistent) in tax_mod._taxonomy_failed_stats

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2459,7 +2459,6 @@ def test_load_local_taxonomy_rechecks_stat_after_acquiring_lock(tmp_path, monkey
     os.utime(persistent, (4e9, 4e9))
     refreshed = tax_mod.Taxonomy(str(persistent))
     new_bytes = persistent.read_text()
-    new_stat = tax_mod._taxonomy_stat_key(str(persistent))
     # Restore the old file so the call under test starts from the old stat.
     _write_taxonomy_json(persistent, "old species")
     os.utime(persistent, (1e9, 1e9))
@@ -2484,7 +2483,13 @@ def test_load_local_taxonomy_rechecks_stat_after_acquiring_lock(tmp_path, monkey
                 self.fired = True
                 persistent.write_text(new_bytes)
                 os.utime(persistent, (4e9, 4e9))
-                tax_mod._taxonomy_cache = (str(persistent), new_stat, refreshed)
+                # Key it off the file as it stands now: the stat key covers
+                # inode and ctime, so it has to be read after the last write.
+                tax_mod._taxonomy_cache = (
+                    str(persistent),
+                    tax_mod._taxonomy_stat_key(str(persistent)),
+                    refreshed,
+                )
             return self
 
         def __exit__(self, *exc):
@@ -2713,51 +2718,50 @@ def test_load_local_taxonomy_retries_corrupt_preferred_after_it_changes(
     assert result.is_taxon("preferred species that is longer")
 
 
-def test_load_local_taxonomy_evicts_fallback_before_parsing_preferred(
+def test_load_local_taxonomy_keeps_fallback_across_transient_preferred_failure(
     tmp_path, monkeypatch,
 ):
-    """When the preferred file appears, the fallback is dropped before the parse.
+    """A cross-path fallback survives a preferred file that keeps failing.
 
-    A parsed iNaturalist taxonomy is ~2.8GB. Holding the cached legacy
-    instance live through ``Taxonomy(preferred_path)`` would double peak RSS
-    to ~5.6GB and can OOM during a normal migration (preferred download
-    completes while legacy is still cached). The eviction must happen
-    before the constructor allocates.
+    Transient errors are deliberately not memoized (a chmod repair would not
+    change the file), so a preferred file with, say, wrong permissions is
+    re-attempted on every request. Evicting cross-path entries on the way
+    past would drop the cached legacy taxonomy each time and re-parse ~500MB
+    of fallback per compare or accept.
+
+    The migration case that motivates dropping a cross-path entry — legacy
+    cached while a newly-downloaded preferred file parses — is covered by
+    download_taxonomy() clearing the cache before it builds its replacement.
     """
     import taxonomy as tax_mod
 
     tax_mod.clear_taxonomy_cache()
     preferred = tmp_path / "persistent.json"
+    _write_taxonomy_json(preferred, "preferred species")
     legacy = tmp_path / "taxonomy.json"
     _write_taxonomy_json(legacy, "legacy species")
     monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
     monkeypatch.setattr(tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(legacy))
 
-    # First load: preferred doesn't exist, so legacy is cached.
-    first = tax_mod.load_local_taxonomy()
-    assert first.is_taxon("legacy species")
-
-    # Preferred file arrives (as if a background download just finished).
-    _write_taxonomy_json(preferred, "preferred species that is longer")
-
+    parses = []
     real_init = tax_mod.Taxonomy.__init__
-    observed_cache = []
 
-    def observing_init(self, path):
-        # By the time we're inside the constructor for the preferred file,
-        # the cached legacy instance must not still be reachable through
-        # _taxonomy_cache — otherwise both instances share peak RSS.
+    def failing_preferred_init(self, path):
+        parses.append(path)
         if path == str(preferred):
-            observed_cache.append(tax_mod._taxonomy_cache)
+            raise PermissionError(13, "Permission denied")
         real_init(self, path)
 
-    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", observing_init)
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", failing_preferred_init)
 
-    result = tax_mod.load_local_taxonomy()
+    results = [tax_mod.load_local_taxonomy() for _ in range(3)]
 
-    assert result.is_taxon("preferred species that is longer")
-    assert result is not first
-    assert observed_cache == [None]
+    assert all(r.is_taxon("legacy species") for r in results)
+    assert results[1] is results[0] and results[2] is results[0]
+    # The preferred file is retried every call (its failure is not memoized),
+    # but the fallback must be parsed exactly once for the process.
+    assert parses.count(str(preferred)) == 3
+    assert parses.count(str(legacy)) == 1
 
 
 def test_clear_taxonomy_cache_also_clears_failure_records(tmp_path, monkeypatch):

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -3,6 +3,7 @@ import gc
 import gzip
 import json
 import os
+import stat
 import sys
 import tempfile
 import weakref
@@ -2734,3 +2735,47 @@ def test_clear_taxonomy_cache_also_clears_failure_records(tmp_path, monkeypatch)
     tax_mod.clear_taxonomy_cache()
     with tax_mod._taxonomy_cache_lock:
         assert tax_mod._taxonomy_failed_stats == {}
+
+
+def test_exhausted_retries_chain_the_last_parse_error(tmp_path, monkeypatch):
+    """"File kept changing" alone doesn't say which byte was malformed."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    counter = {"n": 0}
+
+    def always_racing_and_raising(self, path):
+        counter["n"] += 1
+        os.utime(persistent, (counter["n"] + 6e9, counter["n"] + 6e9))
+        raise ValueError(f"malformed at byte {counter['n']}")
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", always_racing_and_raising)
+
+    with pytest.raises(ValueError, match="kept changing") as excinfo:
+        tax_mod._load_taxonomy_cached(str(persistent))
+
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert "malformed at byte" in str(excinfo.value.__cause__)
+
+
+def test_taxonomy_save_preserves_target_permissions(tmp_path, monkeypatch):
+    """Renaming a fresh temp file must not reset the taxonomy's mode."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    os.chmod(persistent, 0o640)
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    tax = tax_mod.load_local_taxonomy()
+    tax._api_misses.add("nothing here")
+    tax._dirty = True
+    tax.save()
+
+    assert stat.S_IMODE(os.stat(persistent).st_mode) == 0o640
+    assert json.loads(persistent.read_text())["api_misses"] == ["nothing here"]

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2477,3 +2477,75 @@ def test_taxonomy_save_writes_through_a_symlinked_path(tmp_path, monkeypatch):
     assert os.readlink(link) == str(real)
     assert json.loads(real.read_text())["api_misses"] == ["nothing here"]
     assert not (tmp_path / "real-taxonomy.json.tmp").exists()
+
+
+def test_load_local_taxonomy_retries_parse_exception_from_mid_write(
+    tmp_path, monkeypatch,
+):
+    """A parse exception from a mid-write read must be retried, not propagated.
+
+    Taxonomy.save() writes atomically now, but an interrupted download, an
+    external tool rewriting the file, or the same taxonomy on a filesystem
+    that can't do atomic renames all still expose a partial JSON document.
+    A single unlucky read raising json.JSONDecodeError would bubble out of
+    _load_taxonomy_cached, load_local_taxonomy() would log a warning and
+    fall through to the next (usually stale or nonexistent) candidate, and
+    the very next call would have parsed the same file cleanly.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    real_init = tax_mod.Taxonomy.__init__
+    attempts = {"n": 0}
+
+    def flaky_init(self, path):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise ValueError("simulated mid-write JSONDecodeError")
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", flaky_init)
+
+    result = tax_mod.load_local_taxonomy()
+
+    assert result is not None
+    assert result.is_taxon("test species")
+    assert attempts["n"] == 2
+
+
+def test_load_local_taxonomy_raises_when_every_parse_attempt_fails(
+    tmp_path, monkeypatch,
+):
+    """A file that raises on every retry surfaces a clean error, not None.
+
+    Silently returning None would let load_local_taxonomy() log a generic
+    "failed to load" warning and fall through to the next candidate; a
+    persistent-corruption failure that repeats every retry is worth
+    surfacing so the caller can see the last exception's message.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    def always_raise(self, path):
+        raise ValueError("persistent corruption")
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", always_raise)
+
+    # load_local_taxonomy() catches the exception and moves to the next
+    # candidate; with no fallback present the final result is None. What
+    # matters is that the private helper raises so the outer function can
+    # log the concrete failure per candidate.
+    with pytest.raises(ValueError):
+        tax_mod._load_taxonomy_cached(str(persistent))
+
+    # And the outer function still returns None cleanly, so callers that
+    # tolerate no taxonomy at all keep working.
+    assert tax_mod.load_local_taxonomy() is None

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -1,9 +1,11 @@
 # vireo/tests/test_taxonomy.py
+import gc
 import gzip
 import json
 import os
 import sys
 import tempfile
+import weakref
 
 import pytest
 
@@ -2230,8 +2232,6 @@ def test_load_local_taxonomy_releases_between_retries(tmp_path, monkeypatch):
     weakref; only the caller's returned instance should still be
     alive after the final retry.
     """
-    import gc
-    import weakref
     import taxonomy as tax_mod
 
     tax_mod.clear_taxonomy_cache()

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2349,3 +2349,131 @@ def test_taxonomy_save_replaces_file_without_truncating_it(tmp_path, monkeypatch
     assert len(target_during_write) == 1
     assert "test species" in target_during_write[0]["taxa_by_common"]
     assert json.loads(persistent.read_text())["api_misses"] == ["nothing here"]
+
+
+def test_load_local_taxonomy_keeps_fallback_cached_when_preferred_is_corrupt(
+    tmp_path, monkeypatch,
+):
+    """The corrupt-persistent fallback must not defeat the cache.
+
+    load_local_taxonomy() parses the preferred candidate, fails, and falls
+    back to the legacy one. Evicting the legacy entry on the way past would
+    re-parse a multi-GB file on every compare/accept request.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    corrupt = tmp_path / "persistent.json"
+    corrupt.write_text("{ not valid json")
+    legacy = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(legacy, "legacy species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(corrupt))
+    monkeypatch.setattr(tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(legacy))
+
+    parses = []
+    real_init = tax_mod.Taxonomy.__init__
+
+    def counting_init(self, path):
+        parses.append(path)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", counting_init)
+
+    first = tax_mod.load_local_taxonomy()
+    second = tax_mod.load_local_taxonomy()
+
+    assert first.is_taxon("legacy species")
+    assert second is first
+    # Each call attempts the corrupt preferred file; only the first should
+    # have to parse the legacy fallback.
+    assert parses.count(str(legacy)) == 1
+
+
+def test_load_local_taxonomy_rechecks_stat_after_acquiring_lock(tmp_path, monkeypatch):
+    """A caller that waited on the lock must not evict what it was waiting for.
+
+    Statting before the lock lets a caller compare a pre-wait stat against an
+    entry another caller refreshed while it waited, conclude it is stale, and
+    re-parse ~2.8GB for nothing.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "old species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    winner = tax_mod.load_local_taxonomy()
+    assert winner.is_taxon("old species")
+
+    # Build the instance the "other caller" installs, plus the bytes and stat
+    # key that go with it, before the parse counter is armed — otherwise this
+    # setup parse is itself counted.
+    _write_taxonomy_json(persistent, "new species that is longer")
+    os.utime(persistent, (4e9, 4e9))
+    refreshed = tax_mod.Taxonomy(str(persistent))
+    new_bytes = persistent.read_text()
+    new_stat = tax_mod._taxonomy_stat_key(str(persistent))
+    # Restore the old file so the call under test starts from the old stat.
+    _write_taxonomy_json(persistent, "old species")
+    os.utime(persistent, (1e9, 1e9))
+
+    parses = []
+    real_init = tax_mod.Taxonomy.__init__
+
+    def counting_init(self, path):
+        parses.append(path)
+        real_init(self, path)
+
+    class RacingLock:
+        """Simulates another caller refreshing the cache while we wait."""
+
+        def __init__(self, inner):
+            self._inner = inner
+            self.fired = False
+
+        def __enter__(self):
+            self._inner.acquire()
+            if not self.fired:
+                self.fired = True
+                persistent.write_text(new_bytes)
+                os.utime(persistent, (4e9, 4e9))
+                tax_mod._taxonomy_cache = (str(persistent), new_stat, refreshed)
+            return self
+
+        def __exit__(self, *exc):
+            self._inner.release()
+            return False
+
+    racing = RacingLock(tax_mod._taxonomy_cache_lock)
+    monkeypatch.setattr(tax_mod, "_taxonomy_cache_lock", racing)
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", counting_init)
+
+    result = tax_mod.load_local_taxonomy()
+
+    assert result.is_taxon("new species that is longer")
+    # The entry the racing caller installed is served as-is; statting before
+    # the lock would have judged it stale and re-parsed the file.
+    assert parses == []
+
+
+def test_taxonomy_save_writes_through_a_symlinked_path(tmp_path, monkeypatch):
+    """Saving must update a symlink's target, not replace the symlink."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    real = tmp_path / "real-taxonomy.json"
+    _write_taxonomy_json(real, "test species")
+    link = tmp_path / "linked.json"
+    link.symlink_to(real)
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(link))
+
+    tax = tax_mod.load_local_taxonomy()
+    tax._api_misses.add("nothing here")
+    tax._dirty = True
+    tax.save()
+
+    assert link.is_symlink(), "os.replace must not swap the link for a file"
+    assert os.readlink(link) == str(real)
+    assert json.loads(real.read_text())["api_misses"] == ["nothing here"]
+    assert not (tmp_path / "real-taxonomy.json.tmp").exists()

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -15,6 +15,51 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from db import Database
 
 
+@pytest.fixture(autouse=True)
+def _isolate_taxonomy_state(tmp_path, monkeypatch):
+    """Keep the real filesystem and a leftover cache out of every test here.
+
+    Both taxonomy candidates resolve at import time, so a developer with a
+    real ~/.vireo/taxonomy.json or an in-checkout vireo/taxonomy.json (a full
+    iNaturalist dump is ~500MB) had tests that expect a load to fail quietly
+    pick up that file instead — asserting None and counting parses against
+    whatever happened to be on the host. Point both at names that do not
+    exist; tests needing a candidate present aim the constant at their own
+    fixture file.
+
+    Also clears the process-wide parse cache on both sides of the test, so
+    one test's cached instance or memoized failure cannot decide another
+    test's outcome.
+    """
+    import taxonomy as tax_mod
+
+    monkeypatch.setattr(
+        tax_mod, "TAXONOMY_JSON_PATH", str(tmp_path / "absent-persistent.json"),
+    )
+    monkeypatch.setattr(
+        tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(tmp_path / "absent-legacy.json"),
+    )
+    tax_mod.clear_taxonomy_cache()
+    yield
+    tax_mod.clear_taxonomy_cache()
+
+
+def _fake_dwca_download(url, path, progress_callback=None):
+    """Write a minimal but valid DWCA archive so download_taxonomy() completes."""
+    import zipfile as _zf
+    with _zf.ZipFile(path, "w") as zf:
+        zf.writestr(
+            "taxa.csv",
+            "id,parentNameUsageID,scientificName,taxonRank\n"
+            "1,,Test species,species\n",
+        )
+        zf.writestr(
+            "VernacularNames-english.csv",
+            "id,vernacularName,language\n"
+            "1,Test,en\n",
+        )
+
+
 def _create_mock_taxonomy(tmpdir):
     """Create a small taxonomy.json for testing without downloading."""
     taxonomy = {
@@ -2475,7 +2520,10 @@ def test_taxonomy_save_writes_through_a_symlinked_path(tmp_path, monkeypatch):
     tax.save()
 
     assert link.is_symlink(), "os.replace must not swap the link for a file"
-    assert os.readlink(link) == str(real)
+    # Compare resolved paths: Windows readlink() returns an
+    # extended-length "\\\\?\\C:\\..." form that never equals the
+    # plain path the link was created with.
+    assert link.resolve() == real.resolve()
     assert json.loads(real.read_text())["api_misses"] == ["nothing here"]
     assert not list(tmp_path.glob("*.tmp")), "no temp file may survive"
 
@@ -2758,10 +2806,17 @@ def test_exhausted_retries_chain_the_last_parse_error(tmp_path, monkeypatch):
     with pytest.raises(ValueError, match="kept changing") as excinfo:
         tax_mod._load_taxonomy_cached(str(persistent))
 
-    assert isinstance(excinfo.value.__cause__, ValueError)
-    assert "malformed at byte" in str(excinfo.value.__cause__)
+    # The concrete failure travels as text, not as a chained exception: a
+    # chained exception's traceback pins the Taxonomy.__init__ frame and the
+    # multi-GB dict json.load() decoded into it.
+    assert "malformed at byte" in str(excinfo.value)
+    assert excinfo.value.__cause__ is None
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows chmod only toggles the read-only bit, so 0o640 is unrepresentable",
+)
 def test_taxonomy_save_preserves_target_permissions(tmp_path, monkeypatch):
     """Renaming a fresh temp file must not reset the taxonomy's mode."""
     import taxonomy as tax_mod
@@ -2926,23 +2981,7 @@ def test_download_taxonomy_writes_atomically(tmp_path, monkeypatch):
     _write_taxonomy_json(output_path, "pre-existing species")
     original_text = output_path.read_text()
 
-    def fake_download(url, path, progress_callback=None):
-        # Build a minimal but valid DWCA archive with one taxon so the
-        # parse steps run to completion and we reach the write block.
-        import zipfile as _zf
-        with _zf.ZipFile(path, "w") as zf:
-            zf.writestr(
-                "taxa.csv",
-                "id,parentNameUsageID,scientificName,taxonRank\n"
-                "1,,Test species,species\n",
-            )
-            zf.writestr(
-                "VernacularNames-english.csv",
-                "id,vernacularName,language\n"
-                "1,Test,en\n",
-            )
-
-    monkeypatch.setattr(tax_mod, "_download_with_resume", fake_download)
+    monkeypatch.setattr(tax_mod, "_download_with_resume", _fake_dwca_download)
 
     real_dump = tax_mod.json.dump
 
@@ -3018,13 +3057,18 @@ def test_atomic_write_is_shared_by_both_taxonomy_writers(tmp_path, monkeypatch):
     tax.save()
 
     assert calls == [str(persistent)]
-    import inspect
-    download_src = inspect.getsource(tax_mod.download_taxonomy)
-    assert "_write_taxonomy_json_atomically(output_path, result)" in download_src
-    assert 'open(output_path, "w")' not in download_src
+
+    # And the download path routes through it too — asserted by behaviour
+    # rather than by grepping the source, which a rename would break without
+    # anything actually regressing.
+    calls.clear()
+    download_target = tmp_path / "downloaded.json"
+    monkeypatch.setattr(tax_mod, "_download_with_resume", _fake_dwca_download)
+    tax_mod.download_taxonomy(str(download_target))
+    assert calls == [str(download_target)]
 
 
-def test_overlapping_atomic_writes_do_not_share_a_temp_file(tmp_path):
+def test_overlapping_atomic_writes_do_not_share_a_temp_file(tmp_path, monkeypatch):
     """Concurrent writers must not collide on one temp path.
 
     Two POSTs to the download endpoint start two workers — it uses
@@ -3038,12 +3082,23 @@ def test_overlapping_atomic_writes_do_not_share_a_temp_file(tmp_path):
     target = tmp_path / "taxonomy.json"
     _write_taxonomy_json(target, "original species")
 
-    seen_temp_names = []
+    # Record the temp *paths* mkstemp hands out. os.fdopen(fd).name is the
+    # integer fd, not a path, so reading it off the file object would compare
+    # two file descriptors and pass no matter what the filenames were.
+    seen_temp_paths = []
+    real_mkstemp = tax_mod.tempfile.mkstemp
+
+    def recording_mkstemp(*args, **kwargs):
+        fd, tmp = real_mkstemp(*args, **kwargs)
+        seen_temp_paths.append(tmp)
+        return fd, tmp
+
+    monkeypatch.setattr(tax_mod.tempfile, "mkstemp", recording_mkstemp)
+
     real_dump = tax_mod.json.dump
     barrier = {"inner_done": False}
 
     def dump_and_reenter(data, fp, *args, **kwargs):
-        seen_temp_names.append(fp.name)
         if not barrier["inner_done"]:
             # Start a second write while this one still holds its fd open.
             barrier["inner_done"] = True
@@ -3058,10 +3113,11 @@ def test_overlapping_atomic_writes_do_not_share_a_temp_file(tmp_path):
             str(target), {"taxa_by_common": {"outer species": {}}},
         )
 
-    assert len(seen_temp_names) == 2
-    assert seen_temp_names[0] != seen_temp_names[1], (
+    assert len(seen_temp_paths) == 2
+    assert seen_temp_paths[0] != seen_temp_paths[1], (
         "each write needs its own temp file"
     )
+    assert all(p.endswith(".tmp") for p in seen_temp_paths)
     # The outer write renamed last, so it wins — and the target is whole.
     assert json.loads(target.read_text())["taxa_by_common"] == {"outer species": {}}
     assert not list(tmp_path.glob("*.tmp"))

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -3117,3 +3117,55 @@ def test_load_local_taxonomy_with_explicit_path_still_caches(tmp_path, monkeypat
 
     assert pinned is default
     assert len(parses) == 1
+
+
+def test_download_taxonomy_evicts_cache_before_rebuilding(tmp_path, monkeypatch):
+    """Old ~2.8GB parse must not stay reachable through the cache during build.
+
+    The post-download retype routes through load_local_taxonomy() which
+    evicts on parse, but that runs *after* download_taxonomy() has already
+    built its ~2.8GB dict. During the build, the cache's old reference and
+    the new dict would coexist, roughly doubling peak RSS and putting a
+    routine refresh in reach of OOM. Verify eviction happens *before* the
+    build starts.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(persistent, "old species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    # Seed the cache from the current file so we can observe eviction.
+    cached_before = tax_mod.load_local_taxonomy()
+    assert cached_before is not None
+    with tax_mod._taxonomy_cache_lock:
+        assert tax_mod._taxonomy_cache is not None
+
+    observed_cache_state = []
+
+    def observing_download(url, path, progress_callback=None):
+        with tax_mod._taxonomy_cache_lock:
+            observed_cache_state.append(tax_mod._taxonomy_cache)
+        import zipfile as _zf
+        with _zf.ZipFile(path, "w") as zf:
+            zf.writestr(
+                "taxa.csv",
+                "id,parentNameUsageID,scientificName,taxonRank\n"
+                "1,,Test species,species\n",
+            )
+            zf.writestr(
+                "VernacularNames-english.csv",
+                "id,vernacularName,language\n"
+                "1,New species,en\n",
+            )
+
+    monkeypatch.setattr(tax_mod, "_download_with_resume", observing_download)
+
+    tax_mod.download_taxonomy(str(persistent))
+
+    assert observed_cache_state, "observing hook must have fired"
+    assert observed_cache_state[0] is None, (
+        "cache must be evicted BEFORE download_taxonomy() begins building "
+        "its ~2.8GB replacement, otherwise both are live at once"
+    )

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2176,6 +2176,96 @@ def test_load_local_taxonomy_skips_cache_when_file_keeps_changing(tmp_path, monk
         assert tax_mod._taxonomy_cache is None
 
 
+def test_load_local_taxonomy_releases_stale_instance_before_reparse(tmp_path, monkeypatch):
+    """A stale cache entry must not stay reachable while the replacement parses.
+
+    A parsed iNaturalist taxonomy is ~2.8GB. If the old instance is still
+    held by ``_taxonomy_cache`` (or by a local reference inside
+    ``_load_taxonomy_cached``) while ``Taxonomy(path)`` allocates the
+    replacement, peak RSS doubles, and each retry on a file that keeps
+    changing stacks another live copy on top. Assert both the module
+    slot and any local reference are cleared before the next
+    ``Taxonomy(path)`` call runs.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "first species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    first = tax_mod.load_local_taxonomy()
+    assert first is not None
+
+    _write_taxonomy_json(persistent, "second species that is longer")
+    os.utime(persistent, (2e9, 2e9))
+
+    real_init = tax_mod.Taxonomy.__init__
+    observed = []
+
+    def observing_init(self, path):
+        # By the time we are inside the constructor for the replacement,
+        # neither the module-level cache slot nor any live reference to
+        # the previously cached instance should be reachable from this
+        # function's frame — otherwise both instances share peak RSS.
+        observed.append(tax_mod._taxonomy_cache)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", observing_init)
+
+    second = tax_mod.load_local_taxonomy()
+
+    assert second is not None
+    assert second is not first
+    assert observed == [None]
+
+
+def test_load_local_taxonomy_releases_between_retries(tmp_path, monkeypatch):
+    """Retries after mid-parse rewrites must not stack live copies.
+
+    Without dropping the previous retry's instance before the next
+    ``Taxonomy(path)`` call, a file that keeps changing would hold N
+    parsed taxonomies live at once (peak RSS ≈ N × 2.8GB on a real
+    iNaturalist dump). Track every constructed instance with a
+    weakref; only the caller's returned instance should still be
+    alive after the final retry.
+    """
+    import gc
+    import weakref
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    persistent = tmp_path / "persistent.json"
+    _write_taxonomy_json(persistent, "test species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+
+    tracked = []
+    real_init = tax_mod.Taxonomy.__init__
+    counter = {"n": 0}
+
+    def racing_init(self, path):
+        counter["n"] += 1
+        tracked.append(weakref.ref(self))
+        real_init(self, path)
+        # Move the file every time so every retry sees a mismatched stat.
+        os.utime(persistent, (counter["n"] + 1e9, counter["n"] + 1e9))
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", racing_init)
+
+    result = tax_mod.load_local_taxonomy()
+
+    assert result is not None
+    assert counter["n"] == tax_mod._TAXONOMY_PARSE_RETRY_LIMIT
+    gc.collect()
+    live = [ref for ref in tracked if ref() is result]
+    dead = [ref for ref in tracked if ref() is None]
+    # The final instance is the one returned; every earlier retry's
+    # instance should be unreachable, meaning the loop dropped its ref
+    # before allocating the next parse.
+    assert len(live) == 1
+    assert len(dead) == tax_mod._TAXONOMY_PARSE_RETRY_LIMIT - 1
+
+
 def test_taxonomy_save_keeps_cached_instance_current(tmp_path, monkeypatch):
     """save() rewrites the file; the cache must not serve a pre-save copy.
 

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -2538,6 +2538,9 @@ def test_load_local_taxonomy_raises_when_every_parse_attempt_fails(
     persistent = tmp_path / "persistent.json"
     _write_taxonomy_json(persistent, "test species")
     monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(persistent))
+    monkeypatch.setattr(
+        tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(tmp_path / "missing.json"),
+    )
 
     def always_raise(self, path):
         raise ValueError("persistent corruption")
@@ -2588,13 +2591,16 @@ def test_load_local_taxonomy_does_not_retry_a_stably_corrupt_file(
     assert attempts["n"] == 1, "an unchanged corrupt file must be read once"
 
 
-def test_corrupt_preferred_file_costs_one_parse_attempt_per_call(
+def test_load_local_taxonomy_skips_reparsing_known_corrupt_preferred(
     tmp_path, monkeypatch,
 ):
-    """The corrupt-preferred fallback stays cheap on every request.
+    """A corrupt preferred candidate is parsed once, then short-circuited.
 
-    The preferred candidate is attempted once (not once per retry) and the
-    legacy fallback is parsed once for the whole process.
+    Without this, every compare/accept request would re-attempt the corrupt
+    parse (spamming warnings and burning CPU) and, more importantly, force
+    the cache-eviction logic to keep the fallback alive during the parse to
+    avoid re-parsing it. The failure record is what lets us safely evict the
+    fallback before parsing new preferred files.
     """
     import taxonomy as tax_mod
 
@@ -2615,8 +2621,116 @@ def test_corrupt_preferred_file_costs_one_parse_attempt_per_call(
 
     monkeypatch.setattr(tax_mod.Taxonomy, "__init__", counting_init)
 
-    for _ in range(3):
-        assert tax_mod.load_local_taxonomy().is_taxon("legacy species")
+    first = tax_mod.load_local_taxonomy()
+    second = tax_mod.load_local_taxonomy()
+    third = tax_mod.load_local_taxonomy()
 
-    assert parses.count(str(corrupt)) == 3, "one attempt per call, not per retry"
-    assert parses.count(str(legacy)) == 1, "the fallback is parsed once"
+    assert first.is_taxon("legacy species")
+    assert second is first
+    assert third is first
+    # Corrupt file is parsed once (recording the failure); subsequent calls
+    # short-circuit rather than re-attempting.
+    assert parses.count(str(corrupt)) == 1
+    # Legacy is parsed once and served from cache thereafter.
+    assert parses.count(str(legacy)) == 1
+
+
+def test_load_local_taxonomy_retries_corrupt_preferred_after_it_changes(
+    tmp_path, monkeypatch,
+):
+    """A repaired preferred file is picked up — the failure record is cleared."""
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    preferred = tmp_path / "persistent.json"
+    preferred.write_text("{ not valid json")
+    legacy = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(legacy, "legacy species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
+    monkeypatch.setattr(tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(legacy))
+
+    first = tax_mod.load_local_taxonomy()
+    assert first.is_taxon("legacy species")
+    # Same stat → still short-circuited (no re-parse of the corrupt file).
+    assert tax_mod.load_local_taxonomy() is first
+
+    # Repair the preferred file. Its stat changes, so the failure record
+    # is discarded and the new content is parsed.
+    _write_taxonomy_json(preferred, "preferred species that is longer")
+    os.utime(preferred, (5e9, 5e9))
+
+    result = tax_mod.load_local_taxonomy()
+    assert result is not first
+    assert result.is_taxon("preferred species that is longer")
+
+
+def test_load_local_taxonomy_evicts_fallback_before_parsing_preferred(
+    tmp_path, monkeypatch,
+):
+    """When the preferred file appears, the fallback is dropped before the parse.
+
+    A parsed iNaturalist taxonomy is ~2.8GB. Holding the cached legacy
+    instance live through ``Taxonomy(preferred_path)`` would double peak RSS
+    to ~5.6GB and can OOM during a normal migration (preferred download
+    completes while legacy is still cached). The eviction must happen
+    before the constructor allocates.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    preferred = tmp_path / "persistent.json"
+    legacy = tmp_path / "taxonomy.json"
+    _write_taxonomy_json(legacy, "legacy species")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
+    monkeypatch.setattr(tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(legacy))
+
+    # First load: preferred doesn't exist, so legacy is cached.
+    first = tax_mod.load_local_taxonomy()
+    assert first.is_taxon("legacy species")
+
+    # Preferred file arrives (as if a background download just finished).
+    _write_taxonomy_json(preferred, "preferred species that is longer")
+
+    real_init = tax_mod.Taxonomy.__init__
+    observed_cache = []
+
+    def observing_init(self, path):
+        # By the time we're inside the constructor for the preferred file,
+        # the cached legacy instance must not still be reachable through
+        # _taxonomy_cache — otherwise both instances share peak RSS.
+        if path == str(preferred):
+            observed_cache.append(tax_mod._taxonomy_cache)
+        real_init(self, path)
+
+    monkeypatch.setattr(tax_mod.Taxonomy, "__init__", observing_init)
+
+    result = tax_mod.load_local_taxonomy()
+
+    assert result.is_taxon("preferred species that is longer")
+    assert result is not first
+    assert observed_cache == [None]
+
+
+def test_clear_taxonomy_cache_also_clears_failure_records(tmp_path, monkeypatch):
+    """clear_taxonomy_cache() must reset failure tracking too.
+
+    Otherwise a test that clears the cache and then repairs a formerly-corrupt
+    file would still short-circuit on the stale failure record.
+    """
+    import taxonomy as tax_mod
+
+    tax_mod.clear_taxonomy_cache()
+    preferred = tmp_path / "persistent.json"
+    preferred.write_text("{ not valid json")
+    monkeypatch.setattr(tax_mod, "TAXONOMY_JSON_PATH", str(preferred))
+    monkeypatch.setattr(
+        tax_mod, "LEGACY_TAXONOMY_JSON_PATH", str(tmp_path / "missing.json"),
+    )
+
+    assert tax_mod.load_local_taxonomy() is None
+    with tax_mod._taxonomy_cache_lock:
+        assert str(preferred) in tax_mod._taxonomy_failed_stats
+
+    tax_mod.clear_taxonomy_cache()
+    with tax_mod._taxonomy_cache_lock:
+        assert tax_mod._taxonomy_failed_stats == {}


### PR DESCRIPTION
## What broke

`tests/e2e/test_compare_page.py::test_compare_treats_second_detected_species_as_additional` fails locally but passes in CI.

The failure is not in the test — it is a real backend performance bug the test exposed on a machine that has a taxonomy file.

## Root cause

`/api/predictions/compare` calls `load_local_taxonomy()` on **every** request, and `Database.accept_prediction(replace_species=True)` does the same. Each call ran `json.load()` over the entire taxonomy file.

A real iNaturalist `taxonomy.json` is ~500MB. Measured on the 522MB copy in this checkout:

| | before | after |
|---|---|---|
| `load_local_taxonomy()` 1st call | 3.55s | 3.55s |
| 2nd/3rd call | 3.55s each | 0.00s |
| peak RSS per call | ~2.8GB, allocated fresh each time | ~2.8GB, retained once |

Reproduced end-to-end with the taxonomy file present. The test's last step accepts a prediction, which triggers `predictionAction() -> loadComparison()`:

```
WARNING  app:app.py:2916 Slow request: GET /api/predictions/compare took 4.1s
INFO     "POST /api/predictions/6/accept-subject HTTP/1.1" 200
WARNING  app:app.py:2916 Slow request: GET /api/predictions/compare took 1014.5s   <-- overlapping parses thrashing swap
...
E   - text: Loading keyword comparison...
```

CI has no taxonomy file, so `load_local_taxonomy()` returns `None` instantly and the whole thing is invisible there. `app.py` already had a startup-only closure cache with the comment "Parsing taxonomy.json is expensive" — the request path just never got one.

## Changes

**`vireo/taxonomy.py`**
- `load_local_taxonomy()` returns a process-wide cached instance keyed by `(path, mtime_ns, size)`, so a re-downloaded taxonomy is still picked up without a restart.
- The parse runs under a lock: simultaneous requests wait for one result instead of each building its own multi-GB structure (that pile-up is what turned 3.5s into 1014s).
- Misses are not cached — a first-run download can land between calls.
- `Taxonomy.save()` re-stamps the cache key; it just wrote the file it is already consistent with, so that rewrite should not look like an external change.
- `clear_taxonomy_cache()` for tests.
- The legacy candidate path is now a module constant `LEGACY_TAXONOMY_JSON_PATH` instead of an inline `os.path.dirname(__file__)`, so it can be monkeypatched directly. Two existing tests previously patched `os.path.dirname` *globally* to redirect it; they now patch the constant.

**`tests/e2e/conftest.py`** — `live_server` pins both taxonomy candidates to `tmp_path`. Both resolve at import time, so patching `HOME` does not move them; this is the same treatment `cfg.CONFIG_PATH` and `models.DEFAULT_MODELS_DIR` already get. Without it the browser suite silently behaves differently depending on whether the developer has a taxonomy file.

## Trade-off

The parsed taxonomy is now retained for the process lifetime (~2.8GB for a full iNat dump) rather than allocated and freed per request. Peak RSS is unchanged — every request already reached that peak — but steady-state RSS is higher for users who have downloaded the full taxonomy.

## Tests

- `vireo/tests/test_taxonomy.py` — 60 passed. 4 new: instance reuse across loads, reload after the file changes, cache keyed by path, `save()` keeps the cached instance.
- Full browser suite `pytest -o addopts='' -q tests/e2e/` — **644 passed, 1 skipped** (9m19s).
- With the 522MB `taxonomy.json` symlinked into the checkout, `test_compare_page.py` goes from failing to **9 passed in 6.8s**; `test_compare_page + test_review + test_pipeline_review_species + test_pipeline_rapid_review` — 62 passed.
- `tests/test_workspaces.py` + `vireo/tests/{test_db,test_photos_api,test_edits_api,test_jobs_api,test_darktable_api,test_config,test_compare,test_classify_job,test_pipeline_job,test_analyze}.py` — 1942 passed, 34 skipped.
- `vireo/tests/test_app.py` — 466 passed, 1 failure (`test_api_exiftool_status_reports_missing`) that also fails on `main` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved taxonomy loading reliability when files change or are temporarily incomplete.
  * Taxonomy refreshes now report unreadable downloads instead of using invalid or unintended fallback data.
  * Added fallback support for legacy taxonomy file locations.
  * Improved taxonomy save reliability, including safer handling of write failures and concurrent updates.
  * Prevented test environments from using unintended taxonomy files.

* **Performance**
  * Added caching for repeatedly loaded taxonomy data.
  * Automatically refreshes cached data when taxonomy files change or are saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->