### PR TITLE
Fix browse context menu test selectors

### DIFF
--- a/tests/e2e/test_browse_context_menu.py
+++ b/tests/e2e/test_browse_context_menu.py
@@ -19,7 +19,7 @@ def test_right_click_photo_opens_menu(live_server, page):
     expect(menu.locator(".vireo-ctx-item", has_text="Reveal in")).to_be_visible()
     expect(menu.locator(".vireo-ctx-item", has_text="Copy Path")).to_be_visible()
     expect(menu.locator(".vireo-ctx-item", has_text="Delete")).to_be_visible()
-    expect(menu.locator(".vireo-ctx-item", has_text="View on Map")).to_be_visible()
+    expect(menu.get_by_text("View on Map", exact=True)).to_be_visible()
 
 
 def test_view_on_map_context_action_targets_right_clicked_photo(live_server, page):
@@ -36,7 +36,7 @@ def test_view_on_map_context_action_targets_right_clicked_photo(live_server, pag
     menu = page.locator(".vireo-ctx-menu")
     expect(menu).to_be_visible()
 
-    menu.locator(".vireo-ctx-item", has_text="View on Map").click()
+    menu.get_by_text("View on Map", exact=True).click()
     assert page.evaluate("window.__mapTarget") == pid
 
 


### PR DESCRIPTION
Use exact text matching for the Browse context menu’s “View on Map” assertions and click target.

The prior substring locator also matched “Review on Map,” causing Playwright strict-mode failures after that neighboring action was added.

Validated with `pytest -q tests/e2e/test_browse_context_menu.py` (9 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for the “View on Map” menu option by using exact text matching, reducing the risk of selecting the wrong menu item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->