### PR TITLE
Improve import ETA estimates

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -116,6 +116,9 @@ def _invalidate_new_images(db, root):
 # scan, and hash stamping all commit at batch boundaries, so every stopping
 # point (cancel, crash, yanked card) leaves a valid catalog.
 IMPORT_BATCH_SIZE = 200
+_IMPORT_ETA_PROGRESS_KEYS = (
+    "eta_state", "eta_settled", "eta_seconds", "eta_rate_per_min",
+)
 
 
 class _ImportEtaEstimator:
@@ -1251,10 +1254,10 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         expected_new=(params.checked_count if params.skip_duplicates else None),
     )
 
-    def _emit(phase, current, total, current_file=""):
+    def _emit(phase, current, total, current_file="", *, is_importing=False):
         eta_fields = {}
         if total > 0:
-            if phase.endswith(": importing"):
+            if is_importing:
                 eta.note_importing(copied)
             else:
                 eta.note_batch_complete(current, copied)
@@ -1262,6 +1265,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         job["progress"]["current"] = current
         job["progress"]["total"] = total
         job["progress"]["current_file"] = current_file
+        for key in _IMPORT_ETA_PROGRESS_KEYS:
+            job["progress"].pop(key, None)
         job["progress"].update(eta_fields)
         runner.update_step(
             job["id"], "import",
@@ -1697,7 +1702,10 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 )
                 continue
             emitted += 1
-            _emit(f"{rel}: importing", emitted, queued, source_file.name)
+            _emit(
+                f"{rel}: importing", emitted, queued, source_file.name,
+                is_importing=True,
+            )
             if checker is not None:
                 try:
                     token = checker.match(source_file)
@@ -2894,10 +2902,10 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # an empty-but-present dict.
     folder_counts = {}
 
-    def _emit(phase, current, total, current_file=""):
+    def _emit(phase, current, total, current_file="", *, is_importing=False):
         eta_fields = {}
         if total > 0:
-            if phase.endswith(": importing"):
+            if is_importing:
                 eta.note_importing(copied)
             else:
                 eta.note_batch_complete(current, copied)
@@ -2905,6 +2913,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         job["progress"]["current"] = current
         job["progress"]["total"] = total
         job["progress"]["current_file"] = current_file
+        for key in _IMPORT_ETA_PROGRESS_KEYS:
+            job["progress"].pop(key, None)
         job["progress"].update(eta_fields)
         runner.update_step(
             job["id"], "import",
@@ -3345,6 +3355,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             emitted += 1
             _emit(
                 f"{rel}: importing", emitted, queued, source_file.name,
+                is_importing=True,
             )
 
             # Duplicate gate.

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -54,6 +54,7 @@ import os
 import posixpath
 import shutil
 import sys
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -115,6 +116,140 @@ def _invalidate_new_images(db, root):
 # scan, and hash stamping all commit at batch boundaries, so every stopping
 # point (cancel, crash, yanked card) leaves a valid catalog.
 IMPORT_BATCH_SIZE = 200
+
+
+class _ImportEtaEstimator:
+    """Estimate import time from completed batches that landed new files.
+
+    The ordinary job progress counter advances while a batch is being
+    prepared.  For remote imports that means it can jump by 200 and then sit
+    unchanged while rsync and the restricted catalog scan do the expensive
+    work.  A lifetime ``current / elapsed`` rate therefore treats prepared
+    files -- and fast duplicate-only batches -- as completed transfers.
+
+    Keep an independent settled count and separate quick duplicate-only
+    batches from work that actually increased ``copied``. Until the first
+    relevant batch completes the honest answer is "estimating". Later
+    estimates use an EWMA biased toward the newest completed batch, which
+    adapts when file sizes or archive speed change without swinging on every
+    individual file.
+    """
+
+    def __init__(self, clock=None, expected_new=None):
+        self._clock = clock or time.monotonic
+        self._expected_new = expected_new
+        self._batch_started_at = None
+        self._batch_start_settled = 0
+        self._batch_start_copied = 0
+        self._settled = 0
+        self._copied = 0
+        self._seconds_per_file = None
+        self._duplicate_seconds_per_file = None
+
+    @staticmethod
+    def _smooth(previous, measured):
+        if previous is None:
+            return measured
+        return 0.4 * previous + 0.6 * measured
+
+    def note_importing(self, copied):
+        """Start timing the current batch on its first per-file event."""
+        if self._batch_started_at is None:
+            self._batch_started_at = self._clock()
+            self._batch_start_settled = self._settled
+            self._batch_start_copied = copied
+
+    def note_batch_complete(self, current, copied):
+        """Settle a batch and, when it landed files, learn its duration."""
+        current = max(self._settled, int(current or 0))
+        completed = current - self._batch_start_settled
+
+        if (
+            self._batch_started_at is not None
+            and completed > 0
+        ):
+            elapsed = max(0.0, self._clock() - self._batch_started_at)
+            if elapsed > 0:
+                copied_in_batch = max(0, copied - self._batch_start_copied)
+                duplicates_in_batch = max(0, completed - copied_in_batch)
+                if copied_in_batch == 0:
+                    measured = elapsed / completed
+                    self._duplicate_seconds_per_file = self._smooth(
+                        self._duplicate_seconds_per_file, measured,
+                    )
+                elif self._expected_new is not None:
+                    # checked_count tells us how many selected preview files
+                    # were not duplicates. Separate that expensive work from
+                    # duplicate checks when a boundary batch contains both.
+                    duplicate_time = (
+                        duplicates_in_batch
+                        * (self._duplicate_seconds_per_file or 0.0)
+                    )
+                    measured = max(
+                        elapsed - duplicate_time,
+                        0.001 * copied_in_batch,
+                    ) / copied_in_batch
+                    self._seconds_per_file = self._smooth(
+                        self._seconds_per_file, measured,
+                    )
+                else:
+                    # Without a preview count, completed source files are the
+                    # only honest denominator available. Still require some
+                    # landed work so a fast duplicate-only batch cannot seed
+                    # the transfer estimate.
+                    measured = elapsed / completed
+                    self._seconds_per_file = self._smooth(
+                        self._seconds_per_file, measured,
+                    )
+
+        self._settled = current
+        self._copied = copied
+        self._batch_started_at = None
+        self._batch_start_settled = current
+        self._batch_start_copied = copied
+
+    def fields(self, total):
+        """Return JSON-safe telemetry for the progress event and step."""
+        result = {
+            "eta_state": (
+                "ready" if self._seconds_per_file is not None
+                else "estimating"
+            ),
+            "eta_settled": self._settled,
+        }
+        remaining = max(0, int(total or 0) - self._settled)
+        if self._expected_new is not None:
+            remaining_new = min(
+                remaining, max(0, self._expected_new - self._copied),
+            )
+            remaining_duplicates = max(0, remaining - remaining_new)
+            new_rate = self._seconds_per_file
+            duplicate_rate = self._duplicate_seconds_per_file or new_rate
+            ready = (
+                (remaining_new == 0 or new_rate is not None)
+                and (remaining_duplicates == 0 or duplicate_rate is not None)
+            )
+            result["eta_state"] = "ready" if ready else "estimating"
+            if ready:
+                eta_seconds = (
+                    remaining_new * (new_rate or 0.0)
+                    + remaining_duplicates * (duplicate_rate or 0.0)
+                )
+                result["eta_seconds"] = round(eta_seconds, 1)
+                if eta_seconds > 0 and remaining > 0:
+                    result["eta_rate_per_min"] = round(
+                        60.0 * remaining / eta_seconds, 1,
+                    )
+            return result
+
+        if self._seconds_per_file is not None:
+            result["eta_seconds"] = round(
+                remaining * self._seconds_per_file, 1,
+            )
+            result["eta_rate_per_min"] = round(
+                60.0 / self._seconds_per_file, 1,
+            )
+        return result
 
 
 def _capture_source_snapshots(files, sources):
@@ -1116,18 +1251,35 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     ])
     runner.update_step(job["id"], "import", status="running")
 
+    copied = 0
+    eta = _ImportEtaEstimator(
+        expected_new=(params.checked_count if params.skip_duplicates else None),
+    )
+
     def _emit(phase, current, total, current_file=""):
+        eta_fields = {}
+        if total > 0:
+            if phase.endswith(": importing"):
+                eta.note_importing(copied)
+            else:
+                eta.note_batch_complete(current, copied)
+            eta_fields = eta.fields(total)
         job["progress"]["current"] = current
         job["progress"]["total"] = total
         job["progress"]["current_file"] = current_file
+        job["progress"].update(eta_fields)
         runner.update_step(
             job["id"], "import",
             current_file=current_file,
-            progress={"current": current, "total": total},
+            progress={
+                "current": current, "total": total, **eta_fields,
+            },
         )
         runner.push_event(
             job["id"], "progress",
-            progress_event(phase, current, total, current_file),
+            progress_event(
+                phase, current, total, current_file, **eta_fields,
+            ),
         )
 
     # --- Discover (same enumeration-error handling as the local path) ---
@@ -1208,7 +1360,6 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             batches.append((rel, group[i:i + IMPORT_BATCH_SIZE]))
 
     # --- Ledger ---------------------------------------------------------
-    copied = 0
     verified = 0            # count of files independently checksum-verified
     skipped_duplicate = 0
     unverified_duplicate = 0
@@ -2736,6 +2887,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     ])
     runner.update_step(job["id"], "import", status="running")
 
+    copied = 0
+    eta = _ImportEtaEstimator(
+        expected_new=(params.checked_count if params.skip_duplicates else None),
+    )
+
     # Live per-folder counters, mutated by the copy loop via _counts() and
     # snapshotted onto every progress event so the Import page can render
     # truthful per-folder progress mid-run (not just from the terminal
@@ -2744,13 +2900,23 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     folder_counts = {}
 
     def _emit(phase, current, total, current_file=""):
+        eta_fields = {}
+        if total > 0:
+            if phase.endswith(": importing"):
+                eta.note_importing(copied)
+            else:
+                eta.note_batch_complete(current, copied)
+            eta_fields = eta.fields(total)
         job["progress"]["current"] = current
         job["progress"]["total"] = total
         job["progress"]["current_file"] = current_file
+        job["progress"].update(eta_fields)
         runner.update_step(
             job["id"], "import",
             current_file=current_file,
-            progress={"current": current, "total": total},
+            progress={
+                "current": current, "total": total, **eta_fields,
+            },
         )
         runner.push_event(
             job["id"], "progress",
@@ -2761,6 +2927,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 folders={
                     rel: dict(counts) for rel, counts in folder_counts.items()
                 },
+                **eta_fields,
             ),
         )
 
@@ -2845,7 +3012,6 @@ def run_import_job(job, runner, db_path, workspace_id, params):
 
     # --- Ledger -----------------------------------------------------
     # Every discovered file ends in exactly one terminal bucket.
-    copied = 0
     verified = 0
     skipped_duplicate = 0
     unverified_duplicate = 0

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -177,10 +177,14 @@ class _ImportEtaEstimator:
                     self._duplicate_seconds_per_file = self._smooth(
                         self._duplicate_seconds_per_file, measured,
                     )
-                elif self._expected_new is not None:
-                    # checked_count tells us how many selected preview files
-                    # were not duplicates. Separate that expensive work from
-                    # duplicate checks when a boundary batch contains both.
+                else:
+                    # Measure expensive work against files actually copied,
+                    # even when no preview supplied an expected-new count. A
+                    # boundary batch with 199 quick duplicates and one slow
+                    # transfer must not look like 200 fast transfers. Remove
+                    # the duplicate time learned from earlier pure batches
+                    # when available; otherwise retaining it here makes the
+                    # first estimate conservative instead of optimistic.
                     duplicate_time = (
                         duplicates_in_batch
                         * (self._duplicate_seconds_per_file or 0.0)
@@ -189,15 +193,6 @@ class _ImportEtaEstimator:
                         elapsed - duplicate_time,
                         0.001 * copied_in_batch,
                     ) / copied_in_batch
-                    self._seconds_per_file = self._smooth(
-                        self._seconds_per_file, measured,
-                    )
-                else:
-                    # Without a preview count, completed source files are the
-                    # only honest denominator available. Still require some
-                    # landed work so a fast duplicate-only batch cannot seed
-                    # the transfer estimate.
-                    measured = elapsed / completed
                     self._seconds_per_file = self._smooth(
                         self._seconds_per_file, measured,
                     )

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -700,25 +700,52 @@
     if (isExpanded) {
       // 8: Throughput + ETA for running steps
       if (isRunning && step.progress && step.progress.current > 0 && step.started_at) {
-        var stepSecs = (Date.now() - new Date(step.started_at).getTime()) / 1000;
-        if (stepSecs > 0) {
-          var perSec = step.progress.current / stepSecs;
-          var perMin = perSec * 60;
-          var throughput;
-          if (perMin >= 1) {
-            throughput = '~' + Math.round(perMin) + '/min';
-          } else {
-            throughput = '~' + (1 / perSec).toFixed(1) + 's each';
-          }
-          var statusLine = throughput;
-          // ETA only when we know the total and have a non-zero rate
-          if (step.progress.total > 0 && perSec > 0) {
-            var remaining = step.progress.total - step.progress.current;
-            if (remaining > 0) {
-              statusLine += ' &middot; ETA ' + formatElapsed(remaining / perSec);
+        if (job.type === 'import') {
+          // Import's visible counter advances while a batch is prepared,
+          // before its transfer and restricted catalog scan finish. Use the
+          // backend's completed-batch estimate instead of current / elapsed,
+          // which is badly skewed by fast duplicate checks and queued files.
+          var etaState = step.progress.eta_state;
+          var etaSeconds = Number(step.progress.eta_seconds);
+          var etaRate = Number(step.progress.eta_rate_per_min);
+          var importStatusLine;
+          if (etaState === 'ready' && isFinite(etaSeconds)) {
+            if (etaSeconds > 0) {
+              if (isFinite(etaRate) && etaRate > 0) {
+                importStatusLine = '~' + Math.round(etaRate) +
+                  '/min from completed batches';
+              } else {
+                importStatusLine = 'Based on completed batches';
+              }
+              importStatusLine += ' &middot; ETA ' + formatElapsed(etaSeconds);
+            } else {
+              importStatusLine = 'Copy batches complete &middot; finishing import…';
             }
+          } else {
+            importStatusLine = 'Estimating after the first transfer batch…';
           }
-          html += '<div class="tree-step-throughput">' + statusLine + '</div>';
+          html += '<div class="tree-step-throughput">' + importStatusLine + '</div>';
+        } else {
+          var stepSecs = (Date.now() - new Date(step.started_at).getTime()) / 1000;
+          if (stepSecs > 0) {
+            var perSec = step.progress.current / stepSecs;
+            var perMin = perSec * 60;
+            var throughput;
+            if (perMin >= 1) {
+              throughput = '~' + Math.round(perMin) + '/min';
+            } else {
+              throughput = '~' + (1 / perSec).toFixed(1) + 's each';
+            }
+            var statusLine = throughput;
+            // ETA only when we know the total and have a non-zero rate
+            if (step.progress.total > 0 && perSec > 0) {
+              var remaining = step.progress.total - step.progress.current;
+              if (remaining > 0) {
+                statusLine += ' &middot; ETA ' + formatElapsed(remaining / perSec);
+              }
+            }
+            html += '<div class="tree-step-throughput">' + statusLine + '</div>';
+          }
         }
       }
 

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -6153,9 +6153,12 @@ def test_progress_events_carry_live_per_folder_counts(tmp_path):
         ("DSC_0004.jpg", datetime(2026, 7, 4, 9, 5, 0), "white"),
     ])
     runner = FakeRunner()
+    job = _make_job()
+    include_paths = {str(path) for path in card.iterdir()}
     _run_import(tmp_path, ImportParams(
         sources=[str(card)], destination=str(tmp_path / "archive"),
-    ), runner=runner)
+        include_paths=include_paths, previewed_count=4, checked_count=4,
+    ), runner=runner, job=job)
 
     progress_folder_totals = []
     eta_events = []
@@ -6179,6 +6182,7 @@ def test_progress_events_carry_live_per_folder_counts(tmp_path):
     assert eta_events[-1]["eta_state"] == "ready"
     assert eta_events[-1]["eta_settled"] == 4
     assert eta_events[-1]["eta_seconds"] == 0.0
+    assert "eta_rate_per_min" not in job["progress"]
 
 
 def test_remote_import_links_alias_spelled_twin_folder(tmp_path, monkeypatch):

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -91,6 +91,78 @@ def _unsafe_reason(result, path):
                 if u["path"] == path)
 
 
+def test_import_eta_waits_for_a_completed_transfer_batch():
+    """Fast duplicate-only work must not seed the transfer ETA."""
+    from import_job import _ImportEtaEstimator
+
+    now = [0.0]
+    eta = _ImportEtaEstimator(clock=lambda: now[0])
+
+    # A quick duplicate-only batch settles 200 files, but says nothing
+    # about how long the remaining card-to-archive transfers will take.
+    eta.note_importing(copied=0)
+    now[0] = 2.0
+    eta.note_batch_complete(current=200, copied=0)
+    assert eta.fields(1000) == {
+        "eta_state": "estimating",
+        "eta_settled": 200,
+    }
+
+    # The first real transfer+catalog batch supplies the first honest rate.
+    eta.note_importing(copied=0)
+    now[0] = 22.0
+    eta.note_batch_complete(current=400, copied=200)
+    assert eta.fields(1000) == {
+        "eta_state": "ready",
+        "eta_settled": 400,
+        "eta_seconds": 60.0,
+        "eta_rate_per_min": 600.0,
+    }
+
+
+def test_import_eta_does_not_count_an_active_prepared_batch_as_settled():
+    """Queuing the next batch must not make its ETA disappear early."""
+    from import_job import _ImportEtaEstimator
+
+    now = [0.0]
+    eta = _ImportEtaEstimator(clock=lambda: now[0])
+    eta.note_importing(copied=0)
+    now[0] = 20.0
+    eta.note_batch_complete(current=200, copied=200)
+
+    # The UI counter may already say 400 while rsync is still transferring
+    # that second batch. The estimator intentionally remains at 200 settled.
+    eta.note_importing(copied=200)
+    assert eta.fields(1000)["eta_settled"] == 200
+    assert eta.fields(1000)["eta_seconds"] == 80.0
+
+
+def test_import_eta_uses_preview_new_count_for_a_mixed_boundary_batch():
+    """A mostly-duplicate batch must not look like 200 fast transfers."""
+    from import_job import _ImportEtaEstimator
+
+    now = [0.0]
+    eta = _ImportEtaEstimator(clock=lambda: now[0], expected_new=100)
+
+    # Learn the duplicate-check cost separately.
+    eta.note_importing(copied=0)
+    now[0] = 2.0
+    eta.note_batch_complete(current=200, copied=0)
+
+    # The next 200-file batch crosses the old/new boundary: 180 duplicates,
+    # only 20 actual copies. Its 22 seconds therefore imply about 1.01s per
+    # new file after subtracting the learned duplicate-check time.
+    eta.note_importing(copied=0)
+    now[0] = 24.0
+    eta.note_batch_complete(current=400, copied=20)
+    fields = eta.fields(1000)
+
+    # 80 new * 1.01s + 520 duplicates * 0.01s = 86 seconds.
+    assert fields["eta_state"] == "ready"
+    assert fields["eta_settled"] == 400
+    assert fields["eta_seconds"] == 86.0
+
+
 def _ws_linked_folder_paths(db, ws_id):
     return {
         row["path"]
@@ -6062,9 +6134,12 @@ def test_progress_events_carry_live_per_folder_counts(tmp_path):
     ), runner=runner)
 
     progress_folder_totals = []
+    eta_events = []
     for (_, evt, data) in runner.events:
         if evt != "progress" or "folders" not in data:
             continue
+        if "eta_state" in data:
+            eta_events.append(data)
         total_copied = sum(
             c.get("copied", 0) for c in data["folders"].values()
         )
@@ -6076,6 +6151,10 @@ def test_progress_events_carry_live_per_folder_counts(tmp_path):
     assert any(0 < t < 4 for t in progress_folder_totals), (
         progress_folder_totals
     )
+    assert any(e["eta_state"] == "estimating" for e in eta_events)
+    assert eta_events[-1]["eta_state"] == "ready"
+    assert eta_events[-1]["eta_settled"] == 4
+    assert eta_events[-1]["eta_seconds"] == 0.0
 
 
 def test_remote_import_links_alias_spelled_twin_folder(tmp_path, monkeypatch):

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -163,6 +163,30 @@ def test_import_eta_uses_preview_new_count_for_a_mixed_boundary_batch():
     assert fields["eta_seconds"] == 86.0
 
 
+def test_import_eta_no_preview_measures_only_copied_files_in_mixed_batch():
+    """A no-preview mixed batch must not dilute one transfer over 200 files."""
+    from import_job import _ImportEtaEstimator
+
+    now = [0.0]
+    eta = _ImportEtaEstimator(clock=lambda: now[0])
+
+    # Learn a 0.01-second duplicate check from a pure duplicate batch.
+    eta.note_importing(copied=0)
+    now[0] = 2.0
+    eta.note_batch_complete(current=200, copied=0)
+
+    # The next batch takes 12 seconds but contains only one real copy. After
+    # subtracting 1.99 seconds for its 199 duplicates, the expensive rate is
+    # 10.01 seconds per copied file, not 0.06 seconds per settled source.
+    eta.note_importing(copied=0)
+    now[0] = 14.0
+    eta.note_batch_complete(current=400, copied=1)
+    fields = eta.fields(600)
+
+    assert fields["eta_state"] == "ready"
+    assert fields["eta_seconds"] == 2002.0
+
+
 def _ws_linked_folder_paths(db, ws_id):
     return {
         row["path"]


### PR DESCRIPTION
## Summary

- estimate import completion from settled copy-and-catalog batches instead of lifetime counter throughput
- model duplicate checks separately from new transfers when preview counts are available
- keep active prepared batches out of the settled count and smooth estimates over recent batches
- show an honest estimating state until enough completed work exists

## Why

The import progress counter advances while files are checked and queued, before a remote rsync batch and its restricted catalog scan finish. Fast duplicate checks could therefore make the Jobs page report a dramatically optimistic ETA, such as 31 minutes while the first real transfer batch was still taking roughly 20 minutes.

## User impact

Import jobs now withhold the countdown until a representative batch completes. Once available, the ETA is based on completed work and adapts as archive/card conditions change. Duplicate-only and mixed duplicate/new batches no longer masquerade as fast transfers.

## Validation

- `python -m ruff check vireo/import_job.py vireo/tests/test_import_job.py`
- `python -m pytest vireo/tests/test_import_job.py vireo/tests/test_jobs.py -q` — 215 passed, 1 skipped
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch-based ETA estimates for local and remote imports.
  * Import progress now shows estimation status, completion progress, remaining time, and transfer rate.
  * Estimates account for duplicate files and newly copied files for improved accuracy.

* **Bug Fixes**
  * Improved progress reporting so active files aren’t counted as completed.
  * Duplicate-only batches no longer produce misleading transfer rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->