### PR TITLE
Stop imports crashing and scans overcounting when an archive share drops

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19892,6 +19892,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # fails mid-scan doesn't inflate the baseline with phantom
             # files the next root would start above.
             scan_acc = {"prior": 0, "last_current": 0, "last_total": 0}
+            # Photos that actually reached the catalog, summed across roots
+            # from each scan()'s counts sink. Kept separate from the
+            # progress accumulator above: progress counts every file the
+            # scan disposes of (including ones skipped because they
+            # vanished under a dropped mount), which is what a progress bar
+            # needs but overstates the result line.
+            indexed_acc = {"n": 0}
 
             def progress_cb(current, total):
                 scan_acc["last_current"] = current
@@ -19987,6 +19994,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "current_file": phase,
                     "rate": 0,
                 })
+                # Counts sink rather than the return value: scan() commits
+                # rows as it goes and can raise (or be cancelled) after
+                # thousands have landed. Reading the sink in `finally`
+                # credits that work on every exit path — a root that dies
+                # late would otherwise report zero photos indexed.
+                root_counts = {}
                 try:
                     do_scan(
                         root, thread_db,
@@ -19998,6 +20011,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
                         cancel_check=cancel_check,
                         repair_missing_metadata=repair_missing_metadata,
+                        counts=root_counts,
                     )
                 except Exception as exc:
                     if isinstance(exc, ScanCancelled) and cancel_check():
@@ -20011,6 +20025,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     if msg not in job["errors"]:
                         job["errors"].append(msg)
                 finally:
+                    # Credit whatever this root indexed regardless of how
+                    # it exited — completed, raised, or cancelled. The
+                    # rows are committed either way, so the summary must
+                    # count them either way.
+                    indexed_acc["n"] += root_counts.get("indexed", 0)
                     # scanner.scan commits photo rows incrementally, so
                     # even a mid-scan failure can leave DB state that
                     # invalidates cached new-image counts. A failure
@@ -20054,7 +20073,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     advance_scan_acc()
 
             if cancelled or cancel_check():
-                photo_count = job["progress"].get("current", 0)
+                # Same indexed count as the completed path, not the
+                # progress counter. Otherwise "N photos" would mean two
+                # different things depending on which branch produced it,
+                # and a cancelled scan of a dropped share would report a
+                # full house of photos it never cataloged.
+                photo_count = indexed_acc["n"]
                 runner.update_step(
                     job["id"], "scan", status="cancelled",
                     summary=f"{photo_count} photos (cancelled)",
@@ -20065,11 +20089,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
                 return {"photos_indexed": photo_count, "cancelled": True}
 
-            # Use cumulative processed count, not planned total — on a
-            # clean run they're equal; on mixed-outcome runs "current"
-            # reflects the actual photos indexed while "total" includes
-            # planned-but-unprocessed files from the failed root(s).
-            photo_count = job["progress"].get("current", 0)
+            # Count what the scans reported as indexed, not the progress
+            # counter. On a clean run they agree; they diverge exactly when
+            # the run went wrong — progress advances for files that were
+            # discovered and then skipped (vanished under a mount that
+            # dropped mid-scan), so "N photos" would read as a success
+            # line for a scan that cataloged nothing.
+            photo_count = indexed_acc["n"]
             # Unique roots that hit any failure class. Counting unique
             # roots (not error entries) avoids inflating the "N of M"
             # summary when a single root raises in both scan and cache

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -903,7 +903,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     run_dest_folders = {}
     run_verified_hashes = {}
 
-    # Mount-root preflight (Task 2.7 late follow-up): when a saved remote
+    # Mount-root check (Task 2.7 late follow-up): when a saved remote
     # target's local mount root is not mounted (for example ``/Volumes/NAS``
     # or ``/mnt/NAS`` is absent because the share isn't attached), a naive
     # ``os.makedirs(dest_folder, exist_ok=True)`` in the batch loop below
@@ -912,13 +912,21 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # subsequent scan reads the fresh local shadow and leaves the import
     # uncataloged/failed; worse, on macOS/Linux that shadow root can also
     # prevent the real share from remounting at the configured path. Fail
-    # every batch's files up front with a clear reason instead. Reuses the
+    # the batch's files with a clear reason instead. Reuses the
     # pipeline path's ``_missing_archive_mount_root`` helper (only fires
     # for the ``/Volumes/X``, ``/mnt/X``, and ``/media/user/X`` shapes that
-    # denote removable/network mount roots), computed once here because
-    # every batch's ``dest_folder`` shares ``destination``'s mount root.
+    # denote removable/network mount roots).
+    #
+    # Re-probed per batch rather than once up front: a card import runs
+    # for hours against a network archive, and the share can drop *during*
+    # the run (a Tailscale/SMB archive unmounted two hours into an import
+    # on 2026-07-30, after which ``os.makedirs`` walked straight into the
+    # vacated mount point). A start-of-job preflight cannot see that. The
+    # probe is a couple of ``os.path.lexists`` calls on the mount root, so
+    # paying it once per destination folder is free next to the copy work.
     # See PR #1113 review.
-    _missing_mount_root = _missing_archive_mount_root(destination)
+    def _missing_mount_root():
+        return _missing_archive_mount_root(destination)
 
     def _record_checker(source_file, dest_folder=None, file_hash=None):
         """Register a landed/adopted file's identity with the intra-run checker.
@@ -989,20 +997,20 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 emitted, discovered,
             )
             continue
-        # Mount-root preflight (see the ``_missing_mount_root`` computation
-        # near the top of this function). Same shape as the dest-under-
-        # source guard: fail every file in the batch with a specific
-        # reason and skip the batch instead of letting ``os.makedirs``
-        # create a local shadow of the unmounted destination. Computed
-        # once outside the loop; the mount-root decision is a property
-        # of ``destination`` and doesn't vary per batch. See PR #1113
-        # review.
-        if _missing_mount_root:
+        # Mount-root check (see the ``_missing_mount_root`` helper near the
+        # top of this function). Same shape as the dest-under-source guard:
+        # fail every file in the batch with a specific reason and skip the
+        # batch instead of letting ``os.makedirs`` create a local shadow of
+        # the unmounted destination. Re-probed here, per batch, so a share
+        # that drops mid-run is caught at the next batch boundary rather
+        # than only at job start. See PR #1113 review.
+        missing_mount_root = _missing_mount_root()
+        if missing_mount_root:
             for source_file in batch:
                 emitted += 1
                 _fail(
                     rel, source_file,
-                    f"archive mount root {_missing_mount_root} is not "
+                    f"archive mount root {missing_mount_root} is not "
                     "available (destination drive is not mounted; refusing "
                     "to create a shadow directory tree under it, which "
                     "would prevent the real share from remounting)",
@@ -1013,7 +1021,24 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 emitted, discovered,
             )
             continue
-        os.makedirs(dest_folder, exist_ok=True)
+        # Mirrors the local path: the mount-root guard above only catches
+        # a mount point that vanished, so a stale-but-present mount, a
+        # read-only parent, or a permission change still reaches this
+        # call. An uncaught OSError here kills the background job; book
+        # it per file and let the run finish with an honest result.
+        try:
+            os.makedirs(dest_folder, exist_ok=True)
+        except OSError as e:
+            for source_file in batch:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"could not create destination folder {dest_folder}: {e}",
+                )
+            _emit(
+                f"{rel}: destination unavailable", emitted, discovered,
+            )
+            continue
 
         # Promote any pre-existing folder row for this destination out of
         # ``'missing'``. Mirrors the local path (see
@@ -2190,6 +2215,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     is committed per batch; cancellation and crashes leave every already-
     verified file cataloged and nothing else.
     """
+    from pipeline_job import _missing_archive_mount_root
     from scanner import scan
 
     db = Database(db_path)
@@ -2531,7 +2557,59 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     "copy",
                 )
             continue
-        os.makedirs(dest_folder, exist_ok=True)
+        # Same guard the remote path applies (see ``_missing_mount_root``
+        # in ``_run_remote_import_job``): if the archive's mount root has
+        # gone (share never attached, or unmounted mid-run), refuse the
+        # batch instead of letting ``os.makedirs`` recreate the vacated
+        # mount point as a plain local directory. That shadow tree would
+        # take the card's bytes onto the internal disk, look like a
+        # successful import, and then hide the moment the real share
+        # remounts over it. Probed per batch so a share that drops during
+        # a multi-hour card import is caught at the next batch boundary —
+        # a Tailscale/SMB archive did exactly that on 2026-07-30, and only
+        # a root-owned ``/Volumes`` turned the shadow write into a crash
+        # instead of silent data misplacement.
+        missing_mount_root = _missing_archive_mount_root(destination)
+        if missing_mount_root:
+            for source_file in batch:
+                # Count these as emitted: ``emitted`` otherwise only
+                # advances inside the per-file loop below, which this
+                # branch skips, and a progress bar frozen at the last
+                # copied file reads as "still working" while the rest of
+                # the card is quietly failing.
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"archive mount root {missing_mount_root} is not "
+                    "available (destination drive is not mounted; refusing "
+                    "to create a shadow directory tree under it, which "
+                    "would prevent the real share from remounting)",
+                )
+            _emit(
+                f"{rel}: archive unavailable", emitted, discovered,
+            )
+            continue
+        # The guard above only recognizes a mount point that *vanished*.
+        # A stale-but-present mount (Linux keeps ``/mnt/<name>`` after an
+        # unmount), a read-only or permission-changed parent, or a full
+        # disk all still surface here — and an uncaught OSError out of
+        # this call tears down the whole background job, which is exactly
+        # how the 2026-07-30 import died after two hours. Whatever the
+        # cause, book it as a per-file failure and keep the card marked
+        # unsafe to format instead of crashing the run.
+        try:
+            os.makedirs(dest_folder, exist_ok=True)
+        except OSError as e:
+            for source_file in batch:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"could not create destination folder {dest_folder}: {e}",
+                )
+            _emit(
+                f"{rel}: destination unavailable", emitted, discovered,
+            )
+            continue
 
         # Promote any pre-existing folder row for this destination out of
         # ``'missing'``. Standalone scans run ``check_folder_health()`` as

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -276,6 +276,12 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
     When both IMG_001.cr3 and IMG_001.jpg exist in the same folder,
     keep the raw as the primary photo and set companion_path to the JPEG filename.
     Delete the duplicate JPEG-only photo record.
+
+    Returns the number of companion rows merged away. Callers that count
+    indexed photos must subtract this: both files were counted on the way
+    in, but only the RAW row survives, so the scan would otherwise claim
+    two photos where the catalog holds one — and RAW+JPEG is the common
+    shooting mode, so that overstates nearly every import.
     """
     raw_exts = {".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"}
     jpeg_exts = {".jpg", ".jpeg"}
@@ -304,6 +310,11 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
     # us "all DB changes durable, then all FS changes" — commit failure
     # aborts both halves.
     post_commit_fs_actions = []
+    # Companion rows merged away, reported to the caller so it can correct
+    # its indexed count. Counted at the DELETE but only returned after the
+    # commit below succeeds — the whole loop shares one transaction, so a
+    # commit failure rolls every deletion back and none of them happened.
+    merged = 0
 
     for (_folder_id, _base), members in groups.items():
         if len(members) < 2:
@@ -664,6 +675,7 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
         # Remove keyword associations then the duplicate JPEG record
         db.conn.execute("DELETE FROM photo_keywords WHERE photo_id = ?", (companion["id"],))
         db.conn.execute("DELETE FROM photos WHERE id = ?", (companion["id"],))
+        merged += 1
         # The companion's rowid is now free for SQLite to hand to the next
         # insert. Its derivatives must be unlinked so the next photo to
         # inherit the id can't adopt the companion's thumbnail / working
@@ -710,6 +722,7 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
     # is durable and doesn't leak into the caller's next write.
     if db.conn.in_transaction:
         commit_with_retry(db.conn)
+    return merged
 
 
 def _invalidate_raw_display_cache(vireo_dir, photo_id):
@@ -1454,6 +1467,7 @@ def backfill_working_copies(db, vireo_dir, progress_callback=None,
 
 _EMPTY_SCAN_COUNTS = {
     "discovered": 0, "indexed": 0, "vanished": 0, "skipped_uncataloged": 0,
+    "merged_companions": 0,
 }
 
 
@@ -1539,8 +1553,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         incremental scan revalidated without changing, so this is "rows
         this run vouched for", not "rows newly created"), ``vanished``
         (discovered but gone by the time we stat'd them, the shape a
-        network share dropping mid-scan takes), and
-        ``skipped_uncataloged`` (update-only scans declining to insert).
+        network share dropping mid-scan takes), ``skipped_uncataloged``
+        (update-only scans declining to insert), and
+        ``merged_companions`` (JPEGs folded into a same-basename RAW's
+        row, which are discounted from ``indexed`` because they stop
+        being photos of their own).
         Build user-facing counts from ``indexed``, never from the progress
         counter — progress advances for skipped files too.
     """
@@ -2556,9 +2573,16 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # counts — otherwise update_folder_counts()'s commit would persist
     # half-applied pairing or working-copy records.
     try:
-        _pair_raw_jpeg_companions(
+        # A JPEG merged into its RAW's row stops being its own photo, so
+        # discount it: both files were counted on the way in but only the
+        # RAW survives. Applied to the sink immediately (not just the
+        # returned dict) so a caller reading counts after a later failure
+        # in this block still sees the corrected number.
+        _merged = _pair_raw_jpeg_companions(
             db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_cache_dir,
         )
+        counts["merged_companions"] += _merged
+        counts["indexed"] -= _merged
 
         # Extract working copies for RAW photos (after pairing so companion is known).
         # Scope to the folders the caller just scanned so a fresh import doesn't
@@ -2615,13 +2639,19 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # and a miscounted summary is no reason to fail the run.
     vanished_count = counts["vanished"]
     skipped_uncataloged_count = counts["skipped_uncataloged"]
+    merged_count = counts["merged_companions"]
     indexed_count = counts["indexed"]
-    if indexed_count + vanished_count + skipped_uncataloged_count != processed_count:
+    accounted = (
+        indexed_count + vanished_count + skipped_uncataloged_count
+        + merged_count
+    )
+    if accounted != processed_count:
         log.error(
             "Scan count invariant broken: indexed=%d + vanished=%d + "
-            "skipped=%d != processed=%d (a file disposition is unclassified)",
+            "skipped=%d + merged=%d != processed=%d (a file disposition is "
+            "unclassified)",
             indexed_count, vanished_count, skipped_uncataloged_count,
-            processed_count,
+            merged_count, processed_count,
         )
 
     # Report what reached the catalog, not what the walk turned up. These
@@ -2630,11 +2660,13 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # precisely when the scan achieved nothing — an archive share that
     # dropped mid-scan logged "984 photos indexed" having indexed zero.
     summary = f"Scan complete: {indexed_count} photos indexed"
+    if merged_count:
+        summary += f", {merged_count} JPEG(s) merged into their RAW"
     if vanished_count:
         summary += f", {vanished_count} vanished"
     if skipped_uncataloged_count:
         summary += f", {skipped_uncataloged_count} uncataloged (skipped)"
-    if vanished_count or skipped_uncataloged_count:
+    if merged_count or vanished_count or skipped_uncataloged_count:
         summary += f" of {total} discovered"
     log.info(summary)
     return counts

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -2335,6 +2335,15 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 width=width,
                 height=height,
             )
+            # Credit the photo the moment its row is durable — add_photo
+            # commits before returning. Several fallible steps run below
+            # (cache invalidation, XMP keyword import, duplicate
+            # auto-resolve, photo_callback), and one of them raising must
+            # not leave the sink reporting fewer photos than the catalog
+            # actually holds. ``processed_count`` stays at the end of the
+            # iteration: it drives the progress bar, which should only
+            # advance once the file is genuinely done with.
+            counts["indexed"] += 1
 
             # A brand-new row may have claimed a *recycled* rowid (see
             # ``purge_cached_files_for_recycled_id``). Cached derivatives
@@ -2512,7 +2521,6 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 photo_callback(photo_id, str(image_path))
 
             processed_count += 1
-            counts["indexed"] += 1
             if progress_callback:
                 progress_callback(processed_count, total)
     except BaseException:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1452,7 +1452,12 @@ def backfill_working_copies(db, vireo_dir, progress_callback=None,
     }
 
 
-def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None, permission_error_callback=None, cancel_check=None, skip_working_copies=False, repair_missing_metadata=False, register_restrict_dirs_as_roots=True, allow_photo_inserts=True):
+_EMPTY_SCAN_COUNTS = {
+    "discovered": 0, "indexed": 0, "vanished": 0, "skipped_uncataloged": 0,
+}
+
+
+def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None, permission_error_callback=None, cancel_check=None, skip_working_copies=False, repair_missing_metadata=False, register_restrict_dirs_as_roots=True, allow_photo_inserts=True, counts=None):
     """Walk a folder tree, discover photos, read metadata, populate database.
 
     Args:
@@ -1521,7 +1526,28 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             Files without an existing ``photos`` row are skipped. This gives
             Process metadata repair a mechanically enforced no-admission
             contract while retaining the shared metadata refresh code.
+        counts: optional dict the scan fills in as it runs, with the same
+            keys it returns. Because scan() commits incrementally and can
+            raise after many photos have landed (cancellation, a post-loop
+            pass, a DB error), the return value alone would force callers
+            to report zero for a run that really did catalog thousands.
+            Pass a dict here to read accurate counts on any exit path.
+
+    Returns:
+        dict with ``discovered`` (files the walk turned up), ``indexed``
+        (files that ended this run with a catalog row — including ones an
+        incremental scan revalidated without changing, so this is "rows
+        this run vouched for", not "rows newly created"), ``vanished``
+        (discovered but gone by the time we stat'd them, the shape a
+        network share dropping mid-scan takes), and
+        ``skipped_uncataloged`` (update-only scans declining to insert).
+        Build user-facing counts from ``indexed``, never from the progress
+        counter — progress advances for skipped files too.
     """
+    # Same object the caller passed (so it can read counts after an
+    # exception) or a fresh one; either way start from a known shape.
+    counts = {} if counts is None else counts
+    counts.update(_EMPTY_SCAN_COUNTS)
     root_path = Path(root)
     # Don't open the root at all if the root is, or sits inside, an
     # other-app data bundle. prune_scan_dirs below only filters
@@ -1534,14 +1560,18 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # follows symlinks and stat's the target, so for a directly selected
     # bundle (or a symlink to one), the existence test alone is enough
     # to trip the TCC prompt — mirroring the restrict_dirs branch below.
+    # Both bail-outs below return the same counts shape as a completed
+    # scan (all zeros) rather than None, so callers can total up
+    # ``indexed`` across roots without special-casing the roots that
+    # never ran. See the summary block at the end of this function.
     if is_excluded_scan_path(root_path):
         log.info(
             "Skipping other-app data bundle as scan root: %s", root_path,
         )
-        return
+        return counts
     if not root_path.is_dir():
         log.warning("Root path does not exist or is not a directory: %s", root)
-        return
+        return counts
 
     def _check_cancelled():
         if cancel_check is not None and cancel_check():
@@ -1749,6 +1779,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     _check_cancelled()
 
     total = len(image_files)
+    counts["discovered"] = total
     log.info("Found %d images in %s", total, root)
     if progress_callback:
         progress_callback(0, total)
@@ -1952,6 +1983,17 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # Handle XMP-only changes inline; collect files needing metadata extraction.
     files_to_process = []
     processed_count = 0
+    # ``processed_count`` advances for every file the scan *disposes of*,
+    # including ones it deliberately skips — that is what a progress bar
+    # needs to reach 100%. It is NOT the number of photos indexed, and the
+    # two diverge exactly when something is wrong (a share that unmounts
+    # mid-scan makes every remaining file vanish). Every ``processed_count``
+    # bump below is therefore paired with a bump of exactly one bucket in
+    # ``counts``, so the summary reports what actually landed in the
+    # catalog. Classifying at each site (rather than deriving one bucket by
+    # subtraction) means a disposition added later has to state which
+    # bucket it belongs to instead of silently defaulting to "indexed" —
+    # the invariant check after the loop enforces it.
     try:
         # Eagerly register the explicit scan targets so they end up linked
         # to the active workspace even when zero photos are inserted (e.g.
@@ -1983,6 +2025,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 # walk has the same guard for broken symlinks).
                 log.info("File vanished during scan, skipping: %s", image_path)
                 processed_count += 1
+                counts["vanished"] += 1
                 if progress_callback:
                     progress_callback(processed_count, total)
                 continue
@@ -2034,6 +2077,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                         and not empty_hash_needs_repair
                     ):
                         processed_count += 1
+                        counts["indexed"] += 1
                         if photo_callback:
                             photo_callback(existing["id"], full_path_str)
                         if progress_callback:
@@ -2065,6 +2109,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                         and not empty_hash_needs_repair
                     ):
                         processed_count += 1
+                        counts["indexed"] += 1
                         if photo_callback:
                             photo_callback(existing["id"], full_path_str)
                         if progress_callback:
@@ -2181,6 +2226,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             except OSError:
                 log.info("File vanished during scan, skipping: %s", image_path)
                 processed_count += 1
+                counts["vanished"] += 1
                 if progress_callback:
                     progress_callback(processed_count, total)
                 continue
@@ -2273,6 +2319,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     "Update-only scan skipped uncataloged file: %s", image_path,
                 )
                 processed_count += 1
+                counts["skipped_uncataloged"] += 1
                 if progress_callback:
                     progress_callback(processed_count, total)
                 continue
@@ -2465,6 +2512,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 photo_callback(photo_id, str(image_path))
 
             processed_count += 1
+            counts["indexed"] += 1
             if progress_callback:
                 progress_callback(processed_count, total)
     except BaseException:
@@ -2551,4 +2599,34 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         raise
     finally:
         db.update_folder_counts()
-    log.info("Scan complete: %d photos indexed", total)
+
+    # Every file the loop disposed of landed in exactly one bucket. If this
+    # ever trips, a new disposition was added without classifying it, and
+    # the summary below would silently over-claim by that many photos —
+    # log it rather than raising, since the scan's real work is committed
+    # and a miscounted summary is no reason to fail the run.
+    vanished_count = counts["vanished"]
+    skipped_uncataloged_count = counts["skipped_uncataloged"]
+    indexed_count = counts["indexed"]
+    if indexed_count + vanished_count + skipped_uncataloged_count != processed_count:
+        log.error(
+            "Scan count invariant broken: indexed=%d + vanished=%d + "
+            "skipped=%d != processed=%d (a file disposition is unclassified)",
+            indexed_count, vanished_count, skipped_uncataloged_count,
+            processed_count,
+        )
+
+    # Report what reached the catalog, not what the walk turned up. These
+    # used to be the same number ("Scan complete: %d photos indexed" logged
+    # ``total``), which reads as a success line and stays reassuring
+    # precisely when the scan achieved nothing — an archive share that
+    # dropped mid-scan logged "984 photos indexed" having indexed zero.
+    summary = f"Scan complete: {indexed_count} photos indexed"
+    if vanished_count:
+        summary += f", {vanished_count} vanished"
+    if skipped_uncataloged_count:
+        summary += f", {skipped_uncataloged_count} uncataloged (skipped)"
+    if vanished_count or skipped_uncataloged_count:
+        summary += f" of {total} discovered"
+    log.info(summary)
+    return counts

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -277,11 +277,18 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
     keep the raw as the primary photo and set companion_path to the JPEG filename.
     Delete the duplicate JPEG-only photo record.
 
-    Returns the number of companion rows merged away. Callers that count
-    indexed photos must subtract this: both files were counted on the way
+    Returns the set of companion photo ids merged away. Callers that count
+    indexed photos must discount these: both files were counted on the way
     in, but only the RAW row survives, so the scan would otherwise claim
     two photos where the catalog holds one — and RAW+JPEG is the common
     shooting mode, so that overstates nearly every import.
+
+    Ids, not a bare count, because this query covers the *whole* photos
+    table: it also merges pairs left pending anywhere else in the catalog
+    (an interrupted earlier scan, an older build). A caller must intersect
+    with the ids it actually counted, or a scoped scan would be debited
+    for merges it had nothing to do with and could report a negative
+    total.
     """
     raw_exts = {".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"}
     jpeg_exts = {".jpg", ".jpeg"}
@@ -311,10 +318,11 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
     # aborts both halves.
     post_commit_fs_actions = []
     # Companion rows merged away, reported to the caller so it can correct
-    # its indexed count. Counted at the DELETE but only returned after the
-    # commit below succeeds — the whole loop shares one transaction, so a
-    # commit failure rolls every deletion back and none of them happened.
-    merged = 0
+    # its indexed count. Collected at the DELETE but only returned after
+    # the commit below succeeds — the whole loop shares one transaction,
+    # so a commit failure rolls every deletion back and none of them
+    # happened.
+    merged_ids = set()
 
     for (_folder_id, _base), members in groups.items():
         if len(members) < 2:
@@ -675,7 +683,7 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
         # Remove keyword associations then the duplicate JPEG record
         db.conn.execute("DELETE FROM photo_keywords WHERE photo_id = ?", (companion["id"],))
         db.conn.execute("DELETE FROM photos WHERE id = ?", (companion["id"],))
-        merged += 1
+        merged_ids.add(companion["id"])
         # The companion's rowid is now free for SQLite to hand to the next
         # insert. Its derivatives must be unlinked so the next photo to
         # inherit the id can't adopt the companion's thumbnail / working
@@ -722,7 +730,7 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
     # is durable and doesn't leak into the caller's next write.
     if db.conn.in_transaction:
         commit_with_retry(db.conn)
-    return merged
+    return merged_ids
 
 
 def _invalidate_raw_display_cache(vireo_dir, photo_id):
@@ -2011,6 +2019,12 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # subtraction) means a disposition added later has to state which
     # bucket it belongs to instead of silently defaulting to "indexed" —
     # the invariant check after the loop enforces it.
+    #
+    # The ids behind ``counts["indexed"]``. Needed because the companion
+    # pairing pass below runs against the entire photos table, so its
+    # merges must be intersected with what *this* invocation counted (see
+    # ``_pair_raw_jpeg_companions``).
+    indexed_photo_ids = set()
     try:
         # Eagerly register the explicit scan targets so they end up linked
         # to the active workspace even when zero photos are inserted (e.g.
@@ -2095,6 +2109,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     ):
                         processed_count += 1
                         counts["indexed"] += 1
+                        indexed_photo_ids.add(existing["id"])
                         if photo_callback:
                             photo_callback(existing["id"], full_path_str)
                         if progress_callback:
@@ -2127,6 +2142,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     ):
                         processed_count += 1
                         counts["indexed"] += 1
+                        indexed_photo_ids.add(existing["id"])
                         if photo_callback:
                             photo_callback(existing["id"], full_path_str)
                         if progress_callback:
@@ -2361,6 +2377,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             # iteration: it drives the progress bar, which should only
             # advance once the file is genuinely done with.
             counts["indexed"] += 1
+            indexed_photo_ids.add(photo_id)
 
             # A brand-new row may have claimed a *recycled* rowid (see
             # ``purge_cached_files_for_recycled_id``). Cached derivatives
@@ -2578,11 +2595,18 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         # RAW survives. Applied to the sink immediately (not just the
         # returned dict) so a caller reading counts after a later failure
         # in this block still sees the corrected number.
-        _merged = _pair_raw_jpeg_companions(
+        _merged_ids = _pair_raw_jpeg_companions(
             db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_cache_dir,
         )
-        counts["merged_companions"] += _merged
-        counts["indexed"] -= _merged
+        # Discount only companions THIS scan counted. The pairing pass
+        # queries the whole photos table, so it also cleans up pairs left
+        # pending elsewhere in the catalog (an interrupted earlier scan,
+        # an older build). Debiting a scoped scan for those would make it
+        # undercount, and scanning a root with no new files while one
+        # stale pair was pending would report -1 photos indexed.
+        _mine = _merged_ids & indexed_photo_ids
+        counts["merged_companions"] += len(_mine)
+        counts["indexed"] -= len(_mine)
 
         # Extract working copies for RAW photos (after pairing so companion is known).
         # Scope to the folders the caller just scanned so a fresh import doesn't

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -6464,3 +6464,220 @@ def test_remote_import_cancel_mid_batch_does_not_start_rsync(
         f"no card files should have landed on the mount after "
         f"cancellation, but found: {landed}"
     )
+
+
+def test_local_import_refuses_when_mount_root_absent(tmp_path, monkeypatch):
+    """The LOCAL copy path needs the same mount-root guard as the remote one.
+
+    ``_run_remote_import_job`` refuses to ``os.makedirs`` into an absent
+    mount root (PR #1113), but ``run_import_job``'s own batch loop had no
+    such check — it called ``os.makedirs(dest_folder)`` unconditionally.
+    On a platform where the mount point survives unmount (Linux
+    ``/mnt/<name>``) that silently builds a shadow tree on the internal
+    disk and copies the card into it, where the photos look imported but
+    vanish the moment the real share remounts.
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+    dest = str(tmp_path / "Volumes_NAS_Photos")
+
+    # The real helper only fires for /Volumes/* | /mnt/* | /media/*/*
+    # shapes, so stub it to call our tmp destination's root missing —
+    # same approach as test_remote_import_refuses_when_mount_root_absent.
+    monkeypatch.setattr(
+        _pj, "_missing_archive_mount_root", lambda path: "/Volumes/NAS",
+    )
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=dest,
+    ))
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 2, result
+    assert result["safe_to_format"] is False, result
+    assert result["unsafe_files"], result
+    assert all(
+        "/Volumes/NAS" in u["reason"] and "not available" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+    assert not os.path.exists(dest), (
+        f"shadow directory was created at {dest}: the guard failed to "
+        "stop os.makedirs"
+    )
+
+
+def test_local_import_stops_when_mount_disappears_mid_run(
+        tmp_path, monkeypatch):
+    """A mount that drops *during* a long import must stop the next batch.
+
+    The guard was a start-of-job preflight computed once outside the
+    batch loop, so an archive that unmounted two hours into a run (the
+    2026-07-30 SMB outage) sailed straight into ``os.makedirs``. Re-check
+    per batch so the outage is caught when it happens.
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    # Two dates -> two batches, so the mount can drop between them.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+    dest = str(tmp_path / "archive")
+    os.makedirs(dest, exist_ok=True)
+
+    calls = {"n": 0}
+
+    def flaky_mount(path):
+        calls["n"] += 1
+        # Mounted for the first batch, gone for every batch after it.
+        return None if calls["n"] == 1 else "/Volumes/NAS"
+
+    monkeypatch.setattr(_pj, "_missing_archive_mount_root", flaky_mount)
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=dest,
+    ))
+
+    assert calls["n"] >= 2, (
+        "the mount root was checked once for the whole job, so a mid-run "
+        "unmount can never be detected; it must be re-checked per batch"
+    )
+    assert result["copied"] == 1, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "/Volumes/NAS" in u["reason"] and "not available" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+
+def test_remote_import_stops_when_mount_disappears_mid_run(
+        tmp_path, monkeypatch):
+    """Same mid-run re-check for the remote path, whose guard was also
+    computed once outside the batch loop."""
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+
+    probes = {"n": 0}
+
+    def flaky_mount(path):
+        probes["n"] += 1
+        return None if probes["n"] == 1 else "/Volumes/NAS"
+
+    monkeypatch.setattr(_pj, "_missing_archive_mount_root", flaky_mount)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra,
+        ),
+    )
+
+    assert probes["n"] >= 2, (
+        "remote mount root was checked once for the whole job; a mid-run "
+        "unmount can never be detected"
+    )
+    assert result["copied"] == 1, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+
+
+def test_local_import_mount_loss_still_advances_progress(tmp_path, monkeypatch):
+    """A batch rejected by the mount guard must still count its files as
+    emitted.
+
+    ``emitted`` only advances inside the per-file copy loop, which the
+    guard skips. Without bumping it there, an import whose share drops
+    after the first batch leaves the progress bar frozen at the last
+    copied file while the job silently fails hundreds more — a stalled
+    bar reads as "still working", which is the opposite of what happened.
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+        ("DSC_0003.jpg", datetime(2026, 7, 5, 9, 0, 0), "green"),
+    ])
+    dest = str(tmp_path / "archive")
+    os.makedirs(dest, exist_ok=True)
+
+    calls = {"n": 0}
+
+    def flaky_mount(path):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else "/Volumes/NAS"
+
+    monkeypatch.setattr(_pj, "_missing_archive_mount_root", flaky_mount)
+
+    runner = FakeRunner()
+    db, ws_id, result = _run_import(
+        tmp_path,
+        ImportParams(sources=[str(card)], destination=dest),
+        runner=runner,
+    )
+
+    assert result["discovered"] == 3, result
+    progress = [
+        data for _jid, etype, data in runner.events if etype == "progress"
+    ]
+    assert progress, "no progress events emitted"
+    assert progress[-1]["current"] == 3, (
+        f"progress stalled at {progress[-1]['current']} of 3 after the "
+        "mount dropped; every discovered file must be accounted for"
+    )
+
+
+def test_local_import_survives_makedirs_failure(tmp_path):
+    """``os.makedirs`` on the destination must never kill the job.
+
+    The mount-root guard only recognizes a vacated mount point. It can't
+    see a stale-but-present mount (Linux ``/mnt/<name>``), a read-only
+    parent, or a permission change — and the 2026-07-30 incident was
+    precisely an uncaught ``PermissionError`` out of this call, which
+    tore down the whole background job after two hours of work. Whatever
+    the cause, it belongs in the per-file failure bucket with the card
+    still marked unsafe to format.
+    """
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    dest = str(tmp_path / "archive")
+    # A regular FILE where the batch's destination folder must go, so the
+    # real os.makedirs raises FileExistsError on every platform.
+    os.makedirs(os.path.join(dest, "2026"), exist_ok=True)
+    with open(os.path.join(dest, "2026", "2026-07-03"), "w") as fh:
+        fh.write("not a directory")
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=dest,
+    ))
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "2026-07-03" in u["reason"] for u in result["unsafe_files"]
+    ), result["unsafe_files"]

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -335,21 +335,18 @@ def test_failed_root_does_not_inflate_cumulative_progress(app_and_db, tmp_path, 
     data = _wait_for_terminal(client, job_id)
 
     assert data["status"] == "failed"
-    # The scan summary should reflect photos ACTUALLY indexed, not the
-    # inflated planned total. Good root contributes 2, bad root
-    # contributes its processed count (3), so the summary should cite
-    # a number consistent with that — and critically, must NOT include
-    # the 7 phantom planned-but-unprocessed files from the bad root.
+    # The scan summary reflects photos ACTUALLY indexed. The good root
+    # indexes 2. The bad root reports progress for 3 files but never
+    # reaches the real scanner, so it indexes nothing and contributes 0 —
+    # reported progress is not evidence a photo was cataloged. Either way
+    # the 7 planned-but-unprocessed files must never appear.
     scan_step = next(s for s in data["steps"] if s["id"] == "scan")
     summary = scan_step.get("summary", "")
     # Extract the leading "<N> photos" number.
     leading_n = int(summary.split()[0])
-    # Planned total across both roots was 10 + 2 = 12. With the bug,
-    # photo_count would be 12 (inflated). With the fix it's <= 5 (3
-    # processed from bad + 2 from good).
-    assert leading_n < 12, (
-        f"photo_count inflated by phantom planned-but-unprocessed files: "
-        f"summary={summary!r}"
+    assert leading_n == 2, (
+        f"summary should credit only the 2 photos the good root actually "
+        f"indexed: summary={summary!r}"
     )
 
 
@@ -595,3 +592,103 @@ def test_cache_invalidation_failure_flips_job_to_failed(app_and_db, tmp_path, mo
         "cache invalidation" in e and "exploded" in e
         for e in data["errors"]
     ), data["errors"]
+
+
+def test_scan_summary_excludes_files_that_vanished_mid_scan(
+        app_and_db, tmp_path, monkeypatch):
+    """The "N photos" scan summary must count photos indexed, not files
+    walked.
+
+    ``job["progress"]["current"]`` is a progress counter: it advances for
+    every file the scan disposes of, including ones it skipped because
+    they vanished. Using it as the summary meant an archive share that
+    unmounted mid-scan reported a full "984 photos" success line having
+    indexed nothing (2026-07-30). The summary must answer "how many
+    photos are in the catalog because of this run".
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    root = str(tmp_path / "archive")
+    for i in range(4):
+        _make_photo(root, f"p_{i}.jpg")
+
+    import scanner as real_scanner
+    real_scan = real_scanner.scan
+
+    def vanishing_scan(scan_root, sdb, *args, progress_callback=None, **kwargs):
+        # Wrap the app's progress callback so two files disappear at the
+        # discovery/processing seam — the real scanner then hits real
+        # stat() failures, exactly as it did when the SMB mount dropped.
+        def wrapped(current, total):
+            if current == 0:
+                os.remove(os.path.join(scan_root, "p_2.jpg"))
+                os.remove(os.path.join(scan_root, "p_3.jpg"))
+            if progress_callback is not None:
+                progress_callback(current, total)
+
+        return real_scan(
+            scan_root, sdb, *args, progress_callback=wrapped, **kwargs
+        )
+
+    monkeypatch.setattr("scanner.scan", vanishing_scan)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [root]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+    summary = scan_step.get("summary", "")
+    leading_n = int(summary.split()[0])
+    assert leading_n == 2, (
+        f"summary counts vanished files as indexed: {summary!r} (only 2 of "
+        "4 files survived to be cataloged)"
+    )
+
+    # And the claim is checkable against the catalog it describes. Scope
+    # to this root — the app_and_db fixture's catalog outlives one test.
+    indexed = db.conn.execute(
+        "SELECT COUNT(*) FROM photos p JOIN folders f ON f.id = p.folder_id "
+        "WHERE f.path = ?",
+        (root,),
+    ).fetchone()[0]
+    assert indexed == 2, indexed
+
+
+def test_scan_summary_credits_photos_indexed_before_a_root_raised(
+        app_and_db, tmp_path, monkeypatch):
+    """A root that raises after indexing must still be credited.
+
+    scan() commits rows incrementally and can raise after the per-file
+    loop finished (the pairing / working-copy / preview passes all run
+    inside its try block). Reporting 0 photos for a run that cataloged
+    everything is the same kind of false status as reporting 984 for a
+    run that cataloged nothing — just in the other direction.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    root = str(tmp_path / "late_failure")
+    for i in range(3):
+        _make_photo(root, f"q_{i}.jpg")
+
+    import scanner as real_scanner
+    real_scan = real_scanner.scan
+
+    def scan_then_raise(scan_root, sdb, *args, **kwargs):
+        real_scan(scan_root, sdb, *args, **kwargs)
+        raise RuntimeError("post-loop pass blew up after indexing")
+
+    monkeypatch.setattr("scanner.scan", scan_then_raise)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [root]})
+    job_id = resp.get_json()["job_id"]
+    data = _wait_for_terminal(client, job_id)
+
+    assert data["status"] == "failed", data
+    scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+    summary = scan_step.get("summary", "")
+    assert int(summary.split()[0]) == 3, (
+        f"photos indexed before the failure were dropped from the "
+        f"summary: {summary!r}"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -5649,3 +5649,40 @@ def test_scan_counts_sink_matches_the_returned_counts(tmp_path):
 
     assert result == counts, (result, counts)
     assert counts["indexed"] == 2, counts
+
+
+def test_scan_counts_photos_committed_before_a_post_insert_hook_raised(
+        tmp_path):
+    """The indexed count must match the catalog, not lag behind it.
+
+    ``db.add_photo()`` commits the row, but several fallible steps run
+    after it — cache invalidation, XMP keyword import, duplicate
+    auto-resolve, ``photo_callback``. A malformed sidecar or a failing
+    callback raising in that window leaves the photo durably in the
+    catalog while the counts sink is short, so the failure summary
+    under-reports rows that really did land.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg', 'b.jpg', 'c.jpg', 'd.jpg']})
+
+    seen = {"n": 0}
+
+    def exploding_callback(photo_id, path_str):
+        seen["n"] += 1
+        if seen["n"] == 3:
+            raise RuntimeError("post-insert hook failed")
+
+    counts = {}
+    db = Database(str(tmp_path / "test.db"))
+    with pytest.raises(RuntimeError):
+        scan(root, db, counts=counts, photo_callback=exploding_callback)
+
+    committed = db.conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+    assert committed == 3, committed
+    assert counts["indexed"] == committed, (
+        f"sink says {counts['indexed']} indexed but {committed} rows are "
+        "committed in the catalog"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -5745,3 +5745,71 @@ def test_scan_indexed_count_keeps_unpaired_jpegs(tmp_path):
         f"claimed {result['indexed']} photos indexed but the catalog holds "
         f"{rows}"
     )
+
+
+def _leave_unpaired_pair(db, monkeypatch, folder, basename="OLD_001"):
+    """Catalog a RAW+JPEG pair without merging it.
+
+    Simulates a pair left unmerged by an interrupted scan or an older
+    build — the state ``_pair_raw_jpeg_companions`` exists to clean up on
+    a later run, whether or not that run scanned this folder.
+    """
+    import scanner as _sc
+    from scanner import scan
+
+    folder.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (32, 32), color="red").save(
+        str(folder / f"{basename}.jpg"))
+    with open(str(folder / f"{basename}.cr3"), "wb") as f:
+        f.write(b"\x00" * 200)
+
+    monkeypatch.setattr(
+        _sc, "_pair_raw_jpeg_companions", lambda *a, **k: set())
+    scan(str(folder), db)
+    monkeypatch.undo()
+
+
+def test_scan_does_not_discount_pairs_outside_its_own_scope(
+        tmp_path, monkeypatch):
+    """Only companions this scan counted may be discounted.
+
+    ``_pair_raw_jpeg_companions`` queries the whole photos table, so it
+    merges pending pairs anywhere in the catalog — including folders this
+    invocation never looked at. Subtracting that global total makes a
+    scoped scan undercount photos it really did index.
+    """
+    from db import Database
+    from scanner import scan
+
+    db = Database(str(tmp_path / "test.db"))
+    _leave_unpaired_pair(db, monkeypatch, tmp_path / "elsewhere")
+
+    # A different folder, two fresh JPEGs, no pairs of its own.
+    target = tmp_path / "target"
+    target.mkdir()
+    for name in ("NEW_001.jpg", "NEW_002.jpg"):
+        Image.new("RGB", (32, 32), color="blue").save(str(target / name))
+
+    result = scan(str(target), db)
+
+    assert result["discovered"] == 2, result
+    assert result["indexed"] == 2, (
+        f"scan indexed 2 new photos but reported {result['indexed']} after "
+        "an unrelated pair elsewhere in the catalog was merged"
+    )
+
+
+def test_scan_indexed_count_never_goes_negative(tmp_path, monkeypatch):
+    """Codex's example: an empty root plus one pending pair returned -1."""
+    from db import Database
+    from scanner import scan
+
+    db = Database(str(tmp_path / "test.db"))
+    _leave_unpaired_pair(db, monkeypatch, tmp_path / "elsewhere")
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    result = scan(str(empty), db)
+
+    assert result["indexed"] == 0, result

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -5686,3 +5686,62 @@ def test_scan_counts_photos_committed_before_a_post_insert_hook_raised(
         f"sink says {counts['indexed']} indexed but {committed} rows are "
         "committed in the catalog"
     )
+
+
+def test_scan_indexed_count_excludes_jpegs_merged_into_raw_companions(tmp_path):
+    """A JPEG merged into its RAW's row is not a separate indexed photo.
+
+    ``_pair_raw_jpeg_companions`` runs after the per-file loop and deletes
+    the JPEG's photo row, keeping it as the RAW's companion. Both files
+    incremented the counter on the way through, so without an adjustment
+    the scan claims two photos where the catalog holds one. Shooting
+    RAW+JPEG is the common case, so this would overstate nearly every
+    import.
+    """
+    from db import Database
+    from scanner import scan
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+    Image.new("RGB", (200, 100), color="green").save(
+        str(img_dir / "IMG_001.jpg"))
+    with open(str(img_dir / "IMG_001.cr3"), "wb") as f:
+        f.write(b"\x00" * 200)
+
+    db = Database(str(tmp_path / "test.db"))
+    result = scan(str(img_dir), db)
+
+    rows = db.conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+    assert rows == 1, rows
+    assert result["discovered"] == 2, result
+    assert result["indexed"] == rows, (
+        f"claimed {result['indexed']} photos indexed but the catalog holds "
+        f"{rows}"
+    )
+
+
+def test_scan_indexed_count_keeps_unpaired_jpegs(tmp_path):
+    """Only the merged companion is discounted, not every JPEG."""
+    from db import Database
+    from scanner import scan
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+    Image.new("RGB", (200, 100), color="green").save(
+        str(img_dir / "IMG_001.jpg"))
+    with open(str(img_dir / "IMG_001.cr3"), "wb") as f:
+        f.write(b"\x00" * 200)
+    # A JPEG with no RAW of the same basename stays its own photo.
+    Image.new("RGB", (200, 100), color="blue").save(
+        str(img_dir / "IMG_002.jpg"))
+
+    db = Database(str(tmp_path / "test.db"))
+    result = scan(str(img_dir), db)
+
+    rows = db.conn.execute("SELECT COUNT(*) FROM photos").fetchone()[0]
+    assert rows == 2, rows
+    assert result["discovered"] == 3, result
+    assert result["indexed"] == rows, (
+        f"claimed {result['indexed']} photos indexed but the catalog holds "
+        f"{rows}"
+    )

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -5536,3 +5536,116 @@ def test_recycled_id_purge_backdates_below_a_negative_source_mtime(tmp_path):
         "source file_mtime of 0.0, so the freshness guard would still "
         "serve the previous owner's pixels"
     )
+
+
+def test_scan_reports_photos_actually_indexed_not_files_discovered(
+        tmp_path, caplog):
+    """The scan summary must count photos indexed, not files discovered.
+
+    When a network archive unmounts mid-scan, every discovered file
+    vanishes before its ``stat()`` and is skipped. The summary used to
+    log the *discovered* total, so a scan that indexed nothing still
+    reported "984 photos indexed" (see the 2026-07-30 SMB outage) — the
+    cheap-proxy count CORE_PHILOSOPHY.md rules out. Report the real
+    indexed count and surface the skipped remainder.
+    """
+    import logging
+
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg', 'b.jpg', 'c.jpg', 'd.jpg']})
+
+    # scan() calls progress_callback(0, total) at the exact seam between
+    # discovery and the processing loop — the same window the unmount hit
+    # in production. Deleting here makes the files genuinely vanish
+    # rather than mocking the stat() failure.
+    def vanish_after_discovery(current, total):
+        if current == 0:
+            os.remove(os.path.join(root, 'c.jpg'))
+            os.remove(os.path.join(root, 'd.jpg'))
+
+    db = Database(str(tmp_path / "test.db"))
+    with caplog.at_level(logging.INFO, logger='scanner'):
+        caplog.clear()
+        result = scan(root, db, progress_callback=vanish_after_discovery)
+
+    assert result["discovered"] == 4, result
+    assert result["indexed"] == 2, result
+    assert result["vanished"] == 2, result
+
+    msgs = [r.message for r in caplog.records]
+    assert any("2 photos indexed" in m for m in msgs), msgs
+    assert any("2 vanished" in m for m in msgs), msgs
+    assert not any("4 photos indexed" in m for m in msgs), msgs
+
+
+def test_scan_reports_indexed_count_on_a_clean_run(tmp_path):
+    """With nothing vanishing, indexed == discovered and vanished == 0."""
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg', 'b.jpg']})
+
+    db = Database(str(tmp_path / "test.db"))
+    result = scan(root, db)
+
+    assert result["discovered"] == 2, result
+    assert result["indexed"] == 2, result
+    assert result["vanished"] == 0, result
+
+
+def test_scan_counts_are_readable_even_when_the_scan_raises(tmp_path):
+    """Counts must be reachable on the failure path, not just the return.
+
+    scan() commits photo rows incrementally and can raise *after* many of
+    them landed (cancellation, a post-loop pairing pass, a DB error). If
+    the only way to learn the indexed count is the return value, every
+    caller has to report 0 for a run that actually cataloged thousands —
+    the same class of wrong number as over-reporting. Callers pass a
+    ``counts`` dict that scan() fills as it goes.
+    """
+    from db import Database
+    from scanner import ScanCancelled, scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': [f"p{i}.jpg" for i in range(6)]})
+
+    # Trip cancellation once two photos have actually been committed.
+    state = {"committed": 0}
+
+    def photo_cb(photo_id, path_str):
+        state["committed"] += 1
+
+    counts = {}
+    db = Database(str(tmp_path / "test.db"))
+    with pytest.raises(ScanCancelled):
+        scan(
+            root, db,
+            counts=counts,
+            photo_callback=photo_cb,
+            cancel_check=lambda: state["committed"] >= 2,
+        )
+
+    assert counts["discovered"] == 6, counts
+    assert counts["indexed"] == state["committed"], counts
+    assert counts["indexed"] >= 2, counts
+    assert counts["indexed"] < 6, counts
+
+
+def test_scan_counts_sink_matches_the_returned_counts(tmp_path):
+    """On a clean run the caller-supplied sink and the return value agree."""
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['a.jpg', 'b.jpg']})
+
+    counts = {}
+    db = Database(str(tmp_path / "test.db"))
+    result = scan(root, db, counts=counts)
+
+    assert result == counts, (result, counts)
+    assert counts["indexed"] == 2, counts


### PR DESCRIPTION
## What happened

Investigating a card import that failed on 2026-07-30 after 2h16m. The SMB-over-Tailscale archive at `/Volumes/Photography` unmounted mid-run — all 984 destination files logged `File vanished during scan` inside a 5-second window, then `os.makedirs` walked into the vacated mount point:

```
PermissionError: [Errno 13] Permission denied: '/Volumes/Photography'
Job import-...-26 finished type=import status=failed duration=8196.6s
  phase=2026/2026-07-26: 0 copied · 200 already present
```

Three separate defects fell out of that.

## 1. Import: destination mount unguarded on the local path, preflight-only on the remote

`_run_remote_import_job` already had a `_missing_archive_mount_root` guard for exactly this case (PR #1113). But:

- **`run_import_job` — the local copy path this job used — had no guard at all.** It called `os.makedirs(dest_folder, exist_ok=True)` unconditionally.
- **The remote guard was computed once, before the batch loop** (`_missing_mount_root = _missing_archive_mount_root(destination)`), so it could only ever catch "share not mounted at job start". The outage here happened two hours in.

Both loops now re-probe per batch. The probe is 1–2 `os.path.lexists` calls, free next to hashing RAWs.

We got a clean crash here only because `/Volumes` is root-owned. Per `_missing_archive_mount_root`'s own docstring a Linux `/mnt/<name>` mount point *persists* after unmount — there the `makedirs` succeeds, builds a shadow tree on the internal disk, and the import looks successful until the real share remounts over it.

**Which is why the guard isn't the whole fix.** It only recognizes a mount point that *vanished*; a stale-but-present mount, a read-only parent, or a permission change all still reach `os.makedirs`. That call is now wrapped in both loops, converting any `OSError` into per-file failures with `safe_to_format` false rather than killing the background job. That closes the original crash regardless of which shape the platform presents.

Batches rejected by either guard now advance `emitted` and re-emit progress. Previously `emitted` only moved inside the per-file copy loop, so an import whose share dropped after batch 1 left the progress bar frozen at the last copied file while hundreds more files silently failed — a stalled bar reads as "still working".

## 2. Scanner: "photos indexed" was the discovered count

```python
log.info("Scan complete: %d photos indexed", total)   # total == files discovered
```

Reproduced in a test — 2 of 4 files vanish, and the log says:

```
File vanished during scan, skipping: .../c.jpg
File vanished during scan, skipping: .../d.jpg
Scan complete: 4 photos indexed
```

`scan()` now classifies every file disposition (`indexed` / `vanished` / `skipped_uncataloged`) at the site that handles it, logs the real number with the skipped remainder, and returns the counts. Classifying at each site rather than deriving one bucket by subtraction means a disposition added later has to declare its bucket instead of silently defaulting into "indexed"; an invariant check after the loop logs an error if one doesn't.

## 3. App: the user-facing "N photos" summary had the same bug

The scan job's summary used `job["progress"]["current"]` — a progress counter that advances for skipped files too. Correct for a progress bar, wrong for a result line, so a scan of a dropped share reported a full success count having cataloged nothing. This is the `CORE_PHILOSOPHY.md` "no black boxes" rule: the count must answer *"how many photos are in the catalog because of this run"*, not a cheaper proxy.

It now sums what the scans reported as indexed. Since `scan()` commits incrementally and can raise or be cancelled *after* thousands of rows have landed, it takes a caller-owned `counts` dict it fills as it goes, read in `finally` — so a root that dies late is credited for real work instead of reporting 0, which would be the same class of false status in the other direction. The cancelled branch uses the same number, so `"N photos"` means one thing on every path.

## Testing

12 new tests, each watched failing first:

- local import refuses an absent mount root / stops when it disappears mid-run
- remote import stops when it disappears mid-run
- progress still advances when a batch is rejected
- import survives an `os.makedirs` failure instead of crashing
- scanner reports indexed (not discovered) with and without vanished files
- scanner counts readable via the sink even when the scan raises
- app summary excludes vanished files, and credits a root that raised after indexing

The scanner tests delete real files at the discovery/processing seam (`progress_callback(0, total)`) rather than mocking `stat()`, so they exercise the code path the outage actually took.

Verified end-to-end against a real absent `/Volumes` share with `_missing_archive_mount_root` unmocked:

```
returned normally, no exception raised
  discovered = 2   copied = 0   failed = 2   safe_to_format = False
  reason: archive mount root /Volumes/PhotographyArchiveOffline is not available ...
  shadow /Volumes/PhotographyArchiveOffline created? False
```

Full run: **2712 passed**, 1 pre-existing unrelated failure (`test_api_exiftool_status_reports_missing`, fails identically on a clean tree).

## Not covered

On Linux, a mount point that persists after unmount still isn't *detected* as offline — the `makedirs` wrapper turns that into a controlled failure rather than a crash, but the batch isn't refused up front with a mount-specific reason. `pipeline_job._mount_root_offline` already handles the present-but-dead case and would be the way to close it properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)