### PR TITLE
Bring the remote import path to parity on detach handling

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -925,6 +925,26 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     run_dest_folders = {}
     run_verified_hashes = {}
 
+    # Sticky across the rest of the run once a mounted → unmounted
+    # transition is observed. The per-batch rollback below undoes
+    # ``to_transfer`` / ``adopted_paths`` / ``dup_skips`` / ``dup_dirs``
+    # but not the identities the same batch already installed in the
+    # job-wide ``checker`` (and in ``run_dest_folders`` /
+    # ``run_verified_hashes``) via ``_record_checker`` — and
+    # ``DuplicateChecker`` exposes no removal API, so those entries
+    # cannot be surgically undone. If the share remounts before a later
+    # batch (another date group, or after the 200-file batch boundary),
+    # a same-content card file in that later batch would hit the intra-
+    # run fast path at line 1237 and be counted as a duplicate of an
+    # adopted or queued file whose archive claim was just rolled back —
+    # so it is not transferred even though no backing archive copy
+    # exists, and ``copied + skipped_duplicate == discovered`` could
+    # again make ``safe_to_format`` go green over a card that is still
+    # the only real copy. Refusing every remaining batch once a detach
+    # has been observed keeps the stale intra-run cache from ever being
+    # consulted. See PR #1400 review (Codex P2 r3688614624).
+    mount_ever_lost = None
+
     # Mount-root check (Task 2.7 late follow-up): when a saved remote
     # target's local mount root is not mounted (for example ``/Volumes/NAS``
     # or ``/mnt/NAS`` is absent because the share isn't attached), a naive
@@ -982,6 +1002,29 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         if runner.is_cancelled(job["id"]):
             cancelled = True
             break
+
+        # A detach observed in an earlier batch is sticky: the intra-run
+        # duplicate cache and the job-wide checker hold identities for
+        # files whose archive claim was rolled back, and consulting them
+        # against a remounted share would count fresh card files as
+        # duplicates of transfers that never happened. Fail every
+        # remaining file in the run rather than risk a stale-cache hit.
+        # See PR #1400 review (Codex P2 r3688614624).
+        if mount_ever_lost:
+            for source_file in batch:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"archive mount root {mount_ever_lost} detached "
+                    "earlier in this import; the intra-run duplicate "
+                    "cache still holds identities for files whose "
+                    "archive claim was rolled back, so no further batch "
+                    "can be trusted to consult it",
+                )
+            _emit(
+                f"{rel}: archive unmounted", emitted, discovered,
+            )
+            continue
 
         dest_folder = (
             os.path.normpath(os.path.join(destination, rel))
@@ -1477,6 +1520,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 )
             to_transfer = []
             adopted_paths = {}
+            # Trip the run-wide sticky flag so every remaining batch is
+            # refused at the top of the loop rather than allowed to
+            # consult the intra-run duplicate cache (which still holds
+            # identities for the files just rolled back above; the
+            # checker has no removal API). See PR #1400 review (Codex
+            # P2 r3688614624).
+            mount_ever_lost = mount_lost
 
         landed = []   # (dest_path, card_source, src_hash, src_size, src_mtime_ns)
         # Honor cancellation before any network transfer starts. The break
@@ -2602,6 +2652,21 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     run_verified_hashes = {}
     linked_dup_dirs = set()    # dup-twin dirs already scanned+linked
 
+    # Sticky across the rest of the run once a mounted → unmounted
+    # transition is observed. The per-batch rollback below undoes
+    # ``dup_skips`` and ``landed`` but not the identities the same batch
+    # already installed in the job-wide ``checker`` (and in
+    # ``run_dest_folders`` / ``run_verified_hashes``) via
+    # ``_record_checker`` — and ``DuplicateChecker`` exposes no removal
+    # API, so those entries cannot be surgically undone. If the share
+    # remounts before a later batch, a same-content card file would hit
+    # the intra-run fast path and be counted as a duplicate of a landing
+    # whose archive claim was rolled back. Refusing every remaining
+    # batch keeps the stale intra-run cache from ever being consulted.
+    # Same rationale as the remote path (see PR #1400 review, Codex P2
+    # r3688614624).
+    mount_ever_lost = None
+
     def _counts(rel):
         return folder_counts.setdefault(
             rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0},
@@ -2677,6 +2742,29 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         if runner.is_cancelled(job["id"]):
             cancelled = True
             break
+
+        # A detach observed in an earlier batch is sticky for the rest
+        # of the run: the intra-run duplicate cache and the job-wide
+        # checker hold identities for files whose landing was rolled
+        # back, and consulting them against a remounted share would
+        # count fresh card files as duplicates of copies that never
+        # completed. Refuse every remaining file rather than risk a
+        # stale-cache hit. See PR #1400 review (Codex P2 r3688614624).
+        if mount_ever_lost:
+            for source_file in batch:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"archive mount root {mount_ever_lost} detached "
+                    "earlier in this import; the intra-run duplicate "
+                    "cache still holds identities for files whose "
+                    "landing was rolled back, so no further batch can "
+                    "be trusted to consult it",
+                )
+            _emit(
+                f"{rel}: archive unmounted", emitted, discovered,
+            )
+            continue
 
         # Normalize so the "/" strftime puts in ``rel`` (e.g. "2026/07-03")
         # lines up with what scanner stores. Scanner wraps paths in
@@ -3249,6 +3337,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     "not on the share",
                 )
             landed = []
+
+        # Trip the run-wide sticky flag so every remaining batch is
+        # refused at the top of the loop rather than allowed to consult
+        # the intra-run duplicate cache (which still holds identities
+        # for the files just rolled back above; the checker has no
+        # removal API). See PR #1400 review (Codex P2 r3688614624).
+        if mount_lost:
+            mount_ever_lost = mount_lost
 
         # --- Catalog this batch (even when cancelled mid-batch: what
         # landed on disk must be cataloged before we stop, so every

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1149,10 +1149,37 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # to catch that case at enqueue time — the file that was already
         # queued backs this skip. See PR #1113 review.
         queued_src_hashes = {}
+        # Accepted duplicate skips for this batch —
+        # (source_file, counted_unverified). A skip asserts the archive
+        # already holds these bytes, which a detach invalidates: the twin
+        # it matched may be a shadow file on the persistent mount stub
+        # left by an earlier failed import. These never enter ``landed``
+        # or ``adopted_paths``, so they need their own rollback or a
+        # duplicate-only batch reports every file accounted for and the
+        # card looks safe to erase. Mirrors the local path's ``dup_skips``.
+        # See PR #1396 review (Codex P1 r3688498501 / r3688501706).
+        dup_skips = []
+        # Sticky once tripped. The remote copy is one rsync per batch
+        # rather than a per-file write, but the duplicate/adoption
+        # decisions above happen per file and each one reads the mount —
+        # so the mount has to be re-checked at that granularity too.
+        mount_lost = None
         for source_file in batch:
             if runner.is_cancelled(job["id"]):
                 cancelled = True
                 break
+            if not mount_lost:
+                mount_lost = _unmounted_since_baseline(mount_baseline)
+            if mount_lost:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"archive mount root {mount_lost} detached while this "
+                    "batch was being prepared (the directory persists but "
+                    "the share is gone, so neither a transfer nor a "
+                    "duplicate match against it can be trusted)",
+                )
+                continue
             emitted += 1
             _emit(f"{rel}: importing", emitted, discovered, source_file.name)
             if checker is not None:
@@ -1174,6 +1201,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             unverified_duplicate += 1
                             dup_skipped += 1
                             _counts(rel)["skipped_duplicate"] += 1
+                            dup_skips.append((source_file, True))
                             dup_dirs.update(_linkable_twin_dirs(
                                 likely_rows, _path_under_destination,
                             ))
@@ -1258,6 +1286,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         skipped_duplicate += 1
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
+                        dup_skips.append((source_file, False))
                         # Preserve the verified twin folders so the follow-
                         # up dup-link scan can pull them into the active
                         # workspace. Without this a verified duplicate-only
@@ -1324,6 +1353,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 skipped_duplicate += 1
                 dup_skipped += 1
                 _counts(rel)["skipped_duplicate"] += 1
+                dup_skips.append((source_file, False))
                 _record_checker(source_file, dest_folder, src_hash)
                 continue
             stem, suffix = os.path.splitext(source_file.name)
@@ -1352,6 +1382,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         skipped_duplicate += 1
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
+                        dup_skips.append((source_file, False))
                         _record_checker(source_file, dest_folder, src_hash)
                         adopted = True
                         break
@@ -1368,6 +1399,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         skipped_duplicate += 1
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
+                        dup_skips.append((source_file, False))
                         claimed_basenames[candidate_key] = src_hash
                         # Track the adopted mount path + source-side hash
                         # so the restricted scan below picks it up (mixed
@@ -1406,6 +1438,46 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # confirmed the NAS bytes — and blind hash_status='ok' stamping would
         # flip safe_to_format green over storage we never touched. See PR
         # #1113 review.
+        # The per-file probe runs before each file is decided, so it
+        # cannot see a detach that happens while the last (or only) file
+        # is being considered. Probe once more here — before the transfer
+        # and before anything is cataloged — so the whole batch is
+        # covered. As on the local path this is the last probe that can
+        # help: a detach after it races the transfer and catalog scan,
+        # which no amount of probing can prevent.
+        if not mount_lost:
+            mount_lost = _unmounted_since_baseline(mount_baseline)
+
+        # A detach invalidates every accepted "already present" claim in
+        # this batch: the twin each one matched may be a shadow file on
+        # the mount stub rather than a real object on the NAS. Roll them
+        # back into failed, and drop the queued transfers and adoptions
+        # too — with the mount gone we can neither verify what the NAS
+        # holds nor trust the mount-side paths we were about to catalog.
+        if mount_lost:
+            for skipped_file, counted_unverified in dup_skips:
+                skipped_duplicate -= 1
+                dup_skipped -= 1
+                _counts(rel)["skipped_duplicate"] -= 1
+                if counted_unverified:
+                    unverified_duplicate -= 1
+                _fail(
+                    rel, skipped_file,
+                    f"archive mount root {mount_lost} detached mid-batch; "
+                    "the duplicate this file matched cannot be confirmed "
+                    "to be on the archive rather than in a local shadow",
+                )
+            dup_skips = []
+            dup_dirs = set()
+            for queued_file, _dest_basename, _queued_hash in to_transfer:
+                _fail(
+                    rel, queued_file,
+                    f"archive mount root {mount_lost} detached before this "
+                    "file was transferred",
+                )
+            to_transfer = []
+            adopted_paths = {}
+
         landed = []   # (dest_path, card_source, src_hash, src_size, src_mtime_ns)
         # Honor cancellation before any network transfer starts. The break
         # inside the per-file queue-building loop above sets ``cancelled``

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -7234,3 +7234,99 @@ def test_local_import_invalidates_duplicate_skips_when_mount_detaches(
     )
     assert result["failed"] == 1, result
     assert result["safe_to_format"] is False, result
+
+
+def test_remote_import_invalidates_duplicate_skips_when_mount_detaches(
+        tmp_path, monkeypatch):
+    """The remote path needs the local path's duplicate-skip rollback.
+
+    A twin-verified skip increments ``skipped_duplicate``, never enters
+    ``landed`` or ``adopted_paths``, and can be satisfied by a shadow file
+    left on the persistent mount stub by an earlier failed import — so
+    rsync is skipped entirely and ``copied + skipped_duplicate ==
+    discovered`` holds against bytes that are not on the NAS. With
+    ``verify_by_hash`` on, the ``<remote>`` honesty gate stops masking it
+    and safe_to_format can go true over a card that is the only real
+    copy. See PR #1396 review (Codex P1 r3688498501 / r3688501706).
+    """
+    import shutil
+
+    import import_job as _ij
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+    from scanner import compute_file_hash
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+    mount_base = ra["mount_base"]
+
+    # A shadow twin sitting on the mount stub, already cataloged — what an
+    # earlier failed import would have left behind.
+    twin_dir = os.path.join(mount_base, "2026", "2026-07-03")
+    os.makedirs(twin_dir, exist_ok=True)
+    twin_file = os.path.join(twin_dir, "IMG_0100.jpg")
+    Image.new("RGB", (16, 16), "red").save(twin_file)
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(twin_file, (ts, ts))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (twin_dir, "2026-07-03"),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0100.jpg", os.path.getsize(twin_file),
+         compute_file_hash(twin_file)),
+    )
+    db.conn.commit()
+
+    card = tmp_path / "card"
+    card.mkdir()
+    shutil.copy2(twin_file, str(card / "IMG_0100.jpg"))
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [mount_base] if str(path).startswith(mount_base) else [],
+    )
+    state = {"mounted": True}
+    real_ismount = os.path.ismount
+    monkeypatch.setattr(
+        os.path, "ismount",
+        lambda p: (
+            state["mounted"] if str(p) == mount_base else real_ismount(p)
+        ),
+    )
+
+    # Detach while the duplicate gate consults the twin — i.e. after the
+    # batch-boundary probe has already passed.
+    def _detach_after(fn):
+        def wrapper(*a, **kw):
+            rows = fn(*a, **kw)
+            state["mounted"] = False
+            return rows
+        return wrapper
+
+    monkeypatch.setattr(
+        _ij, "_key_twin_rows", _detach_after(_ij._key_twin_rows))
+    monkeypatch.setattr(
+        _ij, "_hash_twin_rows", _detach_after(_ij._hash_twin_rows))
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id, ImportParams(
+            sources=[str(card)], destination=mount_base,
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["skipped_duplicate"] == 0, (
+        "a duplicate accepted against a detached archive still counted as "
+        f"safely already-present: {result}"
+    )
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -7236,6 +7236,92 @@ def test_local_import_invalidates_duplicate_skips_when_mount_detaches(
     assert result["safe_to_format"] is False, result
 
 
+def test_local_import_mount_loss_is_sticky_across_batches(
+        tmp_path, monkeypatch):
+    """Same rationale as the remote-path sticky test: a batch's mount-
+    detach rollback undoes ``dup_skips`` / ``landed`` but not the
+    identities the same batch installed in the job-wide checker (and
+    ``run_dest_folders`` / ``run_verified_hashes``) via
+    ``_record_checker`` — ``DuplicateChecker`` exposes no removal API. If
+    the share remounts before a later batch, a byte-identical card file
+    would hit the intra-run fast path and be counted as a duplicate of a
+    rolled-back landing whose archive bytes never made it. See PR #1400
+    review (Codex P2 r3688614624).
+    """
+    import shutil
+
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+
+    dest = tmp_path / "mnt_NAS"
+    dest.mkdir()
+    day1_dir = dest / "2026" / "2026-07-03"
+    day1_dir.mkdir(parents=True)
+    # A twin file already at the batch 1 destination — the adopt branch
+    # matches it and calls ``_record_checker`` with dest_folder + hash,
+    # populating the job-wide checker's ``_seen_hashes`` and the intra-
+    # run cache. Those are what leak past the rollback.
+    twin_path = day1_dir / "IMG_0100.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(twin_path))
+    ts1 = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(twin_path), (ts1, ts1))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    card = tmp_path / "card"
+    card.mkdir()
+    # Batch 1 (2026-07-03): matches the adopted twin.
+    file_a = card / "IMG_0100.jpg"
+    shutil.copy2(str(twin_path), str(file_a))
+    os.utime(str(file_a), (ts1, ts1))
+    # Batch 2 (2026-07-04): byte-identical to A. Without the sticky
+    # fix, this hits the intra-run fast path against A's stale entry.
+    file_b = card / "IMG_0200.jpg"
+    shutil.copy2(str(twin_path), str(file_b))
+    ts2 = datetime(2026, 7, 4, 10, 0, 0).timestamp()
+    os.utime(str(file_b), (ts2, ts2))
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [str(dest)] if str(path).startswith(str(dest)) else [],
+    )
+    real_ismount = os.path.ismount
+    monkeypatch.setattr(
+        os.path, "ismount",
+        lambda p: True if str(p) == str(dest) else real_ismount(p),
+    )
+
+    # Sequence the mount-probe returns so batch 1 detaches AFTER its
+    # per-file loop and batch 2 would see a REMOUNTED share at its
+    # batch-boundary probe. Local path call sites (per batch):
+    #   batch-boundary, per-file (1x), post-loop.
+    seq = iter([None, None, str(dest), None, None, None])
+
+    def fake_unmounted(baseline):
+        try:
+            return next(seq)
+        except StopIteration:
+            return None
+
+    monkeypatch.setattr(_pj, "_unmounted_since_baseline", fake_unmounted)
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id, ImportParams(
+            sources=[str(card)], destination=str(dest),
+        ),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["skipped_duplicate"] == 0, (
+        "file B in batch 2 was counted as a duplicate of A's rolled-back "
+        f"adopt via the stale intra-run cache: {result}"
+    )
+    assert result["failed"] == 2, result
+    assert result["safe_to_format"] is False, result
+
+
 def test_remote_import_invalidates_duplicate_skips_when_mount_detaches(
         tmp_path, monkeypatch):
     """The remote path needs the local path's duplicate-skip rollback.
@@ -7330,3 +7416,119 @@ def test_remote_import_invalidates_duplicate_skips_when_mount_detaches(
     )
     assert result["failed"] == 1, result
     assert result["safe_to_format"] is False, result
+
+
+def test_remote_import_mount_loss_is_sticky_across_batches(
+        tmp_path, monkeypatch):
+    """Mount loss must be sticky for the rest of the run.
+
+    A batch's mount-detach rollback undoes ``dup_skips`` / ``to_transfer``
+    / ``adopted_paths`` but not the identities the same batch already
+    installed in the job-wide checker (and in ``run_dest_folders`` /
+    ``run_verified_hashes``) via ``_record_checker`` — and
+    ``DuplicateChecker`` exposes no removal API, so those entries cannot
+    be surgically undone. If the share remounts before a later batch, a
+    byte-identical card file in that later batch would hit the intra-run
+    fast path at line 1237 and be counted as a duplicate of an adopted
+    or queued file whose archive claim was rolled back, with no backing
+    NAS copy. Refusing every remaining batch keeps the stale cache from
+    being consulted. See PR #1400 review (Codex P2 r3688614624).
+    """
+    import shutil
+
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+    mount_base = ra["mount_base"]
+
+    # Adopted twin already at the batch 1 destination (crash-recovery
+    # shape). The adopt branch matches its bytes and calls
+    # ``_record_checker`` with dest_folder + hash — populating both the
+    # job-wide checker's ``_seen_hashes`` and the intra-run
+    # ``run_dest_folders`` / ``run_verified_hashes``. Those are the
+    # entries the fix has to keep unreachable after the rollback.
+    day1_dir = os.path.join(mount_base, "2026", "2026-07-03")
+    os.makedirs(day1_dir)
+    twin_path = os.path.join(day1_dir, "IMG_0100.jpg")
+    Image.new("RGB", (16, 16), "red").save(twin_path)
+    ts1 = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(twin_path, (ts1, ts1))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    card = tmp_path / "card"
+    card.mkdir()
+    # Batch 1 (2026-07-03): matches the adopted twin.
+    file_a = card / "IMG_0100.jpg"
+    shutil.copy2(twin_path, str(file_a))
+    os.utime(str(file_a), (ts1, ts1))
+    # Batch 2 (2026-07-04): BYTE-IDENTICAL to A. Without the sticky fix
+    # this hits the intra-run fast path against A's stale entry in
+    # ``run_dest_folders`` and is counted as ``skipped_duplicate`` even
+    # though A's landing was rolled back and the NAS holds nothing for
+    # it. With the fix, batch 2 is refused at the top of the loop.
+    file_b = card / "IMG_0200.jpg"
+    shutil.copy2(twin_path, str(file_b))
+    ts2 = datetime(2026, 7, 4, 10, 0, 0).timestamp()
+    os.utime(str(file_b), (ts2, ts2))
+
+    monkeypatch.setattr(
+        _pj, "_archive_mount_root_candidates",
+        lambda path: [mount_base] if str(path).startswith(mount_base) else [],
+    )
+
+    # Baseline captured at job start uses ismount — leave the mount root
+    # reporting live so the baseline is True. The per-batch detach/remount
+    # timing is driven through ``_unmounted_since_baseline`` below.
+    real_ismount = os.path.ismount
+    monkeypatch.setattr(
+        os.path, "ismount",
+        lambda p: True if str(p) == mount_base else real_ismount(p),
+    )
+
+    # Sequence the mount-probe returns so batch 1 detaches AFTER the
+    # per-file loop (post the adopt-branch _record_checker) and batch 2
+    # would see a REMOUNTED share at its batch-boundary probe. Without
+    # the sticky fix, batch 2 then reaches the dup gate and consults the
+    # stale intra-run cache; with it, ``mount_ever_lost`` already fired
+    # in batch 1 and batch 2's per-file fail loop runs before any probe.
+    #
+    # Call sites (remote path):
+    #   batch 1: batch-boundary, per-file (1x), post-loop
+    #   batch 2 without the fix: batch-boundary, per-file (1x), post-loop
+    seq = iter([None, None, mount_base, None, None, None])
+
+    def fake_unmounted(baseline):
+        try:
+            return next(seq)
+        except StopIteration:
+            return None
+
+    monkeypatch.setattr(_pj, "_unmounted_since_baseline", fake_unmounted)
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id, ImportParams(
+            sources=[str(card)], destination=mount_base,
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # File A was adopted in batch 1 then rolled back on detach; file B
+    # in batch 2 must NOT be counted as skipped_duplicate against A's
+    # stale intra-run cache entry. Both end up failed.
+    assert result["copied"] == 0, result
+    assert result["skipped_duplicate"] == 0, (
+        "file B in batch 2 was counted as a duplicate of A's rolled-back "
+        f"adopt via the stale intra-run cache: {result}"
+    )
+    assert result["failed"] == 2, result
+    assert result["safe_to_format"] is False, result
+
+    # No rsync happened either — both batches short-circuited before the
+    # transfer step.
+    assert calls["rsync"] == [], calls["rsync"]


### PR DESCRIPTION
Follow-up to #1396, closing the two remote-path findings Codex raised there ([P1 r3688498501](https://github.com/jss367/vireo/pull/1396#discussion_r3688498501), [Major r3688501706](https://github.com/jss367/vireo/pull/1396#discussion_r3688501706)).

## I was wrong about this one

On #1396 I argued the remote path was *"a different shape rather than the same bug"* — its copy is one rsync per batch rather than a per-file write, so I reasoned there was no equivalent per-file window. Codex showed the mechanism I missed.

**The exposure isn't the copy, it's the duplicate/adoption path:**

1. A twin-verified skip increments `skipped_duplicate` and never enters `landed` or `adopted_paths`
2. The twin it matches can be a **shadow file left on the persistent mount stub by an earlier failed import**
3. rsync is therefore skipped entirely — nothing is sent to the NAS
4. `copied + skipped_duplicate == discovered` holds, against bytes that aren't there
5. With `verify_by_hash` on, the `<remote>` honesty gate stops masking it, so **`safe_to_format` goes true over a card that is the only real copy**

Those duplicate decisions each read the mount, per file, even though the transfer is batched. So the per-file granularity does apply.

## The fix

Ports the three layers the local path gained in #1396:

- **per-file probe** — the duplicate and adoption decisions each read the mount
- **post-loop probe before the transfer** — covers the last file, which the pre-file probe structurally can't
- **rollback of accepted duplicate skips** (and `dup_dirs`) on detach

Queued transfers and adoptions are dropped as well: with the mount gone we can neither verify what the NAS holds nor trust the mount-side paths we were about to catalog.

## Testing

New test reproduces the exact scenario — a duplicate-only remote batch with a cataloged shadow twin on the mount stub, share detaching while the duplicate gate consults it:

| | before | after |
|---|---|---|
| `skipped_duplicate` | 1 | 0 |
| `failed` | 0 | 1 |
| `safe_to_format` | **TRUE** | false |

119 import-path tests pass. Re-verified unmocked against a real SMB archive: still recognized as a live mount, no false positives for it, for an ordinary directory, or for a mount-shaped path that was never mounted.

## Deliberately not addressed

**First import to an already-detached share** ([r3687552574](https://github.com/jss367/vireo/pull/1396#discussion_r3687552574)). With a new or rebuilt database there's no mount history, and `ismount` is false, so a detached share is *genuinely indistinguishable* from an ordinary local directory that happens to sit at a mount-shaped path. No amount of inference separates them — every heuristic I can construct either misses the detached share or refuses a legitimate local destination.

This likely wants an explicit user-declared "this destination is a network archive" signal (a per-destination setting, or deriving it from a configured remote target) rather than more guessing. That's a product decision, not a bug fix, so it's flagged rather than solved.

Same for the residual TOCTOU window: a detach *after* the final probe races the transfer and catalog scan, and no probe can prevent that. What the guards do guarantee is that nothing is booked as archived — copied or duplicate-skipped — without a mount check bracketing the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import reliability when mounted storage becomes unavailable during a run.
  * Affected duplicate skips, queued transfers, adoptions, and completed copies are now marked as failures.
  * Subsequent import batches are blocked after mount detachment, preventing stale duplicate decisions.
  * Remote imports now verify storage availability immediately before transfers and avoid starting transfers when detached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->