### PR TITLE
Stabilize thumbnail request regression test

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -3137,6 +3137,11 @@ def test_hide_duplicates_does_not_re_request_the_thumbnails_per_click(
     _stub_preview(page, files)
     _preview(page)
 
+    # _preview() returns as soon as the grid is visible, while the thumbnail
+    # scheduler may still be draining its initial queue.  Start measuring only
+    # after those requests have settled so they cannot be mistaken for work
+    # caused by the selection clicks below.
+    expect(page.locator(".import-preview-thumb.skeleton")).to_have_count(0)
     hits = []
     page.on("request", lambda r: hits.append(r.url)
             if "folder-preview/thumbnail" in r.url else None)


### PR DESCRIPTION
The release E2E test could start recording thumbnail requests while the preview's initial scheduler queue was still draining. This made initial thumbnail loads look like requests caused by checkbox clicks and blocked the v0.31.1 release. The test now waits for all thumbnail skeletons to settle before installing its request listener. Verified with 11 consecutive targeted passes, Ruff, and git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved import page test reliability by waiting for initial thumbnail loading to complete before validating checkbox-triggered requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->