### PR TITLE
Browse: slim batch bar, unified photo action menu

### DIFF
--- a/docs/superpowers/plans/2026-08-02-browse-batch-bar-unified-menu.md
+++ b/docs/superpowers/plans/2026-08-02-browse-batch-bar-unified-menu.md
@@ -1,0 +1,269 @@
+# Browse Slim Batch Bar + Unified Action Menu Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Slim the browse batch bar to high-frequency verbs and make `buildPhotoContextMenu()` the single complete action surface, opened both by right-click and a new More ▾ button.
+
+**Architecture:** All changes live in `vireo/templates/browse.html` (inline HTML + JS, per this codebase's one-file-per-page pattern). The context menu builder gains the five batch-bar-only actions plus the missing purple chip; the batch bar HTML is rewritten to 12 controls + More ▾; More ▾ re-uses the builder via `openContextMenu` with synthetic coordinates. Backend untouched.
+
+**Tech Stack:** Flask/Jinja2 template, vanilla JS, pytest (Flask `test_client` HTML assertions), Playwright for live verification.
+
+**Spec:** `docs/superpowers/specs/2026-08-02-browse-batch-bar-unified-menu-design.md`
+
+---
+
+### Task 1: Failing template test
+
+**Files:**
+- Test: `vireo/tests/test_app.py` (append after `test_browse_page`, ~line 61)
+
+- [ ] **Step 1: Write the failing test**
+
+Follow the existing `test_browse_page` pattern (`app_and_db` fixture, string assertions on the rendered page):
+
+```python
+def test_browse_slim_batch_bar_and_unified_menu(app_and_db):
+    """The batch bar keeps only high-frequency verbs plus More; the photo
+    context menu is the complete action surface (spec
+    docs/superpowers/specs/2026-08-02-browse-batch-bar-unified-menu-design.md)."""
+    app, _ = app_and_db
+    html = app.test_client().get('/browse').get_data(as_text=True)
+    # More button opens the unified menu
+    assert 'id="batchMoreBtn"' in html
+    assert 'function openBatchMoreMenu(' in html
+    # Bar-only buttons that moved into the menu are gone from the bar
+    for removed in ('id="resolveGpsSelectedBtn"', 'id="bestBatchBtn"',
+                    'id="prepareFullResolutionBtn"', 'id="developBtn"'):
+        assert removed not in html
+    # The five former bar-only actions now exist as menu items
+    for label in ("label: 'Review on Map'", "label: 'Develop'",
+                  "label: 'Send to iNaturalist'", "label: 'Make Offline'",
+                  "label: 'Export\\u2026'"):
+        assert label in html
+    # Purple joins the menu's color chip row
+    assert "colorChip('purple'" in html
+    # Kept on the bar: Compare, Review Burst, Export, Delete
+    for kept in ('id="compareBtn"', 'id="burstReviewBtn"',
+                 'onclick="openExportModal()"', 'onclick="batchDelete()"'):
+        assert kept in html
+```
+
+Note: `"label: 'Export\\u2026'"` is Python for the literal JS source text
+`label: 'Export\u2026'` — the menu source spells the ellipsis as the
+six characters `\u2026`, matching the existing `'Add Keyword\u2026'` at
+browse.html:8700. Do NOT write a literal `…` character in the JS source
+(the test asserts on the escaped source text).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_app.py::test_browse_slim_batch_bar_and_unified_menu -v`
+Expected: FAIL on `assert 'id="batchMoreBtn"' in html`
+
+- [ ] **Step 3: Commit the failing test? No — commit test + implementation together per task; proceed to Task 2.**
+
+### Task 2: Context menu becomes the complete surface
+
+**Files:**
+- Modify: `vireo/templates/browse.html:8664-8713` (`buildPhotoContextMenu` return value)
+
+- [ ] **Step 1: Add the purple chip**
+
+In the color chip row (currently lines 8666-8672), append after the blue chip:
+
+```js
+      colorChip('purple', '\u25CF', 'Purple'),
+```
+
+- [ ] **Step 2: Add "Review on Map" after "View on Map"**
+
+After the `View on Map` item (lines 8681-8682) insert:
+
+```js
+    { label: 'Review on Map',
+      onClick: function() { reviewLocationsForSelection(); } },
+```
+
+- [ ] **Step 3: Move "Prepare Full Resolution" out of the review group**
+
+Delete the `Prepare Full Resolution` item from its current spot (lines
+8689-8690, directly after `Review Burst`). It reappears in the new final
+group in Step 5.
+
+- [ ] **Step 4: Add "Develop" after "Edit Photo"**
+
+After the `Edit Photo` item (lines 8692-8693) insert:
+
+```js
+    { label: 'Develop',
+      onClick: function() { developSelected(); } },
+```
+
+- [ ] **Step 5: Add the send/prepare group before Delete**
+
+Replace the tail (currently):
+
+```js
+    { label: 'Adjust Capture Time\u2026', onClick: function() { openCaptureTimeModal(); } },
+    { separator: true },
+    { label: 'Delete', onClick: function() { batchDelete(); } },
+  ]);
+```
+
+with:
+
+```js
+    { label: 'Adjust Capture Time\u2026', onClick: function() { openCaptureTimeModal(); } },
+    { separator: true },
+    { label: 'Send to iNaturalist', onClick: function() { batchSubmitInat(); } },
+    { label: 'Make Offline', onClick: function() { makeAvailableOffline(); } },
+    { label: 'Prepare Full Resolution',
+      onClick: function() { prepareFullResolutionSelection(photoIds); } },
+    { label: 'Export\u2026', onClick: function() { openExportModal(); } },
+    { separator: true },
+    { label: 'Delete', onClick: function() { batchDelete(); } },
+  ]);
+```
+
+All five handlers are the exact functions the batch bar buttons call today
+(`browse.html:1587-1596`); they operate on the current selection, which the
+right-click path has already coerced to match `photoIds`.
+
+- [ ] **Step 6: Run the new test — expect it to still FAIL (bar not yet slimmed), but the menu-label assertions now pass**
+
+Run: `python -m pytest vireo/tests/test_app.py::test_browse_slim_batch_bar_and_unified_menu -v`
+Expected: FAIL, now on `assert 'id="resolveGpsSelectedBtn"' not in html` (or `batchMoreBtn`)
+
+### Task 3: Slim the batch bar + More ▾
+
+**Files:**
+- Modify: `vireo/templates/browse.html:1579-1599` (batch bar HTML)
+- Modify: `vireo/templates/browse.html` (add `openBatchMoreMenu` next to `buildPhotoContextMenu`, ~line 8714)
+
+- [ ] **Step 1: Rewrite the batch bar HTML**
+
+Replace lines 1579-1599 with (keeps each button's existing inline style
+idiom; adds thin separator spans between groups; `Clear` keeps
+`margin-left:auto`):
+
+```html
+    <div id="batchBar" style="display:none;background:var(--bg-secondary);padding:8px 20px;border-bottom:1px solid var(--border-primary);align-items:center;gap:10px;flex-shrink:0;">
+      <span id="batchCount" style="font-size:12px;color:var(--accent);font-weight:600;"></span>
+      <button onclick="batchSetRating(1)" style="background:var(--bg-tertiary);color:var(--warning);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">&#9733;1</button>
+      <button onclick="batchSetRating(3)" style="background:var(--bg-tertiary);color:var(--warning);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">&#9733;3</button>
+      <button onclick="batchSetRating(5)" style="background:var(--bg-tertiary);color:var(--warning);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">&#9733;5</button>
+      <button onclick="batchSetFlag('flagged')" style="background:var(--bg-tertiary);color:var(--accent);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Flag</button>
+      <button onclick="batchSetFlag('rejected')" style="background:var(--bg-tertiary);color:var(--danger);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Reject</button>
+      <span style="width:1px;height:20px;background:var(--border-primary);"></span>
+      <button onclick="batchAddKeyword()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Keyword</button>
+      <button onclick="addToCollection()" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Collection</button>
+      <span style="width:1px;height:20px;background:var(--border-primary);"></span>
+      <button id="compareBtn" onclick="openBrowseCompare()" title="Compare two selected photos side by side" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Compare</button>
+      <button id="burstReviewBtn" onclick="openSelectedInBurstReview()" title="Open selected photos in burst review" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Review Burst</button>
+      <span style="width:1px;height:20px;background:var(--border-primary);"></span>
+      <button onclick="openExportModal()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Export</button>
+      <button onclick="batchDelete()" style="background:var(--danger);color:white;border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;" title="Delete selected photos">Delete</button>
+      <button id="batchMoreBtn" onclick="openBatchMoreMenu(this)" title="All actions for the selected photos — same menu as right-click" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;font-weight:600;">More &#9662;</button>
+      <button onclick="clearSelection()" style="background:none;color:var(--text-faint);border:none;padding:4px 8px;font-size:12px;cursor:pointer;margin-left:auto;">Clear</button>
+    </div>
+```
+
+Removed buttons: `resolveGpsSelectedBtn` (Review on Map), `bestBatchBtn`,
+`prepareFullResolutionBtn`, `developBtn`, iNaturalist, Make Offline. Their
+JS helpers stay: `updateBestBatchButton` (browse.html:5427) and
+`_setPrepareFullResolutionButton` (browse.html:9318) both null-guard, and
+`reviewLocationsForSelection` / `developSelected` / `batchSubmitInat` /
+`makeAvailableOffline` / `openBestBatch` are still called from the menu or
+native Tauri menu.
+
+- [ ] **Step 2: Add `openBatchMoreMenu`**
+
+Directly after `buildPhotoContextMenu`'s closing brace (~line 8713), add:
+
+```js
+// The More button on the batch bar opens the same menu as right-click on a
+// card, anchored under the button. openContextMenu only reads clientX/Y and
+// clamps to the viewport, so a synthetic event object is enough.
+function openBatchMoreMenu(btn) {
+  var ids = getActiveSelection();
+  if (!ids.length) return;
+  var r = btn.getBoundingClientRect();
+  openContextMenu({ clientX: r.left, clientY: r.bottom + 4 },
+                  buildPhotoContextMenu(ids));
+}
+```
+
+- [ ] **Step 3: Run the new test to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_app.py::test_browse_slim_batch_bar_and_unified_menu -v`
+Expected: PASS
+
+- [ ] **Step 4: Run the browse-page regression tests**
+
+Run: `python -m pytest vireo/tests/test_app.py -q -k "browse"`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/templates/browse.html vireo/tests/test_app.py
+git commit -m "Slim browse batch bar; unify actions in the photo context menu"
+```
+
+### Task 4: Full required suite
+
+- [ ] **Step 1: Run the CLAUDE.md required suite**
+
+Run: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q`
+Expected: all pass (note: the local machine has 4 known pre-existing failures
+in the *full* `vireo/tests` sweep, but this required subset is expected
+green; investigate anything that fails here).
+
+### Task 5: Live verification (Playwright)
+
+The user's Vireo instance is running (old code) and holds the
+`~/.vireo/runtime.lock` single-instance slot. The lock and config paths hang
+off `$HOME`, so launch the verify server with an isolated HOME and a copy of
+the real DB:
+
+- [ ] **Step 1: Stage an isolated instance**
+
+```bash
+mkdir -p /tmp/vireo-verify/.vireo
+sqlite3 ~/.vireo/vireo.db ".backup /tmp/vireo-verify/.vireo/vireo.db"
+HOME=/tmp/vireo-verify nohup python3 vireo/app.py --db /tmp/vireo-verify/.vireo/vireo.db --port 8199 > /tmp/vireo-verify/server.log 2>&1 &
+for i in $(seq 1 45); do curl -sf http://localhost:8199/browse -o /dev/null && break; sleep 1; done
+```
+
+- [ ] **Step 2: Drive with Playwright (viewport 1400×1000)**
+
+Script checklist (adapt `/tmp/annotate_browse.py` from this session):
+1. Load `/browse`, wait for `.grid-card` count ≥ 4 (poll; first query takes ~4s). The copied DB carries the user's paused/filter state — if 0 cards, click `.vf-mute` (this is a throwaway DB copy, no restore needed).
+2. Select 4 photos (click + shift-click) → `#batchBar` visible; assert the bar's right edge (Clear button) is inside a 1400px viewport.
+3. Click `#batchMoreBtn` → `.vireo-ctx-menu` appears; assert it contains `Review on Map`, `Develop`, `Send to iNaturalist`, `Make Offline`, `Prepare Full Resolution`, `Export…`, `Delete`, and 6 color chips in the color row.
+4. Press Escape; right-click a selected card → same menu appears.
+5. Click `Export…` in the menu → `#exportOverlay` becomes visible.
+6. Screenshot bar + open menu; check `console` for errors.
+
+Expected: all assertions pass, screenshot shows the slim bar and unified menu.
+
+- [ ] **Step 3: Tear down**
+
+```bash
+lsof -ti:8199 -sTCP:LISTEN | xargs -r kill
+rm -rf /tmp/vireo-verify
+```
+
+### Task 6: PR
+
+- [ ] **Step 1: Push and create the PR**
+
+```bash
+git push -u origin nashville
+gh pr create --base main --title "Browse: slim batch bar, unified photo action menu" --body "<what changed + spec link + test results + screenshots>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+PR body must include: problem (overflow + drift), the More ▾ = right-click
+unification, the five added menu items + purple chip, removed bar buttons,
+test results, and the verification screenshot.

--- a/docs/superpowers/specs/2026-08-02-browse-batch-bar-unified-menu-design.md
+++ b/docs/superpowers/specs/2026-08-02-browse-batch-bar-unified-menu-design.md
@@ -1,0 +1,95 @@
+# Browse: slim batch bar + unified action menu
+
+Date: 2026-08-02
+Status: Approved by user (mockup reviewed 2026-08-02)
+
+## Problem
+
+The browse page has two hand-maintained bulk-action surfaces that have drifted apart:
+
+- The **batch bar** (`#batchBar`, `browse.html:1579-1599`) renders 18 controls in one
+  non-wrapping row. At a 1680px-wide window, Make Offline is squeezed and
+  Export / Delete / Clear are cut off entirely.
+- The **photo context menu** (`buildPhotoContextMenu()`, `browse.html:8633`) has 9
+  actions the bar lacks; the bar has 6 the menu lacks. Neither is a superset, so
+  users must remember which surface holds which verb.
+
+## Design
+
+### 1. `buildPhotoContextMenu()` becomes the single complete action surface
+
+Add the five batch-bar-only actions to the menu, reusing the existing handlers
+verbatim (all already operate on the current selection):
+
+| New menu item | Handler | Placement |
+|---|---|---|
+| `Review on Map` | `reviewLocationsForSelection()` | after `View on Map` |
+| `Develop` | `developSelected()` | after `Edit Photo` |
+| `Send to iNaturalist` | `batchSubmitInat()` | new final group, before Delete |
+| `Make Offline` | `makeAvailableOffline()` | same group |
+| `Export…` | `openExportModal()` | same group, after `Prepare Full Resolution` (which moves into this group) |
+
+Resulting menu order: chip rows (rating / color / flag) · Find Similar, View on
+Map, Review on Map, Compare, Best Batch, Review Burst · Edit Photo, Develop,
+Open in Editor, Reveal in Finder/File Manager, Copy Path · Add Keyword…, Add to
+Collection…, Highlights items, Representative items, Adjust Capture Time… ·
+Send to iNaturalist, Make Offline, Prepare Full Resolution, Export… · Delete.
+
+Also: add the missing **Purple** chip to the color row (`colorChip('purple', …)`).
+Purple already exists in the detail panel, filter bar, and collection rules —
+the context menu is the only surface missing it.
+
+### 2. Batch bar slims to high-frequency verbs
+
+New bar contents, left to right:
+
+```
+N selected · ★1 ★3 ★5 · Flag · Reject | + Keyword · + Collection |
+Compare · Review Burst | Export · Delete · More ▾ · Clear (right-aligned)
+```
+
+Removed from the bar (all reachable via More ▾ / right-click): Review on Map,
+Best Batch, Prepare Full Resolution, Develop, iNaturalist, Make Offline.
+Review Burst stays on the bar by explicit user request. Thin visual separators
+divide the groups shown above.
+
+Existing conditional visibility is unchanged: `Compare` and `Review Burst`
+still appear only for selections of ≥2 (`updateCompareButton`,
+`updateBurstReviewButton`). `updateBestBatchButton` and
+`_setPrepareFullResolutionButton` already null-guard their `getElementById`,
+so removing those buttons is safe; Best Batch gating continues to apply to the
+menu item unchanged, and prepare-full-resolution progress remains visible in
+the bottom jobs panel.
+
+### 3. More ▾ opens the same menu
+
+The `More ▾` button calls `openContextMenu(syntheticEvent,
+buildPhotoContextMenu(getActiveSelection()))`, where `syntheticEvent` is
+`{clientX, clientY}` derived from the button's `getBoundingClientRect()`
+(bottom-left corner) — `openContextMenu` only reads those two fields and
+already clamps to the viewport. One builder, two entry points; the surfaces
+cannot drift again.
+
+Single-photo-only items (Find Similar, View on Map, Edit Photo, Open in
+Editor, Reveal, Develop is selection-based so unaffected) keep their existing
+`disabled` + `disabledHint` behavior when the selection has ≥2 photos.
+
+## Not in scope
+
+- Grouping the menu into submenus (separate suggestion, needs
+  `openContextMenu` submenu support in `_navbar.html`).
+- Changing the bar's ★1/★3/★5 to full 0–5 ratings.
+- Keyboard shortcut for the purple color label.
+- Label unification beyond the touched items (the menu keeps `Add Keyword…` /
+  `Add to Collection…`; the bar keeps `+ Keyword` / `+ Collection`).
+- The native Tauri menu (`_navbar.html`) — it dispatches to the same functions,
+  which are all unchanged.
+
+## Testing
+
+- Backend is untouched; run the CLAUDE.md required suite to confirm no
+  regressions.
+- Playwright drive of the real app: select photos, verify the slimmed bar fits
+  at 1400px, More ▾ opens the menu with the five added items and the purple
+  chip, right-click shows the identical menu, and one added action
+  (e.g. Export…) opens its modal from the menu.

--- a/docs/superpowers/specs/2026-08-02-browse-batch-bar-unified-menu-design.md
+++ b/docs/superpowers/specs/2026-08-02-browse-batch-bar-unified-menu-design.md
@@ -18,8 +18,10 @@ The browse page has two hand-maintained bulk-action surfaces that have drifted a
 
 ### 1. `buildPhotoContextMenu()` becomes the single complete action surface
 
-Add the five batch-bar-only actions to the menu, reusing the existing handlers
-verbatim (all already operate on the current selection):
+Add the five batch-bar-only actions to the menu (the sixth bar-only control,
+Clear, stays on the bar — it manages selection rather than acting on photos),
+reusing the existing handlers verbatim (all already operate on the current
+selection):
 
 | New menu item | Handler | Placement |
 |---|---|---|
@@ -63,7 +65,9 @@ the bottom jobs panel.
 
 ### 3. More ▾ opens the same menu
 
-The `More ▾` button calls `openContextMenu(syntheticEvent,
+`More ▾` is always visible whenever the bar is (the bar itself only renders
+for selections of ≥1, so no separate gating is needed). It calls
+`openContextMenu(syntheticEvent,
 buildPhotoContextMenu(getActiveSelection()))`, where `syntheticEvent` is
 `{clientX, clientY}` derived from the button's `getBoundingClientRect()`
 (bottom-left corner) — `openContextMenu` only reads those two fields and

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -3,6 +3,19 @@ import json
 from playwright.sync_api import expect
 
 
+def click_more_menu_item(page, label):
+    """Open the batch bar's More menu and click the named action.
+
+    The slimmed batch bar keeps only high-frequency verbs; everything else
+    lives in the unified context menu that More opens (same builder as
+    right-click on a card).
+    """
+    page.locator("#batchMoreBtn").click()
+    item = page.locator(".vireo-ctx-menu .vireo-ctx-item", has_text=label)
+    expect(item).to_be_visible()
+    item.click()
+
+
 def disable_infinite_scroll(page):
     page.add_init_script("""
       class NoopIntersectionObserver {
@@ -95,8 +108,8 @@ def test_large_library_uses_bounded_placeholder_runway(live_server, page):
 
 
 def test_single_click_reveals_batch_bar(live_server, page):
-    """Normal-click on one photo reveals the batch bar so Develop/Export/Delete
-    are reachable with a single photo selected.
+    """Normal-click on one photo reveals the batch bar so Export/Delete and
+    the More menu (Develop, etc.) are reachable with a single photo selected.
 
     Regression: updateBatchBar() previously only showed the bar when
     selectedPhotos.size > 1, leaving single-click users with no UI path to
@@ -114,7 +127,38 @@ def test_single_click_reveals_batch_bar(live_server, page):
 
     expect(bar).to_be_visible()
     expect(page.locator("#batchCount")).to_have_text("1 selected")
-    expect(page.locator("#developBtn")).to_be_visible()
+    expect(page.locator("#batchMoreBtn")).to_be_visible()
+    # Develop moved off the bar into the unified More menu; it must still be
+    # reachable for a single-photo selection.
+    page.locator("#batchMoreBtn").click()
+    expect(
+        page.locator(".vireo-ctx-menu .vireo-ctx-item", has_text="Develop")
+    ).to_be_visible()
+    page.keyboard.press("Escape")
+
+
+def test_more_menu_scrolls_within_short_viewport(live_server, page):
+    """The unified action menu is tall; at Tauri's 600px minimum window
+    height it must scroll within the viewport instead of rendering lower
+    actions (Prepare Full Resolution, Export, Delete) off-screen where they
+    cannot be clicked.
+    """
+    page.set_viewport_size({"width": 1100, "height": 600})
+    page.goto(f"{live_server['url']}/browse")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    page.locator("#batchMoreBtn").click()
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    box = menu.bounding_box()
+    assert box["y"] >= 0
+    assert box["y"] + box["height"] <= 600
+
+    delete_item = page.locator(".vireo-ctx-menu .vireo-ctx-item", has_text="Delete")
+    delete_item.scroll_into_view_if_needed()
+    expect(delete_item).to_be_visible()
 
 
 def test_prepare_full_resolution_uses_active_browse_selection(live_server, page):
@@ -149,16 +193,12 @@ def test_prepare_full_resolution_uses_active_browse_selection(live_server, page)
     selected_id = int(first.get_attribute("data-id"))
     first.click()
 
-    button = page.locator("#prepareFullResolutionBtn")
-    expect(button).to_be_visible()
-    button.click()
+    click_more_menu_item(page, "Prepare Full Resolution")
 
     page.wait_for_function(
         "() => window._prepareFullResolutionJobId === null"
     )
     assert submitted == [{"photo_ids": [selected_id]}]
-    expect(button).to_be_enabled()
-    expect(button).to_have_text("Prepare Full Resolution")
 
 
 def test_prepare_full_resolution_surfaces_fatal_job_failure(live_server, page):
@@ -186,7 +226,7 @@ def test_prepare_full_resolution_surfaces_fatal_job_failure(live_server, page):
     page.goto(f"{live_server['url']}/browse")
     page.locator(".grid-card").first.wait_for(state="visible")
     page.locator(".grid-card").first.click()
-    page.locator("#prepareFullResolutionBtn").click()
+    click_more_menu_item(page, "Prepare Full Resolution")
 
     page.wait_for_function(
         "() => window._prepareFullResolutionJobId === null"
@@ -222,7 +262,7 @@ def test_prepare_full_resolution_summarizes_partial_failure(live_server, page):
     page.goto(f"{live_server['url']}/browse")
     page.locator(".grid-card").first.wait_for(state="visible")
     page.locator(".grid-card").first.click()
-    page.locator("#prepareFullResolutionBtn").click()
+    click_more_menu_item(page, "Prepare Full Resolution")
 
     page.wait_for_function(
         "() => window._prepareFullResolutionJobId === null"

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -161,6 +161,28 @@ def test_more_menu_scrolls_within_short_viewport(live_server, page):
     expect(delete_item).to_be_visible()
 
 
+def test_batch_bar_wraps_at_minimum_window_width(live_server, page):
+    """At Tauri's 800px minimum window width the fixed sidebar leaves ~533px
+    of content width. The batch bar must wrap rather than clip, so More —
+    the entry point for every action removed from the bar — stays reachable.
+    """
+    page.set_viewport_size({"width": 800, "height": 600})
+    page.goto(f"{live_server['url']}/browse")
+    first = page.locator(".grid-card").first
+    first.wait_for(state="visible")
+    first.click()
+
+    more = page.locator("#batchMoreBtn")
+    expect(more).to_be_visible()
+    box = more.bounding_box()
+    assert box["x"] >= 0
+    assert box["x"] + box["width"] <= 800
+
+    more.click()
+    expect(page.locator(".vireo-ctx-menu")).to_be_visible()
+    page.keyboard.press("Escape")
+
+
 def test_prepare_full_resolution_uses_active_browse_selection(live_server, page):
     submitted = []
 

--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -536,9 +536,12 @@ def test_browse_review_on_map_opens_the_selected_photos(live_server, page):
         photo_id,
     )
 
-    button = page.locator("#resolveGpsSelectedBtn")
-    expect(button).to_have_text("Review on Map")
-    button.click()
+    # Review on Map moved off the slimmed batch bar into the unified More
+    # menu (same builder as right-click on a card).
+    page.locator("#batchMoreBtn").click()
+    item = page.locator(".vireo-ctx-menu .vireo-ctx-item", has_text="Review on Map")
+    expect(item).to_be_visible()
+    item.click()
 
     page.wait_for_url("**/locations/review?source=selection")
     expect(page.locator("#locationReviewGroupTitle")).to_have_text("1 photo")

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1617,6 +1617,10 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   border: 1px solid var(--border-secondary);
   border-radius: 6px; padding: 4px 0;
   min-width: 180px;
+  /* On short viewports (Tauri's 600px minimum) a long menu can exceed the
+     window; openContextMenu only repositions, so scroll instead of clip. */
+  max-height: calc(100vh - 8px);
+  overflow-y: auto;
   box-shadow: 0 4px 16px rgba(0,0,0,0.4);
   font-size: 13px; color: var(--text-primary);
   user-select: none;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1576,7 +1576,7 @@ body.sidebar-resizing {
     <div class="day-tooltip" id="dayTooltip"></div>
 
     <!-- Batch Action Bar -->
-    <div id="batchBar" style="display:none;background:var(--bg-secondary);padding:8px 20px;border-bottom:1px solid var(--border-primary);align-items:center;gap:10px;flex-shrink:0;">
+    <div id="batchBar" style="display:none;background:var(--bg-secondary);padding:8px 20px;border-bottom:1px solid var(--border-primary);align-items:center;gap:10px;flex-shrink:0;flex-wrap:wrap;">
       <span id="batchCount" style="font-size:12px;color:var(--accent);font-weight:600;"></span>
       <button onclick="batchSetRating(1)" style="background:var(--bg-tertiary);color:var(--warning);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">&#9733;1</button>
       <button onclick="batchSetRating(3)" style="background:var(--bg-tertiary);color:var(--warning);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">&#9733;3</button>

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1583,18 +1583,16 @@ body.sidebar-resizing {
       <button onclick="batchSetRating(5)" style="background:var(--bg-tertiary);color:var(--warning);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">&#9733;5</button>
       <button onclick="batchSetFlag('flagged')" style="background:var(--bg-tertiary);color:var(--accent);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Flag</button>
       <button onclick="batchSetFlag('rejected')" style="background:var(--bg-tertiary);color:var(--danger);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Reject</button>
+      <span style="width:1px;height:20px;background:var(--border-primary);"></span>
       <button onclick="batchAddKeyword()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Keyword</button>
-      <button id="resolveGpsSelectedBtn" onclick="reviewLocationsForSelection()" title="Review selected photo coordinates on a map and assign friendly place names" style="background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Review on Map</button>
       <button onclick="addToCollection()" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Collection</button>
+      <span style="width:1px;height:20px;background:var(--border-primary);"></span>
       <button id="compareBtn" onclick="openBrowseCompare()" title="Compare two selected photos side by side" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Compare</button>
-      <button id="bestBatchBtn" onclick="openBestBatch()" title="Find and rank neighboring frames around the selected photo" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Best Batch</button>
       <button id="burstReviewBtn" onclick="openSelectedInBurstReview()" title="Open selected photos in burst review" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Review Burst</button>
-      <button id="prepareFullResolutionBtn" onclick="prepareFullResolutionSelection()" title="Cache originals and full-resolution renders before inspecting detail" style="background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Prepare Full Resolution</button>
-      <button id="developBtn" onclick="developSelected()" title="Develop selected RAW photos with darktable" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Develop</button>
-      <button onclick="batchSubmitInat()" style="background:var(--bg-tertiary);color:#74ac00;border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">iNaturalist</button>
-      <button onclick="makeAvailableOffline()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Make Offline</button>
+      <span style="width:1px;height:20px;background:var(--border-primary);"></span>
       <button onclick="openExportModal()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Export</button>
       <button onclick="batchDelete()" style="background:var(--danger);color:white;border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;" title="Delete selected photos">Delete</button>
+      <button id="batchMoreBtn" onclick="openBatchMoreMenu(this)" title="All actions for the selected photos — same menu as right-click" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;font-weight:600;">More &#9662;</button>
       <button onclick="clearSelection()" style="background:none;color:var(--text-faint);border:none;padding:4px 8px;font-size:12px;cursor:pointer;margin-left:auto;">Clear</button>
     </div>
 
@@ -8669,6 +8667,7 @@ function buildPhotoContextMenu(photoIds) {
       colorChip('yellow', '\u25CF', 'Yellow'),
       colorChip('green', '\u25CF', 'Green'),
       colorChip('blue', '\u25CF', 'Blue'),
+      colorChip('purple', '\u25CF', 'Purple'),
     ] },
     { chips: [
       flagChip('flagged', '\u2691', 'Flag as pick'),
@@ -8680,17 +8679,19 @@ function buildPhotoContextMenu(photoIds) {
       onClick: function() { if (typeof findSimilar === 'function') findSimilar(photoIds[0]); } },
     { label: 'View on Map', disabled: !one, disabledHint: hint,
       onClick: function() { viewPhotoOnMap(photoIds[0]); } },
+    { label: 'Review on Map',
+      onClick: function() { reviewLocationsForSelection(); } },
     { label: 'Compare', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openBrowseCompare(); } },
     { label: 'Best Batch',
       onClick: function() { openBestBatchForIds(photoIds, photoIds[0]); } },
     { label: 'Review Burst', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openSelectedInBurstReview(); } },
-    { label: 'Prepare Full Resolution',
-      onClick: function() { prepareFullResolutionSelection(photoIds); } },
     { separator: true },
     { label: 'Edit Photo', disabled: !one, disabledHint: hint,
       onClick: function() { openPhotoEditor(photoIds[0]); } },
+    { label: 'Develop',
+      onClick: function() { developSelected(); } },
   ].concat(buildOpenInEditorMenuItems(photoIds)).concat([
     { label: window.VIREO_REVEAL_LABEL, disabled: !one, disabledHint: hint,
       onClick: function() { revealPhoto(photoIds[0]); } },
@@ -8708,8 +8709,25 @@ function buildPhotoContextMenu(photoIds) {
   })).concat([
     { label: 'Adjust Capture Time\u2026', onClick: function() { openCaptureTimeModal(); } },
     { separator: true },
+    { label: 'Send to iNaturalist', onClick: function() { batchSubmitInat(); } },
+    { label: 'Make Offline', onClick: function() { makeAvailableOffline(); } },
+    { label: 'Prepare Full Resolution',
+      onClick: function() { prepareFullResolutionSelection(photoIds); } },
+    { label: 'Export\u2026', onClick: function() { openExportModal(); } },
+    { separator: true },
     { label: 'Delete', onClick: function() { batchDelete(); } },
   ]);
+}
+
+// The More button on the batch bar opens the same menu as right-click on a
+// card, anchored under the button. openContextMenu only reads clientX/Y and
+// clamps to the viewport, so a synthetic event object is enough.
+function openBatchMoreMenu(btn) {
+  var ids = getActiveSelection();
+  if (!ids.length) return;
+  var r = btn.getBoundingClientRect();
+  openContextMenu({ clientX: r.left, clientY: r.bottom + 4 },
+                  buildPhotoContextMenu(ids));
 }
 
 // Document-level delegation: grids re-render on sort/filter/scroll, so

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -86,6 +86,19 @@ def test_browse_slim_batch_bar_and_unified_menu(app_and_db):
         assert kept in html
 
 
+def test_shared_context_menu_scrolls_within_viewport(app_and_db):
+    """The unified action menu can exceed the viewport height at Tauri's
+    supported 600px minimum. Without a max-height + overflow-y fallback,
+    openContextMenu's position clamp can only pin the top edge, leaving
+    lower entries (Prepare Full Resolution, Export, Delete) off-screen and
+    unclickable after their batch-bar shortcuts were removed."""
+    app, _ = app_and_db
+    html = app.test_client().get('/browse').get_data(as_text=True)
+    assert '.vireo-ctx-menu' in html
+    assert 'max-height: calc(100vh - 8px)' in html
+    assert 'overflow-y: auto' in html
+
+
 def test_browse_discloses_raw_jpeg_pairs_and_offers_source_switch(app_and_db):
     """The paired-file behavior must be discoverable in Browse rather than
     existing only as an internal ``companion_path`` or delete-dialog detail."""

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -60,6 +60,32 @@ def test_browse_page(app_and_db):
     ) == 5
 
 
+def test_browse_slim_batch_bar_and_unified_menu(app_and_db):
+    """The batch bar keeps only high-frequency verbs plus More; the photo
+    context menu is the complete action surface (spec
+    docs/superpowers/specs/2026-08-02-browse-batch-bar-unified-menu-design.md)."""
+    app, _ = app_and_db
+    html = app.test_client().get('/browse').get_data(as_text=True)
+    # More button opens the unified menu
+    assert 'id="batchMoreBtn"' in html
+    assert 'function openBatchMoreMenu(' in html
+    # Bar-only buttons that moved into the menu are gone from the bar
+    for removed in ('id="resolveGpsSelectedBtn"', 'id="bestBatchBtn"',
+                    'id="prepareFullResolutionBtn"', 'id="developBtn"'):
+        assert removed not in html
+    # The five former bar-only actions now exist as menu items
+    for label in ("label: 'Review on Map'", "label: 'Develop'",
+                  "label: 'Send to iNaturalist'", "label: 'Make Offline'",
+                  "label: 'Export\\u2026'"):
+        assert label in html
+    # Purple joins the menu's color chip row
+    assert "colorChip('purple'" in html
+    # Kept on the bar: Compare, Review Burst, Export, Delete
+    for kept in ('id="compareBtn"', 'id="burstReviewBtn"',
+                 'onclick="openExportModal()"', 'onclick="batchDelete()"'):
+        assert kept in html
+
+
 def test_browse_discloses_raw_jpeg_pairs_and_offers_source_switch(app_and_db):
     """The paired-file behavior must be discoverable in Browse rather than
     existing only as an internal ``companion_path`` or delete-dialog detail."""


### PR DESCRIPTION
## Problem

The browse page had two hand-maintained bulk-action surfaces that drifted apart:

- The **batch bar** packed 18 controls into one non-wrapping row — at a 1680px window, Make Offline was squeezed and Export / Delete / Clear were cut off entirely.
- The **photo context menu** had 9 actions the bar lacked; the bar had 6 the menu lacked. Neither was a superset, so users had to remember which surface held which verb.

## What changed

**`buildPhotoContextMenu()` is now the single complete action surface.** It gains the five former bar-only actions, reusing the exact handlers the bar buttons called: Review on Map (`reviewLocationsForSelection`), Develop (`developSelected`), Send to iNaturalist (`batchSubmitInat`), Make Offline (`makeAvailableOffline`), and Export… (`openExportModal`). Prepare Full Resolution moves into the new send/prepare group. The color chip row also gains the missing **Purple** chip (purple already existed in the detail panel, filter bar, and collection rules — the menu was the only surface without it).

**The batch bar slims to high-frequency verbs:** `N selected · ★1 ★3 ★5 · Flag · Reject | + Keyword · + Collection | Compare · Review Burst | Export · Delete · More ▾ · Clear`, with thin separators between groups. Removed buttons: Review on Map, Best Batch, Prepare Full Resolution, Develop, iNaturalist, Make Offline — all still one click away.

**More ▾ opens the same menu as right-click** — it calls `buildPhotoContextMenu(getActiveSelection())` through `openContextMenu` with synthetic coordinates anchored under the button. One builder, two entry points; the surfaces cannot drift again.

Removed-button JS helpers are untouched: `updateBestBatchButton` and `_setPrepareFullResolutionButton` null-guard their lookups, and every handler is still called from the menu or the native Tauri menu.

Spec: `docs/superpowers/specs/2026-08-02-browse-batch-bar-unified-menu-design.md` (committed in this PR, reviewed + user-approved mockup).

## Tests

- New template test `test_browse_slim_batch_bar_and_unified_menu` (asserts More button + menu presence, removed bar buttons, five new menu labels, purple chip, kept buttons).
- Required suite: `tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py` → **2063 passed, 14 skipped, 1 failed** — the failure (`test_api_exiftool_status_reports_missing`) also fails on `origin/main` on this machine (ExifTool is installed locally; test expects it missing). Not a regression.
- Playwright drive of a live isolated instance (copy of a real 4,833-photo library): 22/22 checks passed — bar fits at 1400px, removed IDs absent, More ▾ menu contains all added items + 6 color chips, right-click menu is byte-identical to the More menu, Export… opens the export modal, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)