### PR TITLE
Stop background jobs from leaking between tests

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -3137,6 +3137,11 @@ def test_hide_duplicates_does_not_re_request_the_thumbnails_per_click(
     _stub_preview(page, files)
     _preview(page)
 
+    # _preview() returns as soon as the grid is visible, while the thumbnail
+    # scheduler may still be draining its initial queue.  Start measuring only
+    # after those requests have settled so they cannot be mistaken for work
+    # caused by the selection clicks below.
+    expect(page.locator(".import-preview-thumb.skeleton")).to_have_count(0)
     hits = []
     page.on("request", lambda r: hits.append(r.url)
             if "folder-preview/thumbnail" in r.url else None)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4132,10 +4132,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except Exception:
             jobs_stopped = False
             log.exception("Failed to shut down background jobs cleanly")
-        with contextlib.suppress(Exception):
+        try:
             app._log_broadcaster.uninstall()
-        with contextlib.suppress(Exception):
+        except Exception:
+            log.exception("Failed to uninstall log broadcaster during cleanup")
+        try:
             init_db.close()
+        except Exception:
+            log.exception("Failed to close database during cleanup")
         return jobs_stopped
 
     app._cleanup_app_resources = _cleanup_app_resources

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4126,11 +4126,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     app._log_broadcaster = LogBroadcaster(buffer_size=500)
     app._log_broadcaster.install()
 
-    def _cleanup_app_resources():
+    def _cleanup_app_resources(job_timeout=10.0):
+        try:
+            jobs_stopped = app._job_runner.shutdown(timeout=job_timeout)
+        except Exception:
+            jobs_stopped = False
+            log.exception("Failed to shut down background jobs cleanly")
         with contextlib.suppress(Exception):
             app._log_broadcaster.uninstall()
         with contextlib.suppress(Exception):
             init_db.close()
+        return jobs_stopped
 
     app._cleanup_app_resources = _cleanup_app_resources
 

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -34,6 +34,20 @@ _JOB_RETENTION_SECS = 3600  # 1 hour
 _PROMOTION_RETRY_DELAY_SECS = 0.1
 
 
+class _TrackedJobThread(threading.Thread):
+    """A normal job thread that reports when its target has fully returned."""
+
+    def __init__(self, *args, on_finish, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._on_finish = on_finish
+
+    def run(self):
+        try:
+            super().run()
+        finally:
+            self._on_finish(self)
+
+
 # Maximum number of pipeline jobs allowed to run concurrently. Bumped
 # to 2 in Step 6 of the concurrency rollout (Steps 1-3 added the
 # ModelCache + GPU/regroup locks that make this safe; Steps 4-5 added
@@ -92,10 +106,101 @@ class JobRunner:
         # millisecond don't collide on the PRIMARY KEY.
         self._enqueue_counter = 0
         self._promotion_retry_scheduled = False
+        # Worker ownership is explicit.  Daemon threads alone are not a
+        # lifecycle: short-lived create_app() callers (especially tests) must
+        # be able to cancel and join their work before tearing down databases
+        # and process-wide monkeypatches.
+        self._worker_threads = set()
+        self._shutting_down = False
         if db:
             self._db_path = db.conn.execute("PRAGMA database_list").fetchone()[2]
             self._ensure_history_table(db)
             self._startup_sweep(db)
+
+    def _start_worker_thread(self, job, work_fn):
+        """Start and retain a worker until its complete cleanup finishes.
+
+        Returns False when shutdown won the race with a caller that had
+        already registered a job but had not started its thread yet.
+        """
+        def forget_thread(thread):
+            with self._lock:
+                self._worker_threads.discard(thread)
+
+        thread = _TrackedJobThread(
+            target=self._run_job,
+            args=(job, work_fn),
+            on_finish=forget_thread,
+            daemon=True,
+            name=f"vireo-job-{job['id']}",
+        )
+        with self._lock:
+            if self._shutting_down:
+                return False
+            self._worker_threads.add(thread)
+            # Start while still holding the ownership lock. shutdown() can
+            # therefore never take a snapshot between registration and start.
+            thread.start()
+        return True
+
+    def _discard_unstarted_job(self, job_id):
+        """Remove a job whose worker lost the race with shutdown()."""
+        with self._lock:
+            self._jobs.pop(job_id, None)
+            self._events.pop(job_id, None)
+            self._subscribers.pop(job_id, None)
+            self._cancelled.discard(job_id)
+            self._pause_requested.discard(job_id)
+            self._uncancellable.discard(job_id)
+
+    def shutdown(self, timeout=10.0):
+        """Stop accepting work, request cancellation, and join workers.
+
+        Cancellation is cooperative: work functions must reach an
+        ``is_cancelled``/``cancellation_requested`` checkpoint before their
+        thread can exit. Returns False when one or more workers remain alive
+        after *timeout*, allowing callers such as pytest fixtures to fail at
+        the test that leaked the work instead of contaminating the next one.
+        """
+        if timeout < 0:
+            raise ValueError("timeout must be non-negative")
+
+        with self._pause_condition:
+            self._shutting_down = True
+            queued_ids = list(self._queued_pipelines)
+            for job_id, job in self._jobs.items():
+                if (
+                    job.get("status") in ("running", "pausing", "paused")
+                    and job_id not in self._uncancellable
+                ):
+                    self._cancelled.add(job_id)
+                    self._pause_requested.discard(job_id)
+            # A paused worker must wake before it can observe cancellation.
+            self._pause_condition.notify_all()
+
+        # Queued jobs have persisted state to transition as well as in-memory
+        # contexts to remove. Do that outside the runner lock.
+        for job_id in queued_ids:
+            self.cancel_job(job_id, promote_after_cancel=False)
+
+        deadline = time.monotonic() + timeout
+        current = threading.current_thread()
+        while True:
+            with self._lock:
+                threads = [
+                    thread for thread in self._worker_threads
+                    if thread is not current and thread.is_alive()
+                ]
+            if not threads:
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                log.warning(
+                    "JobRunner shutdown timed out with %d worker(s) alive: %s",
+                    len(threads), ", ".join(thread.name for thread in threads),
+                )
+                return False
+            threads[0].join(timeout=remaining)
 
     def _ensure_history_table(self, db):
         db.conn.execute(
@@ -182,6 +287,8 @@ class JobRunner:
         Returns the job id.
         """
         with self._lock:
+            if self._shutting_down:
+                raise RuntimeError("JobRunner is shut down")
             self._enqueue_counter += 1
             seq = self._enqueue_counter
         job_id = f"pipeline-{int(time.time() * 1000)}-{seq}"
@@ -213,6 +320,15 @@ class JobRunner:
                 "runtime_warning": runtime_warning,
                 "started_at": now_iso,
             }
+            shutdown_raced = self._shutting_down
+
+        # The database insert happens outside the runner lock. shutdown() may
+        # begin in that window after the initial admission check; publish a
+        # terminal cancellation instead of leaving a queued row behind after
+        # the runner has already reported itself drained.
+        if shutdown_raced:
+            self.cancel_job(job_id, promote_after_cancel=False)
+            raise RuntimeError("JobRunner is shut down")
 
         # Promote eagerly so a free slot is filled before we return.
         self._try_promote_queued()
@@ -227,6 +343,8 @@ class JobRunner:
         lands first, rowcount==0 and promotion quietly gives up.
         """
         with self._lock:
+            if self._shutting_down:
+                return
             active = sum(
                 1 for j in self._jobs.values()
                 if (
@@ -345,18 +463,36 @@ class JobRunner:
             self._try_promote_queued()
             return
 
-        thread = threading.Thread(
-            target=self._run_job, args=(job, work_fn), daemon=True,
-        )
         log.info("Job %s started type=pipeline", job["id"])
-        thread.start()
+        if not self._start_worker_thread(job, work_fn):
+            # shutdown() marked the installed job for cancellation while it
+            # sat between promotion and thread start. Record the terminal row
+            # here because this promoted pipeline was already persisted as
+            # running before its in-memory worker registration existed.
+            now = datetime.now().isoformat()
+            with self._lock:
+                job["status"] = "cancelled"
+                job["finished_at"] = now
+                job["_ended_at"] = time.time()
+                self._cancelled.discard(job["id"])
+            self.push_event(job["id"], "complete", {
+                "job_id": job["id"],
+                "job_type": job["type"],
+                "status": "cancelled",
+                "result": None,
+                "duration": 0.0,
+                "errors": [],
+            })
+            if self._db_path:
+                self._persist_job(job, 0.0)
+            job["_persisted"] = True
 
     def _schedule_promotion_retry_locked(self):
         """Retry queue promotion after a transient DB failure.
 
         Must be called with self._lock held.
         """
-        if self._promotion_retry_scheduled:
+        if self._promotion_retry_scheduled or self._shutting_down:
             return
         self._promotion_retry_scheduled = True
 
@@ -364,6 +500,8 @@ class JobRunner:
             time.sleep(_PROMOTION_RETRY_DELAY_SECS)
             with self._lock:
                 self._promotion_retry_scheduled = False
+                if self._shutting_down:
+                    return
             self._try_promote_queued()
 
         thread = threading.Thread(target=retry, daemon=True)
@@ -436,11 +574,10 @@ class JobRunner:
             counts_for_badge=counts_for_badge, pausable=pausable,
             blocks_local_transitions=blocks_local_transitions,
         )
-        thread = threading.Thread(
-            target=self._run_job, args=(job, work_fn), daemon=True
-        )
         log.info("Job %s started type=%s", job["id"], job_type)
-        thread.start()
+        if not self._start_worker_thread(job, work_fn):
+            self._discard_unstarted_job(job["id"])
+            raise RuntimeError("JobRunner is shut down")
         return job["id"]
 
     def _make_job_dict(self, job_id, job_type, *, config, workspace_id,
@@ -491,6 +628,8 @@ class JobRunner:
         # the second registration overwrite the first in _jobs/_events and
         # clobber its history row.
         with self._lock:
+            if self._shutting_down:
+                raise RuntimeError("JobRunner is shut down")
             self._enqueue_counter += 1
             seq = self._enqueue_counter
             job_id = f"{job_type}-{int(time.time() * 1000)}-{seq}"
@@ -555,6 +694,8 @@ class JobRunner:
         # Compute the joined snapshot / register a new job under one lock
         # acquisition so the check-and-start is genuinely atomic.
         with self._lock:
+            if self._shutting_down:
+                raise RuntimeError("JobRunner is shut down")
             existing_id, existing = self._find_singleton_locked(
                 job_type, singleton_key,
             )
@@ -580,14 +721,13 @@ class JobRunner:
             self._events[job_id] = deque(maxlen=1000)
             self._subscribers[job_id] = []
 
-        thread = threading.Thread(
-            target=self._run_job, args=(job, work_fn), daemon=True,
-        )
         log.info(
             "Job %s started type=%s singleton_key=%s",
             job_id, job_type, singleton_key,
         )
-        thread.start()
+        if not self._start_worker_thread(job, work_fn):
+            self._discard_unstarted_job(job_id)
+            raise RuntimeError("JobRunner is shut down")
         return job_id, False, None
 
     def _prune_finished_jobs(self):

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -165,12 +165,9 @@ class JobRunner:
         if timeout < 0:
             raise ValueError("timeout must be non-negative")
 
-        # Start the deadline clock BEFORE queued cancellation. cancel_job's
-        # SQLite write uses a 30s connection timeout, so a locked db would
-        # otherwise let one queued cancellation burn the whole shutdown
-        # budget with the join phase never running.
+        # Start the deadline clock before queued cancellation so database-lock
+        # waits and worker joins share the caller's shutdown budget.
         deadline = time.monotonic() + timeout
-
         with self._pause_condition:
             self._shutting_down = True
             queued_ids = list(self._queued_pipelines)
@@ -185,12 +182,13 @@ class JobRunner:
             self._pause_condition.notify_all()
 
         # Queued jobs have persisted state to transition as well as in-memory
-        # contexts to remove. Do that outside the runner lock. Contain any
-        # cancel_job failure (e.g. OperationalError from a locked SQLite db)
-        # and stop iterating once the deadline is exhausted so we always
-        # reach the worker join phase below.
+        # contexts to remove. Do that outside the runner lock, bounding each
+        # SQLite lock wait by the time left for the whole shutdown.
+        queued_cancelled = True
         for index, job_id in enumerate(queued_ids):
-            if time.monotonic() >= deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                queued_cancelled = False
                 log.warning(
                     "JobRunner shutdown timed out cancelling queued jobs; "
                     "%d queued job(s) left uncancelled",
@@ -198,8 +196,13 @@ class JobRunner:
                 )
                 break
             try:
-                self.cancel_job(job_id, promote_after_cancel=False)
+                self.cancel_job(
+                    job_id,
+                    promote_after_cancel=False,
+                    db_timeout=remaining,
+                )
             except Exception:
+                queued_cancelled = False
                 log.exception(
                     "Failed to cancel queued job %s during shutdown", job_id,
                 )
@@ -212,7 +215,7 @@ class JobRunner:
                     if thread is not current and thread.is_alive()
                 ]
             if not threads:
-                return True
+                return queued_cancelled
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 log.warning(
@@ -524,7 +527,17 @@ class JobRunner:
                     return
             self._try_promote_queued()
 
-        thread = threading.Thread(target=retry, daemon=True)
+        def forget_thread(thread):
+            with self._lock:
+                self._worker_threads.discard(thread)
+
+        thread = _TrackedJobThread(
+            target=retry,
+            on_finish=forget_thread,
+            daemon=True,
+            name="vireo-promotion-retry",
+        )
+        self._worker_threads.add(thread)
         thread.start()
 
     def _record_terminal_queued_pipeline(self, job_id, ctx, status="cancelled"):
@@ -1306,7 +1319,13 @@ class JobRunner:
                             step[key] = kwargs[key]
                     break
 
-    def cancel_job(self, job_id, expected_status=None, promote_after_cancel=True):
+    def cancel_job(
+        self,
+        job_id,
+        expected_status=None,
+        promote_after_cancel=True,
+        db_timeout=30.0,
+    ):
         """Request cancellation of a running OR queued job.
 
         For running jobs: the work function should periodically check
@@ -1327,6 +1346,7 @@ class JobRunner:
                 removing a queued job. Bulk queued cancellation sets this False
                 so the whole snapshot can be cancelled before another queued job
                 is promoted.
+            db_timeout: maximum time to wait for a locked history database.
 
         Returns True if the job was found and either marked for
         cancellation (running) or transitioned to cancelled (queued).
@@ -1370,7 +1390,7 @@ class JobRunner:
         cancelled = True
         if self._db_path:
             import sqlite3
-            conn = sqlite3.connect(self._db_path, timeout=30)
+            conn = sqlite3.connect(self._db_path, timeout=max(0.0, db_timeout))
             try:
                 cur = conn.execute(
                     "UPDATE job_history "

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -165,6 +165,12 @@ class JobRunner:
         if timeout < 0:
             raise ValueError("timeout must be non-negative")
 
+        # Start the deadline clock BEFORE queued cancellation. cancel_job's
+        # SQLite write uses a 30s connection timeout, so a locked db would
+        # otherwise let one queued cancellation burn the whole shutdown
+        # budget with the join phase never running.
+        deadline = time.monotonic() + timeout
+
         with self._pause_condition:
             self._shutting_down = True
             queued_ids = list(self._queued_pipelines)
@@ -179,11 +185,25 @@ class JobRunner:
             self._pause_condition.notify_all()
 
         # Queued jobs have persisted state to transition as well as in-memory
-        # contexts to remove. Do that outside the runner lock.
-        for job_id in queued_ids:
-            self.cancel_job(job_id, promote_after_cancel=False)
+        # contexts to remove. Do that outside the runner lock. Contain any
+        # cancel_job failure (e.g. OperationalError from a locked SQLite db)
+        # and stop iterating once the deadline is exhausted so we always
+        # reach the worker join phase below.
+        for index, job_id in enumerate(queued_ids):
+            if time.monotonic() >= deadline:
+                log.warning(
+                    "JobRunner shutdown timed out cancelling queued jobs; "
+                    "%d queued job(s) left uncancelled",
+                    len(queued_ids) - index,
+                )
+                break
+            try:
+                self.cancel_job(job_id, promote_after_cancel=False)
+            except Exception:
+                log.exception(
+                    "Failed to cancel queued job %s during shutdown", job_id,
+                )
 
-        deadline = time.monotonic() + timeout
         current = threading.current_thread()
         while True:
             with self._lock:

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -84,18 +84,23 @@ def _shutdown_created_job_runners(monkeypatch):
     yield
 
     leaked = []
+    shutdown_failures = 0
     for runner in reversed(created):
-        if not runner.shutdown(timeout=5.0):
-            leaked.extend(
-                thread.name
-                for thread in runner._worker_threads
-                if thread.is_alive()
-            )
-    if leaked:
-        pytest.fail(
-            "background JobRunner workers outlived their test: "
-            + ", ".join(sorted(leaked))
+        if runner.shutdown(timeout=5.0):
+            continue
+        shutdown_failures += 1
+        leaked.extend(
+            thread.name
+            for thread in runner._worker_threads
+            if thread.is_alive()
         )
+    if shutdown_failures:
+        parts = [f"{shutdown_failures} JobRunner(s) reported unsuccessful shutdown"]
+        if leaked:
+            parts.append(
+                "workers still alive: " + ", ".join(sorted(leaked))
+            )
+        pytest.fail("background JobRunner shutdown failed: " + "; ".join(parts))
 
 
 @pytest.fixture(autouse=True)

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -62,6 +62,43 @@ def _disable_startup_backfill_timers(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _shutdown_created_job_runners(monkeypatch):
+    """Keep background jobs inside the test that created them.
+
+    Tests build apps through many local helpers, so relying on every caller to
+    remember a teardown call has repeatedly let a worker survive into the next
+    test's tmp_path and process-wide monkeypatches. Track JobRunner construction
+    centrally and make leaked work fail its owner instead of poisoning a later
+    assertion.
+    """
+    from jobs import JobRunner
+
+    created = []
+    original_init = JobRunner.__init__
+
+    def tracked_init(runner, *args, **kwargs):
+        original_init(runner, *args, **kwargs)
+        created.append(runner)
+
+    monkeypatch.setattr(JobRunner, "__init__", tracked_init)
+    yield
+
+    leaked = []
+    for runner in reversed(created):
+        if not runner.shutdown(timeout=5.0):
+            leaked.extend(
+                thread.name
+                for thread in runner._worker_threads
+                if thread.is_alive()
+            )
+    if leaked:
+        pytest.fail(
+            "background JobRunner workers outlived their test: "
+            + ", ".join(sorted(leaked))
+        )
+
+
+@pytest.fixture(autouse=True)
 def _reset_model_cache():
     """Drop the process-wide ModelCache between tests.
 
@@ -168,7 +205,10 @@ def app_and_db(tmp_path, monkeypatch):
 
     app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test-token-123")
     yield app, db
+    jobs_stopped = app._cleanup_app_resources(job_timeout=5.0)
     db.close()
+    if not jobs_stopped:
+        pytest.fail("app background jobs did not stop during fixture teardown")
 
 
 @pytest.fixture
@@ -216,4 +256,7 @@ def client_with_photo(tmp_path, monkeypatch):
 
     app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="test-token-123")
     yield app, db, pid
+    jobs_stopped = app._cleanup_app_resources(job_timeout=5.0)
     db.close()
+    if not jobs_stopped:
+        pytest.fail("app background jobs did not stop during fixture teardown")

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -5,6 +5,8 @@ import sys
 import threading
 import time
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -31,6 +33,33 @@ def test_job_runner_starts_and_completes(tmp_path):
     assert job['status'] == 'completed'
     assert job['result'] == {'items': 3}
     assert job['progress']['current'] == 3
+
+
+def test_job_runner_shutdown_cancels_and_joins_workers():
+    """Teardown owns worker lifetime and refuses work after it begins."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+    started = threading.Event()
+    stopped = threading.Event()
+
+    def work(job):
+        started.set()
+        while not runner.cancellation_requested(job["id"]):
+            time.sleep(0.01)
+        stopped.set()
+        return {}
+
+    job_id = runner.start("test", work)
+    assert started.wait(timeout=2)
+
+    assert runner.shutdown(timeout=2) is True
+    assert stopped.is_set()
+    assert runner.get(job_id)["status"] == "cancelled"
+    assert not runner._worker_threads
+
+    with pytest.raises(RuntimeError, match="shut down"):
+        runner.start("late", lambda _job: {})
 
 
 def _wait_for_status(runner, job_id, status, timeout=3.0):

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -62,6 +62,62 @@ def test_job_runner_shutdown_cancels_and_joins_workers():
         runner.start("late", lambda _job: {})
 
 
+def test_shutdown_bounded_by_timeout_when_queued_cancel_stalls():
+    """A slow/raising cancel_job must not consume the join budget."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+
+    started = threading.Event()
+    stopped = threading.Event()
+
+    def work(job):
+        started.set()
+        while not runner.cancellation_requested(job["id"]):
+            time.sleep(0.01)
+        stopped.set()
+        return {}
+
+    running_id = runner.start("test", work)
+    assert started.wait(timeout=2)
+
+    # Simulate queued pipelines whose cancellation blocks or raises the way
+    # a locked SQLite database would. cancel_job's real db path uses a 30s
+    # connect timeout; without deadline containment shutdown would inherit
+    # that delay per queued job and skip the join phase on exceptions.
+    with runner._lock:
+        for i in range(3):
+            runner._queued_pipelines[f"queued-{i}"] = {
+                "work_fn": lambda _job: {},
+                "config": {},
+                "workspace_id": None,
+                "runtime_warning": None,
+                "started_at": "now",
+            }
+
+    cancel_calls = []
+
+    def slow_and_raising_cancel(job_id, expected_status=None,
+                                promote_after_cancel=True):
+        cancel_calls.append(job_id)
+        time.sleep(1.0)
+        raise RuntimeError("simulated locked-db failure")
+
+    runner.cancel_job = slow_and_raising_cancel
+
+    start = time.monotonic()
+    stopped_cleanly = runner.shutdown(timeout=1.5)
+    elapsed = time.monotonic() - start
+
+    assert stopped_cleanly is True
+    assert stopped.is_set()
+    assert runner.get(running_id)["status"] == "cancelled"
+    # At least one queued cancel was attempted; the deadline stopped the
+    # rest and the raised exception did not skip the worker join.
+    assert cancel_calls, "expected at least one queued cancellation attempt"
+    assert elapsed < 3.0, f"shutdown exceeded bounded budget: {elapsed:.2f}s"
+
+
 def _wait_for_status(runner, job_id, status, timeout=3.0):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -52,6 +52,8 @@ def test_job_runner_shutdown_cancels_and_joins_workers():
 
     job_id = runner.start("test", work)
     assert started.wait(timeout=2)
+    with runner._lock:
+        runner._schedule_promotion_retry_locked()
 
     assert runner.shutdown(timeout=2) is True
     assert stopped.is_set()
@@ -62,60 +64,34 @@ def test_job_runner_shutdown_cancels_and_joins_workers():
         runner.start("late", lambda _job: {})
 
 
-def test_shutdown_bounded_by_timeout_when_queued_cancel_stalls():
-    """A slow/raising cancel_job must not consume the join budget."""
+def test_job_runner_shutdown_joins_after_queued_cancel_failure(monkeypatch):
+    """A locked queued row cannot bypass the bounded worker join."""
     from jobs import JobRunner
 
     runner = JobRunner()
-
-    started = threading.Event()
     stopped = threading.Event()
 
     def work(job):
-        started.set()
         while not runner.cancellation_requested(job["id"]):
             time.sleep(0.01)
         stopped.set()
-        return {}
 
-    running_id = runner.start("test", work)
-    assert started.wait(timeout=2)
+    runner.start("test", work)
+    runner._queued_pipelines["queued"] = {}
+    observed_timeouts = []
 
-    # Simulate queued pipelines whose cancellation blocks or raises the way
-    # a locked SQLite database would. cancel_job's real db path uses a 30s
-    # connect timeout; without deadline containment shutdown would inherit
-    # that delay per queued job and skip the join phase on exceptions.
-    with runner._lock:
-        for i in range(3):
-            runner._queued_pipelines[f"queued-{i}"] = {
-                "work_fn": lambda _job: {},
-                "config": {},
-                "workspace_id": None,
-                "runtime_warning": None,
-                "started_at": "now",
-            }
+    def fail_cancel(_job_id, *, promote_after_cancel, db_timeout):
+        observed_timeouts.append(db_timeout)
+        raise RuntimeError("database is locked")
 
-    cancel_calls = []
+    monkeypatch.setattr(runner, "cancel_job", fail_cancel)
 
-    def slow_and_raising_cancel(job_id, expected_status=None,
-                                promote_after_cancel=True):
-        cancel_calls.append(job_id)
-        time.sleep(1.0)
-        raise RuntimeError("simulated locked-db failure")
-
-    runner.cancel_job = slow_and_raising_cancel
-
-    start = time.monotonic()
-    stopped_cleanly = runner.shutdown(timeout=1.5)
-    elapsed = time.monotonic() - start
-
-    assert stopped_cleanly is True
+    assert runner.shutdown(timeout=2) is False
     assert stopped.is_set()
-    assert runner.get(running_id)["status"] == "cancelled"
-    # At least one queued cancel was attempted; the deadline stopped the
-    # rest and the raised exception did not skip the worker join.
-    assert cancel_calls, "expected at least one queued cancellation attempt"
-    assert elapsed < 3.0, f"shutdown exceeded bounded budget: {elapsed:.2f}s"
+    assert observed_timeouts and 0 < observed_timeouts[0] <= 2
+    assert not runner._worker_threads
+    with runner._lock:
+        runner._queued_pipelines.clear()
 
 
 def _wait_for_status(runner, job_id, status, timeout=3.0):


### PR DESCRIPTION
JobRunner previously launched daemon threads without retaining or joining them, allowing test-owned workers to survive fixture teardown and interfere with later temporary paths and monkeypatches. This change tracks workers, adds bounded cooperative shutdown, rejects late work, and wires shutdown into app and pytest cleanup. Leaked workers now fail the test that created them instead of poisoning a later test. Verified with the runner and submission suites, the 306-test jobs API suite under xdist, 30 repeated passes of the previously flaky tests, representative browser tests, Ruff, and git diff checks; no CI workflow expansion is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable background job shutdown with configurable timeouts.
  * New work is rejected during shutdown, while queued and active jobs are cancelled safely.
  * Shutdown now waits for worker processes to finish and reports timeout status.

* **Bug Fixes**
  * Improved cleanup resilience by continuing resource shutdown when individual cleanup steps fail.
  * Prevented jobs from starting during shutdown races.

* **Tests**
  * Added coverage for job cancellation, worker completion, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->