### PR TITLE
Stop duplicate imports from scanning archive folders

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2057,13 +2057,6 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     if params.verify_by_hash:
                         verified -= 1
                     _fail(rel, dest_path, f"catalog scan failed: {e}")
-                # An adopted-only batch has no landed entries to roll back,
-                # but its pre-existing mount file still needs a catalog row.
-                if not landed and adopted_paths:
-                    _fail(
-                        rel, dest_folder,
-                        f"catalog scan failed for adopted mount files: {e}",
-                    )
                 landed = []
             else:
                 _invalidate_new_images(db, dest_folder)

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -3106,12 +3106,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     if src_size == 0 and dest_size == 0:
                         # Zero-byte twin: identical by definition, but kept
                         # out of the duplicate-identity index (see ingest).
-                        skipped_duplicate += 1
-                        _counts(rel)["skipped_duplicate"] += 1
-                        dup_skips.append((source_file, False))
-                        dup_dirs.add(dest_folder)
-                        continue
-                    if src_size == dest_size:
+                        # Treat it as an adopted landing, not a cataloged
+                        # twin: a crash may have left these bytes on disk
+                        # before any folder/photo row was committed. The
+                        # exact-file batch scan below catalogs that recovery
+                        # case without walking the rest of the directory.
+                        adopted_dest = (dest_file, EMPTY_FILE_SHA256)
+                    elif src_size == dest_size:
                         dest_hash = compute_file_hash(dest_file)
                         src_h = _src_hash_cached()
                         if src_h is not None and src_h == dest_hash:

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -35,19 +35,14 @@ Reconnaissance notes (Task 2.0, verified 2026-07-04):
 4. Batch unit: files grouped by destination (template) folder,
    processed in template order, chunked to at most
    ``IMPORT_BATCH_SIZE`` files per scan call. Restricted scans only
-   enumerate the restricted dirs, so per-batch scan cost tracks the
-   batch, not the archive tree. One deliberate deviation from the plan
-   text: duplicate-matched folders are scanned in a SEPARATE
-   ``scan(restrict_dirs=…, incremental=True)`` call without
-   ``restrict_files``, so that uncataloged strays sitting in a matched
-   folder get self-healed into the catalog. ``incremental=True`` is what
-   keeps that affordable: without it the call re-read and re-hashed
-   every file in the matched folders, so importing a card of pure
-   duplicates re-read the whole archive folder (see
-   ``test_duplicate_only_import_does_not_reread_unchanged_twins``).
-   Note the folder rows/workspace links do NOT depend on this call
-   discovering files — ``scanner._ensure_folder`` runs unconditionally
-   for every ``restrict_dirs`` entry (PR #752).
+   enumerate the files the batch actually landed, so per-batch scan cost
+   tracks the batch, not the archive tree. Duplicate-matched folders are
+   linked to the active workspace directly from their existing catalog
+   rows. They are deliberately NOT scanned as part of the import: even an
+   incremental scan must enumerate/stat every entry, which can block a
+   zero-copy import for hours on SMB. Uncataloged strays and ``partial``
+   folder health remain visible for the explicit folder-rescan workflow;
+   archive repair is not part of the import's critical path.
 """
 
 import contextlib
@@ -647,14 +642,14 @@ def _likely_twin_rows(db, token, source_file, path_under_source):
 def _linkable_twin_dirs(rows, under_destination):
     """Destination-scoped folders holding a duplicate's cataloged twin.
 
-    Only folders under the import destination are scanned/linked after a
+    Only folders under the import destination are linked after a
     duplicate skip (a twin in some other library root is none of this
     import's business). Mirrors ingest()'s dup_token_folders guards:
     path under destination and still a real directory on disk. Status
     ``ok``/``partial`` is trusted as-is; ``missing`` is accepted too when
     the path is still a real directory (a reattached archive drive whose
     row hasn't been refreshed yet), and ``run_import_job`` promotes it
-    to ``ok`` before the dup-link scan runs — otherwise a duplicate-only
+    to ``ok`` as part of the direct link — otherwise a duplicate-only
     batch that matches a missing-marked twin folder would drop it from
     ``dup_dirs``, safe_to_format could go green, and the imported
     duplicates would stay filtered out of workspace queries.
@@ -664,7 +659,7 @@ def _linkable_twin_dirs(rows, under_destination):
     semantics). A lexical prefix check would drop a twin folder when the
     destination is a symlink to the twin's on-disk archive root, or
     spelled with different case on a case-insensitive mount — dropping
-    the twin means the duplicate-link scan never runs and the imported
+    the twin means the direct workspace link never runs and the imported
     duplicate stays filtered out of the active workspace while
     safe_to_format still flips green. See PR #1107 review.
     """
@@ -681,18 +676,51 @@ def _linkable_twin_dirs(rows, under_destination):
     return dirs
 
 
-def _dup_link_phase(dup_dirs):
-    """Progress phase for the duplicate-folder link scan.
+def _link_duplicate_twin_dirs(db, workspace_id, dup_dirs):
+    """Link cataloged duplicate folders without walking archive storage.
 
-    Says what the scan is actually walking — the archive folders that
-    already hold this card's photos — rather than a generic "scanning".
-    Wording mirrors the import preview's "N already in your library" so
-    the two screens describe the same files the same way.
+    ``_linkable_twin_dirs`` has already proved each path is a cataloged
+    folder under the destination and is currently a real directory. A
+    filesystem scan adds no evidence about the duplicate bytes themselves;
+    it only used to be an indirect way to create ``workspace_folders`` rows.
+    Doing that directly keeps duplicate-only imports independent of SMB
+    directory-enumeration latency.
+
+    A reattached folder whose stale status is ``missing`` is promoted after
+    the existence check. ``partial`` is intentionally preserved: only an
+    explicit successful rescan may claim that an incomplete scan is repaired.
+    Returns ``(linked_paths, failures)`` so callers can keep
+    ``safe_to_format`` honest if the database link itself fails.
     """
-    n = len(dup_dirs)
-    return (
-        f"Checking {n} folder{'' if n == 1 else 's'} already in your library"
-    )
+    linked = set()
+    failures = {}
+    for folder_path in sorted(dup_dirs):
+        try:
+            folder_row = db.conn.execute(
+                "SELECT id, status FROM folders WHERE path = ?",
+                (folder_path,),
+            ).fetchone()
+            if folder_row is None:
+                raise RuntimeError("folder row not found")
+            if folder_row["status"] == "missing":
+                db.conn.execute(
+                    "UPDATE folders SET status = 'ok' WHERE id = ? "
+                    "AND status = 'missing'",
+                    (folder_row["id"],),
+                )
+            db.add_workspace_folder(
+                workspace_id, folder_row["id"], is_root=True,
+            )
+        except Exception as exc:
+            db.conn.rollback()
+            failures[folder_path] = str(exc)
+            log.exception(
+                "Linking duplicate-matched folder failed: %s", folder_path,
+            )
+            continue
+        linked.add(folder_path)
+        _invalidate_new_images(db, folder_path)
+    return linked, failures
 
 
 def _run_remote_import_job(job, runner, db, workspace_id, params):
@@ -898,12 +926,10 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # successful remote import falls into the "no new photos" branch and
     # the requested process job never runs.
     imported_photo_ids = set()
-    # Dup-twin dirs already scanned/linked across batches (no rescan the
-    # next time the same twin folder appears in a later batch's skip set).
+    # Dup-twin dirs already linked across batches.
     linked_dup_dirs = set()
-    # A duplicate-only batch's ONLY workspace-visibility step is the dup-
-    # link scan; if it raises, safe_to_format must go False (imported bytes
-    # exist on disk but the workspace can't see them).
+    # A duplicate-only batch's workspace visibility depends on the direct
+    # DB link; if it fails, safe_to_format must remain false.
     dup_link_failed = False
 
     def _counts(rel):
@@ -1331,7 +1357,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         _counts(rel)["skipped_duplicate"] += 1
                         dup_skips.append((source_file, False))
                         # Preserve the verified twin folders so the follow-
-                        # up dup-link scan can pull them into the active
+                        # up direct link can pull them into the active
                         # workspace. Without this a verified duplicate-only
                         # remote import whose twins live in a different
                         # folder than this run's template output would skip
@@ -1691,33 +1717,18 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     _record_checker(sf, dest_folder, src_hash)
 
         # --- Catalog this batch ----------------------------------------
-        # Fresh copies AND duplicate skips both need the mount folder
-        # cataloged+linked (a duplicate-only batch would otherwise leave the
-        # mount folder invisible). scan() over the mount is the same call the
-        # local path makes; the mount is locally walkable.
-        if landed or dup_skipped:
+        # Scan only files that were freshly transferred or adopted from an
+        # uncataloged mount-side collision. Cataloged duplicate twins are
+        # linked directly below; scanning a duplicate-only destination would
+        # enumerate/stat the entire mounted NAS folder for no new rows.
+        if landed or adopted_paths:
             landed_paths = {entry[0] for entry in landed}
             # Include collision-loop adopted mount paths so their photo rows
-            # get created by the restricted scan. When ``landed`` is
-            # empty the pre-existing catch-all below (a bare
-            # ``restrict_dirs=[dest_folder]`` scan without ``restrict_files``)
-            # would already discover them via directory walk, but a mixed
-            # batch (some fresh copies + some adopted) has non-empty
-            # ``landed_paths``, and passing that alone as ``restrict_files``
-            # narrows the scan so tightly that the adopted-but-uncataloged
-            # files never become photo rows. See PR #1113 review.
+            # get created by the restricted scan. The explicit file set is
+            # also what prevents a duplicate-only import from falling back
+            # to a whole-directory discovery walk. See PR #1113 review.
             scan_files = landed_paths | set(adopted_paths.keys())
             try:
-                # Incremental ONLY for the duplicate-only case, where
-                # ``scan_files`` is empty so ``restrict_files`` is None and
-                # this call walks the whole ``dest_folder``. Re-importing a
-                # card into the same date folder it originally landed in
-                # means that folder already holds every twin, and walking
-                # it non-incrementally re-read and re-hashed all of them —
-                # an hours-long rescan on a network archive for a zero-copy
-                # import.
-                #
-                # It must stay OFF whenever ``scan_files`` is non-empty.
                 # A landed path is not necessarily uncataloged: a stale row
                 # can survive for a file deleted off the archive, and if
                 # the replacement bytes land at that path carrying an mtime
@@ -1732,8 +1743,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 scan(
                     destination, db,
                     restrict_dirs=[dest_folder],
-                    restrict_files=(scan_files or None),
-                    incremental=not scan_files,
+                    restrict_files=scan_files,
                     vireo_dir=params.vireo_dir,
                     thumb_cache_dir=params.thumb_cache_dir,
                     skip_working_copies=True,
@@ -1746,22 +1756,12 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     if params.verify_by_hash:
                         verified -= 1
                     _fail(rel, dest_path, f"catalog scan failed: {e}")
-                # A duplicate-only batch (all files matched cataloged
-                # twins) still needs the scan() call to link the twin
-                # folder into the workspace. If landed is empty (no fresh
-                # copies) but dup_skipped > 0 and scan() raised, no
-                # per-file failure was recorded above and safe_to_format
-                # could go green while the duplicate folder never became
-                # visible in the workspace. Record a batch-level failure
-                # for that case so ``failed`` reflects "the workspace
-                # cannot see these bytes" and safe_to_format goes False.
-                # Mirrors the local path's ``dup_link_failed`` gate. See
-                # PR #1113 review.
-                if not landed and dup_skipped > 0:
+                # An adopted-only batch has no landed entries to roll back,
+                # but its pre-existing mount file still needs a catalog row.
+                if not landed and adopted_paths:
                     _fail(
                         rel, dest_folder,
-                        f"catalog scan failed for duplicate-only batch "
-                        f"(twin folder not linked): {e}",
+                        f"catalog scan failed for adopted mount files: {e}",
                     )
                 landed = []
             else:
@@ -2128,130 +2128,26 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
 
         # --- Link verified duplicate-twin folders ----------------------
         # A verified duplicate skip's twin folder may live elsewhere under
-        # the archive (older date-layout, ``unsorted``, etc.). The batch
-        # scan above only touches ``dest_folder``, so without this
-        # follow-up scan the twin folder never becomes visible in the
-        # active workspace even though its bytes back the safe-to-format
-        # skip. Mirrors the local path's dup-link scan (see PR #1107). Any
-        # failure here forces ``safe_to_format=False`` — the file is on
-        # disk but the workspace can't see it. See PR #1113 review.
+        # the archive (older date-layout, ``unsorted``, etc.). Link its
+        # existing catalog row directly instead of scanning the folder: an
+        # incremental scan still enumerates/stats every NAS entry and can
+        # turn a zero-copy import into an hours-long metadata walk.
         new_dup_dirs = dup_dirs - linked_dup_dirs
         if new_dup_dirs:
-            # Promote missing rows for twin folders too (a reattached
-            # archive drive with a stale ``missing`` marker wouldn't be
-            # cleared by ``scanner.scan()``'s success stamp, which only
-            # touches ``partial``). Mirrors the fresh-batch promote above.
-            db.conn.executemany(
-                "UPDATE folders SET status = 'ok' "
-                "WHERE path = ? AND status = 'missing'",
-                [(d,) for d in sorted(new_dup_dirs)],
+            linked, failures = _link_duplicate_twin_dirs(
+                db, workspace_id, new_dup_dirs,
             )
-            db.conn.commit()
-            # Twin folders may be cataloged through a symlink alias, or —
-            # on a case-insensitive destination (macOS/SMB/FAT) — spelled
-            # with different case than ``destination``.
-            # ``_path_under_destination`` accepts both via realpath /
-            # case-fold, but scanner's ``_ensure_folder`` walks ``Path``
-            # parents until they *lexically* (case-sensitive string
-            # equality, independent of the filesystem's case sensitivity)
-            # equal the scan root. A restrict_dir ``/alias/…`` under root
-            # ``/real/archive`` — or a case-only alias like
-            # ``/volumes/nas/…`` under root ``/Volumes/NAS/…`` — would
-            # recurse toward ``/`` before the ``workspace_folders`` link
-            # is ever created, leaving the verified duplicate-only remote
-            # import marked failed/unsafe. Split with a LITERAL
-            # (case-sensitive) prefix check: link case- or symlink-alias
-            # twins directly (their folder row and the twin's photos
-            # already exist — no self-heal scan needed for workspace
-            # visibility), scan only the exactly-cased-under-destination
-            # ones. Mirrors the local path's split; see PR #1113 review.
-            lex_dup_dirs = set()
-            alias_dup_dirs = set()
-            _dest_lit_norm = destination.rstrip(os.sep)
-            for d in new_dup_dirs:
-                d_lit = d.rstrip(os.sep)
-                if (
-                    d_lit == _dest_lit_norm
-                    or d_lit.startswith(_dest_lit_norm + os.sep)
-                ):
-                    lex_dup_dirs.add(d)
-                else:
-                    alias_dup_dirs.add(d)
-
-            for d in sorted(alias_dup_dirs):
-                folder_row = db.conn.execute(
-                    "SELECT id FROM folders WHERE path = ?", (d,),
-                ).fetchone()
-                if folder_row is None:
-                    log.warning(
-                        "Alias-spelled dup dir %s vanished from folders "
-                        "between _linkable_twin_dirs and the direct "
-                        "workspace link", d,
-                    )
-                    dup_link_failed = True
+            linked_dup_dirs.update(linked)
+            if failures:
+                dup_link_failed = True
+                for d, detail in failures.items():
                     unsafe_files.append({
                         "path": d,
                         "reason": (
                             "duplicate-folder workspace link failed: "
-                            "folder row not found"
+                            f"{detail}"
                         ),
                     })
-                    continue
-                db.add_workspace_folder(
-                    workspace_id, folder_row["id"], is_root=True,
-                )
-                linked_dup_dirs.add(d)
-                _invalidate_new_images(db, d)
-            db.conn.commit()
-
-            if lex_dup_dirs:
-                try:
-                    # ``incremental=True`` and the phase emits for the
-                    # same reasons as the local path's dup-link scan:
-                    # already-cataloged, unchanged twins must not be
-                    # re-read just to link their folder, and the walk is
-                    # slow enough that silence reads as a hang. See the
-                    # module docstring.
-                    _phase_prefix = _dup_link_phase(lex_dup_dirs)
-                    _emit(_phase_prefix, emitted, discovered)
-                    scan(
-                        destination, db,
-                        restrict_dirs=sorted(lex_dup_dirs),
-                        incremental=True,
-                        vireo_dir=params.vireo_dir,
-                        thumb_cache_dir=params.thumb_cache_dir,
-                        skip_working_copies=True,
-                        cancel_check=lambda: runner.is_cancelled(job["id"]),
-                        status_callback=(
-                            lambda msg, _p=_phase_prefix, _e=emitted,
-                            _d=discovered, **kw: _emit(
-                                f"{_p} — {msg}", _e, _d,
-                            )
-                        ),
-                    )
-                    linked_dup_dirs.update(lex_dup_dirs)
-                    for d in sorted(lex_dup_dirs):
-                        _invalidate_new_images(db, d)
-                except Exception as e:
-                    if (
-                        isinstance(e, RuntimeError)
-                        and str(e) == "scan cancelled"
-                        and runner.is_cancelled(job["id"])
-                    ):
-                        cancelled = True
-                    else:
-                        log.exception(
-                            "Linking duplicate-matched folders failed: %s",
-                            sorted(lex_dup_dirs),
-                        )
-                        dup_link_failed = True
-                        for d in sorted(lex_dup_dirs):
-                            unsafe_files.append({
-                                "path": d,
-                                "reason": (
-                                    f"duplicate-folder link scan failed: {e}"
-                                ),
-                            })
 
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "
@@ -2436,12 +2332,10 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # Also resolve symlinks (``realpath``) so a destination like ``/photos``
     # symlinked at ``/Volumes/Photos`` matches cataloged twin folders whose
     # ``folders.path`` was scanned under the real archive root — otherwise
-    # a duplicate-only import's dup-link scan is called with the symlink
-    # path as root while its ``restrict_dirs`` hold the real path, and
-    # ``_ensure_folder``'s walk never reaches root (dead recurse). Sources
-    # are already ``realpath``-resolved (see ``_norm_source``); doing the
-    # same to destination keeps the two sides symmetric. See PR #1107
-    # review.
+    # duplicate matching compares paths from prior catalog scans against
+    # this destination. Sources are already ``realpath``-resolved (see
+    # ``_norm_source``); doing the same to destination keeps the two sides
+    # symmetric. See PR #1107 review.
     try:
         destination = os.path.realpath(os.path.normpath(str(params.destination)))
     except OSError:
@@ -3721,180 +3615,29 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     )
                 wc_dest_folders.add(dest_folder)
 
-        # --- Link duplicate-twin folders. Separate scan call WITHOUT
-        # restrict_files so any uncataloged strays in these dirs get
-        # self-healed into the catalog — the restricted call above sees
-        # only what this batch landed. ``incremental=True`` bounds the
-        # cost to those strays: a twin that is already cataloged and
-        # unchanged is skipped on mtime instead of being re-opened and
-        # re-hashed. Without it, a card of pure duplicates re-read every
-        # byte of the matched archive folder(s) — hours over a network
-        # archive to import nothing. The folder rows and workspace links
-        # this block exists for do not depend on discovering any file:
-        # ``scanner._ensure_folder`` runs unconditionally per
-        # ``restrict_dirs`` entry (PR #752).
+        # --- Link duplicate-twin folders -------------------------------
+        # The twins already have catalog rows and _linkable_twin_dirs has
+        # checked that their folders exist under this destination. Link
+        # those rows directly. A broad incremental scan would still
+        # enumerate/stat every file in the matched NAS folders before the
+        # import could finish; uncataloged-stray repair belongs to the
+        # explicit folder-rescan workflow instead.
         new_dup_dirs = dup_dirs - linked_dup_dirs
         if new_dup_dirs:
-            # Twin folders may be cataloged through a symlink alias while
-            # ``destination`` is realpath-normalized above. ``_path_under_
-            # destination`` accepts symlink aliases via realpath and
-            # case-only aliases via casefold (on a case-insensitive
-            # destination), but scanner's ``_ensure_folder`` walks
-            # ``Path`` parents until they *lexically* (case-sensitive
-            # string equality, independent of the filesystem's case
-            # sensitivity) equal the scan root. A restrict_dir
-            # ``/alias/2026-07-05`` under root ``/real/archive`` — or a
-            # case-only alias like ``/volumes/nas/…`` under root
-            # ``/Volumes/NAS/…`` — would recurse to ``/alias`` → ``/``
-            # → ``/`` … and hit Python's recursion limit before the
-            # workspace_folders link is ever created. Split with a
-            # LITERAL (case-sensitive) prefix check: link case- or
-            # symlink-alias twins directly (their folder row and the
-            # twin's photos already exist — no self-heal scan needed for
-            # workspace visibility), scan only the exactly-cased-under-
-            # destination ones. See PR #1107 / #1113 reviews.
-            lex_dup_dirs = set()
-            alias_dup_dirs = set()
-            _dest_lit_norm = destination.rstrip(os.sep)
-            for d in new_dup_dirs:
-                d_lit = d.rstrip(os.sep)
-                if (
-                    d_lit == _dest_lit_norm
-                    or d_lit.startswith(_dest_lit_norm + os.sep)
-                ):
-                    lex_dup_dirs.add(d)
-                else:
-                    alias_dup_dirs.add(d)
-
-            # Mirror the fresh-batch ``dest_folder`` promotion (see the
-            # UPDATE at the top of this loop): a twin folder that survived
-            # ``_linkable_twin_dirs`` is real on disk (``os.path.isdir``
-            # passed), and if its row is still ``'missing'`` — a
-            # reattached archive drive whose row hasn't been refreshed —
-            # ``scanner.scan()``'s success stamp only clears ``'partial'``.
-            # Without promoting here, safe_to_format could go green while
-            # the duplicate twin's folder stays ``'missing'`` and its
-            # photos are filtered out of workspace queries. Preserve
-            # ``'partial'`` (a real prior-scan signal). See PR #1107 review.
-            db.conn.executemany(
-                "UPDATE folders SET status = 'ok' "
-                "WHERE path = ? AND status = 'missing'",
-                [(d,) for d in sorted(new_dup_dirs)],
+            linked, failures = _link_duplicate_twin_dirs(
+                db, workspace_id, new_dup_dirs,
             )
-            db.conn.commit()
-
-            # Link alias-spelled twin folders directly to the active
-            # workspace: the folder row and its photos already exist (they
-            # were cataloged by whatever original scan used the alias
-            # spelling), so we just need the ``workspace_folders`` entry.
-            # Passing them through ``scan(root=destination)`` would blow
-            # the stack in ``_ensure_folder`` as described above.
-            for d in sorted(alias_dup_dirs):
-                folder_row = db.conn.execute(
-                    "SELECT id FROM folders WHERE path = ?", (d,),
-                ).fetchone()
-                if folder_row is None:
-                    # Shouldn't happen — _linkable_twin_dirs pulled this
-                    # from folders in the first place — but if it does,
-                    # count it as a link failure so safe_to_format stays
-                    # honest.
-                    log.warning(
-                        "Alias-spelled dup dir %s vanished from folders "
-                        "between _linkable_twin_dirs and the direct "
-                        "workspace link", d,
-                    )
-                    dup_link_failed = True
+            linked_dup_dirs.update(linked)
+            if failures:
+                dup_link_failed = True
+                for d, detail in failures.items():
                     unsafe_files.append({
                         "path": d,
                         "reason": (
                             "duplicate-folder workspace link failed: "
-                            "folder row not found"
+                            f"{detail}"
                         ),
                     })
-                    continue
-                db.add_workspace_folder(
-                    workspace_id, folder_row["id"], is_root=True,
-                )
-                linked_dup_dirs.add(d)
-                _invalidate_new_images(db, d)
-            db.conn.commit()
-
-            if lex_dup_dirs:
-                try:
-                    # Walking the matched folders is the last thing this
-                    # job does and, on a network archive, by far the
-                    # slowest — the enumeration alone runs for minutes.
-                    # Name the phase and stream scanner's own discovery
-                    # counter into it, or the UI sits on the batch's
-                    # "N already present" line looking hung.
-                    _phase_prefix = _dup_link_phase(lex_dup_dirs)
-                    _emit(_phase_prefix, emitted, discovered)
-                    # Same rationale as the fresh-batch scan above: pass
-                    # ``vireo_dir`` / ``thumb_cache_dir`` so pairing keeps
-                    # cache context, and defer per-batch WC extraction to
-                    # the end-of-run pass. See PR #1107 review.
-                    scan(
-                        destination, db,
-                        restrict_dirs=sorted(lex_dup_dirs),
-                        incremental=True,
-                        vireo_dir=params.vireo_dir,
-                        thumb_cache_dir=params.thumb_cache_dir,
-                        skip_working_copies=True,
-                        cancel_check=lambda: runner.is_cancelled(job["id"]),
-                        status_callback=(
-                            lambda msg, _p=_phase_prefix, _e=emitted,
-                            _d=discovered, **kw: _emit(
-                                f"{_p} — {msg}", _e, _d,
-                            )
-                        ),
-                    )
-                    linked_dup_dirs.update(lex_dup_dirs)
-                    # Duplicate-link scan created/linked workspace_folders
-                    # rows for each duplicate twin's folder; the same
-                    # cached-diff staleness applies (see the fresh-batch
-                    # scan branch above). Invalidate every touched dup dir.
-                    for d in sorted(lex_dup_dirs):
-                        _invalidate_new_images(db, d)
-                except Exception as e:
-                    # A duplicate-only batch's ONLY workspace-visibility
-                    # step is this scan — swallowing the error would leave
-                    # safe_to_format green while the imported duplicates
-                    # are invisible in the active workspace. Record it and
-                    # force safe_to_format false; the file(s) are on disk
-                    # (import succeeded), but the operation as a whole is
-                    # not safe.
-                    #
-                    # scanner.scan raises ``RuntimeError("scan cancelled")``
-                    # at cancellation checkpoints when ``cancel_check``
-                    # returns truthy. Match on BOTH the sentinel message
-                    # AND the runner's cancelled state before routing to
-                    # the cancellation branch — a bare RuntimeError catch
-                    # would also swallow real runtime failures (a
-                    # ``RecursionError`` inherits from RuntimeError, or a
-                    # library-level RuntimeError bubbling out of the scan)
-                    # and report the job as cancelled even though nothing
-                    # was cancelled and the workspace-link step actually
-                    # failed. Mirrors pipeline_job.py's convention. See
-                    # PR #1107 review.
-                    if (
-                        isinstance(e, RuntimeError)
-                        and str(e) == "scan cancelled"
-                        and runner.is_cancelled(job["id"])
-                    ):
-                        cancelled = True
-                    else:
-                        log.exception(
-                            "Linking duplicate-matched folders failed: %s",
-                            sorted(lex_dup_dirs),
-                        )
-                        dup_link_failed = True
-                        for d in sorted(lex_dup_dirs):
-                            unsafe_files.append({
-                                "path": d,
-                                "reason": (
-                                    f"duplicate-folder link scan failed: {e}"
-                                ),
-                            })
 
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "
@@ -3966,7 +3709,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # terminal bucket: hash-verified fresh copy, or duplicate whose bytes
     # verifiably exist (hash-backed match, or key match re-hashed against
     # its cataloged twin), AND every source was walked cleanly, AND every
-    # duplicate-only batch's workspace-link scan succeeded (otherwise the
+    # duplicate-only batch's direct workspace link succeeded (otherwise the
     # imported duplicates are on disk but not visible in the workspace),
     # AND the run enumerated the card's full supported-file set. Any
     # narrowing of the walk falls into ``partial_scope``: a narrowed
@@ -4062,7 +3805,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         "cancelled": cancelled,
         "discovery_errors": len(discovery_errors),
         # JobRunner's mixed-outcome convention: a run with any failed
-        # file, unseen source subtree, or workspace-link scan failure is
+        # file, unseen source subtree, or workspace-link failure is
         # recorded "failed" (with per-file / per-operation reasons),
         # never "completed".
         "ok": (

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5696,8 +5696,8 @@ def test_remote_adopted_only_scan_failure_counts_each_file_once(
     folder-level failure would inflate the terminal ledger to N+1 entries.
     """
     import shutil as _shutil
-    import scanner as scanner_module
 
+    import scanner as scanner_module
     from import_job import ImportParams, run_import_job
 
     ra = _remote_archive_for(tmp_path)

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -3212,6 +3212,56 @@ def test_import_invalidates_new_images_cache(tmp_path):
     )
 
 
+def test_zero_byte_destination_collision_is_adopted_and_cataloged(tmp_path):
+    """A crash-recovery zero-byte destination has no hash-index identity.
+
+    It must enter the exact-file landed scan instead of the cataloged-twin
+    link path, because the previous run may have died before creating even
+    the destination folder row.
+    """
+    from import_job import ImportParams, run_import_job
+
+    card = tmp_path / "card"
+    card.mkdir()
+    source_file = card / "EMPTY.jpg"
+    source_file.touch()
+    timestamp = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(source_file), (timestamp, timestamp))
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / source_file.name
+    dest_file.touch()
+    os.utime(str(dest_file), (timestamp, timestamp))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    assert db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (str(dest_dir),),
+    ).fetchone() is None
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["skipped_duplicate"] == 1, result
+    assert result["failed"] == 0, result
+    assert result["safe_to_format"] is True, result
+    row = db.conn.execute(
+        """SELECT p.id, p.hash_status FROM photos p
+           JOIN folders f ON f.id = p.folder_id
+           WHERE f.path = ? AND p.filename = ?""",
+        (str(dest_dir), source_file.name),
+    ).fetchone()
+    assert row is not None
+    assert row["hash_status"] == "ok"
+    assert str(dest_dir) in _ws_linked_folder_paths(db, ws_id)
+
+
 def test_import_promotes_missing_destination_folder_to_ok(tmp_path):
     """A pre-existing ``folders`` row marked ``'missing'`` for the import's
     destination path must transition back to ``'ok'`` before the batch

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5687,6 +5687,59 @@ def test_remote_import_scans_adopted_duplicate_in_mixed_batch(
     assert adopted_row["id"] in result["photo_ids"], result["photo_ids"]
 
 
+def test_remote_adopted_only_scan_failure_counts_each_file_once(
+        tmp_path, monkeypatch):
+    """A failed adopted-only scan reports the source file exactly once.
+
+    The validation pass below the scan already converts every adopted path
+    without a catalog row from ``skipped_duplicate`` to ``failed``. A second
+    folder-level failure would inflate the terminal ledger to N+1 entries.
+    """
+    import shutil as _shutil
+    import scanner as scanner_module
+
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    dest_folder = os.path.join(
+        ra["mount_base"], "2026", "2026-07-03",
+    )
+    os.makedirs(dest_folder, exist_ok=True)
+    _shutil.copy2(
+        str(card / "DSC_0001.jpg"),
+        os.path.join(dest_folder, "DSC_0001.jpg"),
+    )
+
+    def failing_scan(*args, **kwargs):
+        raise OSError("simulated adopted-only catalog scan failure")
+
+    monkeypatch.setattr(scanner_module, "scan", failing_scan)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["discovered"] == 1, result
+    assert result["copied"] == 0, result
+    assert result["skipped_duplicate"] == 0, result
+    assert result["failed"] == 1, result
+    assert len(result["unsafe_files"]) == 1, result
+    assert result["safe_to_format"] is False, result
+
+
 def test_remote_import_result_carries_imported_photo_ids(
         tmp_path, monkeypatch):
     """The after-import chaining hook builds its process-job collection

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2,6 +2,7 @@
 import os
 import sys
 from datetime import datetime
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -147,8 +148,8 @@ def test_run_import_job_copies_verifies_and_catalogs(tmp_path):
 
 def test_duplicate_only_import_links_matched_folders(tmp_path):
     """Importing a card of only already-cataloged duplicates must still
-    scan + link the matched destination folders to the active workspace,
-    even though no fresh files were copied."""
+    link the matched destination folders to the active workspace without
+    scanning them or copying fresh files."""
     from import_dedup import compute_file_hash
     from import_job import ImportParams
 
@@ -196,7 +197,7 @@ def test_duplicate_only_import_links_matched_folders(tmp_path):
     assert result["copied"] == 0
     assert result["skipped_duplicate"] == 1
     assert result["failed"] == 0
-    # The matched folder got scanned and linked despite zero fresh copies.
+    # The matched folder was linked despite zero fresh copies.
     assert str(dest_dir) in _ws_linked_folder_paths(db, ws_id)
     # Still exactly one photo row — no re-import of known bytes.
     assert len(_photo_rows(db)) == 1
@@ -209,8 +210,8 @@ def _mark_exif_extracted(db):
     ``exif_data`` NULL — which scanner reads as "metadata was never
     extracted" and re-processes on the next incremental scan whatever
     the mtime says. That retry path is deliberate and tested in
-    test_scanner.py; the tests below are about the duplicate-link scan,
-    so give the rows the marker a real extraction would have written.
+    test_scanner.py; the tests below are about avoiding archive reads, so
+    give the rows the marker a real extraction would have written.
     """
     db.conn.execute(
         "UPDATE photos SET exif_data = '{}' WHERE exif_data IS NULL",
@@ -241,16 +242,7 @@ def _count_feature_computations(monkeypatch):
 def test_duplicate_only_import_does_not_reread_unchanged_twins(
     tmp_path, monkeypatch,
 ):
-    """The duplicate-folder link scan must not re-read twins that are
-    already cataloged and unchanged.
-
-    The link scan exists to create/link the matched folders and to
-    self-heal uncataloged strays — neither needs the bytes of a file the
-    catalog already knows. Running it non-incrementally re-hashed every
-    file in the matched archive folder, so importing a card of pure
-    duplicates re-read the whole folder: on a network archive that turned
-    a zero-copy import into an hours-long rescan.
-    """
+    """Direct duplicate-folder linking must not read cataloged twin bytes."""
     import shutil
 
     import scanner
@@ -289,7 +281,7 @@ def test_duplicate_only_import_does_not_reread_unchanged_twins(
     assert result["copied"] == 0
     assert result["skipped_duplicate"] == 3
     assert result["failed"] == 0
-    # The folder is still linked — the scan did its actual job.
+    # The folder is still linked without archive reads.
     assert str(twin_dir) in _ws_linked_folder_paths(db, ws_id)
     assert read_paths == [], (
         "duplicate-only import re-read already-cataloged, unchanged twins: "
@@ -297,10 +289,11 @@ def test_duplicate_only_import_does_not_reread_unchanged_twins(
     )
 
 
-def test_duplicate_only_import_reports_the_link_scan_phase(tmp_path):
-    """The dup-link scan walks the matched archive folders, which on a
-    network archive takes minutes. It must say so: without a phase emit
-    the UI sits on the last copy message while the job looks hung."""
+def test_duplicate_only_import_does_not_scan_matched_folder(
+        tmp_path, monkeypatch):
+    """A duplicate-only import links the cataloged folder without asking
+    scanner to enumerate it. This is the SMB/NAS regression: even an
+    incremental scan performs metadata calls for every directory entry."""
     import shutil
 
     import scanner
@@ -321,29 +314,29 @@ def test_duplicate_only_import_reports_the_link_scan_phase(tmp_path):
     card.mkdir()
     shutil.copy2(str(twin_file), str(card / "IMG_0600.jpg"))
 
+    def unexpected_scan(*args, **kwargs):
+        raise AssertionError("duplicate-only import must not scan the archive")
+
+    monkeypatch.setattr(scanner, "scan", unexpected_scan)
+
     runner = FakeRunner()
     result = run_import_job(
         _make_job(), runner, db_path, ws_id,
         ImportParams(sources=[str(card)], destination=str(archive)),
     )
     assert result["skipped_duplicate"] == 1
-
-    phases = [
-        data.get("phase", "")
-        for _jid, kind, data in runner.events if kind == "progress"
-    ]
-    assert any("already in your library" in p for p in phases), (
-        "import must report the duplicate-folder link scan as its own "
-        f"phase; got {phases}"
-    )
+    assert result["failed"] == 0
+    assert str(twin_dir) in _ws_linked_folder_paths(db, ws_id)
 
 
-def test_duplicate_only_import_still_catalogs_stray_in_twin_folder(
+def test_duplicate_only_import_leaves_stray_for_explicit_rescan(
     tmp_path, monkeypatch,
 ):
-    """Skipping unchanged twins must not cost the link scan its other
-    job: a file sitting in the matched folder that the catalog has never
-    seen still gets self-healed in, and it is the ONLY file re-read."""
+    """Import must not hide folder health or repair unrelated archive files.
+
+    A partial matched folder stays partial and its uncataloged stray remains
+    untouched until an explicit rescan repairs both conditions.
+    """
     import shutil
 
     import scanner
@@ -360,6 +353,11 @@ def test_duplicate_only_import_still_catalogs_stray_in_twin_folder(
     ws_id = db._active_workspace_id
     scanner.scan(str(archive), db)
     _mark_exif_extracted(db)
+    db.conn.execute(
+        "UPDATE folders SET status = 'partial' WHERE path = ?",
+        (str(twin_dir),),
+    )
+    db.conn.commit()
 
     # A stray lands in the twin folder AFTER the catalog was built.
     stray = twin_dir / "IMG_0501.jpg"
@@ -379,34 +377,31 @@ def test_duplicate_only_import_still_catalogs_stray_in_twin_folder(
     row_paths = {
         os.path.join(r["folder_path"], r["filename"]) for r in _photo_rows(db)
     }
-    assert str(stray) in row_paths, (
-        "link scan must still self-heal uncataloged strays in the twin folder"
-    )
-    assert read_paths == [str(stray)], (
-        "only the uncataloged stray should be read off the archive: "
-        f"{read_paths}"
-    )
+    assert str(stray) not in row_paths
+    assert read_paths == []
+    status = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (str(twin_dir),),
+    ).fetchone()["status"]
+    assert status == "partial"
+
+    # The existing explicit rescan workflow still performs the repair.
+    scanner.scan(str(archive), db, incremental=True)
+    row_paths = {
+        os.path.join(r["folder_path"], r["filename"]) for r in _photo_rows(db)
+    }
+    assert str(stray) in row_paths
+    assert read_paths == [str(stray)]
+    status = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (str(twin_dir),),
+    ).fetchone()["status"]
+    assert status == "ok"
 
 
 def test_duplicate_only_import_skips_twins_cataloged_in_other_workspace(
     tmp_path, monkeypatch,
 ):
-    """The dup-link scan must skip twins whose folder is cataloged but
-    not yet linked to the active workspace — the exact case this scan
-    exists to repair.
-
-    Regression for PR #1385 Codex review. The scan initially scoped its
-    incremental "skip on mtime" lookup to the active workspace, so a
-    folder cataloged in a different workspace (or previously known but
-    not yet workspace-linked here) would still be re-opened and
-    re-hashed on every file inside it, defeating the fix for the very
-    "cataloged, unchanged twins" case the PR targets. The sibling test
-    ``test_duplicate_only_import_does_not_reread_unchanged_twins``
-    happens to also link the twin folder to the active workspace during
-    setup, so this test forces the "cataloged elsewhere" state
-    explicitly by seeding in one workspace and running the import from
-    a fresh one.
-    """
+    """A folder cataloged in another workspace is directly linked into the
+    active one without reading its already-known photos."""
     import shutil
 
     import scanner
@@ -431,8 +426,7 @@ def test_duplicate_only_import_skips_twins_cataloged_in_other_workspace(
     assert len(_photo_rows(db)) == 3
     assert str(twin_dir) in _ws_linked_folder_paths(db, seed_ws)
 
-    # A fresh workspace has never seen this folder — the exact state the
-    # dup-link scan is intended to repair.
+    # A fresh workspace has never seen this folder.
     fresh_ws = db.create_workspace("Fresh")
     assert str(twin_dir) not in _ws_linked_folder_paths(db, fresh_ws)
 
@@ -450,8 +444,7 @@ def test_duplicate_only_import_skips_twins_cataloged_in_other_workspace(
     assert result["copied"] == 0
     assert result["skipped_duplicate"] == 3, result
     assert result["failed"] == 0, result
-    # The folder is now linked to the fresh workspace — the scan did its
-    # actual job of workspace-linking the matched folder.
+    # The folder is now linked to the fresh workspace without archive reads.
     assert str(twin_dir) in _ws_linked_folder_paths(db, fresh_ws)
     assert read_paths == [], (
         "duplicate-only import re-read twins whose folder was cataloged "
@@ -1882,13 +1875,9 @@ def test_checker_record_oserror_does_not_kill_job(tmp_path, monkeypatch):
         assert r["hash_status"] == "ok"
 
 
-def test_dup_link_scan_failure_marks_unsafe(tmp_path, monkeypatch):
-    """When the workspace-linking scan for a duplicate-only batch raises,
-    swallowing it would leave safe_to_format=true even though the
-    imported duplicates are not visible in the active workspace. The
-    failure must surface: safe_to_format false, ok false, and the
-    failing folder(s) recorded in unsafe_files."""
-    import scanner as scanner_mod
+def test_dup_workspace_link_failure_marks_unsafe(tmp_path, monkeypatch):
+    """A direct workspace-link failure must keep safe_to_format false and
+    identify the folder whose existing catalog rows could not be exposed."""
     from import_dedup import compute_file_hash
     from import_job import ImportParams, run_import_job
 
@@ -1925,27 +1914,14 @@ def test_dup_link_scan_failure_marks_unsafe(tmp_path, monkeypatch):
     import shutil
     shutil.copy2(str(dest_file), str(card / "IMG_0A80.jpg"))
 
-    real_scan = scanner_mod.scan
+    real_link = Database.add_workspace_folder
 
-    def flaky_scan(root, db_arg, **kwargs):
-        # The dup-link scan is called WITHOUT restrict_files, with a
-        # restrict_dirs pointing at our seeded dest_dir. Anything else
-        # (the fresh-copy path) passes through untouched.
-        restrict_dirs = kwargs.get("restrict_dirs") or []
-        if (
-            "restrict_files" not in kwargs
-            or kwargs["restrict_files"] is None
-        ) and any(
-            os.path.normpath(str(d)) == str(dest_dir)
-            for d in restrict_dirs
-        ):
-            # Not RuntimeError — that's reserved for cancellation
-            # (``scanner.scan`` raises ``RuntimeError("scan cancelled")``).
-            # A dup-link scan crash is a distinct failure mode.
-            raise OSError("simulated dup-link scan failure")
-        return real_scan(root, db_arg, **kwargs)
+    def flaky_link(self, workspace_id, folder_id, *, is_root=True):
+        if folder_id == fid:
+            raise OSError("simulated workspace-link failure")
+        return real_link(self, workspace_id, folder_id, is_root=is_root)
 
-    monkeypatch.setattr(scanner_mod, "scan", flaky_scan)
+    monkeypatch.setattr(Database, "add_workspace_folder", flaky_link)
 
     result = run_import_job(
         _make_job(), FakeRunner(), db_path, ws_id,
@@ -1965,17 +1941,10 @@ def test_dup_link_scan_failure_marks_unsafe(tmp_path, monkeypatch):
     assert str(dest_dir) not in _ws_linked_folder_paths(db, ws_id)
 
 
-def test_dup_link_scan_non_cancel_runtime_error_marks_unsafe(
+def test_dup_workspace_link_runtime_error_marks_unsafe(
         tmp_path, monkeypatch):
-    """A non-cancellation ``RuntimeError`` from the dup-link scan (a
-    library-level RuntimeError, or a RecursionError which inherits from
-    RuntimeError) must not be routed to the cancellation branch — the
-    runner was never cancelled, and treating the job as cancelled would
-    hide the workspace-link failure from ``ok``/``safe_to_format`` and
-    let the UI serve an import result that looks successful even though
-    the imported duplicates never became visible. See PR #1107 review.
-    """
-    import scanner as scanner_mod
+    """A RuntimeError from the direct link is a real import failure, not
+    scanner cancellation, and must leave the matched folder unlinked."""
     from import_dedup import compute_file_hash
     from import_job import ImportParams, run_import_job
 
@@ -2009,25 +1978,14 @@ def test_dup_link_scan_non_cancel_runtime_error_marks_unsafe(
     import shutil
     shutil.copy2(str(dest_file), str(card / "IMG_0B81.jpg"))
 
-    real_scan = scanner_mod.scan
+    real_link = Database.add_workspace_folder
 
-    def flaky_scan(root, db_arg, **kwargs):
-        restrict_dirs = kwargs.get("restrict_dirs") or []
-        if (
-            "restrict_files" not in kwargs
-            or kwargs["restrict_files"] is None
-        ) and any(
-            os.path.normpath(str(d)) == str(dest_dir)
-            for d in restrict_dirs
-        ):
-            # A non-sentinel RuntimeError — the runner was never
-            # cancelled. RecursionError (a RuntimeError subclass) or a
-            # library-level RuntimeError bubbling out of the scan would
-            # look like this at the handler.
-            raise RuntimeError("library exploded during scan")
-        return real_scan(root, db_arg, **kwargs)
+    def flaky_link(self, workspace_id, folder_id, *, is_root=True):
+        if folder_id == fid:
+            raise RuntimeError("database link exploded")
+        return real_link(self, workspace_id, folder_id, is_root=is_root)
 
-    monkeypatch.setattr(scanner_mod, "scan", flaky_scan)
+    monkeypatch.setattr(Database, "add_workspace_folder", flaky_link)
 
     result = run_import_job(
         _make_job(), FakeRunner(), db_path, ws_id,
@@ -2035,8 +1993,7 @@ def test_dup_link_scan_non_cancel_runtime_error_marks_unsafe(
     )
 
     assert result["skipped_duplicate"] == 1
-    # The whole point: not routed to cancellation; instead reported as a
-    # dup-link failure so ``safe_to_format`` reflects reality.
+    # Direct-link errors are not cancellation sentinels.
     assert result["cancelled"] is False
     assert result["safe_to_format"] is False
     assert result["ok"] is False
@@ -3213,8 +3170,8 @@ def test_source_equals_dest_file_is_rejected(tmp_path):
 
 
 def test_import_invalidates_new_images_cache(tmp_path):
-    """After per-batch and dup-link scans, run_import_job must invalidate
-    the /new-images cache for the touched destination folders. Otherwise
+    """Per-batch scans and duplicate-folder links must invalidate the
+    /new-images cache for the touched destination folders. Otherwise
     a workspace whose cache was warm before the import keeps reporting
     the just-imported files as new until TTL expires or another full
     scan runs. Mirrors the try/finally in api_job_scan / api_job_import_full
@@ -3351,7 +3308,7 @@ def test_duplicate_only_import_promotes_missing_twin_folder(tmp_path):
     """A duplicate-only import that matches a cataloged twin whose folder
     row is stale-marked ``'missing'`` (but the folder is still on disk
     under the import destination) must promote that folder to ``'ok'``
-    before its dup-link scan runs — otherwise the archive stays filtered
+    as part of its direct link — otherwise the archive stays filtered
     out of workspace queries even though safe_to_format goes green.
     See PR #1107 review.
     """
@@ -3405,7 +3362,7 @@ def test_duplicate_only_import_promotes_missing_twin_folder(tmp_path):
     ).fetchone()["status"]
     assert status == "ok", (
         "duplicate-only import must promote a matched 'missing'-marked "
-        "twin folder to 'ok' before its dup-link scan runs"
+        "twin folder to 'ok' as part of its direct workspace link"
     )
     # And the folder is linked to the active workspace.
     assert str(twin_dir) in _ws_linked_folder_paths(db, ws_id)
@@ -3415,7 +3372,7 @@ def test_duplicate_only_import_links_twin_folder_when_destination_is_symlink(tmp
     """A duplicate-only import whose ``destination`` is a symlink to the
     twin's on-disk archive root must still resolve containment through
     the link and link the twin folder. A lexical prefix check would drop
-    the twin from ``dup_dirs``, the duplicate-link scan would never run,
+    the twin from ``dup_dirs``, the direct workspace link would never run,
     and the imported duplicate would stay filtered out of the active
     workspace even though safe_to_format flipped green. See PR #1107
     review.
@@ -3823,18 +3780,18 @@ def test_key_duplicate_links_only_byte_verified_twin_folder(tmp_path):
     # bytes and links its folder into the workspace UI.
     assert ws_folder_is_root.get(str(verified_dir)) == 1
     # The key-collision folder was NEVER byte-verified against the
-    # card. Before the fix, it was passed to the duplicate-link scan
-    # as a restrict_dir and workspace-linked as its own top-level root
+    # card. Before the verified-row filter, it could be passed to folder
+    # linking and workspace-linked as its own top-level root
     # (``is_root=1``), pulling an unrelated archive folder into the
     # workspace UI. It must NOT surface as a workspace root here, and
     # after the restricted-scan cascade fix (PR #1107, line 1186) it
     # must not appear in ``workspace_folders`` at all.
     assert str(collision_dir) not in ws_folder_is_root
 
-    # Stronger: the collision folder was never scanned this run, so
-    # its pre-seeded row's ``file_hash`` is still NULL. Before the
-    # fix, the dup-link scan visited the collision folder and would
-    # have populated ``file_hash`` from its on-disk bytes.
+    # Neither folder was scanned. The verified folder is linked because the
+    # duplicate gate compared its bytes directly for this run; that proof
+    # does not turn archive repair into an import side effect. The unrelated
+    # collision remains both unlinked and untouched.
     photo_hashes = {
         row["folder_path"]: row["file_hash"]
         for row in db.conn.execute(
@@ -3842,10 +3799,7 @@ def test_key_duplicate_links_only_byte_verified_twin_folder(tmp_path):
             "FROM photos p JOIN folders f ON f.id = p.folder_id"
         )
     }
-    assert photo_hashes.get(str(verified_dir)) is not None, (
-        "verified twin's folder WAS scanned — its file_hash must "
-        "be populated"
-    )
+    assert photo_hashes.get(str(verified_dir)) is None
     assert photo_hashes.get(str(collision_dir)) is None, (
         "key-collision folder must NOT be scanned by a duplicate-"
         "only import: its bytes were never proven to match the card"
@@ -5236,16 +5190,13 @@ def test_remote_import_no_verify_fails_on_mount_hash_mismatch(
             rows["DSC_0001.jpg"])
 
 
-def test_remote_import_dup_only_batch_records_failure_when_scan_raises(
+def test_remote_import_dup_only_batch_does_not_scan_mount(
         tmp_path, monkeypatch):
-    """A duplicate-only remote batch (every card file matched a
-    cataloged twin) still needs ``scan()`` to link the twin folder into
-    the workspace. If ``landed`` is empty (no fresh copies) but
-    ``dup_skipped > 0`` and ``scan()`` raises, no per-file failure was
-    recorded and ``safe_to_format`` could flip green while the duplicate
-    folder never became visible in the workspace. The exception handler
-    must record a batch-level failure for that case, mirroring the local
-    path's ``dup_link_failed`` gate. See PR #1113 review."""
+    """A remote duplicate-only batch neither transfers nor scans files.
+
+    Its cataloged twin folder is linked directly, so a mounted SMB archive
+    cannot turn the no-op batch into a whole-directory metadata walk.
+    """
     import scanner as _scanner
     from import_job import ImportParams, run_import_job
 
@@ -5262,11 +5213,9 @@ def test_remote_import_dup_only_batch_records_failure_when_scan_raises(
     card_file = str(card / "DSC_0001.jpg")
     src_hash = _hash(card_file)
 
-    # Seed an archive folder that owns the byte-identical twin (outside
-    # any import source — the check that Codex asked for filters
-    # source-backed twins, so we need a real off-card twin).
-    archive_twin_dir = tmp_path / "archive_twin"
-    archive_twin_dir.mkdir()
+    # Seed a byte-identical twin beneath the mounted archive destination.
+    archive_twin_dir = Path(ra["mount_base"]) / "unsorted"
+    archive_twin_dir.mkdir(parents=True)
     twin_path = archive_twin_dir / "DSC_0001.jpg"
     import shutil as _shutil
     _shutil.copy2(card_file, str(twin_path))
@@ -5274,8 +5223,10 @@ def test_remote_import_dup_only_batch_records_failure_when_scan_raises(
     # match token.
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)
-    ws_id = db._active_workspace_id
     _scanner.scan(str(archive_twin_dir), db)
+    # Run from a fresh workspace so the import must perform the link.
+    ws_id = db.create_workspace("Fresh")
+    assert str(archive_twin_dir) not in _ws_linked_folder_paths(db, ws_id)
     # Sanity: the twin row is present with the right hash.
     twin_rows = db.conn.execute(
         "SELECT p.file_hash, f.path FROM photos p "
@@ -5285,52 +5236,35 @@ def test_remote_import_dup_only_batch_records_failure_when_scan_raises(
     assert twin_rows and twin_rows[0]["file_hash"] == src_hash, [
         dict(r) for r in twin_rows]
 
-    # Now monkeypatch scan() to raise ONLY on the import job's
-    # per-batch call (the dup-only batch's twin-folder link scan). The
-    # patched scan is bound after the pre-seed above, so it doesn't
-    # interfere with our own setup.
-    orig_scan = _scanner.scan
-
+    # Any import-time scanner call is the regression.
     def failing_scan(*args, **kwargs):
-        raise RuntimeError("scan blew up (simulated NAS mount error)")
+        raise AssertionError("duplicate-only remote import scanned the mount")
 
     monkeypatch.setattr(_scanner, "scan", failing_scan)
-
-    try:
-        result = run_import_job(
-            _make_job(), FakeRunner(), db_path, ws_id,
-            ImportParams(
-                sources=[str(card)], destination=ra["mount_base"],
-                remote_target=ra, verify_by_hash=True,
-            ),
-        )
-    finally:
-        monkeypatch.setattr(_scanner, "scan", orig_scan)
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
 
     # rsync never ran — the file was accepted as a duplicate against the
-    # off-card twin.
+    # off-card twin, and the folder was linked without scanning.
     assert calls["rsync"] == [], calls["rsync"]
-    # A duplicate-only batch whose scan() raised must NOT report
-    # safe_to_format=True. The batch-level failure marker forces
-    # failed>0, which flips safe_to_format False.
-    assert result["failed"] >= 1, result
-    assert result["safe_to_format"] is False, result
+    assert result["failed"] == 0, result
+    assert result["safe_to_format"] is True, result
     assert result["skipped_duplicate"] == 1, result
-    assert any(
-        "duplicate-only batch" in u["reason"]
-        for u in result["unsafe_files"]
-    ), result["unsafe_files"]
+    assert str(archive_twin_dir) in _ws_linked_folder_paths(db, ws_id)
 
 
 def test_remote_import_links_verified_twin_folder_in_other_layout(
         tmp_path, monkeypatch):
     """A verified duplicate skip's twin folder may live under the mount
     destination in a DIFFERENT sub-folder than this run's template output
-    (e.g. an older ``unsorted`` or ``%Y-%m-%d`` layout). Without carrying
-    the verified twin dir into a follow-up dup-link scan, the card is
-    skipped as a duplicate but the twin folder never becomes visible in
-    the active workspace — safe_to_format could go green over folders
-    the UI won't show. See PR #1113 review."""
+    (e.g. an older ``unsorted`` or ``%Y-%m-%d`` layout). Link that cataloged
+    folder directly so it becomes visible without an archive scan. See
+    PR #1113 review."""
     from import_dedup import compute_file_hash as _hash
     from import_job import ImportParams, run_import_job
 
@@ -5399,12 +5333,9 @@ def test_remote_import_links_verified_twin_folder_in_other_layout(
     }
 
 
-def test_remote_import_dup_link_scan_does_not_reread_unchanged_twins(
+def test_remote_import_direct_dup_link_does_not_read_unchanged_twins(
         tmp_path, monkeypatch):
-    """Remote mirror of
-    ``test_duplicate_only_import_does_not_reread_unchanged_twins``: the
-    remote path runs its own dup-link scan, and it must skip already-
-    cataloged, unchanged twins too."""
+    """Remote duplicate links must not read cataloged twin bytes."""
     import scanner
     from import_job import ImportParams, run_import_job
 
@@ -5451,23 +5382,10 @@ def test_remote_import_dup_link_scan_does_not_reread_unchanged_twins(
     )
 
 
-def test_remote_import_dup_only_batch_does_not_reread_dest_folder_twins(
+def test_remote_import_dup_only_batch_does_not_read_dest_folder_twins(
         tmp_path, monkeypatch):
-    """A duplicate-only remote batch whose twins sit in the batch's OWN
-    destination folder must not re-read them.
-
-    ``test_remote_import_dup_link_scan_does_not_reread_unchanged_twins``
-    parks its twins in ``unsorted`` — a different folder from the batch
-    destination — so that test's batch scan walks an empty
-    ``dest_folder`` and reads nothing either way. The common real case is
-    re-importing a card into the same date folder it originally landed
-    in, where ``dest_folder`` already holds every twin. With no fresh
-    landings the batch scan passes ``restrict_files=None``, so it walks
-    the whole destination folder; without ``incremental=True`` it
-    re-reads and re-hashes every already-cataloged file there. On a
-    network archive that turns a zero-copy import into an hours-long
-    rescan.
-    """
+    """A duplicate-only remote batch does not read twins in its own date
+    folder; it skips the batch scan and links their cataloged folder."""
     import scanner
     from import_job import ImportParams, run_import_job
 
@@ -6005,13 +5923,8 @@ def test_progress_events_carry_live_per_folder_counts(tmp_path):
 def test_remote_import_links_alias_spelled_twin_folder(tmp_path, monkeypatch):
     """A verified duplicate skip whose twin was cataloged through a symlink
     alias of the mount base is accepted via ``_path_under_destination``'s
-    realpath check, but the follow-up dup-link scan cannot pass the alias
-    to ``scan(destination, restrict_dirs=[alias])`` — scanner's
-    ``_ensure_folder`` walks parents lexically and would recurse toward
-    ``/`` before creating the workspace link, marking the import failed/
-    unsafe. The remote path must mirror the local split: link alias-
-    spelled dup dirs directly via ``add_workspace_folder`` rather than
-    scanning them. See PR #1113 review."""
+    realpath check. The remote path links that existing alias-spelled
+    catalog row directly. See PR #1113 review."""
     if not hasattr(os, "symlink"):
         return
     from import_dedup import compute_file_hash as _hash
@@ -6038,10 +5951,8 @@ def test_remote_import_links_alias_spelled_twin_folder(tmp_path, monkeypatch):
 
     # Alias root points at the same physical directory via symlink. The
     # twin's cataloged folder path is spelled through the alias — NOT
-    # lexically under the mount base — so scanner._ensure_folder's parent
-    # walk would recurse toward / rather than stopping at the destination
-    # root; the remote dup-link scan must link this folder directly via
-    # add_workspace_folder without calling scan() on the alias path.
+    # lexically under the mount base. Direct linking is independent of that
+    # spelling and does not call scan() on the alias path.
     try:
         alias_root = str(tmp_path / "mount_alias")
         os.symlink(real_mount_base, alias_root)
@@ -6078,9 +5989,7 @@ def test_remote_import_links_alias_spelled_twin_folder(tmp_path, monkeypatch):
     assert calls["rsync"] == [], calls["rsync"]
     assert result["skipped_duplicate"] == 1, result
     # The alias-spelled twin folder MUST be linked into the active
-    # workspace — without the alias/lex split, the dup-link scan would
-    # blow up on _ensure_folder's parent walk and the job would report
-    # failed/unsafe.
+    # workspace through its existing catalog row.
     assert result["failed"] == 0, result
     assert result["safe_to_format"] is True, result
     linked_after = _ws_linked_folder_paths(db, ws_id)
@@ -6181,11 +6090,7 @@ def test_remote_import_links_case_only_twin_folder(tmp_path, monkeypatch):
     assert calls["rsync"] == [], calls["rsync"]
     assert result["skipped_duplicate"] == 1, result
     # The case-only-alias twin folder MUST be linked into the active
-    # workspace via the direct-link path. Without the case-only fix, the
-    # dup-link scan would receive the differently-cased folder path as a
-    # restrict_dir and scanner's parent-walk would blow up before the
-    # workspace_folders row was created — flipping safe_to_format to
-    # False on a legitimately verified duplicate-only run.
+    # workspace via the direct-link path, independent of path case.
     assert result["failed"] == 0, result
     assert result["safe_to_format"] is True, result
     linked_after = _ws_linked_folder_paths(db, ws_id)

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -339,6 +339,9 @@ def test_job_sync_returns_job_id(app_and_db):
     data = resp.get_json()
     assert "job_id" in data
     assert data["job_id"].startswith("sync-")
+    # Do not let this worker outlive the fixture and race into a later
+    # test's process-wide monkeypatch of sync.sync_to_xmp.
+    wait_for_job_via_runner(app._job_runner, data["job_id"])
 
 
 def test_job_sync_accepts_selected_change_ids(app_and_db):
@@ -355,6 +358,10 @@ def test_job_sync_accepts_selected_change_ids(app_and_db):
     data = resp.get_json()
     assert "job_id" in data
     assert data["job_id"].startswith("sync-")
+    # The endpoint is asynchronous, but the test still owns the worker it
+    # starts. Join it before monkeypatch teardown so it cannot leak into the
+    # serialization tests below.
+    wait_for_job_via_runner(app._job_runner, data["job_id"])
 
 
 def test_job_sync_rejects_empty_selected_change_ids(app_and_db):


### PR DESCRIPTION
## Summary

- Link cataloged duplicate folders directly into the active workspace instead of scanning their archive directories.
- Skip remote duplicate-only batch scans while retaining exact-file scans for newly transferred or adopted files.
- Preserve `partial` folder status and leave stray-file repair to the explicit rescan workflow, while keeping workspace-link failures safety-gated.

## Why

Incremental duplicate-folder scans still enumerate and stat every entry, which can block zero-copy imports for hours on SMB-mounted NAS storage.

## Validation

`python -m pytest -q vireo/tests/test_import_job.py vireo/tests/test_jobs_api.py -k 'import' --maxfail=10` — 220 passed, 2 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate folders by linking existing catalog entries directly.
  * Recovered zero-byte files correctly instead of treating them as duplicates.
  * Promoted missing folders and reported linking failures more reliably.
  * Improved support for remote files, aliases, case-insensitive paths, mount changes, and stale cache data.
  * Prevented background sync jobs from interfering with subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->