### PR TITLE
Show storage capacity before working locally

### DIFF
--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -104,7 +104,7 @@ def local_copy_preflight(
         if local_base is None:
             local_base = str(default_local_base(vireo_dir, root_folder_id))
         local_path = local_path_for_base(local_base, root_folder_id, source_path)
-        total_files, total_bytes = source_tree_size(source_path)
+        total_files, total_bytes, estimated_bytes = source_tree_size(source_path)
         space = destination_disk_space(local_path)
         device = int(space["device"])
         volume = volumes_by_device.setdefault(
@@ -122,7 +122,7 @@ def local_copy_preflight(
         # If free space changes during a multi-folder scan, use the most
         # conservative reading for the shared-volume aggregate.
         volume["free_bytes"] = min(volume["free_bytes"], int(space["free_bytes"]))
-        volume["copy_bytes"] += total_bytes
+        volume["copy_bytes"] += estimated_bytes
         volume["destination_paths"].append(str(local_path))
         volume["folder_ids"].append(root_folder_id)
         folders.append(
@@ -132,6 +132,7 @@ def local_copy_preflight(
                 "destination_path": str(local_path),
                 "total_files": total_files,
                 "total_bytes": total_bytes,
+                "estimated_bytes": estimated_bytes,
                 "device": device,
             }
         )

--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -42,6 +42,8 @@ from services.local_workspace import (
     _source_state,
     _walk_entries,
     _write_manifest,
+    destination_disk_space,
+    source_tree_size,
     stage_boundary_lock,
 )
 
@@ -76,6 +78,88 @@ def default_local_path(vireo_dir: str, root_folder_id: int, source_path: str) ->
 
 def local_path_for_base(local_base: str | Path, root_folder_id: int, source_path: str) -> Path:
     return Path(local_base) / _safe_folder_name(source_path, root_folder_id)
+
+
+def local_copy_preflight(
+    db,
+    root_folder_ids: list[int],
+    vireo_dir: str,
+    *,
+    destination_bases: dict[int, str] | None = None,
+) -> dict:
+    """Measure selected sources and capacity on their destination volumes."""
+    destination_bases = destination_bases or {}
+    folders = []
+    volumes_by_device: dict[int, dict] = {}
+
+    for raw_root_id in root_folder_ids:
+        root_folder_id = int(raw_root_id)
+        row = db.conn.execute(
+            "SELECT path FROM folders WHERE id=?", (root_folder_id,)
+        ).fetchone()
+        if row is None:
+            raise LocalWorkspaceError(f"Folder {root_folder_id} was not found")
+        source_path = row["path"]
+        local_base = destination_bases.get(root_folder_id)
+        if local_base is None:
+            local_base = str(default_local_base(vireo_dir, root_folder_id))
+        local_path = local_path_for_base(local_base, root_folder_id, source_path)
+        total_files, total_bytes = source_tree_size(source_path)
+        space = destination_disk_space(local_path)
+        device = int(space["device"])
+        volume = volumes_by_device.setdefault(
+            device,
+            {
+                "device": device,
+                "free_bytes": int(space["free_bytes"]),
+                "total_bytes": int(space["total_bytes"]),
+                "reserve_bytes": int(space["reserve_bytes"]),
+                "copy_bytes": 0,
+                "destination_paths": [],
+                "folder_ids": [],
+            },
+        )
+        # If free space changes during a multi-folder scan, use the most
+        # conservative reading for the shared-volume aggregate.
+        volume["free_bytes"] = min(volume["free_bytes"], int(space["free_bytes"]))
+        volume["copy_bytes"] += total_bytes
+        volume["destination_paths"].append(str(local_path))
+        volume["folder_ids"].append(root_folder_id)
+        folders.append(
+            {
+                "folder_id": root_folder_id,
+                "source_path": source_path,
+                "destination_path": str(local_path),
+                "total_files": total_files,
+                "total_bytes": total_bytes,
+                "device": device,
+            }
+        )
+
+    volumes = []
+    for index, volume in enumerate(volumes_by_device.values(), start=1):
+        volume["id"] = index
+        volume["required_bytes"] = volume["copy_bytes"] + volume["reserve_bytes"]
+        volume["after_copy_bytes"] = volume["free_bytes"] - volume["copy_bytes"]
+        volume["can_copy"] = volume["free_bytes"] >= volume["required_bytes"]
+        volumes.append(volume)
+        for folder in folders:
+            if folder.get("device") == volume["device"]:
+                folder["volume_id"] = volume["id"]
+                folder["free_bytes"] = volume["free_bytes"]
+                folder["reserve_bytes"] = volume["reserve_bytes"]
+    for folder in folders:
+        folder.pop("device", None)
+    for volume in volumes:
+        volume.pop("device", None)
+
+    return {
+        "folder_count": len(folders),
+        "total_bytes": sum(folder["total_bytes"] for folder in folders),
+        "can_copy": all(volume["can_copy"] for volume in volumes),
+        "folders": folders,
+        "volumes": volumes,
+    }
 
 
 def manifest_path(vireo_dir: str, root_folder_id: int) -> Path:

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -179,16 +179,21 @@ def _validated_tree_entries(source: str):
     if not stat.S_ISDIR(root_st.st_mode):
         raise LocalWorkspaceError(f"Workspace folder is unavailable: {source}")
 
-    for rel, full, st in _walk_entries(source):
-        mode = st.st_mode
-        if stat.S_ISLNK(mode):
-            if not _symlink_stays_within(full, source):
-                raise LocalWorkspaceError(
-                    f"Symlink escapes or uses an absolute target and cannot be staged: {full}"
-                )
-        elif not stat.S_ISREG(mode) and not stat.S_ISDIR(mode):
-            raise LocalWorkspaceError(f"Unsupported special file in workspace: {full}")
-        yield rel, full, st
+    try:
+        for rel, full, st in _walk_entries(source):
+            mode = st.st_mode
+            if stat.S_ISLNK(mode):
+                if not _symlink_stays_within(full, source):
+                    raise LocalWorkspaceError(
+                        f"Symlink escapes or uses an absolute target and cannot be staged: {full}"
+                    )
+            elif not stat.S_ISREG(mode) and not stat.S_ISDIR(mode):
+                raise LocalWorkspaceError(f"Unsupported special file in workspace: {full}")
+            yield rel, full, st
+    except OSError as exc:
+        raise LocalWorkspaceError(
+            f"Could not read workspace directory: {exc}"
+        ) from exc
 
 
 def source_tree_size(source: str) -> tuple[int, int, int]:

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -35,7 +35,13 @@ from pathlib import Path
 from config import _replace_with_windows_retry
 
 MANIFEST_VERSION = 2
+# Keep at least 5% of a destination volume free after a local copy, with
+# sensible bounds for very small and very large disks.  The lower bound
+# preserves the historical 1 GiB safety margin; the upper bound avoids making
+# large external SSDs unnecessarily unusable for Work Locally.
 LOCAL_RESERVE_BYTES = 1024**3
+LOCAL_MAX_RESERVE_BYTES = 20 * 1024**3
+LOCAL_RESERVE_FRACTION = 0.05
 
 # Serializes stage/sync/discard per workspace. A short global guard covers
 # stage's cross-workspace overlap validation so two concurrent stages cannot
@@ -82,6 +88,73 @@ class LocalWorkspaceConflict(LocalWorkspaceError):
 
 class LocalWorkspaceCancelled(LocalWorkspaceError):
     """The caller cancelled a still-interruptible transfer."""
+
+
+def local_space_reserve(total_bytes: int) -> int:
+    """Return the free-space reserve Work Locally keeps on a volume."""
+    proportional = int(max(0, total_bytes) * LOCAL_RESERVE_FRACTION)
+    return min(LOCAL_MAX_RESERVE_BYTES, max(LOCAL_RESERVE_BYTES, proportional))
+
+
+def destination_disk_space(path: str | Path) -> dict:
+    """Return capacity details for the volume containing ``path``.
+
+    Destination folders commonly do not exist yet. Walk up to the closest
+    existing ancestor so the preview can report capacity before staging has
+    created anything.
+    """
+    requested = Path(path).expanduser()
+    probe = requested
+    while not os.path.lexists(probe):
+        parent = probe.parent
+        if parent == probe:
+            break
+        probe = parent
+    try:
+        usage = shutil.disk_usage(probe)
+        device = os.stat(probe).st_dev
+    except OSError as exc:
+        raise LocalWorkspaceError(
+            f"Could not check free space at {requested}: {exc}"
+        ) from exc
+    return {
+        "total_bytes": usage.total,
+        "free_bytes": usage.free,
+        "reserve_bytes": local_space_reserve(usage.total),
+        "device": device,
+        "probe_path": str(probe),
+    }
+
+
+def source_tree_size(source: str) -> tuple[int, int]:
+    """Return the exact entry count and logical bytes copied from ``source``."""
+    try:
+        root_st = os.lstat(source)
+    except OSError as exc:
+        raise LocalWorkspaceError(f"Workspace folder is unavailable: {source}") from exc
+    if stat.S_ISLNK(root_st.st_mode):
+        raise LocalWorkspaceError(
+            f"Workspace root is a symlink and cannot be staged: {source}"
+        )
+    if not stat.S_ISDIR(root_st.st_mode):
+        raise LocalWorkspaceError(f"Workspace folder is unavailable: {source}")
+
+    total_files = 0
+    total_bytes = 0
+    for _rel, full, st in _walk_entries(source):
+        mode = st.st_mode
+        if stat.S_ISREG(mode):
+            total_bytes += st.st_size
+            total_files += 1
+        elif stat.S_ISLNK(mode):
+            if not _symlink_stays_within(full, source):
+                raise LocalWorkspaceError(
+                    f"Symlink escapes or uses an absolute target and cannot be staged: {full}"
+                )
+            total_files += 1
+        elif not stat.S_ISDIR(mode):
+            raise LocalWorkspaceError(f"Unsupported special file in workspace: {full}")
+    return total_files, total_bytes
 
 
 def workspace_dir(vireo_dir: str, workspace_id: int) -> Path:
@@ -421,12 +494,13 @@ def _collect_source_entries(roots: list[dict], local_base: Path) -> tuple[dict[i
             entries.append((rel, full, st))
         per_root[index] = entries
 
-    free = shutil.disk_usage(local_base.parent).free
-    required = total_bytes + LOCAL_RESERVE_BYTES
-    if free < required:
+    usage = shutil.disk_usage(local_base.parent)
+    reserve = local_space_reserve(usage.total)
+    required = total_bytes + reserve
+    if usage.free < required:
         raise LocalWorkspaceError(
             f"Not enough local space: need {required:,} bytes including safety reserve, "
-            f"but only {free:,} bytes are free"
+            f"but only {usage.free:,} bytes are free"
         )
     return per_root, total_files, total_bytes
 

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -42,6 +42,11 @@ MANIFEST_VERSION = 2
 LOCAL_RESERVE_BYTES = 1024**3
 LOCAL_MAX_RESERVE_BYTES = 20 * 1024**3
 LOCAL_RESERVE_FRACTION = 0.05
+# A copied entry consumes at least one destination allocation unit even when
+# its logical size is zero. Four KiB is the common minimum on APFS, NTFS, and
+# ext filesystems; the separate volume reserve covers larger cluster sizes and
+# filesystem metadata without making ordinary photo folders look enormous.
+LOCAL_ALLOCATION_UNIT_BYTES = 4096
 
 # Serializes stage/sync/discard per workspace. A short global guard covers
 # stage's cross-workspace overlap validation so two concurrent stages cannot
@@ -126,8 +131,20 @@ def destination_disk_space(path: str | Path) -> dict:
     }
 
 
-def source_tree_size(source: str) -> tuple[int, int]:
-    """Return the exact entry count and logical bytes copied from ``source``."""
+def _estimated_destination_bytes(st) -> int:
+    """Conservatively estimate allocation consumed by one copied entry."""
+    if stat.S_ISREG(st.st_mode):
+        units = max(
+            1,
+            (st.st_size + LOCAL_ALLOCATION_UNIT_BYTES - 1)
+            // LOCAL_ALLOCATION_UNIT_BYTES,
+        )
+        return units * LOCAL_ALLOCATION_UNIT_BYTES
+    return LOCAL_ALLOCATION_UNIT_BYTES
+
+
+def source_tree_size(source: str) -> tuple[int, int, int]:
+    """Return copied-file count, logical bytes, and estimated allocated bytes."""
     try:
         root_st = os.lstat(source)
     except OSError as exc:
@@ -141,20 +158,26 @@ def source_tree_size(source: str) -> tuple[int, int]:
 
     total_files = 0
     total_bytes = 0
+    # The destination root directory itself is created for every source.
+    estimated_bytes = LOCAL_ALLOCATION_UNIT_BYTES
     for _rel, full, st in _walk_entries(source):
         mode = st.st_mode
         if stat.S_ISREG(mode):
             total_bytes += st.st_size
             total_files += 1
+            estimated_bytes += _estimated_destination_bytes(st)
         elif stat.S_ISLNK(mode):
             if not _symlink_stays_within(full, source):
                 raise LocalWorkspaceError(
                     f"Symlink escapes or uses an absolute target and cannot be staged: {full}"
                 )
             total_files += 1
-        elif not stat.S_ISDIR(mode):
+            estimated_bytes += _estimated_destination_bytes(st)
+        elif stat.S_ISDIR(mode):
+            estimated_bytes += _estimated_destination_bytes(st)
+        else:
             raise LocalWorkspaceError(f"Unsupported special file in workspace: {full}")
-    return total_files, total_bytes
+    return total_files, total_bytes, estimated_bytes
 
 
 def workspace_dir(vireo_dir: str, workspace_id: int) -> Path:
@@ -437,11 +460,13 @@ def _collect_source_entries(roots: list[dict], local_base: Path) -> tuple[dict[i
     """
     per_root: dict[int, list] = {}
     total_bytes = 0
+    estimated_bytes = 0
     total_files = 0
     local_base.parent.mkdir(parents=True, exist_ok=True)
     case_insensitive_target = _dest_case_insensitive(local_base)
     for index, root in enumerate(roots):
         source = root["source_path"]
+        estimated_bytes += LOCAL_ALLOCATION_UNIT_BYTES
         # os.path.isdir follows symlinks; a source root that is itself a
         # symlink would activate successfully here but sync_back later lstats
         # and rejects it, leaving every local edit unsyncable. Reject
@@ -463,14 +488,16 @@ def _collect_source_entries(roots: list[dict], local_base: Path) -> tuple[dict[i
             if stat.S_ISREG(mode):
                 total_bytes += st.st_size
                 total_files += 1
+                estimated_bytes += _estimated_destination_bytes(st)
             elif stat.S_ISLNK(mode):
                 if not _symlink_stays_within(full, source):
                     raise LocalWorkspaceError(
                         f"Symlink escapes or uses an absolute target and cannot be staged: {full}"
                     )
                 total_files += 1
+                estimated_bytes += _estimated_destination_bytes(st)
             elif stat.S_ISDIR(mode):
-                pass
+                estimated_bytes += _estimated_destination_bytes(st)
             else:
                 raise LocalWorkspaceError(f"Unsupported special file in workspace: {full}")
             if case_insensitive_target and rel:
@@ -496,7 +523,7 @@ def _collect_source_entries(roots: list[dict], local_base: Path) -> tuple[dict[i
 
     usage = shutil.disk_usage(local_base.parent)
     reserve = local_space_reserve(usage.total)
-    required = total_bytes + reserve
+    required = estimated_bytes + reserve
     if usage.free < required:
         raise LocalWorkspaceError(
             f"Not enough local space: need {required:,} bytes including safety reserve, "

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -131,6 +131,29 @@ def destination_disk_space(path: str | Path) -> dict:
     }
 
 
+def destination_case_insensitive(path: str | Path) -> bool:
+    """Probe whether the existing volume containing ``path`` folds case."""
+    base = Path(path).expanduser()
+    while not base.is_dir():
+        parent = base.parent
+        if parent == base:
+            break
+        base = parent
+    try:
+        fd, probe = tempfile.mkstemp(prefix="VireoCaseProbe-", dir=str(base))
+    except OSError as exc:
+        raise LocalWorkspaceError(
+            f"Could not inspect the destination filesystem at {path}: {exc}"
+        ) from exc
+    os.close(fd)
+    try:
+        lower = os.path.join(os.path.dirname(probe), os.path.basename(probe).lower())
+        return lower != probe and os.path.exists(lower)
+    finally:
+        with suppress(FileNotFoundError):
+            os.unlink(probe)
+
+
 def _estimated_destination_bytes(st) -> int:
     """Conservatively estimate allocation consumed by one copied entry."""
     if stat.S_ISREG(st.st_mode):
@@ -143,8 +166,8 @@ def _estimated_destination_bytes(st) -> int:
     return LOCAL_ALLOCATION_UNIT_BYTES
 
 
-def source_tree_size(source: str) -> tuple[int, int, int]:
-    """Return copied-file count, logical bytes, and estimated allocated bytes."""
+def _validated_tree_entries(source: str):
+    """Yield safe, supported entries from a validated source directory."""
     try:
         root_st = os.lstat(source)
     except OSError as exc:
@@ -156,27 +179,36 @@ def source_tree_size(source: str) -> tuple[int, int, int]:
     if not stat.S_ISDIR(root_st.st_mode):
         raise LocalWorkspaceError(f"Workspace folder is unavailable: {source}")
 
+    for rel, full, st in _walk_entries(source):
+        mode = st.st_mode
+        if stat.S_ISLNK(mode):
+            if not _symlink_stays_within(full, source):
+                raise LocalWorkspaceError(
+                    f"Symlink escapes or uses an absolute target and cannot be staged: {full}"
+                )
+        elif not stat.S_ISREG(mode) and not stat.S_ISDIR(mode):
+            raise LocalWorkspaceError(f"Unsupported special file in workspace: {full}")
+        yield rel, full, st
+
+
+def source_tree_size(source: str) -> tuple[int, int, int]:
+    """Return copied-file count, logical bytes, and estimated allocated bytes."""
+
     total_files = 0
     total_bytes = 0
     # The destination root directory itself is created for every source.
     estimated_bytes = LOCAL_ALLOCATION_UNIT_BYTES
-    for _rel, full, st in _walk_entries(source):
+    for _rel, _full, st in _validated_tree_entries(source):
         mode = st.st_mode
         if stat.S_ISREG(mode):
             total_bytes += st.st_size
             total_files += 1
             estimated_bytes += _estimated_destination_bytes(st)
         elif stat.S_ISLNK(mode):
-            if not _symlink_stays_within(full, source):
-                raise LocalWorkspaceError(
-                    f"Symlink escapes or uses an absolute target and cannot be staged: {full}"
-                )
             total_files += 1
             estimated_bytes += _estimated_destination_bytes(st)
         elif stat.S_ISDIR(mode):
             estimated_bytes += _estimated_destination_bytes(st)
-        else:
-            raise LocalWorkspaceError(f"Unsupported special file in workspace: {full}")
     return total_files, total_bytes, estimated_bytes
 
 
@@ -415,14 +447,7 @@ def _dest_case_insensitive(local_base: Path) -> bool:
     """
     base = local_base.parent
     base.mkdir(parents=True, exist_ok=True)
-    fd, probe = tempfile.mkstemp(prefix="VireoCaseProbe-", dir=str(base))
-    os.close(fd)
-    try:
-        lower = os.path.join(os.path.dirname(probe), os.path.basename(probe).lower())
-        return lower != probe and os.path.exists(lower)
-    finally:
-        with suppress(FileNotFoundError):
-            os.unlink(probe)
+    return destination_case_insensitive(base)
 
 
 def _walk_entries(root: str):
@@ -467,39 +492,19 @@ def _collect_source_entries(roots: list[dict], local_base: Path) -> tuple[dict[i
     for index, root in enumerate(roots):
         source = root["source_path"]
         estimated_bytes += LOCAL_ALLOCATION_UNIT_BYTES
-        # os.path.isdir follows symlinks; a source root that is itself a
-        # symlink would activate successfully here but sync_back later lstats
-        # and rejects it, leaving every local edit unsyncable. Reject
-        # symlinked (or non-directory) roots up front instead.
-        try:
-            root_st = os.lstat(source)
-        except OSError as exc:
-            raise LocalWorkspaceError(f"Workspace folder is unavailable: {source}") from exc
-        if stat.S_ISLNK(root_st.st_mode):
-            raise LocalWorkspaceError(
-                f"Workspace root is a symlink and cannot be staged: {source}"
-            )
-        if not stat.S_ISDIR(root_st.st_mode):
-            raise LocalWorkspaceError(f"Workspace folder is unavailable: {source}")
         entries = []
         folded_seen: dict[str, str] = {}
-        for rel, full, st in _walk_entries(source):
+        for rel, full, st in _validated_tree_entries(source):
             mode = st.st_mode
             if stat.S_ISREG(mode):
                 total_bytes += st.st_size
                 total_files += 1
                 estimated_bytes += _estimated_destination_bytes(st)
             elif stat.S_ISLNK(mode):
-                if not _symlink_stays_within(full, source):
-                    raise LocalWorkspaceError(
-                        f"Symlink escapes or uses an absolute target and cannot be staged: {full}"
-                    )
                 total_files += 1
                 estimated_bytes += _estimated_destination_bytes(st)
             elif stat.S_ISDIR(mode):
                 estimated_bytes += _estimated_destination_bytes(st)
-            else:
-                raise LocalWorkspaceError(f"Unsupported special file in workspace: {full}")
             if case_insensitive_target and rel:
                 # Normalize Unicode form before folding case: macOS
                 # (HFS+/APFS) and Windows also collapse canonically

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -5,6 +5,9 @@
   var activeJob = null;
   var actionInFlight = false;
   var pendingStageItems = [];
+  var stagePreflightGeneration = 0;
+  var stagePreflightTimer = null;
+  var stagePreflightSignature = null;
 
   function selectedItems(folderIds, localOnly) {
     var wanted = folderIds && folderIds.length
@@ -41,10 +44,123 @@
     preview.textContent = joinPath(input.value.trim(), input.dataset.localFolderName);
   }
 
+  function stageRequestBody() {
+    var destinationBases = {};
+    var complete = pendingStageItems.length > 0;
+    pendingStageItems.forEach(function(item) {
+      var id = Number(item.requested_folder_id);
+      var input = document.querySelector('[data-local-destination-base="' + id + '"]');
+      var destination = input ? input.value.trim() : '';
+      if (!destination) complete = false;
+      destinationBases[String(id)] = destination;
+    });
+    return {
+      complete: complete,
+      body: {
+        folder_ids: pendingStageItems.map(function(item) { return item.requested_folder_id; }),
+        destination_bases: destinationBases
+      }
+    };
+  }
+
+  function renderStagePreflight(preflight) {
+    var capacity = document.getElementById('stageLocalFoldersCapacity');
+    var button = document.getElementById('confirmStageLocalFolders');
+    var error = document.getElementById('stageLocalFoldersError');
+    if (error) error.textContent = '';
+    var byFolder = {};
+    (preflight.folders || []).forEach(function(folder) {
+      byFolder[String(folder.folder_id)] = folder;
+    });
+    pendingStageItems.forEach(function(item) {
+      var id = String(item.requested_folder_id);
+      var line = document.querySelector('[data-local-capacity-folder="' + id + '"]');
+      var folder = byFolder[id];
+      if (!line || !folder) return;
+      line.style.color = 'var(--text-secondary)';
+      line.textContent = formatBytesNav(folder.total_bytes || 0) + ' to copy · ' +
+        Number(folder.total_files || 0).toLocaleString() + ' file' +
+        (Number(folder.total_files || 0) === 1 ? '' : 's') + ' · ' +
+        formatBytesNav(folder.free_bytes || 0) + ' free on destination';
+    });
+
+    var blocked = (preflight.volumes || []).filter(function(volume) {
+      return !volume.can_copy;
+    });
+    if (capacity) {
+      capacity.style.color = blocked.length ? 'var(--danger)' : 'var(--text-secondary)';
+      if (blocked.length) {
+        capacity.innerHTML = blocked.map(function(volume) {
+          return '<div><strong>Not enough space.</strong> ' +
+            escapeHtml(formatBytesNav(volume.copy_bytes || 0)) + ' would be copied to this disk, ' +
+            escapeHtml(formatBytesNav(volume.free_bytes || 0)) + ' is free, and Vireo keeps ' +
+            escapeHtml(formatBytesNav(volume.reserve_bytes || 0)) + ' free for safety.</div>';
+        }).join('');
+      } else {
+        var volumeCount = (preflight.volumes || []).length;
+        capacity.textContent = formatBytesNav(preflight.total_bytes || 0) + ' total to copy' +
+          (volumeCount === 1
+            ? ' · ' + formatBytesNav(preflight.volumes[0].after_copy_bytes || 0) + ' will remain free'
+            : ' across ' + volumeCount + ' destination disks') +
+          '. Vireo will stop before using the safety reserve.';
+      }
+    }
+    if (button) button.disabled = !preflight.can_copy;
+  }
+
+  async function runStagePreflight() {
+    var request = stageRequestBody();
+    var capacity = document.getElementById('stageLocalFoldersCapacity');
+    var button = document.getElementById('confirmStageLocalFolders');
+    var generation = ++stagePreflightGeneration;
+    stagePreflightSignature = null;
+    if (button) button.disabled = true;
+    if (!request.complete) {
+      if (capacity) {
+        capacity.style.color = 'var(--danger)';
+        capacity.textContent = 'Choose a destination for every local copy.';
+      }
+      return;
+    }
+    if (capacity) {
+      capacity.style.color = 'var(--text-dim)';
+      capacity.innerHTML = '<span class="btn-spinner" style="display:inline-block;margin-right:6px;"></span>Calculating folder sizes and available space...';
+    }
+    try {
+      var result = await Vireo.api.json('/api/workspaces/active/local-folders/preflight', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(request.body)
+      }, {toast: false});
+      if (generation !== stagePreflightGeneration || !pendingStageItems.length) return;
+      stagePreflightSignature = JSON.stringify(request.body);
+      renderStagePreflight(result);
+    } catch (requestError) {
+      if (generation !== stagePreflightGeneration || !pendingStageItems.length) return;
+      if (capacity) {
+        capacity.style.color = 'var(--danger)';
+        capacity.textContent = requestError.message || 'Could not check folder sizes and free space.';
+      }
+    }
+  }
+
+  function scheduleStagePreflight(delay) {
+    if (stagePreflightTimer) clearTimeout(stagePreflightTimer);
+    stagePreflightGeneration += 1;
+    stagePreflightSignature = null;
+    var button = document.getElementById('confirmStageLocalFolders');
+    if (button) button.disabled = true;
+    stagePreflightTimer = setTimeout(runStagePreflight, delay == null ? 500 : delay);
+  }
+
   function closeStageDialog() {
     if (actionInFlight) return;
     var modal = document.getElementById('stageLocalFoldersModal');
     if (modal) modal.classList.remove('open');
+    stagePreflightGeneration += 1;
+    stagePreflightSignature = null;
+    if (stagePreflightTimer) clearTimeout(stagePreflightTimer);
+    stagePreflightTimer = null;
     pendingStageItems = [];
   }
 
@@ -77,10 +193,12 @@
           '<button class="modal-btn" data-browse-local-destination="' + id + '" style="white-space:nowrap;">Browse...</button>' +
         '</div>' +
         '<div style="font-size:10px;color:var(--text-dim);margin-top:5px;">Local folder: <span data-local-destination-preview="' + id + '" style="font-family:monospace;">' + escapeHtml(finalPath) + '</span></div>' +
+        '<div data-local-capacity-folder="' + id + '" style="font-size:11px;color:var(--text-dim);margin-top:6px;">Calculating size and free space...</div>' +
         (shared > 1 ? '<div style="font-size:10px;color:var(--accent);margin-top:4px;">This copy will be shared by ' + shared + ' linked workspaces.</div>' : '') +
       '</div>';
     }).join('');
     modal.classList.add('open');
+    scheduleStagePreflight(0);
   }
 
   function progressMarkup() {
@@ -258,17 +376,11 @@
     if (actionInFlight || activeJob || !pendingStageItems.length) return;
     var error = document.getElementById('stageLocalFoldersError');
     var button = document.getElementById('confirmStageLocalFolders');
-    var destinationBases = {};
-    for (var i = 0; i < pendingStageItems.length; i += 1) {
-      var id = Number(pendingStageItems[i].requested_folder_id);
-      var input = document.querySelector('[data-local-destination-base="' + id + '"]');
-      var destination = input ? input.value.trim() : '';
-      if (!destination) {
-        if (error) error.textContent = 'Choose a destination for every local copy.';
-        if (input) input.focus();
-        return;
-      }
-      destinationBases[String(id)] = destination;
+    var request = stageRequestBody();
+    if (!request.complete || stagePreflightSignature !== JSON.stringify(request.body)) {
+      if (error) error.textContent = 'Wait for the size and free-space check to finish.';
+      scheduleStagePreflight(0);
+      return;
     }
     actionInFlight = true;
     if (button) button.disabled = true;
@@ -277,10 +389,7 @@
       var result = await Vireo.api.json('/api/workspaces/active/local-folders/stage', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({
-          folder_ids: pendingStageItems.map(function(item) { return item.requested_folder_id; }),
-          destination_bases: destinationBases
-        })
+        body: JSON.stringify(request.body)
       }, {toast: false});
       var modal = document.getElementById('stageLocalFoldersModal');
       if (modal) modal.classList.remove('open');
@@ -290,7 +399,7 @@
       if (error) error.textContent = requestError.message || 'Could not start the local copy.';
     } finally {
       actionInFlight = false;
-      if (button) button.disabled = false;
+      if (pendingStageItems.length) scheduleStagePreflight(0);
     }
   }
 
@@ -454,6 +563,7 @@
   document.getElementById('stageLocalFoldersModalItems').addEventListener('input', function(event) {
     if (event.target.matches('[data-local-destination-base]')) {
       updateStageDestinationPreview(event.target);
+      scheduleStagePreflight();
     }
   });
   document.getElementById('stageLocalFoldersModalItems').addEventListener('click', async function(event) {
@@ -468,6 +578,7 @@
     if (!chosen || Array.isArray(chosen)) return;
     input.value = chosen;
     updateStageDestinationPreview(input);
+    scheduleStagePreflight(0);
   });
   document.getElementById('syncSelectedLocalFolders').addEventListener('click', function() {
     var selected = managerSelection();

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -66,8 +66,6 @@
   function renderStagePreflight(preflight) {
     var capacity = document.getElementById('stageLocalFoldersCapacity');
     var button = document.getElementById('confirmStageLocalFolders');
-    var error = document.getElementById('stageLocalFoldersError');
-    if (error) error.textContent = '';
     var byFolder = {};
     (preflight.folders || []).forEach(function(folder) {
       byFolder[String(folder.folder_id)] = folder;

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -130,10 +130,11 @@
       Choose where Vireo should create each local copy. The source files stay unchanged until you sync back.
     </div>
     <div id="stageLocalFoldersModalItems"></div>
+    <div id="stageLocalFoldersCapacity" style="font-size:12px;line-height:1.5;margin-top:12px;"></div>
     <div class="modal-error" id="stageLocalFoldersError"></div>
     <div class="modal-actions" style="margin-top:16px;display:flex;gap:8px;justify-content:flex-end;">
       <button class="modal-btn" id="cancelStageLocalFolders">Cancel</button>
-      <button class="modal-btn modal-btn-primary" id="confirmStageLocalFolders">Copy Locally</button>
+      <button class="modal-btn modal-btn-primary" id="confirmStageLocalFolders" disabled>Copy Locally</button>
     </div>
   </div>
 </div>

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -379,6 +379,7 @@ POST         /api/workspaces/<int:ws_id>/move-folders
 POST         /api/workspaces/<int:ws_id>/pin
 POST         /api/workspaces/active/config
 POST         /api/workspaces/active/local-folders/discard
+POST         /api/workspaces/active/local-folders/preflight
 POST         /api/workspaces/active/local-folders/stage
 POST         /api/workspaces/active/local-folders/sync
 POST         /api/workspaces/active/local-workspace/discard

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -594,6 +594,48 @@ def test_stage_endpoint_rejects_case_folded_destination_collisions(
     assert "overlap" in response.get_json()["error"]
 
 
+def test_preflight_endpoint_returns_destination_probe_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+    from web import local_folder as local_folder_web
+
+    source = tmp_path / "nas" / "Photos"
+    source.mkdir(parents=True)
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+    db = Database(db_path)
+    workspace_id = db.create_workspace("Probe failure")
+    folder_id = db.add_folder(str(source), name="Photos", link_to_workspace=False)
+    db.add_workspace_folder(workspace_id, folder_id)
+    db.set_active_workspace(workspace_id)
+    db.close()
+
+    def fail_probe(_path):
+        raise LocalWorkspaceError("Could not inspect destination filesystem")
+
+    monkeypatch.setattr(
+        local_folder_web, "destination_case_insensitive", fail_probe
+    )
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={}
+        ).status_code == 200
+        response = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "destination_bases": {str(folder_id): str(tmp_path / "local")},
+            },
+        )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"] == "Could not inspect destination filesystem"
+
+
 def test_local_root_under_folder_finds_descendant_session(tmp_path):
     db = Database(str(tmp_path / "vireo.db"))
     workspace_id = db.create_workspace("Ancestor")

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -127,9 +127,9 @@ def test_local_copy_preflight_aggregates_folders_on_the_same_disk(
         service,
         "destination_disk_space",
         lambda _path: {
-            "total_bytes": 1_000,
-            "free_bytes": 100,
-            "reserve_bytes": 20,
+            "total_bytes": 100_000,
+            "free_bytes": 18_000,
+            "reserve_bytes": 2_000,
             "device": 7,
             "probe_path": str(tmp_path),
         },
@@ -141,9 +141,10 @@ def test_local_copy_preflight_aggregates_folders_on_the_same_disk(
 
         assert result["total_bytes"] == 90
         assert [folder["total_bytes"] for folder in result["folders"]] == [30, 60]
+        assert [folder["estimated_bytes"] for folder in result["folders"]] == [8192, 8192]
         assert len(result["volumes"]) == 1
-        assert result["volumes"][0]["copy_bytes"] == 90
-        assert result["volumes"][0]["after_copy_bytes"] == 10
+        assert result["volumes"][0]["copy_bytes"] == 16384
+        assert result["volumes"][0]["after_copy_bytes"] == 1616
         assert result["volumes"][0]["can_copy"] is False
         assert result["can_copy"] is False
     finally:

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -543,6 +543,57 @@ def test_folder_stage_endpoint_accepts_destination_and_uses_folder_name_in_job(t
         check_db.close()
 
 
+def test_stage_endpoint_rejects_case_folded_destination_collisions(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+    from web import local_folder as local_folder_web
+
+    first = tmp_path / "nas" / "Photos"
+    second = tmp_path / "other-nas" / "PHOTOS"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "one.jpg").write_bytes(b"one")
+    (second / "two.jpg").write_bytes(b"two")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+    db = Database(db_path)
+    workspace_id = db.create_workspace("Case collision")
+    first_id = db.add_folder(str(first), name="Photos", link_to_workspace=False)
+    second_id = db.add_folder(str(second), name="PHOTOS", link_to_workspace=False)
+    db.add_workspace_folder(workspace_id, first_id)
+    db.add_workspace_folder(workspace_id, second_id)
+    db.set_active_workspace(workspace_id)
+    db.close()
+
+    monkeypatch.setattr(
+        local_folder_web, "destination_case_insensitive", lambda _path: True
+    )
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    destination = tmp_path / "local"
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={}
+        ).status_code == 200
+        response = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [first_id, second_id],
+                "destination_bases": {
+                    str(first_id): str(destination),
+                    str(second_id): str(destination),
+                },
+            },
+        )
+
+    assert response.status_code == 400
+    assert "overlap" in response.get_json()["error"]
+
+
 def test_local_root_under_folder_finds_descendant_session(tmp_path):
     db = Database(str(tmp_path / "vireo.db"))
     workspace_id = db.create_workspace("Ancestor")

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -9,6 +9,7 @@ from services.local_folder import (
     LocalWorkspaceError,
     discard_folder,
     folder_status,
+    local_copy_preflight,
     local_root_under_folder,
     local_roots_under_folder,
     stage_folder,
@@ -101,6 +102,75 @@ def test_custom_local_destination_refuses_existing_folder(tmp_path):
             )
         assert (existing / "keep.txt").read_text() == "do not overwrite"
         assert Path(db.get_folder(folder_id)["path"]) == _source
+    finally:
+        db.close()
+
+
+def test_local_copy_preflight_aggregates_folders_on_the_same_disk(
+    tmp_path, monkeypatch
+):
+    from services import local_folder as service
+
+    db = Database(str(tmp_path / "vireo.db"))
+    workspace_id = db.create_workspace("Trip")
+    first = tmp_path / "nas" / "first"
+    second = tmp_path / "nas" / "second"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "one.raw").write_bytes(b"a" * 30)
+    (second / "two.raw").write_bytes(b"b" * 60)
+    first_id = db.add_folder(str(first), name="first", link_to_workspace=False)
+    second_id = db.add_folder(str(second), name="second", link_to_workspace=False)
+    db.add_workspace_folder(workspace_id, first_id)
+    db.add_workspace_folder(workspace_id, second_id)
+    monkeypatch.setattr(
+        service,
+        "destination_disk_space",
+        lambda _path: {
+            "total_bytes": 1_000,
+            "free_bytes": 100,
+            "reserve_bytes": 20,
+            "device": 7,
+            "probe_path": str(tmp_path),
+        },
+    )
+    try:
+        result = local_copy_preflight(
+            db, [first_id, second_id], str(tmp_path / "vireo")
+        )
+
+        assert result["total_bytes"] == 90
+        assert [folder["total_bytes"] for folder in result["folders"]] == [30, 60]
+        assert len(result["volumes"]) == 1
+        assert result["volumes"][0]["copy_bytes"] == 90
+        assert result["volumes"][0]["after_copy_bytes"] == 10
+        assert result["volumes"][0]["can_copy"] is False
+        assert result["can_copy"] is False
+    finally:
+        db.close()
+
+
+def test_stage_refuses_copy_that_would_use_scaled_safety_reserve(
+    tmp_path, monkeypatch
+):
+    from services import local_workspace as workspace_service
+
+    db, vireo_dir, source, _first, _second, folder_id = _shared_environment(tmp_path)
+    large = source / "large.raw"
+    with large.open("wb") as handle:
+        handle.truncate(2 * 1024**3)
+    usage_type = workspace_service.shutil._ntuple_diskusage
+    monkeypatch.setattr(
+        workspace_service.shutil,
+        "disk_usage",
+        lambda _path: usage_type(100 * 1024**3, 94 * 1024**3, 6 * 1024**3),
+    )
+    try:
+        # A 100 GiB destination keeps 5 GiB free. The old fixed 1 GiB
+        # reserve would have allowed this 2 GiB copy with only 6 GiB free.
+        with pytest.raises(LocalWorkspaceError, match="safety reserve"):
+            stage_folder(db, folder_id, str(vireo_dir))
+        assert db.get_folder(folder_id)["path"] == str(source)
     finally:
         db.close()
 
@@ -433,6 +503,24 @@ def test_folder_stage_endpoint_accepts_destination_and_uses_folder_name_in_job(t
         )
         assert item["local_folder_name"] == "104NCZ_8"
         assert Path(item["default_local_path"]).name == "104NCZ_8"
+
+        preflight = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "destination_bases": {str(folder_id): str(destination)},
+            },
+        )
+        assert preflight.status_code == 200, preflight.get_json()
+        capacity = preflight.get_json()
+        assert capacity["can_copy"] is True
+        assert capacity["total_bytes"] == len(b"original")
+        assert capacity["folders"][0]["total_files"] == 1
+        assert capacity["folders"][0]["destination_path"] == str(
+            destination / "104NCZ_8"
+        )
+        assert capacity["volumes"][0]["free_bytes"] > capacity["total_bytes"]
+        assert capacity["volumes"][0]["reserve_bytes"] >= 1024**3
 
         response = client.post(
             "/api/workspaces/active/local-folders/stage",

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -71,6 +71,22 @@ def _source_fs_preserves_case(directory: Path) -> bool:
         probe.unlink()
 
 
+def test_source_tree_size_converts_traversal_race_to_workspace_error(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "source"
+    source.mkdir()
+
+    def raced_walk(_root):
+        raise FileNotFoundError("entry disappeared during traversal")
+        yield
+
+    monkeypatch.setattr(local_workspace, "_walk_entries", raced_walk)
+
+    with pytest.raises(LocalWorkspaceError, match="Could not read workspace directory"):
+        local_workspace.source_tree_size(str(source))
+
+
 def test_stage_modify_and_sync_back(local_workspace_env):
     env = local_workspace_env
     result = stage_workspace(env["db"], env["workspace_id"], str(env["vireo_dir"]))

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -166,11 +166,15 @@ def create_local_folder_blueprint(
             final_path = os.path.abspath(
                 local_path_for_base(destination, root_id, source_paths[root_id])
             )
+            try:
+                case_insensitive = destination_case_insensitive(final_path)
+            except LocalWorkspaceError as exc:
+                return None, json_error(str(exc), 409)
             final_destinations.append(
                 (
                     root_id,
                     os.path.normcase(final_path),
-                    destination_case_insensitive(final_path),
+                    case_insensitive,
                 )
             )
         for index, (root_id, path, case_insensitive) in enumerate(final_destinations):

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -12,6 +12,7 @@ from services.local_folder import (
     affected_workspace_ids,
     discard_folder,
     folder_status,
+    local_copy_preflight,
     local_path_for_base,
     local_root_for_folder,
     local_root_under_folder,
@@ -144,6 +145,48 @@ def create_local_folder_blueprint(
             names[root_id] = os.path.basename(path.rstrip("/\\")) or "Folder"
         return names, paths
 
+    def _stage_destinations(body, root_ids, root_names, source_paths):
+        raw_destinations = body.get("destination_bases") or {}
+        if not isinstance(raw_destinations, dict):
+            return None, json_error("destination_bases must be an object", 400)
+        destination_bases = {}
+        final_destinations = []
+        for root_id in root_ids:
+            raw = raw_destinations.get(str(root_id), raw_destinations.get(root_id))
+            if raw is None:
+                continue
+            if not isinstance(raw, str) or not raw.strip():
+                return None, json_error("Each local destination must be a non-empty path", 400)
+            destination = os.path.normpath(os.path.expanduser(raw.strip()))
+            if not os.path.isabs(destination):
+                return None, json_error("Each local destination must be an absolute path", 400)
+            destination_bases[root_id] = destination
+            final_destinations.append(
+                (
+                    root_id,
+                    os.path.normcase(
+                        os.path.abspath(
+                            local_path_for_base(
+                                destination, root_id, source_paths[root_id]
+                            )
+                        )
+                    ),
+                )
+            )
+        for index, (root_id, path) in enumerate(final_destinations):
+            for other_id, other_path in final_destinations[index + 1 :]:
+                try:
+                    overlaps = os.path.commonpath([path, other_path]) in {path, other_path}
+                except ValueError:
+                    overlaps = False
+                if overlaps:
+                    return None, json_error(
+                        f"The selected destinations for {root_names[root_id]} and "
+                        f"{root_names[other_id]} overlap. Choose separate locations.",
+                        400,
+                    )
+        return destination_bases, None
+
     @blueprint.get("/api/workspaces/active/local-folders")
     def local_folder_status():
         db, workspace_id, error = _active_context()
@@ -180,6 +223,46 @@ def create_local_folder_blueprint(
         payload["jobs"] = jobs
         return jsonify(payload)
 
+    @blueprint.post("/api/workspaces/active/local-folders/preflight")
+    def preflight_local_folders():
+        db, workspace_id, error = _active_context()
+        if error:
+            return error
+        legacy_error = _legacy_error(db, workspace_id)
+        if legacy_error is not None:
+            return legacy_error
+        body = request.get_json(silent=True) or {}
+        root_ids, request_error = _requested_roots(db, workspace_id, body)
+        if request_error is not None:
+            return request_error
+        root_ids = [
+            root_id
+            for root_id in root_ids
+            if local_root_for_folder(db, root_id) is None
+            and local_root_under_folder(db, root_id) is None
+        ]
+        if not root_ids:
+            return json_error(
+                "The selected folders are already local or contain a folder working locally",
+                409,
+            )
+        root_names, source_paths = _folder_names(db, root_ids)
+        destination_bases, destination_error = _stage_destinations(
+            body, root_ids, root_names, source_paths
+        )
+        if destination_error is not None:
+            return destination_error
+        try:
+            result = local_copy_preflight(
+                db,
+                root_ids,
+                vireo_dir,
+                destination_bases=destination_bases,
+            )
+        except LocalWorkspaceError as exc:
+            return json_error(str(exc), 409)
+        return jsonify(result)
+
     @blueprint.post("/api/workspaces/active/local-folders/stage")
     def stage_local_folders():
         db, workspace_id, error = _active_context()
@@ -211,39 +294,12 @@ def create_local_folder_blueprint(
                 "The selected folders are already local or contain a folder working locally",
                 409,
             )
-        raw_destinations = body.get("destination_bases") or {}
-        if not isinstance(raw_destinations, dict):
-            return json_error("destination_bases must be an object", 400)
         root_names, source_paths = _folder_names(db, root_ids)
-        destination_bases = {}
-        final_destinations = []
-        for root_id in root_ids:
-            raw = raw_destinations.get(str(root_id), raw_destinations.get(root_id))
-            if raw is None:
-                continue
-            if not isinstance(raw, str) or not raw.strip():
-                return json_error("Each local destination must be a non-empty path", 400)
-            destination = os.path.normpath(os.path.expanduser(raw.strip()))
-            if not os.path.isabs(destination):
-                return json_error("Each local destination must be an absolute path", 400)
-            destination_bases[root_id] = destination
-            final_destinations.append(
-                (root_id, os.path.normcase(os.path.abspath(local_path_for_base(
-                    destination, root_id, source_paths[root_id]
-                ))))
-            )
-        for index, (root_id, path) in enumerate(final_destinations):
-            for other_id, other_path in final_destinations[index + 1:]:
-                try:
-                    overlaps = os.path.commonpath([path, other_path]) in {path, other_path}
-                except ValueError:
-                    overlaps = False
-                if overlaps:
-                    return json_error(
-                        f"The selected destinations for {root_names[root_id]} and "
-                        f"{root_names[other_id]} overlap. Choose separate locations.",
-                        400,
-                    )
+        destination_bases, destination_error = _stage_destinations(
+            body, root_ids, root_names, source_paths
+        )
+        if destination_error is not None:
+            return destination_error
         runner = get_runner()
 
         def work(job):

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import threading
+import unicodedata
 
 from db import Database
 from flask import Blueprint, jsonify, request
@@ -22,6 +23,7 @@ from services.local_folder import (
     workspace_local_root_ids,
     workspace_status,
 )
+from services.local_workspace import destination_case_insensitive
 from services.local_workspace import local_state as legacy_local_state
 
 LOCAL_FOLDER_JOB_TYPES = frozenset(
@@ -161,22 +163,27 @@ def create_local_folder_blueprint(
             if not os.path.isabs(destination):
                 return None, json_error("Each local destination must be an absolute path", 400)
             destination_bases[root_id] = destination
+            final_path = os.path.abspath(
+                local_path_for_base(destination, root_id, source_paths[root_id])
+            )
             final_destinations.append(
                 (
                     root_id,
-                    os.path.normcase(
-                        os.path.abspath(
-                            local_path_for_base(
-                                destination, root_id, source_paths[root_id]
-                            )
-                        )
-                    ),
+                    os.path.normcase(final_path),
+                    destination_case_insensitive(final_path),
                 )
             )
-        for index, (root_id, path) in enumerate(final_destinations):
-            for other_id, other_path in final_destinations[index + 1 :]:
+        for index, (root_id, path, case_insensitive) in enumerate(final_destinations):
+            for other_id, other_path, other_case_insensitive in final_destinations[index + 1 :]:
+                compared_path = path
+                compared_other_path = other_path
+                if case_insensitive or other_case_insensitive:
+                    compared_path = unicodedata.normalize("NFC", path).casefold()
+                    compared_other_path = unicodedata.normalize("NFC", other_path).casefold()
                 try:
-                    overlaps = os.path.commonpath([path, other_path]) in {path, other_path}
+                    overlaps = os.path.commonpath(
+                        [compared_path, compared_other_path]
+                    ) in {compared_path, compared_other_path}
                 except ValueError:
                     overlaps = False
                 if overlaps:


### PR DESCRIPTION
## Summary

Adds an exact storage preflight before Vireo copies workspace folders locally.
The dialog shows folder sizes, file counts, destination free space, and aggregate requirements for folders sharing a disk.
Copying stays disabled when capacity is insufficient, while the server preserves a disk-scaled safety reserve of 1–20 GiB.
Validated with 98 local-workspace tests and 3 Chromium workspace end-to-end tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local-copy preflight checks that estimate folder sizes, file counts, destination paths, and available disk space.
  * Added validation for destination paths, including invalid or overlapping locations.
  * Added dynamic storage safety reserves based on available volume capacity.
  * The “Copy Locally” action remains disabled until all checks complete successfully.

* **Bug Fixes**
  * Prevented local copies from proceeding when insufficient storage is available.
  * Improved handling of invalid folders, symlinks, and unsupported files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->