### PR TITLE
Guide users to configure location suggestions

### DIFF
--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -229,6 +229,40 @@ def test_location_review_assigns_a_custom_name_to_coordinate_group(
     ]
 
 
+def test_location_review_missing_google_key_links_to_settings(live_server, page):
+    """The empty suggestion state explains how to enable nearby places."""
+    photo_id = live_server["data"]["photos"][0]
+    with live_server["db"].conn:
+        live_server["db"].conn.execute(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            (33.2550, -116.4050, photo_id),
+        )
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        "photoId => sessionStorage.setItem('vireoLocationReviewSource', "
+        "JSON.stringify({photo_ids: [photoId]}))",
+        photo_id,
+    )
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+
+    prompt = page.locator(".location-review-setup-prompt")
+    expect(prompt).to_contain_text("Enable nearby place suggestions")
+    expect(prompt).to_contain_text("Add a Google Maps API key")
+    expect(prompt.get_by_role("link", name="Open Settings")).to_have_attribute(
+        "href", "/settings#google-maps"
+    )
+    expect(page.locator("#locationReviewSuggestionStatus")).to_have_text(
+        "Setup needed"
+    )
+    expect(
+        page.locator("#locationReviewMapMessage").get_by_role(
+            "link", name="Open Settings"
+        )
+    ).to_have_attribute("href", "/settings#google-maps")
+
+
 def test_location_review_ranks_saved_and_google_places_by_distance(
     live_server, page,
 ):

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -125,6 +125,7 @@ body {
   font-size: 11px;
   box-shadow: 0 3px 12px rgba(0,0,0,.24);
 }
+.location-review-map-message a { color: var(--accent); }
 .location-review-thumbnails {
   display: flex;
   gap: 8px;
@@ -251,6 +252,25 @@ body {
   color: var(--accent);
 }
 .location-review-candidates { display: flex; flex-direction: column; gap: 7px; }
+.location-review-setup-prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border-primary));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-primary));
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.location-review-setup-prompt strong { color: var(--text-primary); font-size: 12px; }
+.location-review-setup-prompt .location-review-button {
+  display: inline-block;
+  margin-top: 2px;
+  text-decoration: none;
+}
 .location-review-candidate {
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr);
@@ -519,6 +539,7 @@ body {
     candidateMarkers: [],
     placesService: null,
     autocomplete: null,
+    googleMapsUnavailableReason: null,
     renderToken: 0,
   };
 
@@ -876,11 +897,23 @@ body {
   function renderCandidates() {
     var container = document.getElementById('locationReviewCandidates');
     var candidates = allCandidates();
+    var setupPrompt = '';
+    if (state.googleMapsUnavailableReason === 'missing_key') {
+      setupPrompt = '<div class="location-review-setup-prompt">' +
+        '<strong>Enable nearby place suggestions</strong>' +
+        '<span>Add a Google Maps API key to find named places near these photos. Previously used locations and custom names still work without one.</span>' +
+        '<a class="location-review-button" href="/settings#google-maps">Open Settings</a></div>';
+    } else if (state.googleMapsUnavailableReason === 'load_failed') {
+      setupPrompt = '<div class="location-review-setup-prompt">' +
+        '<strong>Google Maps could not be loaded</strong>' +
+        '<span>Check the API key and enabled Google Maps APIs in Settings. Previously used locations and custom names are still available.</span>' +
+        '<a class="location-review-button" href="/settings#google-maps">Check Settings</a></div>';
+    }
     if (!candidates.length) {
-      container.innerHTML = '<div class="location-review-loading">No nearby named places found. Search the map or enter a custom friendly name.</div>';
+      container.innerHTML = setupPrompt || '<div class="location-review-loading">No nearby named places found. Search the map or enter a custom friendly name.</div>';
       return;
     }
-    container.innerHTML = candidates.map(function(choice, index) {
+    container.innerHTML = setupPrompt + candidates.map(function(choice, index) {
       var selected = candidateKey(choice) === candidateKey(state.selectedChoice) ? ' selected' : '';
       var badge = choice.kind === 'keyword'
         ? '<span class="location-review-candidate-badge">Previously used</span>' : '';
@@ -1090,7 +1123,13 @@ body {
     renderCandidates();
     renderCandidateMarkers();
     var count = allCandidates().length;
-    document.getElementById('locationReviewSuggestionStatus').textContent = count ? count + ' options' : 'No matches';
+    var status = count ? count + (count === 1 ? ' option' : ' options') : 'No matches';
+    if (state.googleMapsUnavailableReason === 'missing_key') {
+      status = count ? count + (count === 1 ? ' saved option' : ' saved options') : 'Setup needed';
+    } else if (state.googleMapsUnavailableReason === 'load_failed') {
+      status = count ? count + (count === 1 ? ' saved option' : ' saved options') : 'Google Maps unavailable';
+    }
+    document.getElementById('locationReviewSuggestionStatus').textContent = status;
   }
 
   async function loadSuggestions(group, token) {
@@ -1203,8 +1242,11 @@ body {
         message.classList.add('location-review-hidden');
         return;
       } catch (e) {
+        state.googleMapsUnavailableReason = 'load_failed';
         console.warn('Google Maps unavailable; using basic map', e);
       }
+    } else {
+      state.googleMapsUnavailableReason = 'missing_key';
     }
 
     state.mapMode = 'leaflet';
@@ -1224,7 +1266,11 @@ body {
     var terrain = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {attribution: '&copy; OpenTopoMap', maxZoom: 17});
     state.map = L.map('locationReviewMap', {layers: [street]}).setView([20,0], 2);
     L.control.layers({'Street': street, 'Satellite': satellite, 'Terrain': terrain}).addTo(state.map);
-    message.textContent = 'Add a Google Maps key in Settings for nearby park and place suggestions. Saved locations and custom names remain available.';
+    if (state.googleMapsUnavailableReason === 'load_failed') {
+      message.innerHTML = 'Google Maps could not be loaded. <a href="/settings#google-maps">Check Settings</a> to restore nearby suggestions.';
+    } else {
+      message.innerHTML = 'Add a Google Maps key for nearby park and place suggestions. <a href="/settings#google-maps">Open Settings</a>.';
+    }
   }
 
   function bindGoogleSearch() {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -835,7 +835,7 @@
   </div>
 
   <!-- Google Maps -->
-  <div class="section">
+  <div class="section" id="google-maps">
     <div class="section-title">Google Maps</div>
     <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
       Used for location autocomplete and for map-based photo location review, including nearby park and landmark suggestions. Get a key from the Google Cloud console (Maps JavaScript API + Places API + Geocoding API enabled). Add an HTTP referrer restriction in the console (e.g. <code>localhost:8080/*</code>) so the key can only be used from your machine.


### PR DESCRIPTION
## Summary

- Replace the misleading empty suggestion result with actionable setup guidance when Google Maps is not configured.
- Link both the suggestion panel and fallback-map notice directly to the Google Maps API-key section in Settings.
- Distinguish a missing key from a configured Google Maps integration that failed to load, while preserving saved-location and custom-name workflows.

## Validation

- `pytest -q tests/e2e/test_location_review.py` (11 passed)
- `pytest -q vireo/tests/test_app.py::test_templates_jinja_free_except_includes` (1 passed)
