### PR TITLE
Make photo deletion fast and failure-safe on network volumes

### DIFF
--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -492,6 +492,52 @@ def test_location_review_lightbox_delete_keeps_selection_source_in_sync(
     ).to_be_visible()
 
 
+def test_location_review_lightbox_retains_photo_after_trash_failure(
+    live_server, page,
+):
+    """A retryable Trash failure must not emit the photo-deleted event."""
+    photo_ids = live_server["data"]["photos"][:2]
+    with live_server["db"].conn:
+        live_server["db"].conn.executemany(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            [
+                (33.2550, -116.4050, photo_ids[0]),
+                (33.2550, -116.4050, photo_ids[1]),
+            ],
+        )
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        "photoIds => sessionStorage.setItem('vireoLocationReviewSource', "
+        "JSON.stringify({photo_ids: photoIds}))",
+        photo_ids,
+    )
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("2 photos")
+    page.evaluate("window.__locationReviewLeafletMarkers[0].fire('click')")
+
+    page.evaluate("lightboxDelete()")
+    page.evaluate(
+        """photoId => {
+          var callback = _deleteCallback;
+          hideDeleteModal();
+          callback({deleted: 0, failed_photo_ids: [photoId]});
+        }""",
+        photo_ids[0],
+    )
+
+    expect(page.locator("#lightboxOverlay")).to_have_class(
+        "lightbox-overlay active"
+    )
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("2 photos")
+    expect(page.locator(".location-review-thumb")).to_have_count(2)
+    stored = page.evaluate(
+        "() => JSON.parse(sessionStorage.getItem('vireoLocationReviewSource'))"
+    )
+    assert stored == {"photo_ids": photo_ids}
+
+
 def test_location_review_thumbnail_opens_the_photo_preview(live_server, page):
     """The thumbnail strip offers the same preview affordance as map dots."""
     photo_id = live_server["data"]["photos"][0]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10182,17 +10182,63 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if mode not in ("vireo", "disk", "disk_permanent"):
             raise ValueError("mode must be 'vireo', 'disk', or 'disk_permanent'")
 
-        def remove_catalog_rows(ids, *, expand_companions):
-            """Atomically remove resolved catalog rows, then clean caches."""
-            result = {"deleted": 0, "ids": [], "files": []}
+        def remove_catalog_rows(ids, *, expand_companions, revalidate_identity=None):
+            """Atomically remove resolved catalog rows, then clean caches.
+
+            ``revalidate_identity`` is an optional ``{photo_id: (folder_id,
+            filename)}`` map captured at the start of the disk operation. When
+            provided, each row is re-checked inside the delete transaction and
+            skipped if its ``(folder_id, filename)`` has changed since — a
+            concurrent ``/api/jobs/move-photos`` can commit a new folder_id
+            while the disk-delete's stale-path ``os.path.isfile`` check is
+            already reporting "gone", and deleting by id alone would then
+            discard the row for a photo that now lives at a completely
+            different path. Skipped ids are returned as ``skipped_ids`` so
+            the caller can surface them alongside filesystem failures.
+            """
+            result = {
+                "deleted": 0, "ids": [], "files": [], "skipped_ids": [],
+            }
+            skipped_ids = []
             total = len(ids)
             prepared = 0
             emit(
                 "Removing from Vireo", 0, total,
                 detail="Preparing database changes; nothing is committed yet.",
             )
+            revalidating = bool(revalidate_identity)
+            # BEGIN IMMEDIATE takes the write lock up front so no other writer
+            # (notably move-photos) can commit an identity change between the
+            # revalidation SELECT and the DELETE that follows. Without it, a
+            # move committed after the SELECT but before the DELETE would let
+            # us delete a row that no longer matches the identity we verified.
+            if revalidating:
+                db.conn.execute("BEGIN IMMEDIATE")
             try:
-                for chunk in _chunked(ids):
+                if revalidating:
+                    verified_ids = []
+                    for chunk in _chunked(ids):
+                        placeholders = ",".join("?" for _ in chunk)
+                        current = {
+                            row["id"]: (row["folder_id"], row["filename"])
+                            for row in db.conn.execute(
+                                f"SELECT id, folder_id, filename FROM photos "
+                                f"WHERE id IN ({placeholders})",
+                                list(chunk),
+                            )
+                        }
+                        for photo_id in chunk:
+                            expected = revalidate_identity.get(photo_id)
+                            actual = current.get(photo_id)
+                            if expected is not None and actual == expected:
+                                verified_ids.append(photo_id)
+                            else:
+                                skipped_ids.append(photo_id)
+                    ids_to_delete = verified_ids
+                else:
+                    ids_to_delete = list(ids)
+
+                for chunk in _chunked(ids_to_delete):
                     chunk_result = db.delete_photos(
                         chunk,
                         include_companions=expand_companions,
@@ -10212,6 +10258,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except Exception:
                 db.conn.rollback()
                 raise
+            result["skipped_ids"] = skipped_ids
 
             emit(
                 "Removed from Vireo", result["deleted"], result["deleted"],
@@ -10261,6 +10308,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         primary_paths = {
             f["photo_id"]: os.path.join(f["folder_path"], f["filename"])
             for f in files
+        }
+        # Snapshot each row's identity so the catalog-removal step can verify
+        # the row still points at the same file it did when we resolved paths.
+        # Without this, a concurrent /api/jobs/move-photos can commit a new
+        # folder_id and remove the source file mid-run; our stale-path
+        # os.path.isfile would then read "already gone" and we would delete
+        # a row that now represents the moved file at a different location.
+        resolved_identity = {
+            f["photo_id"]: (f["folder_id"], f["filename"]) for f in files
         }
         catalog_primary_paths = set(primary_paths.values())
         extra_companions = {}
@@ -10364,8 +10420,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ),
         )
         result = remove_catalog_rows(
-            successful_ids, expand_companions=False,
+            successful_ids,
+            expand_companions=False,
+            revalidate_identity=resolved_identity,
         )
+        # Rows whose identity changed between resolve and catalog-removal
+        # weren't deleted — surface them alongside filesystem failures so
+        # the client keeps them visible and doesn't report them as trashed.
+        skipped_ids = result.get("skipped_ids", []) or []
+        if skipped_ids:
+            already_failed = set(failed_ids)
+            for photo_id in skipped_ids:
+                trash_failed.append({
+                    "photo_id": photo_id,
+                    "path": primary_paths.get(photo_id, ""),
+                    "error": (
+                        "Photo was moved to a new folder during this delete; "
+                        "the catalog row was preserved"
+                    ),
+                })
+            failed_ids = failed_ids + [
+                photo_id for photo_id in skipped_ids
+                if photo_id not in already_failed
+            ]
         emit("Finishing", 1, 1)
         return {
             "ok": True,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1748,12 +1748,16 @@ def _move_to_volume_trash(filepath):
         # the user meant to send to Trash.
         candidate = os.path.join(trash_dir, basename)
         reserved = None
+        reserved_stat = None
         for _ in range(32):
             try:
                 fd = os.open(
                     candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600,
                 )
-                os.close(fd)
+                try:
+                    reserved_stat = os.fstat(fd)
+                finally:
+                    os.close(fd)
                 reserved = candidate
                 break
             except FileExistsError:
@@ -1767,9 +1771,26 @@ def _move_to_volume_trash(filepath):
         try:
             os.rename(filepath, reserved)
         except OSError:
-            # Roll back the placeholder so the reserved name stays free.
+            # A network filesystem can commit a rename but lose the success
+            # response. Never unlink ``reserved`` unless it is still the exact
+            # placeholder we created; otherwise that path may now be the photo.
             try:
-                os.unlink(reserved)
+                current_stat = os.lstat(reserved)
+                try:
+                    os.lstat(filepath)
+                    source_still_exists = True
+                except FileNotFoundError:
+                    source_still_exists = False
+                if not source_still_exists:
+                    return True
+                placeholder_unchanged = (
+                    reserved_stat.st_ino
+                    and current_stat.st_dev == reserved_stat.st_dev
+                    and current_stat.st_ino == reserved_stat.st_ino
+                    and current_stat.st_size == reserved_stat.st_size
+                )
+                if placeholder_unchanged:
+                    os.unlink(reserved)
             except OSError:
                 pass
             raise

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1845,6 +1845,26 @@ def _trash_via_finder(filepaths, timeout=_FINDER_TRASH_TIMEOUT_SECS):
         raise OSError(result.stderr.strip() or f"Finder trash failed ({result.returncode})")
 
 
+def _path_confirmed_gone(filepath):
+    """Return True only when the file is verifiably absent from a live volume.
+
+    ``os.path.exists`` returning False is ambiguous on network volumes: it
+    also returns False when the underlying stat call errors out because the
+    mount went away mid-operation. Treating that as "successfully moved to
+    Trash" would prune the catalog row for a photo that reappears when the
+    mount comes back. Confirm both that the file is missing *and* that the
+    parent directory is still reachable so a genuine live-volume delete is
+    accepted while a mid-flight disconnect is preserved as a failure.
+    """
+    if os.path.exists(filepath):
+        return False
+    parent = os.path.dirname(filepath) or os.sep
+    try:
+        return os.path.isdir(parent)
+    except OSError:
+        return False
+
+
 def _trash_paths(filepaths):
     """Move paths to Trash and return ``(moved, successful, failures)``.
 
@@ -1882,10 +1902,13 @@ def _trash_paths(filepaths):
                 if isinstance(exc, (KeyboardInterrupt, GeneratorExit)):
                     raise
                 # Some platform Trash APIs can complete the move and still
-                # report a post-operation error. Trust the requested end state
-                # so we do not retain a ghost catalog row for a file that is
-                # already gone.
-                if not os.path.exists(filepath):
+                # report a post-operation error. Only trust the "not there"
+                # signal when we can positively verify it — a disconnected
+                # network volume also makes ``os.path.exists`` return False
+                # (the underlying stat fails), which would otherwise mask a
+                # real failure and prune the catalog row for a photo that
+                # reappears when the mount comes back.
+                if _path_confirmed_gone(filepath):
                     successful.add(filepath)
                     moved += 1
                     continue
@@ -1906,7 +1929,10 @@ def _trash_paths(filepaths):
         except Exception:
             log.warning("Finder Trash failed for a file batch", exc_info=True)
         for filepath in finder_batch:
-            if not os.path.exists(filepath):
+            # Only accept "gone" when the parent directory is still reachable;
+            # otherwise a stat failure from a disconnected mount would read
+            # as success.
+            if _path_confirmed_gone(filepath):
                 successful.add(filepath)
                 moved += 1
 
@@ -10233,6 +10259,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         for photo_id in chunk:
                             expected = revalidate_identity.get(photo_id)
                             actual = current.get(photo_id)
+                            if actual is None:
+                                # Row already gone — a concurrent delete beat
+                                # us to it. The requested end state already
+                                # holds, so treat it as successfully deleted
+                                # rather than a stale identity we couldn't
+                                # verify. Reporting it in ``failed_photo_ids``
+                                # here would leave the client showing a photo
+                                # that is absent from both catalog and disk
+                                # until reload.
+                                continue
                             if expected is not None and actual == expected:
                                 verified_ids.append(photo_id)
                             else:
@@ -10325,9 +10361,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         extra_companions = {}
         if include_companions:
             for f in files:
-                if not f.get("companion_path"):
+                companion_path = f.get("companion_path")
+                if not companion_path:
                     continue
-                companion = os.path.join(f["folder_path"], f["companion_path"])
+                # ``companion_path`` is stored as either a relative filename
+                # inside the same folder or an absolute path (see the same
+                # resolution in new_images.py:35-40). Joining an absolute
+                # path with the folder path would silently target the wrong
+                # file — the disk op would either fail or, worse, trash the
+                # wrong photo without ever pruning the correct catalog row.
+                companion = (
+                    companion_path if os.path.isabs(companion_path)
+                    else os.path.join(f["folder_path"], companion_path)
+                )
                 if companion not in catalog_primary_paths:
                     extra_companions.setdefault(f["photo_id"], set()).add(companion)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10215,12 +10215,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             """Atomically remove resolved catalog rows, then clean caches.
 
             ``revalidate_identity`` is an optional ``{photo_id: (folder_id,
-            filename)}`` map captured at the start of the disk operation. When
-            provided, each row is re-checked inside the delete transaction and
-            skipped if its ``(folder_id, filename)`` has changed since — a
-            concurrent ``/api/jobs/move-photos`` can commit a new folder_id
-            while the disk-delete's stale-path ``os.path.isfile`` check is
-            already reporting "gone", and deleting by id alone would then
+            filename, folder_path)}`` map captured at the start of the disk
+            operation. When provided, each row is re-checked inside the delete
+            transaction and skipped if any of those three fields has changed
+            since — a concurrent ``/api/jobs/move-photos`` can commit a new
+            ``folder_id`` while the disk-delete's stale-path
+            ``os.path.isfile`` check is already reporting "gone", and a
+            concurrent ``/api/jobs/move-folder`` can leave ``folder_id`` and
+            ``filename`` unchanged while renaming the underlying
+            ``folders.path``. Deleting by id alone in either case would
             discard the row for a photo that now lives at a completely
             different path. Skipped ids are returned as ``skipped_ids`` so
             the caller can surface them alongside filesystem failures.
@@ -10237,10 +10240,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             revalidating = bool(revalidate_identity)
             # BEGIN IMMEDIATE takes the write lock up front so no other writer
-            # (notably move-photos) can commit an identity change between the
-            # revalidation SELECT and the DELETE that follows. Without it, a
-            # move committed after the SELECT but before the DELETE would let
-            # us delete a row that no longer matches the identity we verified.
+            # (notably move-photos or move-folder) can commit an identity
+            # change between the revalidation SELECT and the DELETE that
+            # follows. Without it, a move committed after the SELECT but
+            # before the DELETE would let us delete a row that no longer
+            # matches the identity we verified.
             if revalidating:
                 db.conn.execute("BEGIN IMMEDIATE")
             try:
@@ -10249,10 +10253,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     for chunk in _chunked(ids):
                         placeholders = ",".join("?" for _ in chunk)
                         current = {
-                            row["id"]: (row["folder_id"], row["filename"])
+                            row["id"]: (
+                                row["folder_id"],
+                                row["filename"],
+                                row["folder_path"],
+                            )
                             for row in db.conn.execute(
-                                f"SELECT id, folder_id, filename FROM photos "
-                                f"WHERE id IN ({placeholders})",
+                                f"SELECT p.id, p.folder_id, p.filename, "
+                                f"f.path AS folder_path "
+                                f"FROM photos p "
+                                f"JOIN folders f ON f.id = p.folder_id "
+                                f"WHERE p.id IN ({placeholders})",
                                 list(chunk),
                             )
                         }
@@ -10354,8 +10365,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # folder_id and remove the source file mid-run; our stale-path
         # os.path.isfile would then read "already gone" and we would delete
         # a row that now represents the moved file at a different location.
+        # The folder_path is included so a concurrent /api/jobs/move-folder,
+        # which keeps folder_id and filename unchanged while renaming
+        # ``folders.path``, is also caught — otherwise the row would still be
+        # deleted even though the copied file remains at the new path.
         resolved_identity = {
-            f["photo_id"]: (f["folder_id"], f["filename"]) for f in files
+            f["photo_id"]: (
+                f["folder_id"], f["filename"], f["folder_path"],
+            )
+            for f in files
         }
         catalog_primary_paths = set(primary_paths.values())
         extra_companions = {}

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1673,6 +1673,22 @@ def _file_manager_labels():
     }
 
 
+_FINDER_TRASH_TIMEOUT_SECS = 30
+_FINDER_TRASH_BATCH_SIZE = 20
+
+
+def _volume_root_for_path(filepath):
+    """Return ``/Volumes/<name>`` for a path on a macOS mounted volume."""
+    try:
+        normalized = os.path.normpath(os.path.abspath(filepath))
+    except (OSError, TypeError, ValueError):
+        return None
+    parts = normalized.split(os.sep)
+    if len(parts) < 4 or parts[0] != "" or parts[1] != "Volumes" or not parts[2]:
+        return None
+    return os.sep.join(parts[:3])
+
+
 def _ensure_volume_trashes_dir(filepath, ensured_volumes):
     """Make sure ``/Volumes/<X>/.Trashes/<uid>/`` exists when ``filepath`` is on
     an external/network mount. macOS ``send2trash`` legacy mode raises
@@ -1686,10 +1702,9 @@ def _ensure_volume_trashes_dir(filepath, ensured_volumes):
     ``makedirs`` (read-only mount, ACL block) is swallowed so the actual
     trash call surfaces a more specific error than "could not mkdir".
     """
-    parts = filepath.split(os.sep)
-    if len(parts) < 4 or parts[0] != "" or parts[1] != "Volumes":
+    volume_root = _volume_root_for_path(filepath)
+    if volume_root is None:
         return
-    volume_root = os.sep.join(parts[:3])
     if volume_root in ensured_volumes:
         return
     ensured_volumes.add(volume_root)
@@ -1700,34 +1715,159 @@ def _ensure_volume_trashes_dir(filepath, ensured_volumes):
         log.debug("could not ensure %s: %s", trashes_dir, exc)
 
 
-def _trash_via_finder(filepath):
-    """Trash a file via Finder using AppleScript.
+def _move_to_volume_trash(filepath):
+    """Move one file directly into its mounted volume's Trash directory.
+
+    Finder ultimately performs a same-volume move into
+    ``/Volumes/<name>/.Trashes/<uid>``. Doing that move directly avoids the
+    legacy Carbon ``send2trash`` failure and the multi-second AppleScript
+    round trip seen on SMB/NAS mounts. Returns ``True`` only when the move
+    completed; callers retain their normal trash fallbacks on ``False``.
+    """
+    if sys.platform != "darwin":
+        return False
+    volume_root = _volume_root_for_path(filepath)
+    if volume_root is None:
+        return False
+
+    trash_dir = os.path.join(volume_root, ".Trashes", str(os.getuid()))
+    try:
+        os.makedirs(trash_dir, mode=0o700, exist_ok=True)
+        # Refuse a redirected Trash directory. The destination must remain on
+        # the same mounted volume as the source.
+        real_trash = os.path.realpath(trash_dir)
+        if os.path.commonpath((volume_root, real_trash)) != volume_root:
+            raise OSError("volume Trash directory resolves outside its volume")
+
+        basename = os.path.basename(filepath)
+        destination = os.path.join(trash_dir, basename)
+        if os.path.lexists(destination):
+            stem, ext = os.path.splitext(basename)
+            destination = os.path.join(
+                trash_dir, f"{stem} {uuid.uuid4().hex[:8]}{ext}",
+            )
+        os.rename(filepath, destination)
+        return True
+    except OSError as exc:
+        log.debug("Direct volume Trash move failed for %s: %s", filepath, exc)
+        return False
+
+
+def _trash_via_finder(filepaths, timeout=_FINDER_TRASH_TIMEOUT_SECS):
+    """Trash one or more files via one bounded Finder AppleScript call.
 
     Fallback for when send2trash fails (e.g. external volumes where the
     legacy Carbon API can't locate .Trashes). macOS-only: on Linux/Windows
     ``send2trash`` already implements the platform trash spec, so there is no
     equivalent fallback. Raising here (instead of spawning a doomed
     ``osascript``) lets the caller surface the original send2trash failure.
+
+    A timeout is mandatory because Finder can otherwise wait indefinitely on
+    an unavailable SMB share. Callers verify path existence after any error,
+    since Finder may have completed only part of a batch before failing.
     """
     if sys.platform != "darwin":
         raise OSError("Finder trash fallback is only available on macOS")
+    if isinstance(filepaths, (str, bytes, os.PathLike)):
+        filepaths = [os.fspath(filepaths)]
+    else:
+        filepaths = [os.fspath(path) for path in filepaths]
+    if not filepaths:
+        return
     result = subprocess.run(
         [
             "osascript",
             "-e", "on run argv",
-            "-e", "set posixPath to item 1 of argv",
-            "-e", "set fileRef to POSIX file posixPath",
+            "-e", "repeat with posixPath in argv",
+            "-e", "set fileRef to POSIX file (contents of posixPath)",
             "-e", "tell application \"Finder\" to delete fileRef",
+            "-e", "end repeat",
             "-e", "end run",
             "--",
-            filepath,
+            *filepaths,
         ],
         capture_output=True,
         text=True,
+        timeout=timeout,
         **no_window_kwargs(),
     )
     if result.returncode != 0:
         raise OSError(result.stderr.strip() or f"Finder trash failed ({result.returncode})")
+
+
+def _trash_paths(filepaths):
+    """Move paths to Trash and return ``(moved, successful, failures)``.
+
+    Missing paths are successful (the requested end state already holds) but
+    are not counted as moved. On macOS mounted volumes we try a direct,
+    same-volume rename first. Remaining paths use send2trash individually so
+    failures can be attributed, then one Finder process per bounded batch.
+    """
+    ordered = list(dict.fromkeys(filepaths))
+    successful = set()
+    moved = 0
+    fallback = []
+
+    for filepath in ordered:
+        if not os.path.isfile(filepath):
+            log.warning("File already missing: %s", filepath)
+            successful.add(filepath)
+            continue
+        if _move_to_volume_trash(filepath):
+            successful.add(filepath)
+            moved += 1
+        else:
+            fallback.append(filepath)
+
+    finder_candidates = []
+    send_errors = {}
+    if fallback:
+        from send2trash import send2trash as _trash
+        for filepath in fallback:
+            try:
+                _trash(filepath)
+                successful.add(filepath)
+                moved += 1
+            except BaseException as exc:
+                if isinstance(exc, (KeyboardInterrupt, GeneratorExit)):
+                    raise
+                # Some platform Trash APIs can complete the move and still
+                # report a post-operation error. Trust the requested end state
+                # so we do not retain a ghost catalog row for a file that is
+                # already gone.
+                if not os.path.exists(filepath):
+                    successful.add(filepath)
+                    moved += 1
+                    continue
+                send_errors[filepath] = str(exc)
+                if sys.platform == "darwin":
+                    finder_candidates.append(filepath)
+
+    for finder_batch in _chunked(
+        finder_candidates, size=_FINDER_TRASH_BATCH_SIZE,
+    ):
+        try:
+            _trash_via_finder(finder_batch)
+        except subprocess.TimeoutExpired:
+            log.warning(
+                "Finder Trash timed out after %ss for %d file(s)",
+                _FINDER_TRASH_TIMEOUT_SECS, len(finder_batch),
+            )
+        except Exception:
+            log.warning("Finder Trash failed for a file batch", exc_info=True)
+        for filepath in finder_batch:
+            if not os.path.exists(filepath):
+                successful.add(filepath)
+                moved += 1
+
+    failures = []
+    for filepath in ordered:
+        if filepath in successful:
+            continue
+        error = send_errors.get(filepath) or "Trash operation failed"
+        failures.append({"path": filepath, "error": error})
+        log.warning("Trash failed for %s: %s", filepath, error)
+    return moved, successful, failures
 
 
 def _compute_time_range(photos_by_id, photo_ids):
@@ -9995,133 +10135,197 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if mode not in ("vireo", "disk", "disk_permanent"):
             raise ValueError("mode must be 'vireo', 'disk', or 'disk_permanent'")
 
-        # Chunked because delete_photos issues several IN-clause queries; a
-        # 1000+ id request would hit SQLite's bound-parameter cap on legacy
-        # builds. We pass ``commit=False`` so all chunks share one outer
-        # transaction — without that, an error on a later chunk would 500
-        # the request after earlier chunks already committed, leaving DB
-        # rows gone and cached files / disk trashing not yet cleaned up
-        # for them. ``commit=False`` also defers the pipeline-cache prune
-        # (a non-transactional file write) to the caller so a rolled-back
-        # later chunk doesn't leave the cache permanently stripped of rows
-        # the DB just restored.
-        result = {"deleted": 0, "ids": [], "files": []}
-        total_requested = len(photo_ids)
-        prepared = 0
-        emit(
-            "Removing from Vireo",
-            0,
-            total_requested,
-            detail="Preparing database changes; nothing is committed yet.",
-        )
-        try:
-            for chunk in _chunked(photo_ids):
-                chunk_result = db.delete_photos(
-                    chunk,
-                    include_companions=include_companions,
-                    commit=False,
-                )
-                result["deleted"] += chunk_result["deleted"]
-                result["ids"].extend(chunk_result["ids"])
-                result["files"].extend(chunk_result["files"])
-                prepared += len(chunk)
-                emit(
-                    "Removing from Vireo",
-                    min(prepared, total_requested),
-                    total_requested,
-                    detail="Preparing database changes; nothing is committed yet.",
-                )
-            db.conn.commit()
-        except Exception:
-            db.conn.rollback()
-            raise
-        emit(
-            "Removed from Vireo",
-            result["deleted"],
-            result["deleted"],
-            detail="Database changes committed.",
-        )
-
-        # Run the deferred non-DB side effects only after the outer
-        # transaction committed successfully.
-        emit("Pruning pipeline cache", 0, 1)
-        try:
-            db.prune_pipeline_cache_for_ids(result["ids"])
-        except BaseException as exc:
-            _reraise_fatal_cleanup_error(exc)
-            log.exception("Failed to prune pipeline cache after delete")
-        emit("Pruning pipeline cache", 1, 1)
-
-        def cache_progress(current, total, filename):
-            emit("Cleaning cached files", current, total, filename)
-
-        emit("Cleaning cached files", 0, len(result["files"]))
-        _cleanup_cached_files_for_deleted_photos(
-            result["files"], progress_callback=cache_progress,
-        )
-
-        trashed = 0
-        trash_failed = []
-        if mode in ("disk", "disk_permanent"):
-            disk_targets = []
-            for f in result["files"]:
-                # Collect all files to delete: primary + companion
-                primary = os.path.join(f["folder_path"], f["filename"])
-                disk_targets.append(primary)
-                if include_companions and f.get("companion_path"):
-                    companion = os.path.join(f["folder_path"], f["companion_path"])
-                    disk_targets.append(companion)
-
-            disk_phase = (
-                "Moving files to Trash"
-                if mode == "disk" else "Deleting files permanently"
+        def remove_catalog_rows(ids, *, expand_companions):
+            """Atomically remove resolved catalog rows, then clean caches."""
+            result = {"deleted": 0, "ids": [], "files": []}
+            total = len(ids)
+            prepared = 0
+            emit(
+                "Removing from Vireo", 0, total,
+                detail="Preparing database changes; nothing is committed yet.",
             )
-            ensured_volumes = set()
-            emit(disk_phase, 0, len(disk_targets))
-            for idx, filepath in enumerate(disk_targets, start=1):
-                basename = os.path.basename(filepath)
+            try:
+                for chunk in _chunked(ids):
+                    chunk_result = db.delete_photos(
+                        chunk,
+                        include_companions=expand_companions,
+                        commit=False,
+                    )
+                    result["deleted"] += chunk_result["deleted"]
+                    result["ids"].extend(chunk_result["ids"])
+                    result["files"].extend(chunk_result["files"])
+                    prepared += len(chunk)
+                    emit(
+                        "Removing from Vireo", min(prepared, total), total,
+                        detail=(
+                            "Preparing database changes; nothing is committed yet."
+                        ),
+                    )
+                db.conn.commit()
+            except Exception:
+                db.conn.rollback()
+                raise
+
+            emit(
+                "Removed from Vireo", result["deleted"], result["deleted"],
+                detail="Database changes committed.",
+            )
+            emit("Pruning pipeline cache", 0, 1)
+            try:
+                db.prune_pipeline_cache_for_ids(result["ids"])
+            except BaseException as exc:
+                _reraise_fatal_cleanup_error(exc)
+                log.exception("Failed to prune pipeline cache after delete")
+            emit("Pruning pipeline cache", 1, 1)
+
+            def cache_progress(current, total_files, filename):
+                emit("Cleaning cached files", current, total_files, filename)
+
+            emit("Cleaning cached files", 0, len(result["files"]))
+            _cleanup_cached_files_for_deleted_photos(
+                result["files"], progress_callback=cache_progress,
+            )
+            return result
+
+        # Database-only mode has no filesystem prerequisite and retains the
+        # original all-or-nothing catalog transaction.
+        if mode == "vireo":
+            result = remove_catalog_rows(
+                photo_ids, expand_companions=include_companions,
+            )
+            emit("Finishing", 1, 1)
+            return {
+                "ok": True,
+                "deleted": result["deleted"],
+                "trashed": 0,
+                "trash_failed": [],
+                "failed_photo_ids": [],
+            }
+
+        # Disk modes resolve paths without changing SQLite. A photo's catalog
+        # row is removed only after its primary file reached the requested end
+        # state. A companion without its own photo row is processed first; if
+        # that fails, its primary is left untouched and its row remains
+        # retryable.
+        resolved = db.resolve_photos_for_delete(
+            photo_ids, include_companions=include_companions,
+        )
+        files = resolved["files"]
+        primary_paths = {
+            f["photo_id"]: os.path.join(f["folder_path"], f["filename"])
+            for f in files
+        }
+        catalog_primary_paths = set(primary_paths.values())
+        extra_companions = {}
+        if include_companions:
+            for f in files:
+                if not f.get("companion_path"):
+                    continue
+                companion = os.path.join(f["folder_path"], f["companion_path"])
+                if companion not in catalog_primary_paths:
+                    extra_companions.setdefault(f["photo_id"], set()).add(companion)
+
+        disk_phase = (
+            "Moving files to Trash"
+            if mode == "disk" else "Deleting files permanently"
+        )
+        all_disk_paths = list(dict.fromkeys(
+            [path for paths_for_id in extra_companions.values() for path in paths_for_id]
+            + list(primary_paths.values())
+        ))
+        emit(disk_phase, 0, len(all_disk_paths))
+
+        def operate(paths_to_change):
+            if not paths_to_change:
+                return 0, set(), []
+            if mode == "disk":
+                return _trash_paths(paths_to_change)
+            successful = set()
+            failures = []
+            removed = 0
+            for filepath in paths_to_change:
                 if not os.path.isfile(filepath):
                     log.warning("File already missing: %s", filepath)
-                    emit(disk_phase, idx, len(disk_targets), basename)
+                    successful.add(filepath)
                     continue
-                if mode == "disk":
-                    _ensure_volume_trashes_dir(filepath, ensured_volumes)
-                    try:
-                        from send2trash import send2trash as _trash
-                        _trash(filepath)
-                        trashed += 1
-                    except BaseException as send_err:
-                        _reraise_fatal_cleanup_error(send_err)
-                        # send2trash implements the platform trash spec on
-                        # Linux/Windows; the AppleScript Finder fallback only
-                        # helps on macOS. Off-mac, report the real send2trash
-                        # error instead of masking it with the Finder guard.
-                        if sys.platform == "darwin":
-                            log.debug("send2trash failed for %s, trying Finder", filepath)
-                            try:
-                                _trash_via_finder(filepath)
-                                trashed += 1
-                            except Exception:
-                                log.warning("Trash failed for %s", filepath, exc_info=True)
-                                trash_failed.append({"path": filepath})
-                        else:
-                            log.warning("Trash failed for %s: %s", filepath, send_err)
-                            trash_failed.append({"path": filepath})
-                else:  # disk_permanent
-                    try:
-                        os.remove(filepath)
-                        trashed += 1
-                    except OSError:
-                        log.warning("Permanent delete failed for %s", filepath, exc_info=True)
-                        trash_failed.append({"path": filepath})
-                emit(disk_phase, idx, len(disk_targets), basename)
+                try:
+                    os.remove(filepath)
+                    successful.add(filepath)
+                    removed += 1
+                except OSError as exc:
+                    log.warning(
+                        "Permanent delete failed for %s", filepath,
+                        exc_info=True,
+                    )
+                    failures.append({"path": filepath, "error": str(exc)})
+            return removed, successful, failures
 
+        companion_paths = list(dict.fromkeys(
+            path for paths_for_id in extra_companions.values()
+            for path in paths_for_id
+        ))
+        trashed, companion_success, companion_failures = operate(companion_paths)
+        eligible_ids = {
+            photo_id for photo_id in resolved["ids"]
+            if extra_companions.get(photo_id, set()) <= companion_success
+        }
+        eligible_primary_paths = [
+            primary_paths[photo_id] for photo_id in resolved["ids"]
+            if photo_id in eligible_ids and photo_id in primary_paths
+        ]
+        primary_moved, primary_success, primary_failures = operate(
+            eligible_primary_paths,
+        )
+        trashed += primary_moved
+        successful_ids = [
+            photo_id for photo_id in resolved["ids"]
+            if photo_id in eligible_ids
+            and primary_paths.get(photo_id) in primary_success
+        ]
+        successful_id_set = set(successful_ids)
+        failed_ids = [
+            photo_id for photo_id in resolved["ids"]
+            if photo_id not in successful_id_set
+        ]
+
+        failure_by_path = {
+            failure["path"]: failure
+            for failure in companion_failures + primary_failures
+        }
+        trash_failed = []
+        for photo_id in failed_ids:
+            failed_paths = [
+                path for path in extra_companions.get(photo_id, set())
+                if path not in companion_success
+            ]
+            primary = primary_paths.get(photo_id)
+            if not failed_paths and primary not in primary_success:
+                failed_paths.append(primary)
+            for filepath in failed_paths:
+                detail = dict(failure_by_path.get(filepath) or {
+                    "path": filepath,
+                    "error": "A companion file could not be removed",
+                })
+                detail["photo_id"] = photo_id
+                trash_failed.append(detail)
+
+        emit(
+            disk_phase, len(all_disk_paths), len(all_disk_paths),
+            detail=(
+                f"{len(successful_ids)} photo(s) ready for catalog removal; "
+                f"{len(failed_ids)} retained after filesystem errors."
+            ),
+        )
+        result = remove_catalog_rows(
+            successful_ids, expand_companions=False,
+        )
         emit("Finishing", 1, 1)
         return {
             "ok": True,
             "deleted": result["deleted"],
             "trashed": trashed,
             "trash_failed": trash_failed,
+            "failed_photo_ids": failed_ids,
         }
 
     @app.route("/api/batch/delete", methods=["POST"])
@@ -21000,11 +21204,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if anchor is not None:
                 anchored_hashes.add(h)
 
-        trashed = 0
+        trash_candidates = []
         trashed_pids = []
         skipped = []
         failed = []
-        ensured_volumes = set()
         for pid in photo_ids:
             row = rows_by_id.get(pid)
             if row is None:
@@ -21030,29 +21233,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 skipped.append({"id": pid, "reason": "file already missing"})
                 trashed_pids.append(pid)
                 continue
-            _ensure_volume_trashes_dir(filepath, ensured_volumes)
-            try:
-                from send2trash import send2trash as _trash
-                _trash(filepath)
-                trashed += 1
+            trash_candidates.append((pid, filepath))
+
+        trashed, successful_paths, trash_failures = _trash_paths(
+            [filepath for _pid, filepath in trash_candidates],
+        )
+        failure_by_path = {
+            failure["path"]: failure for failure in trash_failures
+        }
+        for pid, filepath in trash_candidates:
+            if filepath in successful_paths:
                 trashed_pids.append(pid)
-            except Exception as send_err:
-                # send2trash implements the platform trash spec on Linux/Windows;
-                # the AppleScript Finder fallback only helps on macOS. Off-mac,
-                # surface the real send2trash error rather than masking it with
-                # the Finder guard's "only available on macOS" message.
-                if sys.platform != "darwin":
-                    log.warning("Trash failed for %s", filepath, exc_info=True)
-                    failed.append({"id": pid, "path": filepath, "error": str(send_err)})
-                    continue
-                log.debug("send2trash failed for %s, trying Finder", filepath)
-                try:
-                    _trash_via_finder(filepath)
-                    trashed += 1
-                    trashed_pids.append(pid)
-                except Exception as e:
-                    log.warning("Trash failed for %s", filepath, exc_info=True)
-                    failed.append({"id": pid, "path": filepath, "error": str(e)})
+                continue
+            failure = failure_by_path.get(filepath) or {}
+            failed.append({
+                "id": pid,
+                "path": filepath,
+                "error": failure.get("error", "Trash operation failed"),
+            })
 
         # Drop DB rows + cached derivatives for every photo whose file is now
         # gone. Chunked so ``delete_photos``' five internal IN-clause queries

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10277,10 +10277,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 row["folder_id"],
                                 row["filename"],
                                 row["folder_path"],
+                                row["companion_path"],
                             )
                             for row in db.conn.execute(
                                 f"SELECT p.id, p.folder_id, p.filename, "
-                                f"f.path AS folder_path "
+                                f"p.companion_path, f.path AS folder_path "
                                 f"FROM photos p "
                                 f"JOIN folders f ON f.id = p.folder_id "
                                 f"WHERE p.id IN ({placeholders})",
@@ -10389,9 +10390,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # which keeps folder_id and filename unchanged while renaming
         # ``folders.path``, is also caught — otherwise the row would still be
         # deleted even though the copied file remains at the new path.
+        # ``companion_path`` is included so a concurrent scan that pairs a
+        # RAW with a JPEG mid-delete (scanner.py: ``UPDATE photos SET
+        # companion_path`` on the primary, ``DELETE FROM photos`` on the
+        # merged companion) is also caught — otherwise the primary's tuple
+        # would still match, and we'd trash only the pre-pair paths and
+        # remove the primary row, orphaning the newly-paired companion file
+        # on disk with no catalog entry.
         resolved_identity = {
             f["photo_id"]: (
                 f["folder_id"], f["filename"], f["folder_path"],
+                f["companion_path"],
             )
             for f in files
         }

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1769,7 +1769,10 @@ def _move_to_volume_trash(filepath):
                 f"could not reserve a unique Trash destination in {trash_dir}",
             )
         try:
-            os.rename(filepath, reserved)
+            # ``os.replace`` (not ``os.rename``) so the O_EXCL placeholder we
+            # just reserved is overwritten. POSIX rename replaces silently,
+            # but Windows rename raises when the destination exists.
+            os.replace(filepath, reserved)
         except OSError:
             # A network filesystem can commit a rename but lose the success
             # response. Never unlink ``reserved`` unless it is still the exact

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19,6 +19,7 @@ import queue
 import re
 import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -1845,7 +1846,25 @@ def _trash_via_finder(filepaths, timeout=_FINDER_TRASH_TIMEOUT_SECS):
         raise OSError(result.stderr.strip() or f"Finder trash failed ({result.returncode})")
 
 
-def _path_confirmed_gone(filepath):
+def _snapshot_parent_device(filepath):
+    """Return the parent directory's ``st_dev`` for later mount verification.
+
+    Callers snapshot this before any deletion attempt and pass it to
+    :func:`_path_confirmed_gone` afterwards. A network mount that
+    disconnects mid-op leaves the mount-point directory visible on the
+    underlying local filesystem, so ``os.path.isdir`` alone reports the
+    parent as live even though the actual volume is gone. Comparing the
+    pre-op and post-op ``st_dev`` catches that drop. ``None`` means no
+    baseline could be captured, so the device check is skipped.
+    """
+    parent = os.path.dirname(filepath) or os.sep
+    try:
+        return os.stat(parent).st_dev
+    except OSError:
+        return None
+
+
+def _path_confirmed_gone(filepath, expected_parent_dev=None):
     """Return True only when the file is verifiably absent from a live volume.
 
     ``os.path.exists`` returning False is ambiguous on network volumes: it
@@ -1855,14 +1874,27 @@ def _path_confirmed_gone(filepath):
     mount comes back. Confirm both that the file is missing *and* that the
     parent directory is still reachable so a genuine live-volume delete is
     accepted while a mid-flight disconnect is preserved as a failure.
+
+    When ``expected_parent_dev`` is provided (from
+    :func:`_snapshot_parent_device`), also require the parent's current
+    ``st_dev`` to match — a network mount that vanishes can leave its
+    mount-point directory in place on the underlying local filesystem, so
+    the ``os.path.isdir`` check alone would incorrectly accept the file
+    as gone.
     """
     if os.path.exists(filepath):
         return False
     parent = os.path.dirname(filepath) or os.sep
     try:
-        return os.path.isdir(parent)
+        parent_stat = os.stat(parent)
     except OSError:
         return False
+    if not stat.S_ISDIR(parent_stat.st_mode):
+        return False
+    return not (
+        expected_parent_dev is not None
+        and parent_stat.st_dev != expected_parent_dev
+    )
 
 
 def _trash_paths(filepaths):
@@ -1878,6 +1910,12 @@ def _trash_paths(filepaths):
     moved = 0
     fallback = []
     preflight_errors = {}
+    # Snapshot each parent's st_dev before we touch anything. A network
+    # mount that vanishes mid-batch can leave the mount-point directory
+    # visible on the underlying local FS, so ``os.path.isdir`` alone would
+    # accept the file as gone. Comparing pre-op vs post-op st_dev catches
+    # the mount drop even when the directory still stats cleanly.
+    parent_devs = {path: _snapshot_parent_device(path) for path in ordered}
 
     for filepath in ordered:
         if not os.path.isfile(filepath):
@@ -1885,10 +1923,11 @@ def _trash_paths(filepaths):
             # volumes — it also happens when the underlying stat fails
             # because the mount is already disconnected. Only treat the
             # path as "already gone" when the parent directory is still
-            # reachable; otherwise preserve as a failure so the caller
-            # doesn't prune the catalog row for a photo that reappears
-            # when the mount comes back.
-            if _path_confirmed_gone(filepath):
+            # reachable AND its device matches the pre-op snapshot;
+            # otherwise preserve as a failure so the caller doesn't prune
+            # the catalog row for a photo that reappears when the mount
+            # comes back.
+            if _path_confirmed_gone(filepath, parent_devs.get(filepath)):
                 log.warning("File already missing: %s", filepath)
                 successful.add(filepath)
             else:
@@ -1924,7 +1963,7 @@ def _trash_paths(filepaths):
                 # (the underlying stat fails), which would otherwise mask a
                 # real failure and prune the catalog row for a photo that
                 # reappears when the mount comes back.
-                if _path_confirmed_gone(filepath):
+                if _path_confirmed_gone(filepath, parent_devs.get(filepath)):
                     successful.add(filepath)
                     moved += 1
                     continue
@@ -1945,10 +1984,10 @@ def _trash_paths(filepaths):
         except Exception:
             log.warning("Finder Trash failed for a file batch", exc_info=True)
         for filepath in finder_batch:
-            # Only accept "gone" when the parent directory is still reachable;
-            # otherwise a stat failure from a disconnected mount would read
-            # as success.
-            if _path_confirmed_gone(filepath):
+            # Only accept "gone" when the parent directory is still reachable
+            # AND its device matches the pre-op snapshot; otherwise a stat
+            # against a stale/replaced mount point would read as success.
+            if _path_confirmed_gone(filepath, parent_devs.get(filepath)):
                 successful.add(filepath)
                 moved += 1
 
@@ -10442,6 +10481,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             successful = set()
             failures = []
             removed = 0
+            # Snapshot each parent's st_dev before deletion so a mount that
+            # vanishes mid-batch can be detected even when the mount point
+            # remains visible on the underlying local FS (see
+            # ``_snapshot_parent_device``).
+            parent_devs = {
+                path: _snapshot_parent_device(path)
+                for path in paths_to_change
+            }
             for filepath in paths_to_change:
                 if not os.path.isfile(filepath):
                     # Same live-parent gate as ``_trash_paths`` — a
@@ -10449,7 +10496,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     # return False, and treating that as "already gone"
                     # would prune the catalog row for a photo that
                     # reappears when the volume comes back.
-                    if _path_confirmed_gone(filepath):
+                    if _path_confirmed_gone(
+                        filepath, parent_devs.get(filepath),
+                    ):
                         log.warning("File already missing: %s", filepath)
                         successful.add(filepath)
                     else:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1877,11 +1877,27 @@ def _trash_paths(filepaths):
     successful = set()
     moved = 0
     fallback = []
+    preflight_errors = {}
 
     for filepath in ordered:
         if not os.path.isfile(filepath):
-            log.warning("File already missing: %s", filepath)
-            successful.add(filepath)
+            # ``os.path.isfile`` returning False is ambiguous on network
+            # volumes — it also happens when the underlying stat fails
+            # because the mount is already disconnected. Only treat the
+            # path as "already gone" when the parent directory is still
+            # reachable; otherwise preserve as a failure so the caller
+            # doesn't prune the catalog row for a photo that reappears
+            # when the mount comes back.
+            if _path_confirmed_gone(filepath):
+                log.warning("File already missing: %s", filepath)
+                successful.add(filepath)
+            else:
+                preflight_errors[filepath] = (
+                    "Source path is unreachable"
+                )
+                log.warning(
+                    "Trash preflight: source unreachable for %s", filepath,
+                )
             continue
         if _move_to_volume_trash(filepath):
             successful.add(filepath)
@@ -1940,7 +1956,11 @@ def _trash_paths(filepaths):
     for filepath in ordered:
         if filepath in successful:
             continue
-        error = send_errors.get(filepath) or "Trash operation failed"
+        error = (
+            preflight_errors.get(filepath)
+            or send_errors.get(filepath)
+            or "Trash operation failed"
+        )
         failures.append({"path": filepath, "error": error})
         log.warning("Trash failed for %s: %s", filepath, error)
     return moved, successful, failures
@@ -10415,8 +10435,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             removed = 0
             for filepath in paths_to_change:
                 if not os.path.isfile(filepath):
-                    log.warning("File already missing: %s", filepath)
-                    successful.add(filepath)
+                    # Same live-parent gate as ``_trash_paths`` — a
+                    # disconnected mount also makes ``os.path.isfile``
+                    # return False, and treating that as "already gone"
+                    # would prune the catalog row for a photo that
+                    # reappears when the volume comes back.
+                    if _path_confirmed_gone(filepath):
+                        log.warning("File already missing: %s", filepath)
+                        successful.add(filepath)
+                    else:
+                        log.warning(
+                            "Permanent delete preflight: source "
+                            "unreachable for %s", filepath,
+                        )
+                        failures.append({
+                            "path": filepath,
+                            "error": "Source path is unreachable",
+                        })
                     continue
                 try:
                     os.remove(filepath)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1740,13 +1740,39 @@ def _move_to_volume_trash(filepath):
             raise OSError("volume Trash directory resolves outside its volume")
 
         basename = os.path.basename(filepath)
-        destination = os.path.join(trash_dir, basename)
-        if os.path.lexists(destination):
-            stem, ext = os.path.splitext(basename)
-            destination = os.path.join(
-                trash_dir, f"{stem} {uuid.uuid4().hex[:8]}{ext}",
+        stem, ext = os.path.splitext(basename)
+        # Atomically reserve the destination name with O_CREAT|O_EXCL so two
+        # concurrent moves for same-named files from different folders can't
+        # both observe an empty slot and then rename to the same path — POSIX
+        # rename would silently replace one file, permanently losing a photo
+        # the user meant to send to Trash.
+        candidate = os.path.join(trash_dir, basename)
+        reserved = None
+        for _ in range(32):
+            try:
+                fd = os.open(
+                    candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600,
+                )
+                os.close(fd)
+                reserved = candidate
+                break
+            except FileExistsError:
+                candidate = os.path.join(
+                    trash_dir, f"{stem} {uuid.uuid4().hex[:8]}{ext}",
+                )
+        if reserved is None:
+            raise OSError(
+                f"could not reserve a unique Trash destination in {trash_dir}",
             )
-        os.rename(filepath, destination)
+        try:
+            os.rename(filepath, reserved)
+        except OSError:
+            # Roll back the placeholder so the reserved name stays free.
+            try:
+                os.unlink(reserved)
+            except OSError:
+                pass
+            raise
         return True
     except OSError as exc:
         log.debug("Direct volume Trash move failed for %s: %s", filepath, exc)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -8602,23 +8602,20 @@ class Database:
                 raise
             log.exception("Failed to prune pipeline cache after delete")
 
-    def delete_photos(self, photo_ids, include_companions=False, commit=True):
-        """Delete photos and all associated data.
+    def resolve_photos_for_delete(self, photo_ids, include_companions=False):
+        """Resolve photo ids to the rows and paths a delete would remove.
 
-        Returns dict with 'deleted' count, 'ids' list of deleted photo IDs
-        (post-companion-resolution), and 'files' list of
-        {photo_id, folder_path, filename, companion_path} for file cleanup.
+        This is intentionally read-only. Disk-delete callers use it to move
+        originals to Trash *before* deleting their catalog rows, so a failed
+        filesystem operation leaves the photo visible and retryable in Vireo.
 
-        When ``commit`` is ``False``, this call participates in an outer
-        transaction managed by the caller: no ``commit()``/``rollback()`` is
-        issued here, **and** the non-DB pipeline-cache prune is skipped so
-        a later failed chunk can roll the DB back without leaving a
-        permanently-mutated cache file on disk. The caller is responsible
-        for invoking ``prune_pipeline_cache_for_ids`` with the union of
-        returned ``ids`` after the outer commit succeeds.
+        Returns a dict with ``ids``, ``files``, and the private ``_rows`` used
+        by :meth:`delete_photos`. ``files`` retains the long-standing cleanup
+        shape and additionally includes ``folder_id`` for callers that need to
+        group related paths.
         """
         if not photo_ids:
-            return {"deleted": 0, "ids": [], "files": []}
+            return {"ids": [], "files": [], "_rows": []}
 
         # Resolve to actual existing photos. Chunked — callers like
         # /api/audit/remove-missing pass arbitrarily large id lists straight
@@ -8634,7 +8631,7 @@ class Database:
             ).fetchall())
 
         if not rows:
-            return {"deleted": 0, "ids": [], "files": []}
+            return {"ids": [], "files": [], "_rows": []}
 
         # Resolve companions
         if include_companions:
@@ -8664,12 +8661,39 @@ class Database:
         files = [
             {
                 "photo_id": row["id"],
+                "folder_id": row["folder_id"],
                 "folder_path": row["folder_path"],
                 "filename": row["filename"],
                 "companion_path": row["companion_path"],
             }
             for row in rows
         ]
+
+        return {"ids": all_ids, "files": files, "_rows": rows}
+
+    def delete_photos(self, photo_ids, include_companions=False, commit=True):
+        """Delete photos and all associated data.
+
+        Returns dict with 'deleted' count, 'ids' list of deleted photo IDs
+        (post-companion-resolution), and 'files' list of
+        {photo_id, folder_path, filename, companion_path} for file cleanup.
+
+        When ``commit`` is ``False``, this call participates in an outer
+        transaction managed by the caller: no ``commit()``/``rollback()`` is
+        issued here, **and** the non-DB pipeline-cache prune is skipped so
+        a later failed chunk can roll the DB back without leaving a
+        permanently-mutated cache file on disk. The caller is responsible
+        for invoking ``prune_pipeline_cache_for_ids`` with the union of
+        returned ``ids`` after the outer commit succeeds.
+        """
+        resolved = self.resolve_photos_for_delete(
+            photo_ids, include_companions=include_companions,
+        )
+        rows = resolved.pop("_rows")
+        if not rows:
+            return {"deleted": 0, "ids": [], "files": []}
+        all_ids = resolved["ids"]
+        files = resolved["files"]
 
         # Count photos per folder for decrementing
         folder_counts = {}

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8140,6 +8140,20 @@ function lightboxDelete() {
   var companionCount = (p && p.companion_path) ? 1 : 0;
 
   showDeleteDialog([currentId], companionCount, function(data) {
+    // If the server retained this photo because its Trash step failed (and
+    // the user declined the permanent-delete fallback), leave it in the
+    // lightbox and grid. Dropping it here would hide a file still on disk
+    // until the next reload — the toast already told the user it was kept.
+    var retained = (data && data.failed_photo_ids) || [];
+    if (retained.indexOf(currentId) !== -1) {
+      try {
+        document.dispatchEvent(new CustomEvent('lightbox:photodeleted', {
+          detail: { photoId: currentId, result: data || null, retained: true }
+        }));
+      } catch (_) {}
+      return;
+    }
+
     // Remove from lightbox photo list
     var idx = _lightboxPhotoList.findIndex(function(x) { return x.id === currentId; });
     _lightboxPhotoList.splice(idx, 1);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7967,7 +7967,7 @@ function updateDeleteProgress(data) {
   if (detail) detail.textContent = parts.join(' · ');
 }
 
-function handleDeleteJobComplete(evt, savedCallback, mode) {
+async function handleDeleteJobComplete(evt, savedCallback, mode, includeCompanions) {
   var data = evt && evt.result;
   if (!evt || evt.status !== 'completed' || !data) {
     hideDeleteModal();
@@ -7980,22 +7980,48 @@ function handleDeleteJobComplete(evt, savedCallback, mode) {
 
   if (data.trash_failed && data.trash_failed.length > 0) {
     var paths = data.trash_failed.map(function(f) { return f.path; });
+    var failedIds = (data.failed_photo_ids || []).filter(function(id, idx, all) {
+      return all.indexOf(id) === idx;
+    });
     if (confirm('Trash not available for ' + paths.length + ' file(s):\n' +
         paths.slice(0, 5).join('\n') +
         (paths.length > 5 ? '\n... and ' + (paths.length - 5) + ' more' : '') +
         '\n\nPermanently delete instead?')) {
-      safeFetch('/api/batch/delete', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({paths: paths, mode: 'disk_permanent'}),
-      }).catch(function() { /* already removed from DB */ });
+      try {
+        // Newer servers retain catalog rows whose Trash operation failed, so
+        // retry by photo id and let the server remove each row only after its
+        // permanent file deletion succeeds. ``paths`` remains the compatibility
+        // path for an in-flight job started by an older build that already
+        // removed its rows.
+        var retryBody = failedIds.length
+          ? {
+              photo_ids: failedIds,
+              mode: 'disk_permanent',
+              include_companions: !!includeCompanions,
+            }
+          : {paths: paths, mode: 'disk_permanent'};
+        var retry = await safeFetch('/api/batch/delete', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify(retryBody),
+        });
+        data.deleted += Number(retry.deleted || 0);
+        data.trashed += Number(retry.trashed || 0);
+        data.trash_failed = retry.trash_failed || [];
+        data.failed_photo_ids = retry.failed_photo_ids || [];
+      } catch (e) {
+        // safeFetch already surfaced the actionable error.
+      }
     }
   }
 
   var msg = mode === 'vireo'
     ? data.deleted + ' photo' + (data.deleted === 1 ? '' : 's') + ' removed'
     : data.deleted + ' photo' + (data.deleted === 1 ? '' : 's') + ' moved to Trash';
-  showToast(msg, 'success');
+  if (data.failed_photo_ids && data.failed_photo_ids.length) {
+    msg += '; ' + data.failed_photo_ids.length + ' retained after file errors';
+  }
+  showToast(msg, data.failed_photo_ids && data.failed_photo_ids.length ? 'error' : 'success');
 
   if (savedCallback) savedCallback(data);
 }
@@ -8065,7 +8091,7 @@ async function confirmDelete() {
     onProgress: updateDeleteProgress,
     onComplete: function(evt) {
       _deleteJobSource = null;
-      handleDeleteJobComplete(evt, savedCallback, mode);
+      handleDeleteJobComplete(evt, savedCallback, mode, includeCompanions);
     },
     onError: function() {
       _deleteJobSource = null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8146,11 +8146,6 @@ function lightboxDelete() {
     // until the next reload — the toast already told the user it was kept.
     var retained = (data && data.failed_photo_ids) || [];
     if (retained.indexOf(currentId) !== -1) {
-      try {
-        document.dispatchEvent(new CustomEvent('lightbox:photodeleted', {
-          detail: { photoId: currentId, result: data || null, retained: true }
-        }));
-      } catch (_) {}
       return;
     }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6394,13 +6394,23 @@ function batchDelete() {
     if (p && p.companion_path) companionCount++;
   });
   showDeleteDialog(ids, companionCount, function(data) {
-    // Remove deleted photos from local array
-    var deletedSet = new Set(ids);
+    // The server may have retained rows whose Trash step failed (and the
+    // user declined the permanent-delete fallback). Keep those rows visible
+    // — dropping them from ``photos`` would hide files still on disk until
+    // the next reload.
+    var retained = new Set((data && data.failed_photo_ids) || []);
+    var deletedSet = new Set(ids.filter(function(id) { return !retained.has(id); }));
     photos = photos.filter(function(p) { return !deletedSet.has(p.id); });
     totalPhotos = Math.max(0, totalPhotos - (data.deleted || 0));
-    selectedPhotos.clear();
-    selectedPhotoId = null;
-    document.getElementById('batchBar').style.display = 'none';
+    selectedPhotos = new Set(Array.from(selectedPhotos).filter(function(id) {
+      return !deletedSet.has(id);
+    }));
+    if (selectedPhotoId != null && deletedSet.has(selectedPhotoId)) {
+      selectedPhotoId = null;
+    }
+    if (selectedPhotos.size === 0) {
+      document.getElementById('batchBar').style.display = 'none';
+    }
     renderGrid();
     updateFilterSummary();
     loadSummary();
@@ -6409,7 +6419,7 @@ function batchDelete() {
     var countEl = document.getElementById('photoCount');
     if (countEl) {
       var current = parseInt(countEl.textContent) || 0;
-      countEl.textContent = (current - data.deleted);
+      countEl.textContent = (current - (data.deleted || 0));
     }
   });
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6408,9 +6408,11 @@ function batchDelete() {
     if (selectedPhotoId != null && deletedSet.has(selectedPhotoId)) {
       selectedPhotoId = null;
     }
-    if (selectedPhotos.size === 0) {
-      document.getElementById('batchBar').style.display = 'none';
-    }
+    // Re-sync the batch bar (count, compare/best/burst buttons, selection
+    // inspector) against the shrunk selection. Just hiding the bar when the
+    // set empties leaves stale state — the count and buttons stayed sized for
+    // the pre-delete IDs on a partial deletion.
+    updateBatchBar();
     renderGrid();
     updateFilterSummary();
     loadSummary();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6421,7 +6421,7 @@ function batchDelete() {
     var countEl = document.getElementById('photoCount');
     if (countEl) {
       var current = parseInt(countEl.textContent) || 0;
-      countEl.textContent = (current - (data.deleted || 0));
+      countEl.textContent = Math.max(0, current - (data.deleted || 0));
     }
   });
 }

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1753,9 +1753,13 @@ async function deleteSelectedMisses() {
     // callbacks: ``failed_photo_ids`` lists IDs kept intentionally.
     var retained = new Set((data && data.failed_photo_ids) || []);
     var actuallyDeleted = ids.filter(function(id) { return !retained.has(id); });
-    clearSelection();
+    // Match browse.html: retained IDs stay selected so the user can retry
+    // immediately. clearSelection() would drop everything, including the
+    // rows they still need to act on.
+    actuallyDeleted.forEach(function(id) { selection.delete(id); });
     removePhotosFromMissesData(actuallyDeleted);
     render();
+    updateSelectionBar();
     loadMisses();
   };
 

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1747,8 +1747,14 @@ async function deleteSelectedMisses() {
   var companionCount = rows.filter(function(p) { return !!p.companion_path; }).length;
 
   var afterDelete = function(data) {
+    // Rows the server retained after Trash failures must remain visible —
+    // dropping them from ``missesData`` would hide files still on disk until
+    // reload. Callback receives the same ``data`` shape as other delete
+    // callbacks: ``failed_photo_ids`` lists IDs kept intentionally.
+    var retained = new Set((data && data.failed_photo_ids) || []);
+    var actuallyDeleted = ids.filter(function(id) { return !retained.has(id); });
     clearSelection();
-    removePhotosFromMissesData(ids);
+    removePhotosFromMissesData(actuallyDeleted);
     render();
     loadMisses();
   };

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3973,6 +3973,74 @@ def test_trash_paths_preserves_failure_when_volume_becomes_unreachable(
     assert [failure["path"] for failure in failures] == [str(photo)]
 
 
+def test_trash_paths_preflight_preserves_failure_on_disconnected_mount(
+    monkeypatch, tmp_path,
+):
+    """A mount disconnected BEFORE the preflight must not be reported as
+    already-gone. ``os.path.isfile`` returns False in that case because the
+    underlying stat fails, and previously the preflight would silently mark
+    the path successful and let the caller prune the catalog row for a
+    photo that reappears when the mount comes back.
+    """
+    import app as app_module
+
+    volume = tmp_path / "SMB_Share"
+    volume.mkdir()
+    photo = volume / "bird.NEF"
+    photo.write_bytes(b"raw")
+    photo_path = str(photo)
+
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    monkeypatch.setattr(app_module, "_move_to_volume_trash", lambda _p: False)
+
+    import shutil
+    shutil.rmtree(str(volume))
+
+    called = {"send2trash": False, "finder": False}
+
+    import send2trash
+
+    def unexpected_send2trash(_path):
+        called["send2trash"] = True
+        raise AssertionError("send2trash must not be called for a preflight-detected unreachable mount")
+
+    def unexpected_finder(_paths):
+        called["finder"] = True
+        raise AssertionError("Finder must not be called for a preflight-detected unreachable mount")
+
+    monkeypatch.setattr(send2trash, "send2trash", unexpected_send2trash)
+    monkeypatch.setattr(app_module, "_trash_via_finder", unexpected_finder)
+
+    moved, successful, failures = app_module._trash_paths([photo_path])
+
+    assert moved == 0
+    assert successful == set()
+    assert [failure["path"] for failure in failures] == [photo_path]
+    assert failures[0]["error"] == "Source path is unreachable"
+    assert called["send2trash"] is False
+    assert called["finder"] is False
+
+
+def test_trash_paths_preflight_accepts_already_missing_on_live_volume(
+    monkeypatch, tmp_path,
+):
+    """A file legitimately missing on a still-mounted volume is accepted."""
+    import app as app_module
+
+    folder = tmp_path / "local"
+    folder.mkdir()
+    ghost = folder / "already_gone.NEF"
+
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    monkeypatch.setattr(app_module, "_move_to_volume_trash", lambda _p: False)
+
+    moved, successful, failures = app_module._trash_paths([str(ghost)])
+
+    assert moved == 0
+    assert successful == {str(ghost)}
+    assert failures == []
+
+
 def test_trash_paths_marks_success_when_send2trash_reports_after_move(
     monkeypatch, tmp_path,
 ):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3751,6 +3751,89 @@ def test_trash_via_finder_guarded_off_mac(monkeypatch):
     assert called == [], "osascript must not be spawned off macOS"
 
 
+def test_trash_via_finder_batches_paths_and_sets_timeout(monkeypatch):
+    """Finder fallback uses one bounded AppleScript process for a batch."""
+    import types
+
+    import app as app_module
+
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return types.SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(app_module.subprocess, "run", fake_run)
+    app_module._trash_via_finder(["/Volumes/X/a.NEF", "/Volumes/X/b.NEF"])
+
+    assert len(calls) == 1
+    argv, kwargs = calls[0]
+    assert "/Volumes/X/a.NEF" in argv
+    assert "/Volumes/X/b.NEF" in argv
+    assert "repeat with posixPath in argv" in argv
+    assert kwargs["timeout"] == app_module._FINDER_TRASH_TIMEOUT_SECS
+
+
+def test_move_to_volume_trash_renames_without_finder(monkeypatch, tmp_path):
+    """Mounted-volume fast path performs a same-volume move into .Trashes."""
+    import app as app_module
+
+    volume = tmp_path / "Photography"
+    source_dir = volume / "Raw Files"
+    source_dir.mkdir(parents=True)
+    source = source_dir / "bird.NEF"
+    source.write_bytes(b"raw")
+
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        app_module, "_volume_root_for_path", lambda _path: str(volume),
+    )
+    monkeypatch.setattr(app_module.os, "getuid", lambda: 501)
+
+    assert app_module._move_to_volume_trash(str(source)) is True
+    assert not source.exists()
+    assert (volume / ".Trashes" / "501" / "bird.NEF").read_bytes() == b"raw"
+
+
+def test_trash_paths_batches_finder_fallback_and_retains_timeout_failures(
+    monkeypatch, tmp_path,
+):
+    """Failed send2trash paths share one Finder call and remain retryable."""
+    import subprocess
+
+    import app as app_module
+    import send2trash
+
+    first = tmp_path / "first.NEF"
+    second = tmp_path / "second.NEF"
+    first.write_bytes(b"one")
+    second.write_bytes(b"two")
+
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    monkeypatch.setattr(app_module, "_move_to_volume_trash", lambda _path: False)
+    monkeypatch.setattr(
+        send2trash, "send2trash",
+        lambda _path: (_ for _ in ()).throw(OSError("legacy Trash failed")),
+    )
+    finder_calls = []
+
+    def timeout(paths):
+        finder_calls.append(list(paths))
+        raise subprocess.TimeoutExpired("osascript", 30)
+
+    monkeypatch.setattr(app_module, "_trash_via_finder", timeout)
+    moved, successful, failures = app_module._trash_paths([
+        str(first), str(second),
+    ])
+
+    assert finder_calls == [[str(first), str(second)]]
+    assert moved == 0
+    assert successful == set()
+    assert {failure["path"] for failure in failures} == {str(first), str(second)}
+    assert first.exists() and second.exists()
+
+
 def test_navbar_js_fallbacks_match_python_constants():
     """The hardcoded fallback lists in _navbar.html must mirror the
     canonical Python lists. The navbar's JS uses these fallbacks when

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3796,6 +3796,76 @@ def test_move_to_volume_trash_renames_without_finder(monkeypatch, tmp_path):
     assert (volume / ".Trashes" / "501" / "bird.NEF").read_bytes() == b"raw"
 
 
+def test_move_to_volume_trash_preserves_both_files_on_name_collision(
+    monkeypatch, tmp_path,
+):
+    """Same-named files from different folders must both survive in Trash.
+
+    Regression: the earlier ``lexists`` check followed by ``os.rename`` was a
+    TOCTOU race — two concurrent moves could observe an empty destination and
+    then both rename to the same path, permanently losing one photo. The
+    atomic reservation must assign a unique suffix to the second caller.
+    """
+    import app as app_module
+
+    volume = tmp_path / "Photography"
+    first_dir = volume / "A"
+    second_dir = volume / "B"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    first = first_dir / "bird.NEF"
+    second = second_dir / "bird.NEF"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        app_module, "_volume_root_for_path", lambda _path: str(volume),
+    )
+    monkeypatch.setattr(app_module.os, "getuid", lambda: 501, raising=False)
+
+    assert app_module._move_to_volume_trash(str(first)) is True
+    assert app_module._move_to_volume_trash(str(second)) is True
+
+    trash_dir = volume / ".Trashes" / "501"
+    assert not first.exists()
+    assert not second.exists()
+
+    trashed = sorted(p for p in trash_dir.iterdir() if p.suffix == ".NEF")
+    assert len(trashed) == 2, [p.name for p in trashed]
+    contents = sorted(p.read_bytes() for p in trashed)
+    assert contents == [b"first", b"second"]
+
+
+def test_move_to_volume_trash_removes_placeholder_when_rename_fails(
+    monkeypatch, tmp_path,
+):
+    """A failed ``os.rename`` must not leak the reserved placeholder file."""
+    import app as app_module
+
+    volume = tmp_path / "Photography"
+    source_dir = volume / "Raw"
+    source_dir.mkdir(parents=True)
+    source = source_dir / "bird.NEF"
+    source.write_bytes(b"raw")
+
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        app_module, "_volume_root_for_path", lambda _path: str(volume),
+    )
+    monkeypatch.setattr(app_module.os, "getuid", lambda: 501, raising=False)
+
+    def boom(_src, _dst):
+        raise OSError("rename refused")
+
+    monkeypatch.setattr(app_module.os, "rename", boom)
+
+    assert app_module._move_to_volume_trash(str(source)) is False
+    assert source.exists()
+    trash_dir = volume / ".Trashes" / "501"
+    assert list(trash_dir.iterdir()) == []
+
+
 def test_trash_paths_batches_finder_fallback_and_retains_timeout_failures(
     monkeypatch, tmp_path,
 ):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4076,6 +4076,101 @@ def test_trash_paths_marks_success_when_send2trash_reports_after_move(
     assert failures == []
 
 
+def test_path_confirmed_gone_rejects_stale_mount_point_directory(
+    monkeypatch, tmp_path,
+):
+    """When a managed folder is itself a mount point (e.g. /mnt/photos) and
+    the network volume disconnects, the local mount-point directory can
+    remain on the underlying local filesystem. ``os.path.isdir`` then
+    still returns True even though the actual volume is gone. Compare the
+    pre-op ``st_dev`` snapshot against the post-op device so the file is
+    not falsely accepted as ``gone``.
+    """
+    import app as app_module
+
+    mount_root = tmp_path / "mnt_photos"
+    mount_root.mkdir()
+    photo = mount_root / "bird.NEF"
+    photo.write_bytes(b"raw")
+
+    baseline_dev = app_module._snapshot_parent_device(str(photo))
+    assert baseline_dev is not None
+
+    # The file appears gone (the "disconnect" symptom) but the parent
+    # directory is still stat'able on a different device (the mount point
+    # replaced by the underlying local FS).
+    photo.unlink()
+    real_stat = os.stat
+
+    def stat_with_shifted_dev(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if os.path.normpath(path) == os.path.normpath(str(mount_root)):
+            class _Shifted:
+                st_dev = baseline_dev + 1
+                st_mode = result.st_mode
+            return _Shifted()
+        return result
+
+    monkeypatch.setattr(app_module.os, "stat", stat_with_shifted_dev)
+
+    # Without the snapshot the legacy check accepts the file as gone.
+    assert app_module._path_confirmed_gone(str(photo)) is True
+    # With the snapshot it correctly refuses to accept the change.
+    assert app_module._path_confirmed_gone(
+        str(photo), expected_parent_dev=baseline_dev,
+    ) is False
+
+
+def test_trash_paths_rejects_success_when_mount_replaced_by_local_fs(
+    monkeypatch, tmp_path,
+):
+    """A send2trash that raises after the mount vanished but left the
+    mount-point directory behind must be reported as a failure, not as a
+    successful trash.
+    """
+    import app as app_module
+    import send2trash
+
+    mount_root = tmp_path / "SMB_Share"
+    mount_root.mkdir()
+    photo = mount_root / "bird.NEF"
+    photo.write_bytes(b"raw")
+
+    baseline_dev = os.stat(str(mount_root)).st_dev
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    monkeypatch.setattr(app_module, "_move_to_volume_trash", lambda _p: False)
+
+    real_stat = os.stat
+
+    def mount_disconnect_after_send2trash(path):
+        # Simulate the mount vanishing during send2trash: the file is gone
+        # but the mount-point directory remains, backed by a different
+        # underlying device.
+        os.unlink(path)
+
+        def stat_with_shifted_dev(target, *args, **kwargs):
+            result = real_stat(target, *args, **kwargs)
+            if os.path.normpath(target) == os.path.normpath(str(mount_root)):
+                class _Shifted:
+                    st_dev = baseline_dev + 1
+                    st_mode = result.st_mode
+                return _Shifted()
+            return result
+
+        monkeypatch.setattr(app_module.os, "stat", stat_with_shifted_dev)
+        raise OSError("Network volume unavailable")
+
+    monkeypatch.setattr(
+        send2trash, "send2trash", mount_disconnect_after_send2trash,
+    )
+
+    moved, successful, failures = app_module._trash_paths([str(photo)])
+
+    assert moved == 0
+    assert successful == set()
+    assert [failure["path"] for failure in failures] == [str(photo)]
+
+
 def test_navbar_js_fallbacks_match_python_constants():
     """The hardcoded fallback lists in _navbar.html must mirror the
     canonical Python lists. The navbar's JS uses these fallbacks when

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3789,7 +3789,7 @@ def test_move_to_volume_trash_renames_without_finder(monkeypatch, tmp_path):
     monkeypatch.setattr(
         app_module, "_volume_root_for_path", lambda _path: str(volume),
     )
-    monkeypatch.setattr(app_module.os, "getuid", lambda: 501)
+    monkeypatch.setattr(app_module.os, "getuid", lambda: 501, raising=False)
 
     assert app_module._move_to_volume_trash(str(source)) is True
     assert not source.exists()

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3840,7 +3840,7 @@ def test_move_to_volume_trash_preserves_both_files_on_name_collision(
 def test_move_to_volume_trash_removes_placeholder_when_rename_fails(
     monkeypatch, tmp_path,
 ):
-    """A failed ``os.rename`` must not leak the reserved placeholder file."""
+    """A failed rename must not leak the reserved placeholder file."""
     import app as app_module
 
     volume = tmp_path / "Photography"
@@ -3858,7 +3858,7 @@ def test_move_to_volume_trash_removes_placeholder_when_rename_fails(
     def boom(_src, _dst):
         raise OSError("rename refused")
 
-    monkeypatch.setattr(app_module.os, "rename", boom)
+    monkeypatch.setattr(app_module.os, "replace", boom)
 
     assert app_module._move_to_volume_trash(str(source)) is False
     assert source.exists()
@@ -3883,13 +3883,13 @@ def test_move_to_volume_trash_preserves_committed_rename_after_reported_error(
         app_module, "_volume_root_for_path", lambda _path: str(volume),
     )
     monkeypatch.setattr(app_module.os, "getuid", lambda: 501, raising=False)
-    real_rename = app_module.os.rename
+    real_replace = app_module.os.replace
 
-    def rename_then_report_error(src, dst):
-        real_rename(src, dst)
+    def replace_then_report_error(src, dst):
+        real_replace(src, dst)
         raise OSError("network response lost")
 
-    monkeypatch.setattr(app_module.os, "rename", rename_then_report_error)
+    monkeypatch.setattr(app_module.os, "replace", replace_then_report_error)
 
     assert app_module._move_to_volume_trash(str(source)) is True
     assert not source.exists()

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3866,6 +3866,37 @@ def test_move_to_volume_trash_removes_placeholder_when_rename_fails(
     assert list(trash_dir.iterdir()) == []
 
 
+def test_move_to_volume_trash_preserves_committed_rename_after_reported_error(
+    monkeypatch, tmp_path,
+):
+    """A lost network success response must not unlink the moved photo."""
+    import app as app_module
+
+    volume = tmp_path / "Photography"
+    source_dir = volume / "Raw"
+    source_dir.mkdir(parents=True)
+    source = source_dir / "bird.NEF"
+    source.write_bytes(b"raw")
+
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        app_module, "_volume_root_for_path", lambda _path: str(volume),
+    )
+    monkeypatch.setattr(app_module.os, "getuid", lambda: 501, raising=False)
+    real_rename = app_module.os.rename
+
+    def rename_then_report_error(src, dst):
+        real_rename(src, dst)
+        raise OSError("network response lost")
+
+    monkeypatch.setattr(app_module.os, "rename", rename_then_report_error)
+
+    assert app_module._move_to_volume_trash(str(source)) is True
+    assert not source.exists()
+    trashed = volume / ".Trashes" / "501" / "bird.NEF"
+    assert trashed.read_bytes() == b"raw"
+
+
 def test_trash_paths_batches_finder_fallback_and_retains_timeout_failures(
     monkeypatch, tmp_path,
 ):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3935,6 +3935,79 @@ def test_trash_paths_batches_finder_fallback_and_retains_timeout_failures(
     assert first.exists() and second.exists()
 
 
+def test_trash_paths_preserves_failure_when_volume_becomes_unreachable(
+    monkeypatch, tmp_path,
+):
+    """A disconnected-mid-flight mount must not be reported as success.
+
+    ``os.path.exists`` returning False is ambiguous: it also happens when the
+    underlying stat fails because the mount vanished. Trusting that as
+    "successfully in Trash" would prune the catalog row for a photo that
+    reappears when the mount comes back. When both the file AND its parent
+    directory look absent, treat it as a failure and let the caller retry.
+    """
+    import app as app_module
+    import send2trash
+
+    volume = tmp_path / "SMB_Share"
+    volume.mkdir()
+    photo = volume / "bird.NEF"
+    photo.write_bytes(b"raw")
+
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    monkeypatch.setattr(app_module, "_move_to_volume_trash", lambda _path: False)
+
+    def send2trash_after_disconnect(_path):
+        # Simulate the mount vanishing during send2trash: the call raises and
+        # the entire directory tree is gone.
+        import shutil
+        shutil.rmtree(str(volume))
+        raise OSError("Network volume unavailable")
+
+    monkeypatch.setattr(send2trash, "send2trash", send2trash_after_disconnect)
+
+    moved, successful, failures = app_module._trash_paths([str(photo)])
+
+    assert moved == 0
+    assert successful == set()
+    assert [failure["path"] for failure in failures] == [str(photo)]
+
+
+def test_trash_paths_marks_success_when_send2trash_reports_after_move(
+    monkeypatch, tmp_path,
+):
+    """A live-volume send2trash that raises after the move still succeeds.
+
+    Some Trash APIs commit the move and then raise a post-op error. As long
+    as the file is verifiably absent AND the parent directory is still
+    reachable, honor the requested end state so we don't leave a ghost row.
+    """
+    import app as app_module
+    import send2trash
+
+    folder = tmp_path / "local"
+    folder.mkdir()
+    photo = folder / "bird.NEF"
+    photo.write_bytes(b"raw")
+
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    monkeypatch.setattr(app_module, "_move_to_volume_trash", lambda _path: False)
+
+    def send2trash_committed_then_raises(path):
+        os.remove(path)
+        raise OSError("post-move Trash API glitch")
+
+    monkeypatch.setattr(
+        send2trash, "send2trash", send2trash_committed_then_raises,
+    )
+
+    moved, successful, failures = app_module._trash_paths([str(photo)])
+
+    assert moved == 1
+    assert successful == {str(photo)}
+    assert failures == []
+
+
 def test_navbar_js_fallbacks_match_python_constants():
     """The hardcoded fallback lists in _navbar.html must mirror the
     canonical Python lists. The navbar's JS uses these fallbacks when

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -610,6 +610,63 @@ def test_api_batch_delete_disk_targets_absolute_companion_path(
     assert db.get_photo(photo["id"]) is None
 
 
+def test_api_batch_delete_skips_row_whose_folder_path_changed_mid_delete(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """A concurrent /api/jobs/move-folder must not turn a disk delete into an orphan.
+
+    A folder move keeps each photo's ``folder_id`` and ``filename`` unchanged
+    while renaming ``folders.path``. Comparing only ``(folder_id, filename)``
+    would pass, and the delete would strip the catalog row even though the
+    copied file now lives at the new folder path. The revalidation must also
+    include the resolved folder path.
+    """
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+    original_folder = str(tmp_path / "original")
+    renamed_folder = str(tmp_path / "renamed")
+    fid = db.add_folder(original_folder, name="original")
+    pid = db.add_photo(
+        folder_id=fid, filename="bird.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    os.makedirs(renamed_folder, exist_ok=True)
+    moved_file = os.path.join(renamed_folder, "bird.jpg")
+    Image.new("RGB", (10, 10)).save(moved_file)
+
+    def concurrent_folder_rename_then_trash(paths):
+        # Simulate move-folder committing a new folders.path mid-delete while
+        # keeping folder_id and filename intact — the same photo row now
+        # points at moved_file instead of the resolved original_folder path.
+        db.conn.execute(
+            "UPDATE folders SET path = ? WHERE id = ?",
+            (renamed_folder, fid),
+        )
+        db.conn.commit()
+        return 0, set(paths), []
+
+    monkeypatch.setattr(
+        appmod, "_trash_paths", concurrent_folder_rename_then_trash,
+    )
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [pid],
+        "mode": "disk",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["failed_photo_ids"] == [pid]
+    assert any(
+        entry.get("photo_id") == pid for entry in data["trash_failed"]
+    )
+    row = db.get_photo(pid)
+    assert row is not None, "renamed-folder row must survive a racing disk delete"
+    assert os.path.exists(moved_file), "moved file must not be orphaned"
+
+
 def test_api_batch_delete_companion_failure_does_not_move_primary(
     app_and_db, tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -603,8 +603,14 @@ def test_api_batch_delete_disk_targets_absolute_companion_path(
         "absolute companion path must be trashed as-is, not joined "
         "with folder_path"
     )
-    joined = os.path.join(folder_path, absolute_companion.lstrip(os.sep))
-    assert joined not in all_paths
+    # Only the primary and the absolute companion should be trashed. Any
+    # additional path (e.g. a naively ``os.path.join``-ed variant of the
+    # absolute companion) indicates the code failed to detect that
+    # ``companion_path`` was already absolute.
+    unexpected = set(all_paths) - {primary, absolute_companion}
+    assert not unexpected, (
+        f"unexpected paths trashed alongside primary/companion: {unexpected}"
+    )
     assert not os.path.exists(absolute_companion)
     assert not os.path.exists(primary)
     assert db.get_photo(photo["id"]) is None

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -345,6 +345,144 @@ def test_api_batch_delete_disk_mode(app_and_db, tmp_path):
     assert db.get_photo(pid) is None
 
 
+def test_api_batch_delete_disk_failure_retains_catalog_row(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """A Trash failure leaves both the original and its Vireo row retryable."""
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.get_photos()[0]
+    folder_path = str(tmp_path / "disk_photos")
+    db.conn.execute(
+        "UPDATE folders SET path = ? WHERE id = ?",
+        (folder_path, photo["folder_id"]),
+    )
+    db.conn.commit()
+    os.makedirs(folder_path, exist_ok=True)
+    real_file = os.path.join(folder_path, photo["filename"])
+    Image.new("RGB", (10, 10)).save(real_file)
+
+    def fail_trash(paths):
+        paths = list(paths)
+        return 0, set(), [
+            {"path": path, "error": "SMB Trash unavailable"} for path in paths
+        ]
+
+    monkeypatch.setattr(appmod, "_trash_paths", fail_trash)
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [photo["id"]],
+        "mode": "disk",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["trashed"] == 0
+    assert data["failed_photo_ids"] == [photo["id"]]
+    assert data["trash_failed"][0]["photo_id"] == photo["id"]
+    assert os.path.exists(real_file)
+    assert db.get_photo(photo["id"]) is not None
+
+
+def test_api_batch_delete_disk_partial_failure_deletes_only_successes(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """A mixed filesystem result deletes only successfully trashed rows."""
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+    folder_path = str(tmp_path / "partial")
+    fid = db.add_folder(folder_path, name="partial")
+    success_id = db.add_photo(
+        folder_id=fid, filename="success.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    failed_id = db.add_photo(
+        folder_id=fid, filename="failed.jpg", extension=".jpg",
+        file_size=10, file_mtime=2.0,
+    )
+    os.makedirs(folder_path, exist_ok=True)
+    success_path = os.path.join(folder_path, "success.jpg")
+    failed_path = os.path.join(folder_path, "failed.jpg")
+    Image.new("RGB", (10, 10)).save(success_path)
+    Image.new("RGB", (10, 10)).save(failed_path)
+
+    def partial_trash(paths):
+        paths = list(paths)
+        os.remove(success_path)
+        return 1, {success_path}, [{
+            "path": failed_path, "error": "simulated failure",
+        }]
+
+    monkeypatch.setattr(appmod, "_trash_paths", partial_trash)
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [success_id, failed_id],
+        "mode": "disk",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 1
+    assert data["trashed"] == 1
+    assert data["failed_photo_ids"] == [failed_id]
+    assert db.get_photo(success_id) is None
+    assert db.get_photo(failed_id) is not None
+    assert not os.path.exists(success_path)
+    assert os.path.exists(failed_path)
+
+
+def test_api_batch_delete_companion_failure_does_not_move_primary(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """An untracked companion must succeed before its primary is touched."""
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.get_photos()[0]
+    folder_path = str(tmp_path / "companions")
+    db.conn.execute(
+        "UPDATE folders SET path = ? WHERE id = ?",
+        (folder_path, photo["folder_id"]),
+    )
+    db.conn.execute(
+        "UPDATE photos SET companion_path = 'bird.xmp' WHERE id = ?",
+        (photo["id"],),
+    )
+    db.conn.commit()
+    os.makedirs(folder_path, exist_ok=True)
+    primary = os.path.join(folder_path, photo["filename"])
+    companion = os.path.join(folder_path, "bird.xmp")
+    Image.new("RGB", (10, 10)).save(primary)
+    with open(companion, "w") as f:
+        f.write("sidecar")
+
+    calls = []
+
+    def fail_companion(paths):
+        paths = list(paths)
+        calls.append(paths)
+        return 0, set(), [
+            {"path": path, "error": "sidecar locked"} for path in paths
+        ]
+
+    monkeypatch.setattr(appmod, "_trash_paths", fail_companion)
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [photo["id"]],
+        "mode": "disk",
+        "include_companions": True,
+    })
+
+    assert resp.status_code == 200
+    assert calls == [[companion]], "primary must not be attempted after dependency failure"
+    assert os.path.exists(primary)
+    assert os.path.exists(companion)
+    assert db.get_photo(photo["id"]) is not None
+
+
 def test_api_batch_delete_removes_thumbnails(app_and_db):
     """Deleting a photo removes its thumbnail file."""
     app, db = app_and_db

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -673,6 +673,73 @@ def test_api_batch_delete_skips_row_whose_folder_path_changed_mid_delete(
     assert os.path.exists(moved_file), "moved file must not be orphaned"
 
 
+def test_api_batch_delete_disk_revalidates_companion_pairing_before_delete(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """A concurrent scan that pairs RAW+JPEG must not orphan the JPEG on disk.
+
+    A scan pairing step commits ``UPDATE photos SET companion_path`` on the
+    surviving RAW and ``DELETE FROM photos`` on the merged JPEG row while
+    keeping the RAW's ``(folder_id, filename, folder_path)`` untouched.
+    Comparing only that tuple would still match, and the delete would trash
+    the RAW file + remove the RAW row while never touching the JPEG file —
+    leaving the JPEG on disk with no catalog entry. The revalidation must
+    also include ``companion_path`` so the newly-paired row is skipped and
+    reported retained.
+    """
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+    folder_path = str(tmp_path / "raw_pair")
+    fid = db.add_folder(folder_path, name="raw_pair")
+    raw_id = db.add_photo(
+        folder_id=fid, filename="bird.nef", extension=".nef",
+        file_size=10, file_mtime=1.0,
+    )
+    os.makedirs(folder_path, exist_ok=True)
+    raw_file = os.path.join(folder_path, "bird.nef")
+    jpeg_file = os.path.join(folder_path, "bird.jpg")
+    with open(raw_file, "wb") as f:
+        f.write(b"raw bytes")
+    Image.new("RGB", (10, 10)).save(jpeg_file)
+
+    def concurrent_pair_then_trash(paths):
+        # Emulate scanner pairing committing a new companion_path on the RAW
+        # mid-delete. The (folder_id, filename, folder_path) tuple is
+        # unchanged, but the row now claims the JPEG as its companion and
+        # any real trash step would need to include that file too.
+        db.conn.execute(
+            "UPDATE photos SET companion_path = 'bird.jpg' WHERE id = ?",
+            (raw_id,),
+        )
+        db.conn.commit()
+        return 0, set(paths), []
+
+    monkeypatch.setattr(appmod, "_trash_paths", concurrent_pair_then_trash)
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [raw_id],
+        "mode": "disk",
+        "include_companions": True,
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["failed_photo_ids"] == [raw_id]
+    assert any(
+        entry.get("photo_id") == raw_id for entry in data["trash_failed"]
+    )
+    row = db.get_photo(raw_id)
+    assert row is not None, (
+        "newly-paired row must survive a racing disk delete"
+    )
+    assert row["companion_path"] == "bird.jpg"
+    assert os.path.exists(jpeg_file), (
+        "companion file must not be orphaned by a stale-tuple delete"
+    )
+
+
 def test_api_batch_delete_companion_failure_does_not_move_primary(
     app_and_db, tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -434,6 +434,67 @@ def test_api_batch_delete_disk_partial_failure_deletes_only_successes(
     assert os.path.exists(failed_path)
 
 
+def test_api_batch_delete_skips_row_whose_identity_changed_mid_delete(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """A concurrent move-photos must not turn a disk delete into an orphan.
+
+    The disk-mode trash step reports success when it finds the resolved path
+    already missing — but that "missing" file could have been removed by a
+    concurrent ``/api/jobs/move-photos`` job that ALSO committed a new
+    ``folder_id`` for the same row. Deleting the row by id after the fact
+    would strand the moved file in the destination folder with no catalog
+    entry. Simulate that race by relocating the row inside the trash stub
+    and confirm the catalog row is preserved and reported retained.
+    """
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+    source_folder = str(tmp_path / "source")
+    dest_folder = str(tmp_path / "dest")
+    src_fid = db.add_folder(source_folder, name="source")
+    dst_fid = db.add_folder(dest_folder, name="dest")
+    pid = db.add_photo(
+        folder_id=src_fid, filename="bird.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    os.makedirs(source_folder, exist_ok=True)
+    os.makedirs(dest_folder, exist_ok=True)
+    dest_file = os.path.join(dest_folder, "bird.jpg")
+    Image.new("RGB", (10, 10)).save(dest_file)
+
+    def concurrent_move_then_trash(paths):
+        # Emulate move-photos committing a new folder_id while the trash
+        # stub runs. The source file was already removed by the "move" so
+        # the real trash step (had it run) would treat the path as
+        # successfully absent.
+        db.conn.execute(
+            "UPDATE photos SET folder_id = ? WHERE id = ?",
+            (dst_fid, pid),
+        )
+        db.conn.commit()
+        return 0, set(paths), []
+
+    monkeypatch.setattr(appmod, "_trash_paths", concurrent_move_then_trash)
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [pid],
+        "mode": "disk",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["failed_photo_ids"] == [pid]
+    assert any(
+        entry.get("photo_id") == pid for entry in data["trash_failed"]
+    )
+    row = db.get_photo(pid)
+    assert row is not None, "moved row must survive a racing disk delete"
+    assert row["folder_id"] == dst_fid
+    assert os.path.exists(dest_file), "moved file must not be orphaned"
+
+
 def test_api_batch_delete_companion_failure_does_not_move_primary(
     app_and_db, tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -412,10 +412,14 @@ def test_api_batch_delete_disk_partial_failure_deletes_only_successes(
 
     def partial_trash(paths):
         paths = list(paths)
-        os.remove(success_path)
-        return 1, {success_path}, [{
-            "path": failed_path, "error": "simulated failure",
-        }]
+        successes = {p for p in paths if p == success_path}
+        for p in successes:
+            os.remove(p)
+        failures = [
+            {"path": p, "error": "simulated failure"}
+            for p in paths if p not in successes
+        ]
+        return len(successes), successes, failures
 
     monkeypatch.setattr(appmod, "_trash_paths", partial_trash)
     resp = client.post("/api/batch/delete", json={
@@ -493,6 +497,117 @@ def test_api_batch_delete_skips_row_whose_identity_changed_mid_delete(
     assert row is not None, "moved row must survive a racing disk delete"
     assert row["folder_id"] == dst_fid
     assert os.path.exists(dest_file), "moved file must not be orphaned"
+
+
+def test_api_batch_delete_treats_concurrently_deleted_row_as_completed(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """A row already removed by a racing delete must not resurface as failed.
+
+    Two overlapping delete requests can race — the first commits the row's
+    removal before the second reaches identity revalidation. When the
+    second's SELECT returns nothing for that id, the requested end state
+    already holds; reporting it as ``failed_photo_ids`` would leave the
+    client showing a photo that is absent from both catalog and disk until
+    reload.
+    """
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+    folder_path = str(tmp_path / "raced")
+    fid = db.add_folder(folder_path, name="raced")
+    pid = db.add_photo(
+        folder_id=fid, filename="bird.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0,
+    )
+    os.makedirs(folder_path, exist_ok=True)
+
+    def concurrent_delete_then_trash(paths):
+        # A racing delete finished the same row before revalidation runs.
+        db.conn.execute("DELETE FROM photos WHERE id = ?", (pid,))
+        db.conn.commit()
+        return 0, set(paths), []
+
+    monkeypatch.setattr(appmod, "_trash_paths", concurrent_delete_then_trash)
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [pid],
+        "mode": "disk",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["failed_photo_ids"] == [], (
+        "row that was already deleted must not be reported as failed"
+    )
+    assert data["trash_failed"] == []
+    assert db.get_photo(pid) is None
+
+
+def test_api_batch_delete_disk_targets_absolute_companion_path(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """An absolute ``companion_path`` must not be joined with folder_path.
+
+    ``companion_path`` is stored as either a bare filename (same folder) or
+    an absolute path; joining an absolute path with the folder would silently
+    target the wrong file, either failing the operation or trashing an
+    unrelated photo without ever pruning the correct catalog row.
+    """
+    import app as appmod
+
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.get_photos()[0]
+    folder_path = str(tmp_path / "abs")
+    sidecar_folder = str(tmp_path / "sidecars")
+    db.conn.execute(
+        "UPDATE folders SET path = ? WHERE id = ?",
+        (folder_path, photo["folder_id"]),
+    )
+    absolute_companion = os.path.join(sidecar_folder, "bird.xmp")
+    db.conn.execute(
+        "UPDATE photos SET companion_path = ? WHERE id = ?",
+        (absolute_companion, photo["id"]),
+    )
+    db.conn.commit()
+    os.makedirs(folder_path, exist_ok=True)
+    os.makedirs(sidecar_folder, exist_ok=True)
+    primary = os.path.join(folder_path, photo["filename"])
+    Image.new("RGB", (10, 10)).save(primary)
+    with open(absolute_companion, "w") as f:
+        f.write("sidecar")
+
+    seen_paths = []
+
+    def record_trash(paths):
+        paths = list(paths)
+        seen_paths.append(paths)
+        removed = set()
+        for p in paths:
+            if os.path.isfile(p):
+                os.remove(p)
+                removed.add(p)
+        return len(removed), removed, []
+
+    monkeypatch.setattr(appmod, "_trash_paths", record_trash)
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [photo["id"]],
+        "mode": "disk",
+        "include_companions": True,
+    })
+
+    assert resp.status_code == 200
+    all_paths = [p for call in seen_paths for p in call]
+    assert absolute_companion in all_paths, (
+        "absolute companion path must be trashed as-is, not joined "
+        "with folder_path"
+    )
+    joined = os.path.join(folder_path, absolute_companion.lstrip(os.sep))
+    assert joined not in all_paths
+    assert not os.path.exists(absolute_companion)
+    assert not os.path.exists(primary)
+    assert db.get_photo(photo["id"]) is None
 
 
 def test_api_batch_delete_companion_failure_does_not_move_primary(


### PR DESCRIPTION
Moves files on macOS mounted volumes directly into the per-user Trash, batches and bounds the Finder fallback, and reuses the same path for duplicate cleanup. Disk deletion now retains catalog rows after filesystem failures and removes database/cache state only for successful files, with a corrected permanent-delete retry flow. Adds regression coverage for mounted-volume moves, Finder timeouts, partial failures, and companion safety. Tests: 37 deletion tests, 32 duplicate-cleanup tests, 51 focused integration tests, Python compilation, and Ruff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Trash handling with safer same-volume moves, collision protection, and Finder fallback behavior.
  * Failed or partial deletions now preserve files, catalog entries, and retry options.
  * Lightbox, grids, miss views, and selections retain photos when deletion fails.
  * Batch deletions remove only successfully trashed photos and update controls correctly.
  * Companion-file failures no longer trigger incomplete primary-file deletion.
* **Tests**
  * Added regression coverage for failed, partial, timed-out, and collision-prone Trash operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->