### PR TITLE
Stop duplicate-only remote imports from rescanning the destination folder

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1516,10 +1516,22 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # files never become photo rows. See PR #1113 review.
             scan_files = landed_paths | set(adopted_paths.keys())
             try:
+                # ``incremental=True`` is what keeps a duplicate-only batch
+                # affordable. With no fresh landings and no adopted paths,
+                # ``restrict_files`` is None and this call walks the whole
+                # ``dest_folder`` — and re-importing a card into the same
+                # date folder it originally landed in means that folder
+                # already holds every twin. Non-incrementally that re-read
+                # and re-hashed all of them, turning a zero-copy import
+                # into an hours-long rescan on a network archive. Fresh
+                # landings are unaffected: they have no catalog row yet, so
+                # the skip path can't fire for them. Mirrors the dup-link
+                # scan below and the local path's equivalent.
                 scan(
                     destination, db,
                     restrict_dirs=[dest_folder],
                     restrict_files=(scan_files or None),
+                    incremental=True,
                     vireo_dir=params.vireo_dir,
                     thumb_cache_dir=params.thumb_cache_dir,
                     skip_working_copies=True,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1516,22 +1516,32 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # files never become photo rows. See PR #1113 review.
             scan_files = landed_paths | set(adopted_paths.keys())
             try:
-                # ``incremental=True`` is what keeps a duplicate-only batch
-                # affordable. With no fresh landings and no adopted paths,
-                # ``restrict_files`` is None and this call walks the whole
-                # ``dest_folder`` — and re-importing a card into the same
-                # date folder it originally landed in means that folder
-                # already holds every twin. Non-incrementally that re-read
-                # and re-hashed all of them, turning a zero-copy import
-                # into an hours-long rescan on a network archive. Fresh
-                # landings are unaffected: they have no catalog row yet, so
-                # the skip path can't fire for them. Mirrors the dup-link
-                # scan below and the local path's equivalent.
+                # Incremental ONLY for the duplicate-only case, where
+                # ``scan_files`` is empty so ``restrict_files`` is None and
+                # this call walks the whole ``dest_folder``. Re-importing a
+                # card into the same date folder it originally landed in
+                # means that folder already holds every twin, and walking
+                # it non-incrementally re-read and re-hashed all of them —
+                # an hours-long rescan on a network archive for a zero-copy
+                # import.
+                #
+                # It must stay OFF whenever ``scan_files`` is non-empty.
+                # A landed path is not necessarily uncataloged: a stale row
+                # can survive for a file deleted off the archive, and if
+                # the replacement bytes land at that path carrying an mtime
+                # equal to the stale row's, the incremental fast path skips
+                # it without comparing size or content. ``file_hash`` then
+                # keeps the stale value, the post-scan cross-check below
+                # compares the copy-time hash against it, and a file that
+                # transferred fine is reported failed — with retries unable
+                # to refresh the row. ``restrict_files`` already narrows
+                # those batches to a handful of paths, so incremental buys
+                # nothing there anyway. See PR #1398 review.
                 scan(
                     destination, db,
                     restrict_dirs=[dest_folder],
                     restrict_files=(scan_files or None),
-                    incremental=True,
+                    incremental=not scan_files,
                     vireo_dir=params.vireo_dir,
                     thumb_cache_dir=params.thumb_cache_dir,
                     skip_working_copies=True,

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5515,6 +5515,86 @@ def test_remote_import_dup_only_batch_does_not_reread_dest_folder_twins(
     )
 
 
+def test_remote_import_landing_refreshes_stale_row_with_matching_mtime(
+        tmp_path, monkeypatch):
+    """A fresh landing at a destination path that carries a stale catalog
+    row must overwrite the row's ``file_hash`` even when the newly
+    transferred bytes inherit the same ``file_mtime`` the stale row
+    remembers.
+
+    ``scanner.scan()``'s incremental fast path treats a path as unchanged
+    when the on-disk ``file_mtime`` matches the catalog row's
+    ``file_mtime``. rsync ``-a`` (and ``shutil.copy2`` in the fake
+    harness) preserves the source's mtime on the destination, so a source
+    card whose file happens to share an mtime with a stale row — an
+    orphan left after the actual file was deleted, then re-landed by a
+    fresh import — would otherwise slip through incremental with its
+    stale ``file_hash`` intact. The subsequent
+    ``scan_h`` vs ``src_h_norm`` cross-check would then reject the
+    landing as a mount-hash mismatch and no retry could fix it (mtime has
+    not moved). The batch scan must therefore run non-incrementally
+    whenever it targets landed/adopted paths, matching the local path.
+    """
+    import scanner
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Stale row: seed the destination path with red bytes and catalog
+    # them, then delete the file so the fresh landing goes through the
+    # "no collision" branch.
+    dest_folder = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(dest_folder, exist_ok=True)
+    stale_target = os.path.join(dest_folder, "DSC_0001.jpg")
+    Image.new("RGB", (16, 16), "red").save(stale_target)
+    pinned_mtime = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(stale_target, (pinned_mtime, pinned_mtime))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    scanner.scan(ra["mount_base"], db)
+    _mark_exif_extracted(db)
+    stale_row = db.conn.execute(
+        "SELECT id, file_hash FROM photos WHERE filename = ?",
+        ("DSC_0001.jpg",),
+    ).fetchone()
+    assert stale_row is not None
+    stale_hash = stale_row["file_hash"]
+
+    os.remove(stale_target)
+
+    # Card file with byte-different content but the SAME mtime the stale
+    # row remembers, so shutil.copy2 in the fake rsync lands bytes that
+    # match the incremental fast path's "unchanged" trigger.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["failed"] == 0, result
+    assert result["copied"] == 1, result
+    assert result["safe_to_format"] is True, result
+    updated_row = db.conn.execute(
+        "SELECT file_hash FROM photos WHERE filename = ?",
+        ("DSC_0001.jpg",),
+    ).fetchone()
+    assert updated_row["file_hash"] != stale_hash, (
+        "stale catalog row was not refreshed after a fresh landing at the "
+        "same path with a matching mtime; the batch scan's incremental "
+        "fast path skipped the freshly transferred file"
+    )
+
+
 def test_remote_import_scans_adopted_duplicate_in_mixed_batch(
         tmp_path, monkeypatch):
     """A retry / crash-recovery batch that (a) copies one fresh file AND

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5451,6 +5451,70 @@ def test_remote_import_dup_link_scan_does_not_reread_unchanged_twins(
     )
 
 
+def test_remote_import_dup_only_batch_does_not_reread_dest_folder_twins(
+        tmp_path, monkeypatch):
+    """A duplicate-only remote batch whose twins sit in the batch's OWN
+    destination folder must not re-read them.
+
+    ``test_remote_import_dup_link_scan_does_not_reread_unchanged_twins``
+    parks its twins in ``unsorted`` — a different folder from the batch
+    destination — so that test's batch scan walks an empty
+    ``dest_folder`` and reads nothing either way. The common real case is
+    re-importing a card into the same date folder it originally landed
+    in, where ``dest_folder`` already holds every twin. With no fresh
+    landings the batch scan passes ``restrict_files=None``, so it walks
+    the whole destination folder; without ``incremental=True`` it
+    re-reads and re-hashes every already-cataloged file there. On a
+    network archive that turns a zero-copy import into an hours-long
+    rescan.
+    """
+    import scanner
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    # The twins live in the very folder this card's files map to, which is
+    # what re-importing an already-imported card looks like.
+    dest_folder = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(dest_folder, exist_ok=True)
+    import shutil as _shutil
+    for name in ("DSC_0001.jpg", "DSC_0002.jpg"):
+        _shutil.copy2(str(card / name), os.path.join(dest_folder, name))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    scanner.scan(ra["mount_base"], db)
+    _mark_exif_extracted(db)
+    assert len(_photo_rows(db)) == 2
+
+    read_paths = _count_feature_computations(monkeypatch)
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert calls["rsync"] == [], calls["rsync"]
+    assert result["skipped_duplicate"] == 2, result
+    assert result["copied"] == 0, result
+    assert result["failed"] == 0, result
+    assert dest_folder in _ws_linked_folder_paths(db, ws_id)
+    assert read_paths == [], (
+        "remote duplicate-only import re-read already-cataloged, unchanged "
+        f"twins in the destination folder: {read_paths}"
+    )
+
+
 def test_remote_import_scans_adopted_duplicate_in_mixed_batch(
         tmp_path, monkeypatch):
     """A retry / crash-recovery batch that (a) copies one fresh file AND


### PR DESCRIPTION
## What's wrong

`_run_remote_import_job`'s per-batch catalog scan (`vireo/import_job.py:1506`) ran without `incremental=True`:

```python
if landed or dup_skipped:              # local path uses `if landed:`
    scan_files = landed_paths | set(adopted_paths.keys())
    scan(destination, db,
         restrict_dirs=[dest_folder],
         restrict_files=(scan_files or None),   # → None when nothing landed
         ...)                                   # no incremental= → defaults False
```

For a **duplicate-only batch** — every card file already in the catalog — `landed` is empty, so `restrict_files` collapses to `None`. `scanner.scan` reads that as *no file filter* (`scanner.py:1621`, `1682`), so the call walks the **entire destination folder**, and with `incremental` defaulting to `False` the skip logic at `scanner.py:1998-2035` never runs. Every already-cataloged file in that folder gets re-read and re-hashed.

Re-importing a card into the same date folder it originally landed in means that folder already holds every twin, so this re-reads the whole folder.

## Impact

Found while diagnosing a real import that had been running 2h10m with zero files copied. It was re-reading EXIF from 984 already-imported photos in a single archive folder, over an SMB-over-Tailscale mount, at **~3 files/min** — sampled live:

```
04:02:49   DSC_6774.NEF … DSC_6798.NEF   (25-file batch)
04:03:29   DSC_6774.NEF … DSC_6798.NEF   (same batch, still going)
04:04:09   DSC_6774.NEF … DSC_6785.NEF   (split to 12 after timeout)
```

exiftool batches kept exceeding their timeout on the high-latency mount and halving (50 → 25 → 12 → 6 → 3), burning the split budget. Projected ~5.5h for one folder, producing nothing — every value it fetched was already in the catalog.

## The fix

Pass `incremental=True` at that call site. Fresh landings are unaffected: they have no catalog row yet, so the skip path can't fire for them.

The local path never had this bug — its guard is `if landed:`, so a duplicate-only batch skips this scan entirely and falls through to the dedicated dup-link scan, which already passes `incremental=True`. The other three `scan()` call sites in the file were already correct.

## Why the existing test missed it

`test_remote_import_dup_link_scan_does_not_reread_unchanged_twins` already asserted this, but parks its twins in `mount_base/unsorted` — a *different* folder from the batch destination `mount_base/2026/2026-07-03`. So `restrict_dirs=[dest_folder]` walked an empty directory and read nothing either way. Right assertion, wrong geometry.

The new test puts the twins in the destination folder. On the old code:

```
AssertionError: remote duplicate-only import re-read already-cataloged,
unchanged twins in the destination folder: [.../DSC_0001.jpg, .../DSC_0002.jpg]
```

It seeds `_mark_exif_extracted(db)` like its siblings, since scanner's incremental skip requires non-NULL `exif_data` — without that the test would pass locally and fail in CI where ExifTool isn't installed.

## Tests

| Suite | Result |
|---|---|
| New test, before fix | **fails** (re-read both twins) |
| New test, after fix | passes |
| `vireo/tests/test_import_job.py` | 105 passed, 1 skipped |
| CLAUDE.md required set | 2029 passed, 1 failed |
| `test_scanner.py` + `test_import_dedup.py` | 157 passed |

The single failure is `test_app.py::test_api_exiftool_status_reports_missing`, a pre-existing environmental failure on the dev machine (ExifTool *is* installed there, so the test's "missing binary" premise doesn't hold). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)