### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # ── Version sync ──────────────────────────────────────
       - name: Sync version from tag
@@ -68,7 +68,7 @@ jobs:
 
       # ── Python & sidecar ──────────────────────────────────
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # Windows: PyInstaller --onefile DLL loading bug with 3.14
           python-version: ${{ runner.os == 'Windows' && '3.13' || env.PYTHON_VERSION }}
@@ -170,7 +170,7 @@ jobs:
 
       # ── Node.js (for Tauri CLI) ───────────────────────────
       - name: Set up Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -484,7 +484,7 @@ jobs:
       - name: Upload Windows application binaries for signing
         id: upload_windows_binaries
         if: runner.os == 'Windows' && steps.win_signing.outputs.should_sign == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vireo-windows-binaries-unsigned
           path: windows-binaries-unsigned/*
@@ -572,7 +572,7 @@ jobs:
       - name: Upload unsigned Windows signing input
         id: upload_windows_installers
         if: runner.os == 'Windows' && steps.win_signing.outputs.should_sign == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vireo-windows-installers-unsigned
           path: windows-installers-unsigned/*
@@ -637,7 +637,7 @@ jobs:
       # ── Upload artifacts ──────────────────────────────────
       - name: Upload build artifacts
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vireo-${{ matrix.label }}
           path: |
@@ -657,7 +657,7 @@ jobs:
 
       - name: Upload unsigned Windows CI artifacts
         if: runner.os == 'Windows' && steps.win_signing.outputs.should_sign != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: vireo-${{ matrix.label }}
           path: |
@@ -670,7 +670,7 @@ jobs:
 
       - name: Upload signed Windows artifacts
         if: runner.os == 'Windows' && steps.win_signing.outputs.should_sign == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.sign_windows_candidate && inputs.tag_name == '' && 'vireo-windows-x86_64-signed-candidate' || 'vireo-windows-x86_64' }}
           path: signed-windows/**/*
@@ -686,10 +686,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: false
@@ -771,13 +771,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ secrets.WEBSITE_PR_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -20,9 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -38,7 +38,7 @@ jobs:
           PUBLIC_CLOUDFLARE_WEB_ANALYTICS_TOKEN: ${{ vars.CLOUDFLARE_WEB_ANALYTICS_TOKEN }}
         run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: website/dist
 
@@ -50,4 +50,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
           cache: pip

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -14,8 +14,8 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install Vireo

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -60,7 +60,7 @@ jobs:
             || true
           gh pr edit "$PR" --repo "$REPO" --add-label "$AGENT_LABEL"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fire routine
         uses: ./.github/actions/fire-routine
@@ -91,7 +91,7 @@ jobs:
           || github.actor == 'chatgpt-codex-connector[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fire routine
         uses: ./.github/actions/fire-routine
@@ -117,7 +117,7 @@ jobs:
           || github.actor == 'chatgpt-codex-connector[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check for open review threads
         id: threads
@@ -190,7 +190,7 @@ jobs:
             echo "is_fork=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.fork-check.outputs.is_fork == 'false'
 
       - name: Check for open review threads
@@ -264,7 +264,7 @@ jobs:
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "should_fix=true" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.pr.outputs.should_fix == 'true'
 
       - name: Fire routine
@@ -334,7 +334,7 @@ jobs:
             echo "pr_csv=$pr_csv" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.conflicts.outputs.has_conflicts == 'true'
 
       - name: Fire routine

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -61,6 +61,8 @@ jobs:
           gh pr edit "$PR" --repo "$REPO" --add-label "$AGENT_LABEL"
 
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Fire routine
         uses: ./.github/actions/fire-routine
@@ -92,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Fire routine
         uses: ./.github/actions/fire-routine
@@ -118,6 +122,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Check for open review threads
         id: threads
@@ -192,6 +198,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: steps.fork-check.outputs.is_fork == 'false'
+        with:
+          persist-credentials: false
 
       - name: Check for open review threads
         id: threads
@@ -266,6 +274,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: steps.pr.outputs.should_fix == 'true'
+        with:
+          persist-credentials: false
 
       - name: Fire routine
         if: steps.pr.outputs.should_fix == 'true'
@@ -336,6 +346,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: steps.conflicts.outputs.has_conflicts == 'true'
+        with:
+          persist-credentials: false
 
       - name: Fire routine
         if: steps.conflicts.outputs.has_conflicts == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: needs.changes.outputs.python == 'true'
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         if: needs.changes.outputs.python == 'true'
@@ -242,6 +244,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: needs.changes.outputs.python == 'true'
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         if: needs.changes.outputs.python == 'true'
@@ -273,6 +277,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: needs.changes.outputs.python == 'true'
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         if: needs.changes.outputs.python == 'true'
@@ -319,6 +325,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: needs.changes.outputs.build == 'true'
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
         if: needs.changes.outputs.build == 'true'
@@ -349,6 +357,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: needs.changes.outputs.python == 'true'
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         if: needs.changes.outputs.python == 'true'
@@ -375,6 +385,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: needs.changes.outputs.website == 'true'
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         if: needs.changes.outputs.website == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Classify changed files
         id: filter
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -88,12 +88,12 @@ jobs:
           echo "No Python application, script, or test files changed."
           echo "Build-only paths changed: ${{ needs.changes.outputs.build }}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.python == 'true'
 
       - name: Set up Python
         if: needs.changes.outputs.python == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -117,7 +117,7 @@ jobs:
       - name: Cache MegaDetector weights
         id: cache-mdv6
         if: needs.changes.outputs.python == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.vireo/models/megadetector-v6
           key: megadetector-v6-${{ runner.os }}-v1
@@ -240,12 +240,12 @@ jobs:
         if: needs.changes.outputs.python != 'true'
         run: echo "No Python application, script, or test files changed."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.python == 'true'
 
       - name: Set up Python
         if: needs.changes.outputs.python == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -271,12 +271,12 @@ jobs:
         if: needs.changes.outputs.python != 'true'
         run: echo "No application or browser-test files changed."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.python == 'true'
 
       - name: Set up Python
         if: needs.changes.outputs.python == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 
@@ -317,7 +317,7 @@ jobs:
         if: needs.changes.outputs.build != 'true'
         run: echo "No Tauri or build files changed."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.build == 'true'
 
       - uses: dtolnay/rust-toolchain@stable
@@ -347,10 +347,10 @@ jobs:
         if: needs.changes.outputs.python != 'true'
         run: echo "No application files changed."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.python == 'true'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: needs.changes.outputs.python == 'true'
         with:
           python-version: "3.14"
@@ -373,12 +373,12 @@ jobs:
         if: needs.changes.outputs.website != 'true'
         run: echo "No website files changed."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.website == 'true'
 
       - name: Set up Node.js
         if: needs.changes.outputs.website == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm


### PR DESCRIPTION
Updates all official actions used across the build, test, release, Pages, performance, and PR-agent workflows to Node 24-compatible majors. This removes the Node 20 action-runtime deprecation warnings while preserving Vireo's configured application runtime and existing workflow behavior. Validated with YAML parsing, a repository-wide deprecated-reference check, and git diff checks against origin/main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, release, testing, deployment, and performance workflows to use newer action versions.
  * Improved the reliability and maintainability of continuous integration and website deployment processes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->