### PR TITLE
Refuse imports when the archive mount point persists after unmount

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -717,7 +717,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     """
     from pipeline_job import (
         _archive_mount_baseline,
+        _load_known_mount_roots,
         _missing_archive_mount_root,
+        _record_known_mount_roots,
         _unmounted_since_baseline,
     )
     from scanner import scan
@@ -738,7 +740,16 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # pre-copy phases would otherwise be baked in as "never mounted" and
     # disarm the guard. See ``_archive_mount_baseline`` and PR #1396
     # review (Codex P1 r3687336684).
-    mount_baseline = _archive_mount_baseline(destination)
+    #
+    # Cross-run mount history: seed the baseline True for mount roots we
+    # previously observed live, then persist any candidate we see live
+    # this run. Without this, an SMB share that detached BEFORE the run
+    # started never earns a True → False transition; rsync would still
+    # push to the NAS while the per-batch mount-side scan reads a fresh
+    # local shadow. See PR #1396 review (Codex P1 r3687401636).
+    known_mount_roots = _load_known_mount_roots(db)
+    mount_baseline = _archive_mount_baseline(destination, known_mount_roots)
+    _record_known_mount_roots(db, mount_baseline)
 
     # Reject cataloged twins that live under the card being imported: a stale
     # scan of the mounted card can leave a photos row whose ``folder_path``
@@ -2251,7 +2262,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     """
     from pipeline_job import (
         _archive_mount_baseline,
+        _load_known_mount_roots,
         _missing_archive_mount_root,
+        _record_known_mount_roots,
         _unmounted_since_baseline,
     )
     from scanner import scan
@@ -2303,7 +2316,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # Keying on the transition (rather than "is it mounted?") is what lets
     # an ordinary local directory at a mount-shaped path stay usable: it
     # is False here and stays False, so it never trips the check.
-    mount_baseline = _archive_mount_baseline(destination)
+    #
+    # ``known_mounted_roots`` seeds True from a persistent record of
+    # mount roots ever observed live. Without it, a share that detached
+    # BEFORE the run started (baseline is False from the outset) escapes
+    # the guard: no True → False transition can fire against a False
+    # baseline, so the persistent ``/mnt/<name>`` stub still passes the
+    # per-batch check and copies land on the local disk. Cross-run
+    # history closes that hole; a hand-made local dir is never observed
+    # as a live mount and stays out of the known-set. See PR #1396
+    # review (Codex P1 r3687401636).
+    known_mount_roots = _load_known_mount_roots(db)
+    mount_baseline = _archive_mount_baseline(destination, known_mount_roots)
+    _record_known_mount_roots(db, mount_baseline)
 
     # Reject cataloged twins that live under the card being imported. The
     # /api/jobs/import-photos route already refuses destinations that sit

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2718,11 +2718,29 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # bytes, never the just-written archive copy.
         landed = []
         dup_dirs = set()
+        # Sticky once tripped: a batch can hold hundreds of files (the
+        # 2026-07-26 folder held 200), and when it is the only batch there
+        # is no later batch boundary to catch a detach. Probing per file
+        # keeps the blast radius at one file instead of a whole folder.
+        # One ismount call is nothing next to copying and hashing a RAW.
+        mount_lost = None
 
         for source_file in batch:
             if runner.is_cancelled(job["id"]):
                 cancelled = True
                 break
+            if not mount_lost:
+                mount_lost = _unmounted_since_baseline(mount_baseline)
+            if mount_lost:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"archive mount root {mount_lost} detached while this "
+                    "batch was copying (the directory persists but the "
+                    "share is gone, so further writes would land on the "
+                    "local disk under a stale mount point)",
+                )
+                continue
             emitted += 1
             _emit(
                 f"{rel}: importing", emitted, discovered, source_file.name,
@@ -3066,6 +3084,23 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                  src_size, src_mtime_ns),
             )
             _record_checker(source_file, dest_folder, file_hash)
+
+        # Anything that landed BEFORE the detach is sitting in the local
+        # shadow, not on the archive. Roll those out of copied/
+        # skipped_duplicate into failed and drop them: cataloging them
+        # would record archive paths for bytes that vanish when the real
+        # share remounts, and leaving them booked as copied could let
+        # safe_to_format go green over a card that is still the only
+        # copy. Emptying ``landed`` also skips the catalog scan below.
+        if mount_lost and landed:
+            for entry in landed:
+                _reclassify_landed_failed(
+                    rel, entry,
+                    f"archive mount root {mount_lost} detached mid-batch; "
+                    "this file landed in a local shadow of the archive, "
+                    "not on the share",
+                )
+            landed = []
 
         # --- Catalog this batch (even when cancelled mid-batch: what
         # landed on disk must be cataloged before we stop, so every

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2743,6 +2743,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # bytes, never the just-written archive copy.
         landed = []
         dup_dirs = set()
+        # Duplicate skips accepted in this batch that never enter
+        # ``landed`` — (source_file, counted_unverified). An accepted skip
+        # asserts "the archive already holds these bytes", which stops
+        # being true the moment the share detaches: the twin it matched
+        # may be in the local shadow. A duplicate-only batch would
+        # otherwise satisfy copied + skipped_duplicate == discovered and
+        # report safe_to_format True over an archive holding nothing.
+        # See PR #1396 review (Codex P1 r3687506040).
+        dup_skips = []
         # Sticky once tripped: a batch can hold hundreds of files (the
         # 2026-07-26 folder held 200), and when it is the only batch there
         # is no later batch boundary to catch a detach. Probing per file
@@ -2790,6 +2799,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             skipped_duplicate += 1
                             unverified_duplicate += 1
                             _counts(rel)["skipped_duplicate"] += 1
+                            dup_skips.append((source_file, True))
                             dup_dirs.update(_linkable_twin_dirs(
                                 likely_rows, _path_under_destination,
                             ))
@@ -2901,6 +2911,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     if accept:
                         skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
+                        dup_skips.append((source_file, False))
                         # verified_twin_rows carries only twins whose
                         # bytes we re-hashed and matched this run — the
                         # only rows whose folders are safe to link. For
@@ -3021,6 +3032,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         # out of the duplicate-identity index (see ingest).
                         skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
+                        dup_skips.append((source_file, False))
                         dup_dirs.add(dest_folder)
                         continue
                     if src_size == dest_size:
@@ -3124,6 +3136,30 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # a mount check on both sides of every copy in the batch.
         if not mount_lost:
             mount_lost = _unmounted_since_baseline(mount_baseline)
+
+        # Accepted duplicate skips rest on a twin that may live in the
+        # local shadow rather than on the share, so a detach invalidates
+        # the "already present" claim exactly as it invalidates a copy.
+        # These never enter ``landed``, so they need their own rollback:
+        # without it a duplicate-only batch reports every file safely
+        # accounted for and the card looks safe to erase over an archive
+        # holding none of the bytes. ``dup_dirs`` is dropped for the same
+        # reason — linking those folders would pull shadow paths into the
+        # workspace. See PR #1396 review (Codex P1 r3687506040).
+        if mount_lost and dup_skips:
+            for skipped_file, counted_unverified in dup_skips:
+                skipped_duplicate -= 1
+                _counts(rel)["skipped_duplicate"] -= 1
+                if counted_unverified:
+                    unverified_duplicate -= 1
+                _fail(
+                    rel, skipped_file,
+                    f"archive mount root {mount_lost} detached mid-batch; "
+                    "the duplicate this file matched cannot be confirmed "
+                    "to be on the archive rather than in a local shadow",
+                )
+            dup_skips = []
+            dup_dirs = set()
 
         # Anything that landed BEFORE the detach is sitting in the local
         # shadow, not on the archive. Roll those out of copied/

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -3085,6 +3085,21 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             )
             _record_checker(source_file, dest_folder, file_hash)
 
+        # The per-file probe runs BEFORE each copy, so it cannot see a
+        # detach that happens during the last (or only) file — there is no
+        # next iteration to catch it. Probe once more here, after the loop
+        # and before anything is cataloged, so the whole batch including
+        # its final file is covered. See PR #1396 review (Codex P1
+        # r3687456172).
+        #
+        # This is the last probe that can help: a detach after this point
+        # races the catalog scan itself, which is irreducible — no probe
+        # can make a network filesystem stay mounted across a write. What
+        # it does guarantee is that nothing is booked as archived without
+        # a mount check on both sides of every copy in the batch.
+        if not mount_lost:
+            mount_lost = _unmounted_since_baseline(mount_baseline)
+
         # Anything that landed BEFORE the detach is sitting in the local
         # shadow, not on the archive. Roll those out of copied/
         # skipped_duplicate into failed and drop them: cataloging them

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -733,6 +733,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     except OSError:
         destination = os.path.normpath(str(params.destination))
 
+    # Live-mount baseline for the destination, captured before discovery
+    # for the same reason as the local path: a detach during the slow
+    # pre-copy phases would otherwise be baked in as "never mounted" and
+    # disarm the guard. See ``_archive_mount_baseline`` and PR #1396
+    # review (Codex P1 r3687336684).
+    mount_baseline = _archive_mount_baseline(destination)
+
     # Reject cataloged twins that live under the card being imported: a stale
     # scan of the mounted card can leave a photos row whose ``folder_path``
     # IS the card, and re-hashing it just re-reads the very source we're
@@ -931,11 +938,6 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # See PR #1113 review.
     def _missing_mount_root():
         return _missing_archive_mount_root(destination)
-
-    # Baseline for the persistent-mount-point case the check above cannot
-    # see (Linux keeps ``/mnt/<name>`` after an unmount). Mirrors the
-    # local path; see ``_archive_mount_baseline``.
-    mount_baseline = _archive_mount_baseline(destination)
 
     def _record_checker(source_file, dest_folder=None, file_hash=None):
         """Register a landed/adopted file's identity with the intra-run checker.
@@ -2288,6 +2290,21 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     except OSError:
         destination = os.path.normpath(str(params.destination))
 
+    # Which of the destination's mount-root candidates are live mounts.
+    # Captured HERE — immediately after normalization, before discovery,
+    # catalog-index construction or timestamp extraction — because all of
+    # those are slow against a network archive (the 2026-07-30 incident
+    # spent eight minutes just enumerating the destination). A share that
+    # detached during that window would be recorded as already-unmounted,
+    # the mounted → unmounted transition would never fire, and the guard
+    # would be silently disarmed for the rest of the run. See PR #1396
+    # review (Codex P1 r3687336684).
+    #
+    # Keying on the transition (rather than "is it mounted?") is what lets
+    # an ordinary local directory at a mount-shaped path stay usable: it
+    # is False here and stays False, so it never trips the check.
+    mount_baseline = _archive_mount_baseline(destination)
+
     # Reject cataloged twins that live under the card being imported. The
     # /api/jobs/import-photos route already refuses destinations that sit
     # inside a source (formatting the card would erase the archive copy),
@@ -2558,13 +2575,6 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # explicitly so safe_to_format reflects "workspace can actually see
     # these bytes" and not just "the bytes are somewhere on disk".
     dup_link_failed = False
-
-    # Which of the destination's mount-root candidates are live mounts
-    # right now. Taken once, before any copying, because the guard in the
-    # loop keys on a mounted → unmounted *transition*: an ordinary local
-    # directory that happens to sit at a mount-shaped path is False here
-    # and stays False, so it is never mistaken for a detached share.
-    mount_baseline = _archive_mount_baseline(destination)
 
     for rel, batch in batches:
         if runner.is_cancelled(job["id"]):

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -715,7 +715,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     reason ``"enable verify_by_hash for remote verification"`` — the card is
     off-loaded but its landing wasn't independently hash-confirmed.
     """
-    from pipeline_job import _missing_archive_mount_root
+    from pipeline_job import (
+        _archive_mount_baseline,
+        _missing_archive_mount_root,
+        _unmounted_since_baseline,
+    )
     from scanner import scan
 
     rt = params.remote_target
@@ -928,6 +932,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     def _missing_mount_root():
         return _missing_archive_mount_root(destination)
 
+    # Baseline for the persistent-mount-point case the check above cannot
+    # see (Linux keeps ``/mnt/<name>`` after an unmount). Mirrors the
+    # local path; see ``_archive_mount_baseline``.
+    mount_baseline = _archive_mount_baseline(destination)
+
     def _record_checker(source_file, dest_folder=None, file_hash=None):
         """Register a landed/adopted file's identity with the intra-run checker.
 
@@ -1021,11 +1030,34 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 emitted, discovered,
             )
             continue
-        # Mirrors the local path: the mount-root guard above only catches
-        # a mount point that vanished, so a stale-but-present mount, a
-        # read-only parent, or a permission change still reaches this
-        # call. An uncaught OSError here kills the background job; book
-        # it per file and let the run finish with an honest result.
+        # Persistent-mount-point case (Linux ``/mnt/<name>`` survives the
+        # unmount), which the vanished-root check above structurally
+        # cannot see. Same baseline-transition logic as the local path so
+        # an ordinary directory at a mount-shaped path is never refused.
+        # Matters more here, not less: rsync keeps pushing to the NAS
+        # while the batch scan reads a local shadow, so the import lands
+        # bytes remotely and catalogs nothing.
+        stale_mount_root = _unmounted_since_baseline(mount_baseline)
+        if stale_mount_root:
+            for source_file in batch:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"archive mount root {stale_mount_root} is no longer "
+                    "mounted (it was at the start of this import; the "
+                    "directory persists but the share has detached, so "
+                    "cataloging here would read a local shadow of the "
+                    "archive)",
+                )
+            _emit(
+                f"{rel}: archive unmounted", emitted, discovered,
+            )
+            continue
+        # Mirrors the local path: the checks above only catch a mount
+        # point that vanished or detached, so a stale-but-registered
+        # mount, a read-only parent, or a permission change still reaches
+        # this call. An uncaught OSError here kills the background job;
+        # book it per file and let the run finish with an honest result.
         try:
             os.makedirs(dest_folder, exist_ok=True)
         except OSError as e:
@@ -2215,7 +2247,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     is committed per batch; cancellation and crashes leave every already-
     verified file cataloged and nothing else.
     """
-    from pipeline_job import _missing_archive_mount_root
+    from pipeline_job import (
+        _archive_mount_baseline,
+        _missing_archive_mount_root,
+        _unmounted_since_baseline,
+    )
     from scanner import scan
 
     db = Database(db_path)
@@ -2523,6 +2559,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # these bytes" and not just "the bytes are somewhere on disk".
     dup_link_failed = False
 
+    # Which of the destination's mount-root candidates are live mounts
+    # right now. Taken once, before any copying, because the guard in the
+    # loop keys on a mounted → unmounted *transition*: an ordinary local
+    # directory that happens to sit at a mount-shaped path is False here
+    # and stays False, so it is never mistaken for a detached share.
+    mount_baseline = _archive_mount_baseline(destination)
+
     for rel, batch in batches:
         if runner.is_cancelled(job["id"]):
             cancelled = True
@@ -2589,9 +2632,34 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 f"{rel}: archive unavailable", emitted, discovered,
             )
             continue
-        # The guard above only recognizes a mount point that *vanished*.
-        # A stale-but-present mount (Linux keeps ``/mnt/<name>`` after an
-        # unmount), a read-only or permission-changed parent, or a full
+        # The check above only sees a mount point that VANISHED. Linux
+        # keeps ``/mnt/<name>`` as an empty directory after the share
+        # detaches, so there the destination still "exists" and
+        # ``os.makedirs`` below would happily build the archive tree on
+        # the system disk and copy the card into it — bytes that vanish
+        # under the real share the moment it remounts, after
+        # safe_to_format may already have gone green. Catch that by
+        # comparing against the baseline taken at job start: only a
+        # mounted → unmounted transition counts, so an ordinary local
+        # directory that merely looks mount-shaped is never refused.
+        stale_mount_root = _unmounted_since_baseline(mount_baseline)
+        if stale_mount_root:
+            for source_file in batch:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"archive mount root {stale_mount_root} is no longer "
+                    "mounted (it was at the start of this import; the "
+                    "directory persists but the share has detached, so "
+                    "copying here would write to the local disk under a "
+                    "stale mount point)",
+                )
+            _emit(
+                f"{rel}: archive unmounted", emitted, discovered,
+            )
+            continue
+        # A stale-but-registered mount (ismount still true while reads
+        # fail), a read-only or permission-changed parent, or a full
         # disk all still surface here — and an uncaught OSError out of
         # this call tears down the whole background job, which is exactly
         # how the 2026-07-30 import died after two hours. Whatever the

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -149,6 +149,51 @@ def _archive_mount_root_candidates(path: str) -> list[str]:
     return seen
 
 
+def _archive_mount_baseline(path: str) -> dict[str, bool]:
+    """Snapshot whether ``path``'s mount-root candidates are live mounts.
+
+    Pairs with ``_unmounted_since_baseline`` to catch the case
+    ``_missing_archive_mount_root`` structurally cannot see: a mount point
+    that *persists* as an empty directory after the share detaches. Linux
+    ``/mnt/<name>`` behaves that way (macOS removes ``/Volumes/<share>``,
+    which is why ``lexists`` is enough there), so on Linux an unmounted
+    archive looks exactly like a valid empty destination — ``os.makedirs``
+    succeeds and the import writes onto the system disk under the stale
+    mount point. See PR #1394 review (Codex P1 r3687190865).
+
+    ``os.path.ismount`` is the right primitive rather than a hand-rolled
+    ``st_dev`` comparison: on POSIX it already compares the directory's
+    device against its parent's, and ``_archive_mount_root_candidates``
+    deliberately returns Windows drive letters with a trailing separator
+    so ismount accepts them.
+
+    Recording the *baseline* is what makes this safe. An ordinary local
+    directory that merely looks mount-shaped (a plain ``/mnt/photos`` the
+    user created by hand) is False here and stays False, so it can never
+    trip the staleness check — a bare "is it mounted?" test would refuse
+    that destination outright and break working setups.
+    """
+    return {
+        root: os.path.ismount(root)
+        for root in _archive_mount_root_candidates(path)
+    }
+
+
+def _unmounted_since_baseline(baseline: dict[str, bool]) -> str | None:
+    """Return a root that was mounted at baseline and no longer is.
+
+    Deliberately one-directional: only a True → False transition counts.
+    A root that was never a mount is an ordinary directory and is ignored,
+    and a root still reporting mounted is left to the existing offline
+    probes (a stale-but-registered SMB mount keeps ``ismount`` True while
+    every read raises EIO — see ``_mount_root_offline``).
+    """
+    for root, was_mounted in baseline.items():
+        if was_mounted and not os.path.ismount(root):
+            return root
+    return None
+
+
 def _missing_archive_mount_root(path: str) -> str | None:
     """Return a likely missing mount root that must not be auto-created.
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -149,7 +149,10 @@ def _archive_mount_root_candidates(path: str) -> list[str]:
     return seen
 
 
-def _archive_mount_baseline(path: str) -> dict[str, bool]:
+def _archive_mount_baseline(
+    path: str,
+    known_mounted_roots: set[str] | None = None,
+) -> dict[str, bool]:
     """Snapshot whether ``path``'s mount-root candidates are live mounts.
 
     Pairs with ``_unmounted_since_baseline`` to catch the case
@@ -172,11 +175,86 @@ def _archive_mount_baseline(path: str) -> dict[str, bool]:
     user created by hand) is False here and stays False, so it can never
     trip the staleness check — a bare "is it mounted?" test would refuse
     that destination outright and break working setups.
+
+    ``known_mounted_roots`` seeds the baseline as ``True`` for any
+    candidate the caller previously observed as a live mount (see
+    ``_load_known_mount_roots`` / ``_record_known_mount_roots``). Without
+    it, a share that was already detached BEFORE this run started
+    escapes the guard: its baseline is False and no mounted → unmounted
+    transition can fire against a False baseline, so the persistent
+    ``/mnt/<name>`` stub still passes the per-batch guard and copies
+    land on the local disk. Cross-run history closes that hole without
+    refusing hand-made local dirs — those never enter the known-set to
+    begin with (no run ever observed them as a live mount) and their
+    baseline stays False. See PR #1396 review (Codex P1 r3687401636).
     """
-    return {
-        root: os.path.ismount(root)
-        for root in _archive_mount_root_candidates(path)
-    }
+    known = known_mounted_roots or set()
+    baseline = {}
+    for root in _archive_mount_root_candidates(path):
+        baseline[root] = os.path.ismount(root) or root in known
+    return baseline
+
+
+_KNOWN_MOUNT_ROOTS_KEY = "known_archive_mount_roots"
+
+
+def _load_known_mount_roots(db) -> set[str]:
+    """Return the persistent set of mount roots ever observed as live.
+
+    Used by ``_archive_mount_baseline`` to seed True across runs: a share
+    that was live on a prior successful run and is detached now must be
+    treated as a mounted → unmounted transition, not as a plain local
+    dir that was never a mount. Read failures (missing key, malformed
+    JSON, DB gone) fall back to an empty set — a stale-history failure
+    is not a reason to refuse a fresh import.
+    """
+    try:
+        row = db.conn.execute(
+            "SELECT value FROM db_meta WHERE key = ?",
+            (_KNOWN_MOUNT_ROOTS_KEY,),
+        ).fetchone()
+    except Exception:
+        return set()
+    if row is None or row["value"] is None:
+        return set()
+    try:
+        entries = json.loads(row["value"])
+    except (TypeError, ValueError):
+        return set()
+    if not isinstance(entries, list):
+        return set()
+    return {str(e) for e in entries if isinstance(e, str)}
+
+
+def _record_known_mount_roots(db, baseline: dict[str, bool]) -> None:
+    """Merge any True baseline entries into the persistent known-mounted set.
+
+    Only additive — a root that was recorded once stays recorded, so a
+    share that is currently detached still gets its True → False
+    transition detected on the next run. If persistence itself fails
+    (DB locked, missing table on an ancient DB), silently give up: the
+    run has already captured its own within-run baseline and the cross-
+    run upgrade is best-effort. See PR #1396 review
+    (Codex P1 r3687401636).
+    """
+    fresh = {root for root, live in baseline.items() if live}
+    if not fresh:
+        return
+    try:
+        existing = _load_known_mount_roots(db)
+        merged = sorted(existing | fresh)
+        db.conn.execute(
+            "INSERT INTO db_meta(key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (_KNOWN_MOUNT_ROOTS_KEY, json.dumps(merged)),
+        )
+        db.conn.commit()
+    except Exception:
+        log.debug(
+            "Could not persist known archive mount roots (%r); "
+            "cross-run mount-baseline seeding will be skipped for the "
+            "next run.", sorted(fresh), exc_info=True,
+        )
 
 
 def _unmounted_since_baseline(baseline: dict[str, bool]) -> str | None:

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -6712,15 +6712,19 @@ def test_local_import_stops_when_mount_point_persists_after_unmount(
         lambda path: [dest] if str(path).startswith(dest) else [],
     )
     real_ismount = os.path.ismount
-    first_landed = os.path.join(dest, "2026", "2026-07-03", "DSC_0001.jpg")
+    second_batch_dir = os.path.join(dest, "2026", "2026-07-04")
 
     def fake_ismount(p):
         if str(p) != dest:
             return real_ismount(p)
-        # Mounted until the first batch's file has landed, detached after.
-        # Keyed on observable state rather than a probe count, so adding
-        # or removing a probe elsewhere can't silently retime the test.
-        return not os.path.exists(first_landed)
+        # Detach cleanly BETWEEN batches: still mounted while batch one
+        # copies and catalogs, gone by the time batch two starts writing.
+        # Keyed on observable state (has batch two's folder been created)
+        # rather than a probe count, so adding or removing a probe cannot
+        # silently retime the test — and deliberately later than "batch
+        # one's file landed", which would instead exercise a mid-batch
+        # detach and correctly fail batch one too.
+        return not os.path.exists(second_batch_dir)
 
     monkeypatch.setattr(os.path, "ismount", fake_ismount)
 
@@ -6731,8 +6735,12 @@ def test_local_import_stops_when_mount_point_persists_after_unmount(
     assert result["copied"] == 1, result
     assert result["failed"] == 1, result
     assert result["safe_to_format"] is False, result
+    # "detached" is common to the batch-level and per-file guard messages.
+    # Which one fires depends on exactly when the share drops relative to
+    # the batch boundary, and this test cares that the detach is reported
+    # at all, not which probe noticed it first.
     assert any(
-        "no longer mounted" in u["reason"] for u in result["unsafe_files"]
+        "detached" in u["reason"] for u in result["unsafe_files"]
     ), result["unsafe_files"]
 
 
@@ -7009,3 +7017,50 @@ def test_local_import_detects_mount_loss_inside_a_single_batch(
     # Nothing from this run may be cataloged under the shadow directory.
     rows = _photo_rows(db)
     assert rows == [], rows
+
+
+def test_local_import_detects_mount_loss_during_the_final_file(
+        tmp_path, monkeypatch):
+    """A detach during the LAST file's copy must still be caught.
+
+    The pre-file probe runs before each copy, so with a single-file batch
+    (or on the last file of any batch) there is no next iteration to trip
+    it. Without a post-loop probe the copy, hash verification and catalog
+    scan all succeed against the local shadow and safe_to_format can go
+    true. See PR #1396 review (Codex P1 r3687456172).
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    # A single file -> a single batch -> exactly one loop iteration.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    dest = str(tmp_path / "mnt_NAS")
+    os.makedirs(dest, exist_ok=True)
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [dest] if str(path).startswith(dest) else [],
+    )
+    real_ismount = os.path.ismount
+    landed_path = os.path.join(dest, "2026", "2026-07-03", "DSC_0001.jpg")
+
+    def fake_ismount(p):
+        if str(p) != dest:
+            return real_ismount(p)
+        # Mounted right up until the file lands — i.e. the share drops
+        # while that final copy is in flight.
+        return not os.path.exists(landed_path)
+
+    monkeypatch.setattr(os.path, "ismount", fake_ismount)
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=dest,
+    ))
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    # The shadow copy must not be cataloged as an archive photo.
+    assert _photo_rows(db) == [], _photo_rows(db)

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -6712,14 +6712,15 @@ def test_local_import_stops_when_mount_point_persists_after_unmount(
         lambda path: [dest] if str(path).startswith(dest) else [],
     )
     real_ismount = os.path.ismount
-    probes = {"n": 0}
+    first_landed = os.path.join(dest, "2026", "2026-07-03", "DSC_0001.jpg")
 
     def fake_ismount(p):
-        if str(p) == dest:
-            probes["n"] += 1
-            # Mounted for the baseline and the first batch; gone after.
-            return probes["n"] <= 2
-        return real_ismount(p)
+        if str(p) != dest:
+            return real_ismount(p)
+        # Mounted until the first batch's file has landed, detached after.
+        # Keyed on observable state rather than a probe count, so adding
+        # or removing a probe elsewhere can't silently retime the test.
+        return not os.path.exists(first_landed)
 
     monkeypatch.setattr(os.path, "ismount", fake_ismount)
 
@@ -6794,13 +6795,16 @@ def test_remote_import_stops_when_mount_point_persists_after_unmount(
         lambda path: [mount_base] if str(path).startswith(mount_base) else [],
     )
     real_ismount = os.path.ismount
-    probes = {"n": 0}
+    first_landed = os.path.join(
+        mount_base, "2026", "2026-07-03", "DSC_0001.jpg")
 
     def fake_ismount(p):
-        if str(p) == mount_base:
-            probes["n"] += 1
-            return probes["n"] <= 2
-        return real_ismount(p)
+        if str(p) != mount_base:
+            return real_ismount(p)
+        # Detaches once the first batch has landed. Keyed on observable
+        # state rather than a probe count so the test can't be retimed by
+        # a probe being added elsewhere.
+        return not os.path.exists(first_landed)
 
     monkeypatch.setattr(os.path, "ismount", fake_ismount)
 
@@ -6942,3 +6946,66 @@ def test_remote_import_takes_mount_baseline_before_discovery(
     assert all(
         "no longer mounted" in u["reason"] for u in non_remote
     ), result["unsafe_files"]
+
+
+def test_local_import_detects_mount_loss_inside_a_single_batch(
+        tmp_path, monkeypatch):
+    """A detach mid-batch must not ride out to the end of the batch.
+
+    Batch-boundary probing alone leaves a whole folder unguarded, and when
+    there is only ONE batch there is no later boundary at all — every
+    remaining file is copied, hash-verified and cataloged into the local
+    shadow, and safe_to_format can still go green over a card that is the
+    only real copy. See PR #1396 review (Codex P1 r3687401641).
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    # One batch: four files, same capture date. Distinct colours so each
+    # is genuinely copied — identical bytes would route files 2-4 through
+    # the intra-run duplicate gate and never exercise the copy path.
+    card = _make_card(tmp_path, [
+        (f"DSC_000{i}.jpg", datetime(2026, 7, 3, 10, i, 0), colour)
+        for i, colour in enumerate(
+            ("red", "green", "blue", "yellow"), start=1)
+    ])
+    dest = str(tmp_path / "mnt_NAS")
+    os.makedirs(dest, exist_ok=True)
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [dest] if str(path).startswith(dest) else [],
+    )
+
+    state = {"mounted": True, "probes": 0}
+    real_ismount = os.path.ismount
+
+    def fake_ismount(p):
+        if str(p) != dest:
+            return real_ismount(p)
+        state["probes"] += 1
+        # Baseline + batch-level check + first two files stay mounted;
+        # the share drops partway through the single batch.
+        if state["probes"] > 4:
+            state["mounted"] = False
+        return state["mounted"]
+
+    monkeypatch.setattr(os.path, "ismount", fake_ismount)
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=dest,
+    ))
+
+    assert result["discovered"] == 4, result
+    # Whatever the split, nothing may be left claiming a successful
+    # archive copy, and the card must not be declared safe to format.
+    assert result["copied"] == 0, result
+    assert result["failed"] == 4, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "detached" in u["reason"] for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+    # Nothing from this run may be cataloged under the shadow directory.
+    rows = _photo_rows(db)
+    assert rows == [], rows

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -6681,3 +6681,142 @@ def test_local_import_survives_makedirs_failure(tmp_path):
     assert any(
         "2026-07-03" in u["reason"] for u in result["unsafe_files"]
     ), result["unsafe_files"]
+
+
+def test_local_import_stops_when_mount_point_persists_after_unmount(
+        tmp_path, monkeypatch):
+    """A Linux-shaped unmount must stop the import, not shadow-write.
+
+    ``_missing_archive_mount_root`` only sees a mount point that vanished
+    (macOS ejects remove ``/Volumes/<share>``). Linux keeps ``/mnt/<name>``
+    as an empty directory, so the destination still "exists", os.makedirs
+    succeeds, and the remaining card files land on the system disk under
+    a stale mount point — where safe_to_format could go green over photos
+    that disappear the moment the real archive remounts.
+    See PR #1394 review (Codex P1 r3687190865).
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+    dest = str(tmp_path / "mnt_NAS")
+    os.makedirs(dest, exist_ok=True)
+
+    # The destination is a real mount at job start, then the share drops
+    # while leaving the directory in place.
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [dest] if str(path).startswith(dest) else [],
+    )
+    real_ismount = os.path.ismount
+    probes = {"n": 0}
+
+    def fake_ismount(p):
+        if str(p) == dest:
+            probes["n"] += 1
+            # Mounted for the baseline and the first batch; gone after.
+            return probes["n"] <= 2
+        return real_ismount(p)
+
+    monkeypatch.setattr(os.path, "ismount", fake_ismount)
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=dest,
+    ))
+
+    assert result["copied"] == 1, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "no longer mounted" in u["reason"] for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+
+def test_local_import_allows_a_plain_directory_that_looks_mount_shaped(
+        tmp_path, monkeypatch):
+    """An ordinary directory under /mnt must still be a valid destination.
+
+    The guard keys on a mounted → unmounted transition precisely so a
+    hand-made local ``/mnt/photos`` (never a mount, so ismount is False
+    throughout) is not refused. A bare "is it mounted?" check would break
+    this setup.
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+    dest = str(tmp_path / "mnt_photos")
+    os.makedirs(dest, exist_ok=True)
+
+    # Mount-shaped path, but ismount is False the whole way through.
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [dest] if str(path).startswith(dest) else [],
+    )
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=dest,
+    ))
+
+    assert result["copied"] == 2, result
+    assert result["failed"] == 0, result
+
+
+def test_remote_import_stops_when_mount_point_persists_after_unmount(
+        tmp_path, monkeypatch):
+    """Same persistent-unmount guard on the remote path.
+
+    Worse here than locally: rsync keeps succeeding against the NAS while
+    the per-batch scan reads the empty local shadow, so the bytes land
+    remotely and the catalog records nothing.
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+    mount_base = ra["mount_base"]
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [mount_base] if str(path).startswith(mount_base) else [],
+    )
+    real_ismount = os.path.ismount
+    probes = {"n": 0}
+
+    def fake_ismount(p):
+        if str(p) == mount_base:
+            probes["n"] += 1
+            return probes["n"] <= 2
+        return real_ismount(p)
+
+    monkeypatch.setattr(os.path, "ismount", fake_ismount)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=mount_base, remote_target=ra,
+        ),
+    )
+
+    assert result["copied"] == 1, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "no longer mounted" in u["reason"] for u in result["unsafe_files"]
+    ), result["unsafe_files"]

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -6820,3 +6820,125 @@ def test_remote_import_stops_when_mount_point_persists_after_unmount(
     assert any(
         "no longer mounted" in u["reason"] for u in result["unsafe_files"]
     ), result["unsafe_files"]
+
+
+def test_local_import_takes_mount_baseline_before_discovery(
+        tmp_path, monkeypatch):
+    """The baseline must predate discovery, not follow it.
+
+    Discovery, catalog-index construction and timestamp extraction all run
+    before the copy loop and are slow against a network archive — the
+    2026-07-30 incident spent eight minutes just enumerating the
+    destination. A share that detaches during that window would be
+    recorded as ``False`` by a late baseline, so the mounted -> unmounted
+    transition never fires and the guard is silently disarmed for the
+    whole run. See PR #1396 review (Codex P1 r3687336684).
+    """
+    import import_job as _ij
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+    dest = str(tmp_path / "mnt_NAS")
+    os.makedirs(dest, exist_ok=True)
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [dest] if str(path).startswith(dest) else [],
+    )
+
+    state = {"mounted": True}
+    real_ismount = os.path.ismount
+    monkeypatch.setattr(
+        os.path, "ismount",
+        lambda p: state["mounted"] if str(p) == dest else real_ismount(p),
+    )
+
+    # The share drops WHILE discovery is running.
+    real_discover = _ij.discover_source_files
+
+    def discover_then_detach(*a, **kw):
+        result = list(real_discover(*a, **kw))
+        state["mounted"] = False
+        return result
+
+    monkeypatch.setattr(_ij, "discover_source_files", discover_then_detach)
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=dest,
+    ))
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 2, result
+    assert result["safe_to_format"] is False, result
+    assert all(
+        "no longer mounted" in u["reason"] for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+
+def test_remote_import_takes_mount_baseline_before_discovery(
+        tmp_path, monkeypatch):
+    """Remote path takes its baseline before discovery too.
+
+    Same disarming window as the local path — Codex flagged both in
+    PR #1396 review (P1 r3687336684).
+    """
+    import import_job as _ij
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+    mount_base = ra["mount_base"]
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [mount_base] if str(path).startswith(mount_base) else [],
+    )
+    state = {"mounted": True}
+    real_ismount = os.path.ismount
+    monkeypatch.setattr(
+        os.path, "ismount",
+        lambda p: state["mounted"] if str(p) == mount_base else real_ismount(p),
+    )
+
+    real_discover = _ij.discover_source_files
+
+    def discover_then_detach(*a, **kw):
+        result = list(real_discover(*a, **kw))
+        state["mounted"] = False
+        return result
+
+    monkeypatch.setattr(_ij, "discover_source_files", discover_then_detach)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=mount_base, remote_target=ra,
+        ),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 2, result
+    assert result["safe_to_format"] is False, result
+    # Drop the ``<remote>`` honesty-gate marker (verify_by_hash advice) so
+    # the mount reason is asserted over a non-empty set rather than
+    # vacuously — same filtering as
+    # ``test_remote_import_refuses_when_mount_root_absent``.
+    non_remote = [u for u in result["unsafe_files"] if u["path"] != "<remote>"]
+    assert non_remote, result["unsafe_files"]
+    assert all(
+        "no longer mounted" in u["reason"] for u in non_remote
+    ), result["unsafe_files"]

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -7145,3 +7145,92 @@ def test_local_import_refuses_when_share_detached_before_run_starts(
         "no longer mounted" in u["reason"] or "detached" in u["reason"]
         for u in result["unsafe_files"]
     ), result["unsafe_files"]
+
+
+def test_local_import_invalidates_duplicate_skips_when_mount_detaches(
+        tmp_path, monkeypatch):
+    """A duplicate-only batch must not vouch for a detached archive.
+
+    An accepted duplicate never enters ``landed``, so reclassifying only
+    landed entries leaves the skip standing. A duplicate-only batch can
+    then satisfy ``copied + skipped_duplicate == discovered`` and report
+    safe_to_format=True while the real archive holds none of the bytes —
+    the card gets erased and the shadow disappears on remount.
+    See PR #1396 review (Codex P1 r3687506040).
+    """
+    import shutil
+
+    import import_job as _ij
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+    from scanner import compute_file_hash
+
+    dest = tmp_path / "mnt_NAS"
+    dest_dir = dest / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / "IMG_0100.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(dest_file))
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(dest_file), (ts, ts))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0100.jpg", os.path.getsize(str(dest_file)),
+         compute_file_hash(str(dest_file))),
+    )
+    db.conn.commit()
+
+    card = tmp_path / "card"
+    card.mkdir()
+    shutil.copy2(str(dest_file), str(card / "IMG_0100.jpg"))
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [str(dest)] if str(path).startswith(str(dest)) else [],
+    )
+    state = {"mounted": True}
+    real_ismount = os.path.ismount
+    monkeypatch.setattr(
+        os.path, "ismount",
+        lambda p: (
+            state["mounted"] if str(p) == str(dest) else real_ismount(p)
+        ),
+    )
+
+    # The share drops while the duplicate gate is consulting the twin —
+    # after the per-file probe has already passed. Both lookup helpers are
+    # wrapped because which one runs depends on whether the checker
+    # produced a hash token or a metadata-key token.
+    def _detach_after(fn):
+        def wrapper(*a, **kw):
+            rows = fn(*a, **kw)
+            state["mounted"] = False
+            return rows
+        return wrapper
+
+    monkeypatch.setattr(
+        _ij, "_key_twin_rows", _detach_after(_ij._key_twin_rows))
+    monkeypatch.setattr(
+        _ij, "_hash_twin_rows", _detach_after(_ij._hash_twin_rows))
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id, ImportParams(
+            sources=[str(card)], destination=str(dest),
+        ),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["skipped_duplicate"] == 0, (
+        "a duplicate accepted against a detached archive still counted as "
+        f"safely already-present: {result}"
+    )
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -7064,3 +7064,84 @@ def test_local_import_detects_mount_loss_during_the_final_file(
     assert result["safe_to_format"] is False, result
     # The shadow copy must not be cataloged as an archive photo.
     assert _photo_rows(db) == [], _photo_rows(db)
+
+
+def test_local_import_refuses_when_share_detached_before_run_starts(
+        tmp_path, monkeypatch):
+    """A share detached BEFORE baseline capture must still be refused.
+
+    Every check in this file so far assumes ``ismount == True`` at least
+    for baseline capture: the transition-only guard fires only on
+    True → False. A share that was already down when the run started
+    baselines False, no transition can fire against a False baseline,
+    and the persistent ``/mnt/<name>`` stub still passes the per-batch
+    check — the same silent-shadow-write shape this PR opened, just
+    with the timing shifted earlier so no within-run probe can see it.
+
+    Cross-run history (mount roots ever observed live, persisted in
+    ``db_meta``) is what closes that hole: a second run to the same
+    destination baselines True by seeding, and the still-False current
+    state fires the transition just as it would mid-run. A hand-made
+    local ``/mnt/photos`` never enters the known-set (no run ever
+    observed it as a live mount), so its baseline stays False and it
+    stays a valid destination. See PR #1396 review
+    (Codex P1 r3687401636).
+    """
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+    dest = str(tmp_path / "mnt_NAS")
+    os.makedirs(dest, exist_ok=True)
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [dest] if str(path).startswith(dest) else [],
+    )
+    state = {"mounted": True}
+    real_ismount = os.path.ismount
+    monkeypatch.setattr(
+        os.path, "ismount",
+        lambda p: state["mounted"] if str(p) == dest else real_ismount(p),
+    )
+
+    # First run: share is live, files copy, persistent record captures
+    # that ``dest`` was seen mounted.
+    db_path = str(tmp_path / "test.db")
+    db1 = Database(db_path)
+    ws_id = db1._active_workspace_id
+    first = run_import_job(
+        _make_job("import-first"), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=dest),
+    )
+    assert first["copied"] == 2, first
+    assert first["failed"] == 0, first
+    # Sanity: the DB now knows this destination as a mount root.
+    assert dest in _pj._load_known_mount_roots(db1)
+
+    # Second run: same destination, share detached BEFORE the run starts.
+    # Without the persisted history the baseline would be False and the
+    # guard would silently disarm.
+    state["mounted"] = False
+    card2 = _make_card(tmp_path, [
+        ("DSC_0003.jpg", datetime(2026, 7, 5, 8, 0, 0), "green"),
+        ("DSC_0004.jpg", datetime(2026, 7, 6, 7, 0, 0), "yellow"),
+    ], card_name="card2")
+    result = run_import_job(
+        _make_job("import-second"), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card2)], destination=dest),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 2, result
+    assert result["safe_to_format"] is False, result
+    # Either the batch-level or per-file guard may notice first; the
+    # substring common to both messages is "detached" / "no longer
+    # mounted", so key the assertion on either.
+    assert any(
+        "no longer mounted" in u["reason"] or "detached" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -16625,3 +16625,82 @@ def test_unmounted_since_baseline_fires_only_for_a_lost_mount(
     assert _pj._unmounted_since_baseline({still: True}) is None
     # Empty baseline (destination not mount-shaped at all).
     assert _pj._unmounted_since_baseline({}) is None
+
+
+def test_archive_mount_baseline_seeds_true_from_known_mounted_roots(
+        tmp_path, monkeypatch):
+    """A candidate ever seen live must baseline True even when detached now.
+
+    Otherwise a share that was already unmounted BEFORE the run started
+    escapes the guard: its baseline is False, no mounted → unmounted
+    transition can fire against a False baseline, and the persistent
+    ``/mnt/<name>`` stub still passes the per-batch check. Cross-run
+    history is what closes the hole. See PR #1396 review
+    (Codex P1 r3687401636).
+    """
+    import os as _os
+
+    import pipeline_job as _pj
+
+    detached = str(tmp_path / "detached")
+    virgin = str(tmp_path / "virgin")
+    _os.makedirs(detached)
+    _os.makedirs(virgin)
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [detached, virgin],
+    )
+    real_ismount = _os.path.ismount
+    monkeypatch.setattr(
+        _os.path, "ismount",
+        # Neither candidate is currently a mount — but ``detached`` is in
+        # the known-set (a prior run saw it live), so the baseline must
+        # record it True so a still-detached state fires the transition.
+        lambda p: False if str(p) in (detached, virgin) else real_ismount(p),
+    )
+
+    baseline = _pj._archive_mount_baseline(
+        "/anything", known_mounted_roots={detached},
+    )
+    assert baseline == {detached: True, virgin: False}, baseline
+    # The staleness check then sees the True → False transition for
+    # ``detached``, exactly as it would for a share that dropped
+    # mid-run.
+    assert _pj._unmounted_since_baseline(baseline) == detached
+
+
+def test_known_mount_roots_round_trip_through_db_meta(tmp_path):
+    """Persisted mount roots survive across runs; only True is remembered.
+
+    Any candidate observed False in the baseline stays out of the record,
+    so a hand-made local ``/mnt/photos`` (never mounted) never joins the
+    known-set and never trips the staleness check. Merging with the
+    existing set is what keeps a mount root once-seen recorded across
+    subsequent runs, even when it's not live at capture time.
+    """
+    import pipeline_job as _pj
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+
+    # Nothing recorded yet.
+    assert _pj._load_known_mount_roots(db) == set()
+
+    # A run observes /mnt/nas live but /mnt/photos not.
+    _pj._record_known_mount_roots(db, {"/mnt/nas": True, "/mnt/photos": False})
+    assert _pj._load_known_mount_roots(db) == {"/mnt/nas"}
+
+    # A second run observes /mnt/photos live; both roots are remembered.
+    _pj._record_known_mount_roots(db, {"/mnt/photos": True})
+    assert _pj._load_known_mount_roots(db) == {"/mnt/nas", "/mnt/photos"}
+
+    # A third run observes /mnt/nas detached now — the previous True
+    # stays recorded so the next baseline still seeds it True.
+    _pj._record_known_mount_roots(db, {"/mnt/nas": False})
+    assert _pj._load_known_mount_roots(db) == {"/mnt/nas", "/mnt/photos"}
+
+    # Recording an all-False baseline is a no-op (empty ``fresh`` set —
+    # a run that saw no live mounts must not blank the record).
+    _pj._record_known_mount_roots(db, {"/mnt/nas": False, "/mnt/photos": False})
+    assert _pj._load_known_mount_roots(db) == {"/mnt/nas", "/mnt/photos"}

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -16563,3 +16563,65 @@ def test_pipeline_extract_masks_offline_survives_finalizer_override(
         f"The extract_masks Fatal error must name the outage as "
         f"source-offline; got {em_fatal[0]!r}"
     )
+
+
+def test_archive_mount_baseline_records_only_real_mount_points(
+        tmp_path, monkeypatch):
+    """The baseline distinguishes a real mount from an ordinary directory.
+
+    An ordinary ``/mnt/photos`` that was never a mount must record False,
+    so the staleness check below can never fire for it. That is what keeps
+    the guard from refusing legitimate local destinations.
+    """
+    import os as _os
+
+    import pipeline_job as _pj
+
+    mounted = str(tmp_path / "mounted")
+    plain = str(tmp_path / "plain")
+    _os.makedirs(mounted)
+    _os.makedirs(plain)
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [mounted, plain],
+    )
+    real_ismount = _os.path.ismount
+    monkeypatch.setattr(
+        _os.path, "ismount",
+        lambda p: True if str(p) == mounted else real_ismount(p),
+    )
+
+    baseline = _pj._archive_mount_baseline("/anything")
+
+    assert baseline == {mounted: True, plain: False}, baseline
+
+
+def test_unmounted_since_baseline_fires_only_for_a_lost_mount(
+        tmp_path, monkeypatch):
+    """Only a root that WAS mounted and no longer is counts as lost."""
+    import os as _os
+
+    import pipeline_job as _pj
+
+    lost = str(tmp_path / "lost")
+    never = str(tmp_path / "never")
+    still = str(tmp_path / "still")
+    for p in (lost, never, still):
+        _os.makedirs(p)
+
+    real_ismount = _os.path.ismount
+    monkeypatch.setattr(
+        _os.path, "ismount",
+        lambda p: True if str(p) == still else real_ismount(p),
+    )
+
+    # ``lost`` was mounted at baseline and now is not -> reported.
+    assert _pj._unmounted_since_baseline({lost: True}) == lost
+    # ``never`` was not a mount to begin with -> an ordinary directory,
+    # never reported no matter what.
+    assert _pj._unmounted_since_baseline({never: False}) is None
+    # ``still`` is mounted now as it was then -> nothing lost.
+    assert _pj._unmounted_since_baseline({still: True}) is None
+    # Empty baseline (destination not mount-shaped at all).
+    assert _pj._unmounted_since_baseline({}) is None


### PR DESCRIPTION
Follow-up to #1394, closing the P1 Codex raised there ([r3687190865](https://github.com/jss367/vireo/pull/1394#discussion_r3687190865)) which I deliberately left out of that PR to keep it reviewable.

## The hole

The mount guard in #1394 only recognizes a mount point that **vanished** — which is what macOS does, since an eject removes `/Volumes/<share>` entirely, making `os.path.lexists` sufficient.

**Linux keeps `/mnt/<name>` as an empty directory after the share detaches.** So the destination still "exists":

1. `_missing_archive_mount_root()` returns `None` — nothing looks wrong
2. `os.makedirs(dest_folder)` **succeeds**, building the archive tree on the system disk
3. The import copies and hash-verifies the remaining card files into it
4. `safe_to_format` can go green — so the card gets erased
5. The real archive remounts over the mount point and those photos are gone

This is the one variant where the failure is **silent data misplacement rather than a crash**. On macOS the same situation produced the `PermissionError` that started all of this, which at least failed loudly.

To be clear about severity framing: this is **pre-existing, not a regression from #1394**. Before that PR the local path had no mount guard at all. #1394 narrowed the hole; this closes it.

## The fix

`_archive_mount_baseline()` snapshots which of a destination's mount-root candidates are live mounts at job start. `_unmounted_since_baseline()` reports one that has since stopped being a mount. Both import loops take the baseline before copying and re-check per batch, alongside the existing checks.

**Keying on a mounted → unmounted *transition* is what makes this safe.** The obvious implementation — just test `os.path.ismount(root)` — would refuse an ordinary hand-made `/mnt/photos` that was never a mount, breaking working setups. Under the baseline approach that path is `False` throughout and can never trip the check.

A stale-but-*registered* mount (`ismount` stays true while every read raises `EIO`) is deliberately **not** handled here — that shape is already covered by `_mount_root_offline` and the `makedirs` error path from #1394, and `_mount_root_offline`'s docstring documents prior review rounds (#1388) that argued specifically against widening it.

`os.path.ismount` rather than a hand-rolled `st_dev` comparison: on POSIX it already compares the directory against its parent's device, and `_archive_mount_root_candidates` deliberately emits Windows drive letters with a trailing separator so `ismount` accepts them.

## Testing

5 new tests, each watched failing first:

- baseline records only real mount points, not lookalike directories
- `_unmounted_since_baseline` fires only on True → False, ignoring never-mounted and still-mounted roots
- local import stops mid-run when the mount point persists after unmount
- **local import still accepts a plain directory at a mount-shaped path** (the false-positive guard)
- remote import stops on the same transition — worse there, since rsync keeps succeeding against the NAS while the batch scan reads the empty local shadow

Verified unmocked against the real SMB archive:

```
/Volumes/Photography mounted? True
real archive destination: /Volumes/Photography/Raw Files/USA
  baseline    = {'/Volumes/Photography': True}
  lost mount? = None
ordinary local directory: /var/folders/.../tmp0_jd60bb
  baseline    = {}          lost mount? = None
mount-shaped but not mounted: /Volumes/NotAMountedShare
  baseline    = {'/Volumes/NotAMountedShare': False}   lost mount? = None
OK: live mount recognized, no false positives.
```

Full run: **2577 passed**, 1 pre-existing unrelated failure (`test_api_exiftool_status_reports_missing`, fails identically on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import safety by detecting archive mounts that become unavailable before, during, or after processing.
  * Prevented files from detached mounts from being incorrectly cataloged or counted as successfully archived.
  * Added equivalent protection for remote imports and duplicate-file handling.
  * Improved pipeline handling of mount changes across runs while preserving normal directory behavior.

* **Tests**
  * Added comprehensive coverage for mount loss, cross-run tracking, duplicate invalidation, and local and remote imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->