### PR TITLE
Add Work Locally to the Browse folder menu

### DIFF
--- a/tests/e2e/test_folder_tree_context_menu.py
+++ b/tests/e2e/test_folder_tree_context_menu.py
@@ -6,6 +6,7 @@ Menu items:
 - Reveal in Finder/Folder
 - Copy Path
 - separator
+- Work Locally…
 - Move…
 - Rescan this Folder
 
@@ -31,6 +32,7 @@ def test_folder_tree_right_click_opens_menu(live_server, page):
         "Filter by this folder",
         "Reveal in",
         "Copy Path",
+        "Work Locally…",
         "Move…",
         "Rescan this Folder",
     ]:
@@ -55,6 +57,47 @@ def test_folder_tree_move_opens_move_page_with_source_selected(live_server, page
     page.wait_for_url(f"**/move?folder_id={fid}")
     expect(page.locator("#quickFolderSelect")).to_have_value(fid)
     expect(page.locator("#quickFolderInfo")).not_to_be_empty()
+
+
+def test_folder_tree_work_locally_copies_selected_root(live_server, page, tmp_path):
+    """Work Locally… opens the chooser and copies the selected root."""
+    db = live_server["db"]
+    source = tmp_path / "nas-source"
+    source.mkdir()
+    (source / "bird.jpg").write_bytes(b"original")
+    workspace_id = db.create_workspace("Browse Local Copy")
+    db.set_active_workspace(workspace_id)
+    folder_id = db.add_folder(str(source), name="nas-source")
+    assert page.request.post(
+        f"{live_server['url']}/api/workspaces/{workspace_id}/activate"
+    ).ok
+
+    page.goto(f"{live_server['url']}/browse")
+    item = page.locator(f'.tree-item[data-folder-id="{folder_id}"]')
+    item.wait_for(state="visible")
+    item.click(button="right")
+    page.locator(
+        ".vireo-ctx-menu .vireo-ctx-item", has_text="Work Locally…"
+    ).click()
+
+    modal = page.locator("#stageLocalFoldersModal")
+    expect(modal).to_have_class("modal-overlay open")
+    destination = tmp_path / "fast-storage"
+    modal.locator("[data-local-destination-base]").fill(str(destination))
+    expect(modal.locator("[data-local-destination-preview]")).to_contain_text(
+        str(destination / "nas-source")
+    )
+    modal.get_by_role("button", name="Copy Locally", exact=True).click()
+
+    expect(page.locator("#toastContainer")).to_contain_text(
+        "Local folder update complete", timeout=15000
+    )
+    local_root = destination / "nas-source"
+    assert (local_root / "bird.jpg").read_bytes() == b"original"
+    catalog_path = db.conn.execute(
+        "SELECT path FROM folders WHERE id=?", (folder_id,)
+    ).fetchone()["path"]
+    assert catalog_path == str(local_root)
 
 
 def test_folder_tree_filter_by_folder_fires_filter(live_server, page):

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -439,53 +439,83 @@
     }
   }
 
-  document.getElementById('localWorkspaceContent').addEventListener('click', function(event) {
-    var button = event.target.closest('[data-local-folders-action], [data-legacy-action]');
-    if (!button || button.disabled) return;
-    var action = button.dataset.localFoldersAction;
-    if (action === 'stage-all') openStageDialog(null);
-    else if (action === 'manage') openManager();
-    else if (button.dataset.legacyAction) legacyAction(button.dataset.legacyAction);
-  });
-
-  document.getElementById('closeLocalFoldersModal').addEventListener('click', closeManager);
-  document.getElementById('cancelStageLocalFolders').addEventListener('click', closeStageDialog);
-  document.getElementById('confirmStageLocalFolders').addEventListener('click', submitStageDialog);
-  document.getElementById('stageLocalFoldersModalItems').addEventListener('input', function(event) {
-    if (event.target.matches('[data-local-destination-base]')) {
-      updateStageDestinationPreview(event.target);
-    }
-  });
-  document.getElementById('stageLocalFoldersModalItems').addEventListener('click', async function(event) {
-    var button = event.target.closest('[data-browse-local-destination]');
-    if (!button) return;
-    var id = button.dataset.browseLocalDestination;
-    var input = document.querySelector('[data-local-destination-base="' + id + '"]');
-    if (!input || typeof pickDirectory !== 'function') return;
-    var chosen = await pickDirectory('Choose a location for ' + input.dataset.folderName, {
-      defaultPath: input.value.trim()
+  var panel = document.getElementById('localWorkspaceContent');
+  if (panel) {
+    panel.addEventListener('click', function(event) {
+      var button = event.target.closest('[data-local-folders-action], [data-legacy-action]');
+      if (!button || button.disabled) return;
+      var action = button.dataset.localFoldersAction;
+      if (action === 'stage-all') openStageDialog(null);
+      else if (action === 'manage') openManager();
+      else if (button.dataset.legacyAction) legacyAction(button.dataset.legacyAction);
     });
-    if (!chosen || Array.isArray(chosen)) return;
-    input.value = chosen;
-    updateStageDestinationPreview(input);
-  });
-  document.getElementById('syncSelectedLocalFolders').addEventListener('click', function() {
-    var selected = managerSelection();
-    if (!selected.length) return;
-    closeManager();
-    sync(selected);
-  });
-  document.getElementById('discardSelectedLocalFolders').addEventListener('click', function() {
-    var selected = managerSelection();
-    if (!selected.length) return;
-    closeManager();
-    discard(selected);
-  });
+  }
+
+  var closeManagerButton = document.getElementById('closeLocalFoldersModal');
+  if (closeManagerButton) closeManagerButton.addEventListener('click', closeManager);
+  var cancelStageButton = document.getElementById('cancelStageLocalFolders');
+  if (cancelStageButton) cancelStageButton.addEventListener('click', closeStageDialog);
+  var confirmStageButton = document.getElementById('confirmStageLocalFolders');
+  if (confirmStageButton) confirmStageButton.addEventListener('click', submitStageDialog);
+  var stageItems = document.getElementById('stageLocalFoldersModalItems');
+  if (stageItems) {
+    stageItems.addEventListener('input', function(event) {
+      if (event.target.matches('[data-local-destination-base]')) {
+        updateStageDestinationPreview(event.target);
+      }
+    });
+    stageItems.addEventListener('click', async function(event) {
+      var button = event.target.closest('[data-browse-local-destination]');
+      if (!button) return;
+      var id = button.dataset.browseLocalDestination;
+      var input = document.querySelector('[data-local-destination-base="' + id + '"]');
+      if (!input || typeof pickDirectory !== 'function') return;
+      var chosen = await pickDirectory('Choose a location for ' + input.dataset.folderName, {
+        defaultPath: input.value.trim()
+      });
+      if (!chosen || Array.isArray(chosen)) return;
+      input.value = chosen;
+      updateStageDestinationPreview(input);
+    });
+  }
+  var syncSelectedButton = document.getElementById('syncSelectedLocalFolders');
+  if (syncSelectedButton) {
+    syncSelectedButton.addEventListener('click', function() {
+      var selected = managerSelection();
+      if (!selected.length) return;
+      closeManager();
+      sync(selected);
+    });
+  }
+  var discardSelectedButton = document.getElementById('discardSelectedLocalFolders');
+  if (discardSelectedButton) {
+    discardSelectedButton.addEventListener('click', function() {
+      var selected = managerSelection();
+      if (!selected.length) return;
+      closeManager();
+      discard(selected);
+    });
+  }
+
+  async function stageFromAnywhere(folderId) {
+    if (!data) await load();
+    if (activeJob || (data && data.legacy_workspace_session)) {
+      window.location.href = '/workspace#work-locally';
+      return false;
+    }
+    var item = statusFor(Number(folderId));
+    if (!item || item.state !== 'remote') {
+      window.location.href = '/workspace#work-locally';
+      return false;
+    }
+    openStageDialog([Number(folderId)]);
+    return true;
+  }
 
   window.vireoLocalFolders = {
     load: load,
     statusFor: statusFor,
-    stage: function(folderId) { return openStageDialog([Number(folderId)]); },
+    stage: stageFromAnywhere,
     sync: function(folderId) { return sync([Number(folderId)]); },
     discard: function(folderId) { return discard([Number(folderId)]); }
   };

--- a/vireo/templates/_work_locally_stage_modal.html
+++ b/vireo/templates/_work_locally_stage_modal.html
@@ -1,0 +1,15 @@
+<!-- Choose a destination for one or more managed local folder copies. -->
+<div class="modal-overlay" id="stageLocalFoldersModal">
+  <div class="modal" style="max-width:680px;width:90%;">
+    <h3 style="margin:0 0 8px 0;font-size:16px;">Work Locally</h3>
+    <div style="font-size:12px;color:var(--text-secondary);line-height:1.5;margin-bottom:14px;">
+      Choose where Vireo should create each local copy. The source files stay unchanged until you sync back.
+    </div>
+    <div id="stageLocalFoldersModalItems"></div>
+    <div class="modal-error" id="stageLocalFoldersError"></div>
+    <div class="modal-actions" style="margin-top:16px;display:flex;gap:8px;justify-content:flex-end;">
+      <button class="modal-btn" id="cancelStageLocalFolders">Cancel</button>
+      <button class="modal-btn modal-btn-primary" id="confirmStageLocalFolders">Copy Locally</button>
+    </div>
+  </div>
+</div>

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1816,6 +1816,8 @@ body.sidebar-resizing {
   </div>
 </div>
 
+{% include '_work_locally_stage_modal.html' %}
+
 <!-- Collection Modal -->
 <div class="modal-overlay" id="collectionModal">
   <div class="modal">
@@ -1949,6 +1951,7 @@ body.sidebar-resizing {
 </div>
 
 
+<script src="/static/vireo-work-locally.js"></script>
 <script>
 /* Google Maps API key — populated from /api/config below (window._cfgPromise).
    Empty string when no key is configured; the Location section then
@@ -8774,6 +8777,14 @@ function moveFolder(fid) {
   window.location.href = '/move?folder_id=' + encodeURIComponent(fid);
 }
 
+function workLocallyFolder(fid) {
+  if (window.vireoLocalFolders) {
+    window.vireoLocalFolders.stage(fid);
+    return;
+  }
+  window.location.href = '/workspace#work-locally';
+}
+
 async function rescanFolder(fid) {
   showToast('Starting folder rescan...', 'info');
   try {
@@ -8804,6 +8815,7 @@ document.addEventListener('contextmenu', function(e) {
     { label: window.VIREO_REVEAL_LABEL, onClick: function() { revealFolder(fid); } },
     { label: 'Copy Path', onClick: function() { copyFolderPath(fid); } },
     { separator: true },
+    { label: 'Work Locally\u2026', onClick: function() { workLocallyFolder(fid); } },
     { label: 'Move\u2026', onClick: function() { moveFolder(fid); } },
     { label: 'Rescan this Folder', onClick: function() { rescanFolder(fid); } },
   ]);

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -59,7 +59,7 @@
   </div>
 
   <!-- Work Locally -->
-  <div class="section">
+  <div class="section" id="work-locally">
     <div class="section-title">Work Locally</div>
     <div id="localWorkspaceContent"><span style="color:var(--text-ghost);font-size:13px;">Loading...</span></div>
   </div>
@@ -122,21 +122,7 @@
   </div>
 </div>
 
-<!-- Choose local-copy destinations -->
-<div class="modal-overlay" id="stageLocalFoldersModal">
-  <div class="modal" style="max-width:680px;width:90%;">
-    <h3 style="margin:0 0 8px 0;font-size:16px;">Work Locally</h3>
-    <div style="font-size:12px;color:var(--text-secondary);line-height:1.5;margin-bottom:14px;">
-      Choose where Vireo should create each local copy. The source files stay unchanged until you sync back.
-    </div>
-    <div id="stageLocalFoldersModalItems"></div>
-    <div class="modal-error" id="stageLocalFoldersError"></div>
-    <div class="modal-actions" style="margin-top:16px;display:flex;gap:8px;justify-content:flex-end;">
-      <button class="modal-btn" id="cancelStageLocalFolders">Cancel</button>
-      <button class="modal-btn modal-btn-primary" id="confirmStageLocalFolders">Copy Locally</button>
-    </div>
-  </div>
-</div>
+{% include '_work_locally_stage_modal.html' %}
 
 <!-- Shared local-folder bulk actions -->
 <div class="modal-overlay" id="localFoldersModal">


### PR DESCRIPTION
Adds a Work Locally… action to the Browse folder context menu, reusing the existing destination chooser and managed-copy workflow. Unsupported nested, active, or legacy cases fall back to the anchored Work Locally section on the Workspace page. Adds end-to-end coverage that copies a selected root locally and verifies the catalog path update. Tests: targeted Browse/Workspace E2E and local-folder/local-workspace/page-load suites passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Work Locally…” option to folder context menus.
  * Added a destination picker and preview for copying managed folders locally.
  * Users can confirm copies and see updated folder paths in the catalog.
  * Opening the action now intelligently loads or redirects to the appropriate workspace when needed.

* **Bug Fixes**
  * Improved handling when Work Locally interface elements are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->