### PR TITLE
Cancel obsolete Work Locally preflight scans

### DIFF
--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -86,6 +86,7 @@ def local_copy_preflight(
     vireo_dir: str,
     *,
     destination_bases: dict[int, str] | None = None,
+    cancel_check=None,
 ) -> dict:
     """Measure selected sources and capacity on their destination volumes."""
     destination_bases = destination_bases or {}
@@ -93,6 +94,8 @@ def local_copy_preflight(
     volumes_by_device: dict[int, dict] = {}
 
     for raw_root_id in root_folder_ids:
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
         root_folder_id = int(raw_root_id)
         row = db.conn.execute(
             "SELECT path FROM folders WHERE id=?", (root_folder_id,)
@@ -104,7 +107,11 @@ def local_copy_preflight(
         if local_base is None:
             local_base = str(default_local_base(vireo_dir, root_folder_id))
         local_path = local_path_for_base(local_base, root_folder_id, source_path)
-        total_files, total_bytes, estimated_bytes = source_tree_size(source_path)
+        total_files, total_bytes, estimated_bytes = source_tree_size(
+            source_path, cancel_check=cancel_check
+        )
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
         space = destination_disk_space(local_path)
         device = int(space["device"])
         volume = volumes_by_device.setdefault(

--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -112,7 +112,7 @@ def local_copy_preflight(
         )
         if cancel_check and cancel_check():
             raise LocalWorkspaceCancelled("Folder scan cancelled")
-        space = destination_disk_space(local_path)
+        space = destination_disk_space(local_path, cancel_check=cancel_check)
         device = int(space["device"])
         volume = volumes_by_device.setdefault(
             device,

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -505,6 +505,8 @@ def _walk_entries(root: str, *, cancel_check=None):
         if cancel_check and cancel_check():
             raise LocalWorkspaceCancelled("Folder scan cancelled")
         current_st = os.lstat(dirpath)
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
         if directory_st is not None:
             yield _relative(dirpath, root), dirpath, current_st
         elif not stat.S_ISDIR(current_st.st_mode):

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -101,7 +101,7 @@ def local_space_reserve(total_bytes: int) -> int:
     return min(LOCAL_MAX_RESERVE_BYTES, max(LOCAL_RESERVE_BYTES, proportional))
 
 
-def destination_disk_space(path: str | Path) -> dict:
+def destination_disk_space(path: str | Path, *, cancel_check=None) -> dict:
     """Return capacity details for the volume containing ``path``.
 
     Destination folders commonly do not exist yet. Walk up to the closest
@@ -110,13 +110,21 @@ def destination_disk_space(path: str | Path) -> dict:
     """
     requested = Path(path).expanduser()
     probe = requested
-    while not os.path.lexists(probe):
+    while True:
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
+        if os.path.lexists(probe):
+            break
         parent = probe.parent
         if parent == probe:
             break
         probe = parent
+    if cancel_check and cancel_check():
+        raise LocalWorkspaceCancelled("Folder scan cancelled")
     try:
         usage = shutil.disk_usage(probe)
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
         device = os.stat(probe).st_dev
     except OSError as exc:
         raise LocalWorkspaceError(
@@ -131,14 +139,20 @@ def destination_disk_space(path: str | Path) -> dict:
     }
 
 
-def destination_case_insensitive(path: str | Path) -> bool:
+def destination_case_insensitive(path: str | Path, *, cancel_check=None) -> bool:
     """Probe whether the existing volume containing ``path`` folds case."""
     base = Path(path).expanduser()
-    while not base.is_dir():
+    while True:
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
+        if base.is_dir():
+            break
         parent = base.parent
         if parent == base:
             break
         base = parent
+    if cancel_check and cancel_check():
+        raise LocalWorkspaceCancelled("Folder scan cancelled")
     try:
         fd, probe = tempfile.mkstemp(prefix="VireoCaseProbe-", dir=str(base))
     except OSError as exc:
@@ -147,8 +161,13 @@ def destination_case_insensitive(path: str | Path) -> bool:
         ) from exc
     os.close(fd)
     try:
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
         lower = os.path.join(os.path.dirname(probe), os.path.basename(probe).lower())
-        return lower != probe and os.path.exists(lower)
+        result = lower != probe and os.path.exists(lower)
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
+        return result
     finally:
         with suppress(FileNotFoundError):
             os.unlink(probe)

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -504,7 +504,10 @@ def _walk_entries(root: str, *, cancel_check=None):
         dirpath, directory_st = pending.pop()
         if cancel_check and cancel_check():
             raise LocalWorkspaceCancelled("Folder scan cancelled")
-        current_st = os.lstat(dirpath)
+        try:
+            current_st = os.lstat(dirpath)
+        except OSError as error:
+            _raise_walk_error(error)
         if cancel_check and cancel_check():
             raise LocalWorkspaceCancelled("Folder scan cancelled")
         if directory_st is not None:

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -565,6 +565,13 @@ def _walk_entries(root: str, *, cancel_check=None):
                         raise LocalWorkspaceError(
                             f"Workspace root changed during directory scan: {root}"
                         ) from error
+                    if stat.S_ISDIR(swapped_st.st_mode):
+                        # A transient open failure followed by a directory
+                        # lstat is ambiguous: skipping it would silently omit
+                        # the entire subtree from size checks and staging.
+                        raise LocalWorkspaceError(
+                            f"Workspace directory changed during directory scan: {dirpath}"
+                        ) from error
                     yield _relative(dirpath, root), dirpath, swapped_st
                     continue
                 _raise_walk_error(error)

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -184,7 +184,7 @@ def _validated_tree_entries(source: str, *, cancel_check=None):
         raise LocalWorkspaceError(f"Workspace folder is unavailable: {source}")
 
     try:
-        for rel, full, st in _walk_entries(source):
+        for rel, full, st in _walk_entries(source, cancel_check=cancel_check):
             # Filesystem calls on network volumes may take a long time and
             # cannot be interrupted while the kernel is servicing them. Check
             # immediately after each one returns so an obsolete preflight does
@@ -467,13 +467,20 @@ def _dest_case_insensitive(local_base: Path) -> bool:
     return destination_case_insensitive(base)
 
 
-def _walk_entries(root: str):
+def _walk_entries(root: str, *, cancel_check=None):
     """Yield ``(rel, full, lstat)`` for every entry under root.
 
     Directories are included (so callers can recreate structure, including
     empty directories); directory symlinks are yielded as link entries and
     not descended into. Each entry is stat'ed exactly once here — callers
     classify via the yielded stat instead of re-statting.
+
+    ``cancel_check`` is checked before every ``os.lstat`` on a child entry.
+    ``os.walk`` batches the per-child ``os.lstat`` calls (via the inner
+    ``for dirname in dirnames`` classification), and on a slow network volume
+    those blocking calls are what a cancellation actually needs to interrupt
+    — waiting for the whole batch before a caller-level check would let a
+    cancelled scan continue through every child of a large directory.
     """
     for dirpath, dirnames, filenames in os.walk(root, followlinks=False, onerror=_raise_walk_error):
         rel_dir = _relative(dirpath, root)
@@ -481,6 +488,8 @@ def _walk_entries(root: str):
             yield rel_dir, dirpath, os.lstat(dirpath)
         kept = []
         for dirname in dirnames:
+            if cancel_check and cancel_check():
+                raise LocalWorkspaceCancelled("Folder scan cancelled")
             full = os.path.join(dirpath, dirname)
             st = os.lstat(full)
             if stat.S_ISLNK(st.st_mode):
@@ -489,6 +498,8 @@ def _walk_entries(root: str):
                 kept.append(dirname)
         dirnames[:] = kept
         for filename in filenames:
+            if cancel_check and cancel_check():
+                raise LocalWorkspaceCancelled("Folder scan cancelled")
             full = os.path.join(dirpath, filename)
             yield rel_dir and os.path.join(rel_dir, filename) or filename, full, os.lstat(full)
 

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -475,33 +475,44 @@ def _walk_entries(root: str, *, cancel_check=None):
     not descended into. Each entry is stat'ed exactly once here — callers
     classify via the yielded stat instead of re-statting.
 
-    ``cancel_check`` is checked before every ``os.lstat`` on a child entry.
-    ``os.walk`` batches the per-child ``os.lstat`` calls (via the inner
-    ``for dirname in dirnames`` classification), and on a slow network volume
-    those blocking calls are what a cancellation actually needs to interrupt
-    — waiting for the whole batch before a caller-level check would let a
-    cancelled scan continue through every child of a large directory.
+    ``cancel_check`` is checked between ``scandir`` entries and before every
+    ``os.lstat``. On a slow network volume, either operation may block, but the
+    scan stops as soon as the current filesystem call returns instead of
+    letting a directory-wide batch finish first.
     """
-    for dirpath, dirnames, filenames in os.walk(root, followlinks=False, onerror=_raise_walk_error):
-        rel_dir = _relative(dirpath, root)
-        if rel_dir:
-            yield rel_dir, dirpath, os.lstat(dirpath)
-        kept = []
-        for dirname in dirnames:
+    pending = [(root, None)]
+    while pending:
+        dirpath, directory_st = pending.pop()
+        if directory_st is not None:
+            yield _relative(dirpath, root), dirpath, directory_st
+        child_directories = []
+        try:
+            entries = os.scandir(dirpath)
+            with entries:
+                iterator = iter(entries)
+                while True:
+                    if cancel_check and cancel_check():
+                        raise LocalWorkspaceCancelled("Folder scan cancelled")
+                    try:
+                        entry = next(iterator)
+                    except StopIteration:
+                        break
+                    if cancel_check and cancel_check():
+                        raise LocalWorkspaceCancelled("Folder scan cancelled")
+                    full = entry.path
+                    st = os.lstat(full)
+                    if stat.S_ISDIR(st.st_mode):
+                        child_directories.append((full, st))
+                    else:
+                        yield _relative(full, root), full, st
+        except OSError as error:
+            _raise_walk_error(error)
+
+        # Stack order preserves scandir's depth-first ordering.
+        for child in reversed(child_directories):
             if cancel_check and cancel_check():
                 raise LocalWorkspaceCancelled("Folder scan cancelled")
-            full = os.path.join(dirpath, dirname)
-            st = os.lstat(full)
-            if stat.S_ISLNK(st.st_mode):
-                yield _relative(full, root), full, st
-            else:
-                kept.append(dirname)
-        dirnames[:] = kept
-        for filename in filenames:
-            if cancel_check and cancel_check():
-                raise LocalWorkspaceCancelled("Folder scan cancelled")
-            full = os.path.join(dirpath, filename)
-            yield rel_dir and os.path.join(rel_dir, filename) or filename, full, os.lstat(full)
+            pending.append(child)
 
 
 def _collect_source_entries(roots: list[dict], local_base: Path) -> tuple[dict[int, list], int, int]:

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -20,6 +20,7 @@ began publishing to the source and did not finish).
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import os
@@ -493,11 +494,19 @@ def _walk_entries(root: str, *, cancel_check=None):
     empty directories); directory symlinks are yielded as link entries and
     not descended into. Child directories are re-stat'ed immediately before
     descent so a symlink replacement cannot redirect traversal outside root.
+    On Unix the directory is then reopened with ``O_NOFOLLOW`` before its
+    contents are enumerated, which closes the narrow window between the
+    fresh ``lstat`` and the ``scandir`` opendir; a swap in that window
+    fails the open with ``ELOOP`` instead of letting ``scandir`` follow a
+    replacement symlink into an unrelated tree. Per-entry ``stat`` is done
+    via the parent's directory descriptor so intermediate ancestor swaps
+    cannot redirect the child's stat either.
 
-    ``cancel_check`` is checked between ``scandir`` entries and before every
-    ``os.lstat``. On a slow network volume, either operation may block, but the
-    scan stops as soon as the current filesystem call returns instead of
-    letting a directory-wide batch finish first.
+    ``cancel_check`` is checked between ``scandir`` entries, before every
+    ``os.lstat``, and between the ``lstat`` and the potentially blocking
+    directory open. On a slow network volume, any of these operations may
+    block, but the scan stops as soon as the current filesystem call returns
+    instead of letting a directory-wide batch finish first.
     """
     pending = [(root, None)]
     while pending:
@@ -508,19 +517,63 @@ def _walk_entries(root: str, *, cancel_check=None):
             current_st = os.lstat(dirpath)
         except OSError as error:
             _raise_walk_error(error)
+        # Slow SMB shares can block for many seconds inside the enumeration
+        # below. Recheck cancellation between the potentially blocking lstat
+        # above and the open/scandir so an obsolete preflight does not have
+        # to wait for another whole filesystem call before it can back out.
+        # Codex flagged this for the root specifically, whose lstat is not
+        # followed by a yield, but it applies to popped children too.
         if cancel_check and cancel_check():
             raise LocalWorkspaceCancelled("Folder scan cancelled")
-        if directory_st is not None:
+        # A queued child that is no longer a directory (replaced by a symlink
+        # or a plain file since the parent's scandir listed it) is yielded
+        # with the fresh stat and skipped for descent. The caller's symlink
+        # guard then refuses escaping targets; a type flip to a regular file
+        # is reported through the normal unsupported-type check.
+        if directory_st is not None and not stat.S_ISDIR(current_st.st_mode):
             yield _relative(dirpath, root), dirpath, current_st
-        elif not stat.S_ISDIR(current_st.st_mode):
+            continue
+        if directory_st is None and not stat.S_ISDIR(current_st.st_mode):
             raise LocalWorkspaceError(
                 f"Workspace root changed during directory scan: {root}"
             )
-        if not stat.S_ISDIR(current_st.st_mode):
-            continue
+        # Open the directory with O_NOFOLLOW so a symlink swap in the tiny
+        # window between the lstat above and scandir cannot silently redirect
+        # enumeration into an unrelated tree. Enumerating through the fd also
+        # keeps per-entry stat calls anchored to the parent's descriptor, so
+        # an intermediate ancestor swap cannot escape either. On Windows
+        # (no O_NOFOLLOW) NTFS symlink creation requires elevation, so fall
+        # back to the direct path.
+        dir_fd = None
+        if hasattr(os, "O_NOFOLLOW"):
+            open_flags = os.O_RDONLY | os.O_NOFOLLOW
+            if hasattr(os, "O_DIRECTORY"):
+                open_flags |= os.O_DIRECTORY
+            try:
+                dir_fd = os.open(dirpath, open_flags)
+            except OSError as error:
+                if error.errno in {errno.ELOOP, errno.ENOTDIR, errno.ENOENT}:
+                    # dirpath became a symlink, changed type, or was removed
+                    # between our lstat and this open. Re-lstat so the caller
+                    # sees the fresh type; a queued child is yielded with its
+                    # new stat while a root topology change is fatal.
+                    try:
+                        swapped_st = os.lstat(dirpath)
+                    except OSError as swapped_err:
+                        _raise_walk_error(swapped_err)
+                    if directory_st is None:
+                        raise LocalWorkspaceError(
+                            f"Workspace root changed during directory scan: {root}"
+                        ) from error
+                    yield _relative(dirpath, root), dirpath, swapped_st
+                    continue
+                _raise_walk_error(error)
+        if directory_st is not None:
+            yield _relative(dirpath, root), dirpath, current_st
+        scan_target = dir_fd if dir_fd is not None else dirpath
         child_directories = []
         try:
-            entries = os.scandir(dirpath)
+            entries = os.scandir(scan_target)
             with entries:
                 iterator = iter(entries)
                 while True:
@@ -532,14 +585,21 @@ def _walk_entries(root: str, *, cancel_check=None):
                         break
                     if cancel_check and cancel_check():
                         raise LocalWorkspaceCancelled("Folder scan cancelled")
-                    full = entry.path
-                    st = os.lstat(full)
+                    full = os.path.join(dirpath, entry.name)
+                    # entry.stat with the fd-based scandir routes through
+                    # fstatat on the parent descriptor, so an intermediate
+                    # swap cannot redirect the stat of the final component.
+                    st = entry.stat(follow_symlinks=False)
                     if stat.S_ISDIR(st.st_mode):
                         child_directories.append((full, st))
                     else:
                         yield _relative(full, root), full, st
         except OSError as error:
             _raise_walk_error(error)
+        finally:
+            if dir_fd is not None:
+                with suppress(OSError):
+                    os.close(dir_fd)
 
         # Stack order preserves scandir's depth-first ordering.
         for child in reversed(child_directories):

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -491,8 +491,8 @@ def _walk_entries(root: str, *, cancel_check=None):
 
     Directories are included (so callers can recreate structure, including
     empty directories); directory symlinks are yielded as link entries and
-    not descended into. Each entry is stat'ed exactly once here — callers
-    classify via the yielded stat instead of re-statting.
+    not descended into. Child directories are re-stat'ed immediately before
+    descent so a symlink replacement cannot redirect traversal outside root.
 
     ``cancel_check`` is checked between ``scandir`` entries and before every
     ``os.lstat``. On a slow network volume, either operation may block, but the
@@ -502,8 +502,17 @@ def _walk_entries(root: str, *, cancel_check=None):
     pending = [(root, None)]
     while pending:
         dirpath, directory_st = pending.pop()
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
+        current_st = os.lstat(dirpath)
         if directory_st is not None:
-            yield _relative(dirpath, root), dirpath, directory_st
+            yield _relative(dirpath, root), dirpath, current_st
+        elif not stat.S_ISDIR(current_st.st_mode):
+            raise LocalWorkspaceError(
+                f"Workspace root changed during directory scan: {root}"
+            )
+        if not stat.S_ISDIR(current_st.st_mode):
+            continue
         child_directories = []
         try:
             entries = os.scandir(dirpath)

--- a/vireo/services/local_workspace.py
+++ b/vireo/services/local_workspace.py
@@ -166,12 +166,16 @@ def _estimated_destination_bytes(st) -> int:
     return LOCAL_ALLOCATION_UNIT_BYTES
 
 
-def _validated_tree_entries(source: str):
+def _validated_tree_entries(source: str, *, cancel_check=None):
     """Yield safe, supported entries from a validated source directory."""
+    if cancel_check and cancel_check():
+        raise LocalWorkspaceCancelled("Folder scan cancelled")
     try:
         root_st = os.lstat(source)
     except OSError as exc:
         raise LocalWorkspaceError(f"Workspace folder is unavailable: {source}") from exc
+    if cancel_check and cancel_check():
+        raise LocalWorkspaceCancelled("Folder scan cancelled")
     if stat.S_ISLNK(root_st.st_mode):
         raise LocalWorkspaceError(
             f"Workspace root is a symlink and cannot be staged: {source}"
@@ -181,6 +185,12 @@ def _validated_tree_entries(source: str):
 
     try:
         for rel, full, st in _walk_entries(source):
+            # Filesystem calls on network volumes may take a long time and
+            # cannot be interrupted while the kernel is servicing them. Check
+            # immediately after each one returns so an obsolete preflight does
+            # not continue walking the rest of the tree.
+            if cancel_check and cancel_check():
+                raise LocalWorkspaceCancelled("Folder scan cancelled")
             mode = st.st_mode
             if stat.S_ISLNK(mode):
                 if not _symlink_stays_within(full, source):
@@ -196,14 +206,16 @@ def _validated_tree_entries(source: str):
         ) from exc
 
 
-def source_tree_size(source: str) -> tuple[int, int, int]:
+def source_tree_size(source: str, *, cancel_check=None) -> tuple[int, int, int]:
     """Return copied-file count, logical bytes, and estimated allocated bytes."""
 
     total_files = 0
     total_bytes = 0
     # The destination root directory itself is created for every source.
     estimated_bytes = LOCAL_ALLOCATION_UNIT_BYTES
-    for _rel, _full, st in _validated_tree_entries(source):
+    for _rel, _full, st in _validated_tree_entries(
+        source, cancel_check=cancel_check
+    ):
         mode = st.st_mode
         if stat.S_ISREG(mode):
             total_bytes += st.st_size

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -10,10 +10,10 @@
   var stagePreflightSignature = null;
   var stagePreflightAbort = null;
   var stagePreflightId = null;
-  // Client-side monotonic counter shared with the server as ``preflight_seq``.
-  // The server tracks the highest seq it has ever registered per workspace so
-  // that a delayed obsolete request (older seq) cannot supersede a newer scan
-  // that already registered — even when its cancel signal was never delivered.
+  var stagePreflightClientId = newPreflightId();
+  // Client-side monotonic counter scoped by ``stagePreflightClientId``. A new
+  // page gets a new id, so its first request is not rejected by the server's
+  // high-water mark from an earlier page load.
   var stagePreflightSeq = 0;
 
   function newPreflightId() {
@@ -172,6 +172,7 @@
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(Object.assign({}, request.body, {
           preflight_id: preflightId,
+          preflight_client_id: stagePreflightClientId,
           preflight_seq: preflightSeq
         })),
         signal: controller.signal

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -810,6 +810,10 @@
     });
   }
 
+  window.addEventListener('pagehide', function() {
+    cancelStagePreflight(true);
+  });
+
   async function stageFromAnywhere(folderId) {
     if (!data) await load();
     if (activeJob || (data && data.legacy_workspace_session)) {

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -29,9 +29,9 @@
   function loadPreflightClientState() {
     // sessionStorage survives reloads, but browsers may copy it when a tab is
     // duplicated or opened from another tab. Only reuse the stored identity
-    // for an actual reload; a copied browsing context reports a normal
-    // navigation and must get its own server-side cancellation slot.
-    if (isReloadNavigation()) {
+    // for a reload or same-tab history restoration; a copied browsing context
+    // reports a normal navigation and must get its own cancellation slot.
+    if (isRestoredNavigation()) {
       try {
         var stored = JSON.parse(window.sessionStorage.getItem(stagePreflightStorageKey));
         if (
@@ -50,16 +50,18 @@
     return state;
   }
 
-  function isReloadNavigation() {
+  function isRestoredNavigation() {
     try {
       if (window.performance && typeof window.performance.getEntriesByType === 'function') {
         var navigations = window.performance.getEntriesByType('navigation');
-        if (navigations.length) return navigations[0].type === 'reload';
+        if (navigations.length) {
+          return ['reload', 'back_forward'].indexOf(navigations[0].type) >= 0;
+        }
       }
       // Navigation Timing Level 1 fallback for older WebKit versions.
       return Boolean(
         window.performance && window.performance.navigation &&
-        window.performance.navigation.type === 1
+        [1, 2].indexOf(window.performance.navigation.type) >= 0
       );
     } catch (_error) {
       return false;

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -10,6 +10,7 @@
   var stagePreflightSignature = null;
   var stagePreflightAbort = null;
   var stagePreflightId = null;
+  var stagePreflightWorkspaceId = null;
   var stagePreflightClientId = newPreflightId();
   // Client-side monotonic counter scoped by ``stagePreflightClientId``. A new
   // page gets a new id, so its first request is not rejected by the server's
@@ -30,9 +31,11 @@
 
   function cancelStagePreflight(notifyServer) {
     var preflightId = stagePreflightId;
+    var workspaceId = stagePreflightWorkspaceId;
     if (stagePreflightAbort) stagePreflightAbort.abort();
     stagePreflightAbort = null;
     stagePreflightId = null;
+    stagePreflightWorkspaceId = null;
     if (!notifyServer || !preflightId) return;
     // Aborting fetch stops the browser from waiting, but a WSGI handler may
     // already be blocked in SMB I/O. Notify the server so it stops walking as
@@ -41,7 +44,10 @@
     Vireo.api.fetch('/api/workspaces/active/local-folders/preflight/cancel', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({preflight_id: preflightId}),
+      body: JSON.stringify({
+        preflight_id: preflightId,
+        workspace_id: workspaceId
+      }),
       keepalive: true
     }).catch(function() {});
   }
@@ -264,6 +270,9 @@
     var preflightSeq = newPreflightSeq();
     stagePreflightAbort = controller;
     stagePreflightId = preflightId;
+    stagePreflightWorkspaceId = data && data.workspace_id != null
+      ? Number(data.workspace_id)
+      : null;
     if (capacity) {
       capacity.style.color = 'var(--text-dim)';
       capacity.innerHTML = '<span class="btn-spinner" style="display:inline-block;margin-right:6px;"></span>Calculating folder sizes and available space...';
@@ -290,7 +299,10 @@
       }
     } finally {
       if (stagePreflightAbort === controller) stagePreflightAbort = null;
-      if (stagePreflightId === preflightId) stagePreflightId = null;
+      if (stagePreflightId === preflightId) {
+        stagePreflightId = null;
+        stagePreflightWorkspaceId = null;
+      }
     }
   }
 

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -11,12 +11,12 @@
   var stagePreflightAbort = null;
   var stagePreflightId = null;
   var stagePreflightWorkspaceId = null;
-  var stagePreflightStorageKey = 'vireoWorkLocallyPreflightClient';
+  var stagePreflightStorageKey = preflightClientStorageKey();
   var stagePreflightClientState = loadPreflightClientState();
   var stagePreflightClientId = stagePreflightClientState.id;
-  // The per-tab token and counter survive reloads. If a pagehide keepalive is
-  // dropped, the first request from the reloaded page can still supersede the
-  // old scan without sharing cancellation state with an unrelated tab.
+  // The per-history-entry token and counter survive reloads and Back/Forward.
+  // If a pagehide keepalive is dropped, a restored page can still supersede
+  // its old scan without sharing cancellation state with an unrelated tab.
   var stagePreflightSeq = stagePreflightClientState.seq;
 
   function newPreflightId() {
@@ -27,27 +27,45 @@
   }
 
   function loadPreflightClientState() {
-    // sessionStorage survives reloads, but browsers may copy it when a tab is
-    // duplicated or opened from another tab. Only reuse the stored identity
-    // for a reload or same-tab history restoration; a copied browsing context
-    // reports a normal navigation and must get its own cancellation slot.
-    if (isRestoredNavigation()) {
-      try {
-        var stored = JSON.parse(window.sessionStorage.getItem(stagePreflightStorageKey));
-        if (
-          stored && typeof stored.id === 'string' && stored.id &&
-          Number.isSafeInteger(stored.seq) && stored.seq >= 0
-        ) {
-          return stored;
-        }
-      } catch (_error) {
-        // Storage can be disabled by browser privacy settings. The in-memory
-        // state below still preserves normal same-page supersession.
+    try {
+      var stored = JSON.parse(window.sessionStorage.getItem(stagePreflightStorageKey));
+      if (
+        stored && typeof stored.id === 'string' && stored.id &&
+        Number.isSafeInteger(stored.seq) && stored.seq >= 0
+      ) {
+        return stored;
       }
+    } catch (_error) {
+      // Storage can be disabled by browser privacy settings. The in-memory
+      // state below still preserves normal same-page supersession.
     }
     var state = {id: newPreflightId(), seq: 0};
     persistPreflightClientState(state);
     return state;
+  }
+
+  function preflightClientStorageKey() {
+    var stateKey = 'vireoWorkLocallyPreflightEntryId';
+    var keyPrefix = 'vireoWorkLocallyPreflightClient:';
+    try {
+      var historyState = window.history.state;
+      var entryId = isRestoredNavigation() && historyState &&
+        typeof historyState[stateKey] === 'string'
+        ? historyState[stateKey]
+        : null;
+      if (!entryId) {
+        entryId = newPreflightId();
+        var nextState = historyState && typeof historyState === 'object'
+          ? Object.assign({}, historyState)
+          : {};
+        nextState[stateKey] = entryId;
+        window.history.replaceState(nextState, document.title);
+      }
+      return keyPrefix + entryId;
+    } catch (_error) {
+      // History state can be unavailable in hardened browsing contexts.
+      return keyPrefix + newPreflightId();
+    }
   }
 
   function isRestoredNavigation() {

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -228,6 +228,7 @@
     return {
       complete: complete,
       body: {
+        workspace_id: data && data.workspace_id,
         folder_ids: pendingStageItems.map(function(item) { return item.requested_folder_id; }),
         destination_bases: destinationBases
       }

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -8,6 +8,33 @@
   var stagePreflightGeneration = 0;
   var stagePreflightTimer = null;
   var stagePreflightSignature = null;
+  var stagePreflightAbort = null;
+  var stagePreflightId = null;
+
+  function newPreflightId() {
+    if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+      return window.crypto.randomUUID();
+    }
+    return Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+  }
+
+  function cancelStagePreflight(notifyServer) {
+    var preflightId = stagePreflightId;
+    if (stagePreflightAbort) stagePreflightAbort.abort();
+    stagePreflightAbort = null;
+    stagePreflightId = null;
+    if (!notifyServer || !preflightId) return;
+    // Aborting fetch stops the browser from waiting, but a WSGI handler may
+    // already be blocked in SMB I/O. Notify the server so it stops walking as
+    // soon as that filesystem call returns. A later preflight also supersedes
+    // the earlier one server-side if this best-effort request cannot arrive.
+    Vireo.api.fetch('/api/workspaces/active/local-folders/preflight/cancel', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({preflight_id: preflightId}),
+      keepalive: true
+    }).catch(function() {});
+  }
 
   function selectedItems(folderIds, localOnly) {
     var wanted = folderIds && folderIds.length
@@ -120,6 +147,10 @@
       }
       return;
     }
+    var controller = new AbortController();
+    var preflightId = newPreflightId();
+    stagePreflightAbort = controller;
+    stagePreflightId = preflightId;
     if (capacity) {
       capacity.style.color = 'var(--text-dim)';
       capacity.innerHTML = '<span class="btn-spinner" style="display:inline-block;margin-right:6px;"></span>Calculating folder sizes and available space...';
@@ -128,22 +159,27 @@
       var result = await Vireo.api.json('/api/workspaces/active/local-folders/preflight', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(request.body)
+        body: JSON.stringify(Object.assign({}, request.body, {preflight_id: preflightId})),
+        signal: controller.signal
       }, {toast: false});
       if (generation !== stagePreflightGeneration || !pendingStageItems.length) return;
       stagePreflightSignature = JSON.stringify(request.body);
       renderStagePreflight(result);
     } catch (requestError) {
-      if (generation !== stagePreflightGeneration || !pendingStageItems.length) return;
+      if (controller.signal.aborted || generation !== stagePreflightGeneration || !pendingStageItems.length) return;
       if (capacity) {
         capacity.style.color = 'var(--danger)';
         capacity.textContent = requestError.message || 'Could not check folder sizes and free space.';
       }
+    } finally {
+      if (stagePreflightAbort === controller) stagePreflightAbort = null;
+      if (stagePreflightId === preflightId) stagePreflightId = null;
     }
   }
 
   function scheduleStagePreflight(delay) {
     if (stagePreflightTimer) clearTimeout(stagePreflightTimer);
+    cancelStagePreflight(true);
     stagePreflightGeneration += 1;
     stagePreflightSignature = null;
     var button = document.getElementById('confirmStageLocalFolders');
@@ -157,6 +193,7 @@
     if (modal) modal.classList.remove('open');
     stagePreflightGeneration += 1;
     stagePreflightSignature = null;
+    cancelStagePreflight(true);
     if (stagePreflightTimer) clearTimeout(stagePreflightTimer);
     stagePreflightTimer = null;
     pendingStageItems = [];

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -11,11 +11,13 @@
   var stagePreflightAbort = null;
   var stagePreflightId = null;
   var stagePreflightWorkspaceId = null;
-  var stagePreflightClientId = newPreflightId();
-  // Client-side monotonic counter scoped by ``stagePreflightClientId``. A new
-  // page gets a new id, so its first request is not rejected by the server's
-  // high-water mark from an earlier page load.
-  var stagePreflightSeq = 0;
+  var stagePreflightStorageKey = 'vireoWorkLocallyPreflightClient';
+  var stagePreflightClientState = loadPreflightClientState();
+  var stagePreflightClientId = stagePreflightClientState.id;
+  // The per-tab token and counter survive reloads. If a pagehide keepalive is
+  // dropped, the first request from the reloaded page can still supersede the
+  // old scan without sharing cancellation state with an unrelated tab.
+  var stagePreflightSeq = stagePreflightClientState.seq;
 
   function newPreflightId() {
     if (window.crypto && typeof window.crypto.randomUUID === 'function') {
@@ -24,8 +26,36 @@
     return Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
   }
 
+  function loadPreflightClientState() {
+    try {
+      var stored = JSON.parse(window.sessionStorage.getItem(stagePreflightStorageKey));
+      if (
+        stored && typeof stored.id === 'string' && stored.id &&
+        Number.isSafeInteger(stored.seq) && stored.seq >= 0
+      ) {
+        return stored;
+      }
+    } catch (_error) {
+      // Storage can be disabled by browser privacy settings. The in-memory
+      // state below still preserves normal same-page supersession.
+    }
+    var state = {id: newPreflightId(), seq: 0};
+    persistPreflightClientState(state);
+    return state;
+  }
+
+  function persistPreflightClientState(state) {
+    try {
+      window.sessionStorage.setItem(stagePreflightStorageKey, JSON.stringify(state));
+    } catch (_error) {
+      // Best effort: blocked or full storage should not prevent preflighting.
+    }
+  }
+
   function newPreflightSeq() {
     stagePreflightSeq += 1;
+    stagePreflightClientState.seq = stagePreflightSeq;
+    persistPreflightClientState(stagePreflightClientState);
     return stagePreflightSeq;
   }
 

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -813,6 +813,18 @@
   window.addEventListener('pagehide', function() {
     cancelStagePreflight(true);
   });
+  window.addEventListener('pageshow', function(event) {
+    var modal = document.getElementById('stageLocalFoldersModal');
+    if (
+      event.persisted &&
+      modal && modal.classList.contains('open') &&
+      pendingStageItems.length &&
+      !stageBlockedByJob &&
+      stagePreflightSignature === null
+    ) {
+      scheduleStagePreflight(0);
+    }
+  });
 
   async function stageFromAnywhere(folderId) {
     if (!data) await load();

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -10,12 +10,22 @@
   var stagePreflightSignature = null;
   var stagePreflightAbort = null;
   var stagePreflightId = null;
+  // Client-side monotonic counter shared with the server as ``preflight_seq``.
+  // The server tracks the highest seq it has ever registered per workspace so
+  // that a delayed obsolete request (older seq) cannot supersede a newer scan
+  // that already registered — even when its cancel signal was never delivered.
+  var stagePreflightSeq = 0;
 
   function newPreflightId() {
     if (window.crypto && typeof window.crypto.randomUUID === 'function') {
       return window.crypto.randomUUID();
     }
     return Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+  }
+
+  function newPreflightSeq() {
+    stagePreflightSeq += 1;
+    return stagePreflightSeq;
   }
 
   function cancelStagePreflight(notifyServer) {
@@ -149,6 +159,7 @@
     }
     var controller = new AbortController();
     var preflightId = newPreflightId();
+    var preflightSeq = newPreflightSeq();
     stagePreflightAbort = controller;
     stagePreflightId = preflightId;
     if (capacity) {
@@ -159,7 +170,10 @@
       var result = await Vireo.api.json('/api/workspaces/active/local-folders/preflight', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(Object.assign({}, request.body, {preflight_id: preflightId})),
+        body: JSON.stringify(Object.assign({}, request.body, {
+          preflight_id: preflightId,
+          preflight_seq: preflightSeq
+        })),
         signal: controller.signal
       }, {toast: false});
       if (generation !== stagePreflightGeneration || !pendingStageItems.length) return;

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -27,21 +27,43 @@
   }
 
   function loadPreflightClientState() {
-    try {
-      var stored = JSON.parse(window.sessionStorage.getItem(stagePreflightStorageKey));
-      if (
-        stored && typeof stored.id === 'string' && stored.id &&
-        Number.isSafeInteger(stored.seq) && stored.seq >= 0
-      ) {
-        return stored;
+    // sessionStorage survives reloads, but browsers may copy it when a tab is
+    // duplicated or opened from another tab. Only reuse the stored identity
+    // for an actual reload; a copied browsing context reports a normal
+    // navigation and must get its own server-side cancellation slot.
+    if (isReloadNavigation()) {
+      try {
+        var stored = JSON.parse(window.sessionStorage.getItem(stagePreflightStorageKey));
+        if (
+          stored && typeof stored.id === 'string' && stored.id &&
+          Number.isSafeInteger(stored.seq) && stored.seq >= 0
+        ) {
+          return stored;
+        }
+      } catch (_error) {
+        // Storage can be disabled by browser privacy settings. The in-memory
+        // state below still preserves normal same-page supersession.
       }
-    } catch (_error) {
-      // Storage can be disabled by browser privacy settings. The in-memory
-      // state below still preserves normal same-page supersession.
     }
     var state = {id: newPreflightId(), seq: 0};
     persistPreflightClientState(state);
     return state;
+  }
+
+  function isReloadNavigation() {
+    try {
+      if (window.performance && typeof window.performance.getEntriesByType === 'function') {
+        var navigations = window.performance.getEntriesByType('navigation');
+        if (navigations.length) return navigations[0].type === 'reload';
+      }
+      // Navigation Timing Level 1 fallback for older WebKit versions.
+      return Boolean(
+        window.performance && window.performance.navigation &&
+        window.performance.navigation.type === 1
+      );
+    } catch (_error) {
+      return false;
+    }
   }
 
   function persistPreflightClientState(state) {

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -380,6 +380,7 @@ POST         /api/workspaces/<int:ws_id>/pin
 POST         /api/workspaces/active/config
 POST         /api/workspaces/active/local-folders/discard
 POST         /api/workspaces/active/local-folders/preflight
+POST         /api/workspaces/active/local-folders/preflight/cancel
 POST         /api/workspaces/active/local-folders/stage
 POST         /api/workspaces/active/local-folders/sync
 POST         /api/workspaces/active/local-workspace/discard

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -127,7 +127,7 @@ def test_local_copy_preflight_aggregates_folders_on_the_same_disk(
     monkeypatch.setattr(
         service,
         "destination_disk_space",
-        lambda _path: {
+        lambda _path, **_kwargs: {
             "total_bytes": 100_000,
             "free_bytes": 18_000,
             "reserve_bytes": 2_000,
@@ -571,7 +571,9 @@ def test_stage_endpoint_rejects_case_folded_destination_collisions(
     db.close()
 
     monkeypatch.setattr(
-        local_folder_web, "destination_case_insensitive", lambda _path: True
+        local_folder_web,
+        "destination_case_insensitive",
+        lambda _path, **_kwargs: True,
     )
     app = create_app(db_path, thumb_cache_dir=str(thumbs))
     app.config["TESTING"] = True
@@ -613,7 +615,7 @@ def test_preflight_endpoint_returns_destination_probe_error(tmp_path, monkeypatc
     db.set_active_workspace(workspace_id)
     db.close()
 
-    def fail_probe(_path):
+    def fail_probe(_path, **_kwargs):
         raise LocalWorkspaceError("Could not inspect destination filesystem")
 
     monkeypatch.setattr(
@@ -777,7 +779,7 @@ def test_preflight_cancel_stops_destination_probing(tmp_path, monkeypatch):
     release_probe = threading.Event()
     probe_paths = []
 
-    def slow_case_insensitive(final_path):
+    def slow_case_insensitive(final_path, **_kwargs):
         probe_paths.append(final_path)
         if len(probe_paths) == 1:
             first_probe_started.set()

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -893,6 +893,7 @@ def test_older_seq_arrival_cannot_supersede_newer_registered_scan(tmp_path, monk
                 json={
                     "folder_ids": [folder_id],
                     "preflight_id": "newer",
+                    "preflight_client_id": "browser-one",
                     "preflight_seq": 5,
                 },
             )
@@ -906,6 +907,7 @@ def test_older_seq_arrival_cannot_supersede_newer_registered_scan(tmp_path, monk
             json={
                 "folder_ids": [folder_id],
                 "preflight_id": "older",
+                "preflight_client_id": "browser-one",
                 "preflight_seq": 3,
             },
         )
@@ -920,6 +922,40 @@ def test_older_seq_arrival_cannot_supersede_newer_registered_scan(tmp_path, monk
     # Newer scan ran to completion — was not cancelled by the stale arrival.
     assert newer_result["response"].status_code == 200
     assert newer_result["response"].get_json()["total_bytes"] == 999
+
+
+def test_new_browser_client_can_restart_preflight_sequence(tmp_path, monkeypatch):
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        return {"folder_count": 1, "total_bytes": 1, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    with app.test_client() as client:
+        old_page = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "old-page",
+                "preflight_client_id": "browser-one",
+                "preflight_seq": 5,
+            },
+        )
+        refreshed_page = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "refreshed-page",
+                "preflight_client_id": "browser-two",
+                "preflight_seq": 1,
+            },
+        )
+
+    assert old_page.status_code == 200
+    assert refreshed_page.status_code == 200
 
 
 def test_new_preflight_supersedes_old_scan(tmp_path, monkeypatch):

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1303,6 +1303,78 @@ def test_new_preflight_supersedes_old_scan(tmp_path, monkeypatch):
     )
 
 
+def test_reloaded_page_supersedes_obsolete_scan_under_same_client_id(
+    tmp_path, monkeypatch
+):
+    """A page reload that reuses its persisted client id (as the browser now
+    does via ``sessionStorage``) has to supersede the obsolete scan still
+    running under that same key. A different client id would create a fresh
+    ``(workspace_id, preflight_client_id)`` slot and let the old scan keep
+    walking the filesystem in parallel with the reloaded page's scan."""
+    from services.local_folder import LocalWorkspaceCancelled
+
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls_lock = threading.Lock()
+    calls = 0
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            first_started.set()
+            assert release_first.wait(5), "test did not release the first preflight"
+            if cancel_check and cancel_check():
+                raise LocalWorkspaceCancelled("superseded by reload")
+        return {"folder_count": 1, "total_bytes": call_number, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    original_result = {}
+
+    def request_original():
+        with app.test_client() as client:
+            original_result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={
+                    "folder_ids": [folder_id],
+                    "preflight_id": "original-page",
+                    "preflight_client_id": "browser-persisted",
+                    "preflight_seq": 5,
+                },
+            )
+
+    thread = threading.Thread(target=request_original)
+    thread.start()
+    assert first_started.wait(5), "original preflight did not start"
+    with app.test_client() as client:
+        reloaded = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "reloaded-page",
+                "preflight_client_id": "browser-persisted",
+                "preflight_seq": 6,
+            },
+        )
+    release_first.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    assert reloaded.status_code == 200
+    assert reloaded.get_json()["total_bytes"] == 2
+    assert original_result["response"].status_code == 409
+    assert original_result["response"].get_json()["error"] == (
+        "Folder size calculation was cancelled"
+    )
+
+
 def test_local_root_under_folder_finds_descendant_session(tmp_path):
     db = Database(str(tmp_path / "vireo.db"))
     workspace_id = db.create_workspace("Ancestor")

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1167,6 +1167,82 @@ def test_older_seq_arrival_cannot_supersede_newer_registered_scan(tmp_path, monk
     assert newer_result["response"].get_json()["total_bytes"] == 999
 
 
+def test_sequence_cache_does_not_evict_active_client(tmp_path, monkeypatch):
+    """Cache pressure must not let an older request replace an active scan."""
+    from services.local_folder import LocalWorkspaceCancelled
+
+    active_started = threading.Event()
+    release_active = threading.Event()
+    calls_lock = threading.Lock()
+    calls = 0
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("stale sequence")
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            active_started.set()
+            assert release_active.wait(5), "test did not release the active scan"
+            if cancel_check and cancel_check():
+                raise LocalWorkspaceCancelled("active scan was superseded")
+        return {"folder_count": 1, "total_bytes": call_number, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    active_result = {}
+
+    def request_active():
+        with app.test_client() as client:
+            active_result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={
+                    "folder_ids": [folder_id],
+                    "preflight_id": "active-newer",
+                    "preflight_client_id": "active-client",
+                    "preflight_seq": 5,
+                },
+            )
+
+    thread = threading.Thread(target=request_active)
+    thread.start()
+    assert active_started.wait(5), "active preflight did not start"
+    with app.test_client() as client:
+        for index in range(64):
+            response = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={
+                    "folder_ids": [folder_id],
+                    "preflight_id": f"cache-pressure-{index}",
+                    "preflight_client_id": f"other-client-{index}",
+                    "preflight_seq": 1,
+                },
+            )
+            assert response.status_code == 200
+        older = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "active-older",
+                "preflight_client_id": "active-client",
+                "preflight_seq": 3,
+            },
+        )
+    release_active.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    assert older.status_code == 409
+    assert older.get_json()["error"] == "Folder size calculation was cancelled"
+    assert active_result["response"].status_code == 200
+
+
 def test_new_browser_client_can_restart_preflight_sequence(tmp_path, monkeypatch):
     def fake_preflight(
         _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -762,6 +762,74 @@ def test_preflight_cancel_can_arrive_before_scan_starts(tmp_path, monkeypatch):
     assert older.get_json()["error"] == "Folder size calculation was cancelled"
 
 
+def test_preflight_precancelled_newer_request_stops_intervening_older_scan(
+    tmp_path, monkeypatch
+):
+    from services.local_folder import LocalWorkspaceCancelled
+
+    older_started = threading.Event()
+    release_older = threading.Event()
+    calls_lock = threading.Lock()
+    calls = 0
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            older_started.set()
+            assert release_older.wait(5), "test did not release the older scan"
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("cancelled")
+        return {"folder_count": 1, "total_bytes": 1, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    older_result = {}
+
+    def request_older():
+        with app.test_client() as client:
+            older_result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={
+                    "folder_ids": [folder_id],
+                    "preflight_id": "older",
+                    "preflight_client_id": "browser-one",
+                    "preflight_seq": 3,
+                },
+            )
+
+    thread = threading.Thread(target=request_older)
+    thread.start()
+    assert older_started.wait(5), "older preflight did not start"
+    with app.test_client() as client:
+        cancel = client.post(
+            "/api/workspaces/active/local-folders/preflight/cancel",
+            json={"preflight_id": "newer"},
+        )
+        newer = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "newer",
+                "preflight_client_id": "browser-one",
+                "preflight_seq": 5,
+            },
+        )
+    release_older.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    assert cancel.get_json() == {"cancelled": False}
+    assert newer.status_code == 409
+    assert older_result["response"].status_code == 409
+
+
 def test_preflight_cancel_stops_destination_probing(tmp_path, monkeypatch):
     """A cancel request must break the destination-validation loop so a
     dismissed dialog does not continue probing every remaining destination

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -737,13 +737,29 @@ def test_preflight_cancel_can_arrive_before_scan_starts(tmp_path, monkeypatch):
         )
         preflight = client.post(
             "/api/workspaces/active/local-folders/preflight",
-            json={"folder_ids": [folder_id], "preflight_id": "late-request"},
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "late-request",
+                "preflight_client_id": "browser-one",
+                "preflight_seq": 5,
+            },
+        )
+        older = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "older-request",
+                "preflight_client_id": "browser-one",
+                "preflight_seq": 3,
+            },
         )
 
     assert cancel.status_code == 200
     assert cancel.get_json() == {"cancelled": False}
     assert preflight.status_code == 409
     assert preflight.get_json()["error"] == "Folder size calculation was cancelled"
+    assert older.status_code == 409
+    assert older.get_json()["error"] == "Folder size calculation was cancelled"
 
 
 def test_preflight_cancel_stops_destination_probing(tmp_path, monkeypatch):
@@ -958,6 +974,44 @@ def test_new_browser_client_can_restart_preflight_sequence(tmp_path, monkeypatch
 
     assert old_page.status_code == 200
     assert refreshed_page.status_code == 200
+
+
+def test_preflight_sequence_cache_is_bounded(tmp_path, monkeypatch):
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        return {"folder_count": 1, "total_bytes": 1, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    with app.test_client() as client:
+        for index in range(65):
+            response = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={
+                    "folder_ids": [folder_id],
+                    "preflight_id": f"request-{index}",
+                    "preflight_client_id": f"browser-{index}",
+                    "preflight_seq": 5,
+                },
+            )
+            assert response.status_code == 200
+
+        # The oldest of 65 page entries was evicted from the 64-entry cache,
+        # so its restarted sequence is accepted rather than rejected as stale.
+        evicted_client = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "evicted-client",
+                "preflight_client_id": "browser-0",
+                "preflight_seq": 1,
+            },
+        )
+
+    assert evicted_client.status_code == 200
 
 
 def test_new_preflight_supersedes_old_scan(tmp_path, monkeypatch):

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -688,6 +688,13 @@ def test_preflight_cancel_endpoint_stops_matching_scan(tmp_path, monkeypatch):
         tmp_path, monkeypatch, fake_preflight
     )
     result = {}
+    with app.test_client() as client:
+        origin_workspace_id = client.get(
+            "/api/workspaces/active/local-folders"
+        ).get_json()["workspace_id"]
+        other_workspace_id = client.post(
+            "/api/workspaces", json={"name": "Other workspace"}
+        ).get_json()["id"]
 
     def request_preflight():
         with app.test_client() as client:
@@ -700,9 +707,15 @@ def test_preflight_cancel_endpoint_stops_matching_scan(tmp_path, monkeypatch):
     thread.start()
     assert started.wait(5), "preflight did not start"
     with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{other_workspace_id}/activate", json={}
+        ).status_code == 200
         cancelled = client.post(
             "/api/workspaces/active/local-folders/preflight/cancel",
-            json={"preflight_id": "dialog-one"},
+            json={
+                "preflight_id": "dialog-one",
+                "workspace_id": origin_workspace_id,
+            },
         )
     release.set()
     thread.join(5)

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -943,6 +943,88 @@ def test_preflight_cancel_stops_destination_probing(tmp_path, monkeypatch):
     assert len(probe_paths) == 1
 
 
+def test_preflight_cancel_after_workspace_switch_stops_scan(tmp_path, monkeypatch):
+    """A cancel POSTed after switching to another workspace must still stop
+    the scan started under the previous workspace.
+
+    ``switchWorkspace`` activates the new workspace before ``pagehide`` fires
+    the best-effort cancel, so the cancel handler sees the new workspace as
+    the active one. Scoping cancellation by that active workspace would leave
+    the old workspace's SMB scan running; the ``preflight_id`` UUID is
+    globally unique, so cancellation resolves by that instead."""
+    from services.local_folder import LocalWorkspaceCancelled
+    from app import create_app
+    from web import local_folder as local_folder_web
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    source = tmp_path / "nas" / "Photos"
+    source.mkdir(parents=True)
+    (source / "bird.raw").write_bytes(b"raw")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+    db = Database(db_path)
+    first_workspace = db.create_workspace("First")
+    second_workspace = db.create_workspace("Second")
+    folder_id = db.add_folder(str(source), name="Photos", link_to_workspace=False)
+    db.add_workspace_folder(first_workspace, folder_id)
+    db.close()
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        started.set()
+        assert release.wait(5), "test did not release the fake preflight"
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("cancelled after workspace switch")
+        return {"folder_count": 1, "total_bytes": 0, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    monkeypatch.setattr(local_folder_web, "local_copy_preflight", fake_preflight)
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{first_workspace}/activate", json={}
+        ).status_code == 200
+
+    result = {}
+
+    def request_preflight():
+        with app.test_client() as client:
+            result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={"folder_ids": [folder_id], "preflight_id": "scan-in-first"},
+            )
+
+    thread = threading.Thread(target=request_preflight)
+    thread.start()
+    assert started.wait(5), "preflight did not start under first workspace"
+
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{second_workspace}/activate", json={}
+        ).status_code == 200
+        cancelled = client.post(
+            "/api/workspaces/active/local-folders/preflight/cancel",
+            json={"preflight_id": "scan-in-first"},
+        )
+    release.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    assert cancelled.status_code == 200
+    assert cancelled.get_json() == {"cancelled": True}
+    assert result["response"].status_code == 409
+    assert result["response"].get_json()["error"] == (
+        "Folder size calculation was cancelled"
+    )
+
+
 def test_older_seq_arrival_cannot_supersede_newer_registered_scan(tmp_path, monkeypatch):
     """A delayed request with an older ``preflight_seq`` must not cancel a
     newer scan that already registered.

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -775,6 +775,57 @@ def test_preflight_cancel_can_arrive_before_scan_starts(tmp_path, monkeypatch):
     assert older.get_json()["error"] == "Folder size calculation was cancelled"
 
 
+def test_queued_preflight_stays_bound_to_origin_workspace(tmp_path, monkeypatch):
+    """A delayed POST must consume the origin workspace's cancel tombstone."""
+    from services.local_folder import LocalWorkspaceCancelled
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("cancelled before queued request ran")
+        return {"folder_count": 1, "total_bytes": 0, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    with app.test_client() as client:
+        origin_workspace_id = client.get(
+            "/api/workspaces/active/local-folders"
+        ).get_json()["workspace_id"]
+        other_workspace_id = client.post(
+            "/api/workspaces",
+            json={"name": "Shared workspace", "folder_ids": [folder_id]},
+        ).get_json()["id"]
+        assert client.post(
+            f"/api/workspaces/{other_workspace_id}/activate", json={}
+        ).status_code == 200
+
+        cancel = client.post(
+            "/api/workspaces/active/local-folders/preflight/cancel",
+            json={
+                "preflight_id": "queued-origin-request",
+                "workspace_id": origin_workspace_id,
+            },
+        )
+        preflight = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "queued-origin-request",
+                "preflight_client_id": "origin-tab",
+                "preflight_seq": 1,
+                "workspace_id": origin_workspace_id,
+            },
+        )
+
+    assert cancel.status_code == 200
+    assert cancel.get_json() == {"cancelled": False}
+    assert preflight.status_code == 409
+    assert preflight.get_json()["error"] == "Folder size calculation was cancelled"
+
+
 def test_preflight_precancelled_newer_request_stops_intervening_older_scan(
     tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -952,8 +952,8 @@ def test_preflight_cancel_after_workspace_switch_stops_scan(tmp_path, monkeypatc
     the active one. Scoping cancellation by that active workspace would leave
     the old workspace's SMB scan running; the ``preflight_id`` UUID is
     globally unique, so cancellation resolves by that instead."""
-    from services.local_folder import LocalWorkspaceCancelled
     from app import create_app
+    from services.local_folder import LocalWorkspaceCancelled
     from web import local_folder as local_folder_web
 
     monkeypatch.setenv("HOME", str(tmp_path))

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1044,6 +1044,66 @@ def test_new_browser_client_can_restart_preflight_sequence(tmp_path, monkeypatch
     assert refreshed_page.status_code == 200
 
 
+def test_preflights_from_different_browser_clients_do_not_cancel_each_other(
+    tmp_path, monkeypatch
+):
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls_lock = threading.Lock()
+    calls = 0
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            first_started.set()
+            assert release_first.wait(5), "test did not release the first page"
+        assert not (cancel_check and cancel_check())
+        return {"folder_count": 1, "total_bytes": call_number, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    first_result = {}
+
+    def request_first_page():
+        with app.test_client() as client:
+            first_result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={
+                    "folder_ids": [folder_id],
+                    "preflight_id": "first-page",
+                    "preflight_client_id": "browser-one",
+                    "preflight_seq": 1,
+                },
+            )
+
+    thread = threading.Thread(target=request_first_page)
+    thread.start()
+    assert first_started.wait(5), "first page preflight did not start"
+    with app.test_client() as client:
+        second = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "second-page",
+                "preflight_client_id": "browser-two",
+                "preflight_seq": 1,
+            },
+        )
+    release_first.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    assert second.status_code == 200
+    assert first_result["response"].status_code == 200
+
+
 def test_preflight_sequence_cache_is_bounded(tmp_path, monkeypatch):
     def fake_preflight(
         _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -844,6 +844,84 @@ def test_preflight_cancel_stops_destination_probing(tmp_path, monkeypatch):
     assert len(probe_paths) == 1
 
 
+def test_older_seq_arrival_cannot_supersede_newer_registered_scan(tmp_path, monkeypatch):
+    """A delayed request with an older ``preflight_seq`` must not cancel a
+    newer scan that already registered.
+
+    Waitress can deliver requests out of order (an older one waited longer for
+    a free worker, or its cancel signal was dropped). Without the ordering
+    token the older arrival unconditionally cancels the newer scan and takes
+    over as active — a subsequent cancel for the older id then cancels it
+    too, and the client is stuck at 409 while its latest inputs never get a
+    size back."""
+    from services.local_folder import LocalWorkspaceCancelled
+
+    newer_started = threading.Event()
+    release_newer = threading.Event()
+    calls_lock = threading.Lock()
+    calls = 0
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        # A stale arrival rejected by the ordering token gets a pre-set
+        # ``cancel_check``; short-circuit here rather than doing any scan
+        # work so the test can distinguish rejection from a full scan.
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("stale seq arrival was rejected")
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call_number = calls
+        assert call_number == 1, "older seq arrival should not run a scan"
+        newer_started.set()
+        assert release_newer.wait(5), "test did not release the newer preflight"
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("newer was superseded")
+        return {"folder_count": 1, "total_bytes": 999, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    newer_result = {}
+
+    def request_newer():
+        with app.test_client() as client:
+            newer_result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={
+                    "folder_ids": [folder_id],
+                    "preflight_id": "newer",
+                    "preflight_seq": 5,
+                },
+            )
+
+    thread = threading.Thread(target=request_newer)
+    thread.start()
+    assert newer_started.wait(5), "newer preflight did not start"
+    with app.test_client() as client:
+        older = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={
+                "folder_ids": [folder_id],
+                "preflight_id": "older",
+                "preflight_seq": 3,
+            },
+        )
+    release_newer.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    # Older arrival is rejected with the same 409 the client already knows
+    # about; it never touched active_preflights.
+    assert older.status_code == 409
+    assert older.get_json()["error"] == "Folder size calculation was cancelled"
+    # Newer scan ran to completion — was not cancelled by the stale arrival.
+    assert newer_result["response"].status_code == 200
+    assert newer_result["response"].get_json()["total_bytes"] == 999
+
+
 def test_new_preflight_supersedes_old_scan(tmp_path, monkeypatch):
     from services.local_folder import LocalWorkspaceCancelled
 

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -876,11 +876,22 @@ def test_preflight_cancel_stops_destination_probing(tmp_path, monkeypatch):
     release_probe = threading.Event()
     probe_paths = []
 
-    def slow_case_insensitive(final_path, **_kwargs):
+    def slow_case_insensitive(final_path, *, cancel_check=None, **_kwargs):
         probe_paths.append(final_path)
         if len(probe_paths) == 1:
             first_probe_started.set()
             assert release_probe.wait(5), "test did not release the destination probe"
+        # Emulate the real probe honouring the cancellation callback so we
+        # exercise ``LocalWorkspaceCancelled`` propagating out of the probe
+        # (as opposed to only checking the loop's between-iteration check).
+        # ``LocalWorkspaceCancelled`` subclasses ``LocalWorkspaceError``, so a
+        # naive ``except LocalWorkspaceError`` around the probe would swallow
+        # this into the generic destination-error 409 instead of the
+        # cancellation error text.
+        if cancel_check and cancel_check():
+            from services.local_folder import LocalWorkspaceCancelled
+
+            raise LocalWorkspaceCancelled("Folder scan cancelled")
         return False
 
     def fake_preflight(

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -744,6 +744,106 @@ def test_preflight_cancel_can_arrive_before_scan_starts(tmp_path, monkeypatch):
     assert preflight.get_json()["error"] == "Folder size calculation was cancelled"
 
 
+def test_preflight_cancel_stops_destination_probing(tmp_path, monkeypatch):
+    """A cancel request must break the destination-validation loop so a
+    dismissed dialog does not continue probing every remaining destination
+    volume — each ``destination_case_insensitive`` call can hang for seconds
+    on an unavailable network mount."""
+    from web import local_folder as local_folder_web
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+
+    source_a = tmp_path / "nas" / "PhotosA"
+    source_b = tmp_path / "nas" / "PhotosB"
+    source_a.mkdir(parents=True)
+    source_b.mkdir(parents=True)
+    (source_a / "bird.raw").write_bytes(b"raw")
+    (source_b / "bird.raw").write_bytes(b"raw")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+    db = Database(db_path)
+    workspace_id = db.create_workspace("Cancellable destination probe")
+    folder_a = db.add_folder(str(source_a), name="PhotosA", link_to_workspace=False)
+    folder_b = db.add_folder(str(source_b), name="PhotosB", link_to_workspace=False)
+    db.add_workspace_folder(workspace_id, folder_a)
+    db.add_workspace_folder(workspace_id, folder_b)
+    db.set_active_workspace(workspace_id)
+    db.close()
+
+    first_probe_started = threading.Event()
+    release_probe = threading.Event()
+    probe_paths = []
+
+    def slow_case_insensitive(final_path):
+        probe_paths.append(final_path)
+        if len(probe_paths) == 1:
+            first_probe_started.set()
+            assert release_probe.wait(5), "test did not release the destination probe"
+        return False
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        raise AssertionError(
+            "preflight should not run after cancellation during destination validation"
+        )
+
+    monkeypatch.setattr(
+        local_folder_web, "destination_case_insensitive", slow_case_insensitive
+    )
+    monkeypatch.setattr(local_folder_web, "local_copy_preflight", fake_preflight)
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={}
+        ).status_code == 200
+
+    destination_a = str(tmp_path / "local" / "a")
+    destination_b = str(tmp_path / "local" / "b")
+    result = {}
+
+    def request_preflight():
+        with app.test_client() as client:
+            result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={
+                    "folder_ids": [folder_a, folder_b],
+                    "preflight_id": "probe-cancel",
+                    "destination_bases": {
+                        str(folder_a): destination_a,
+                        str(folder_b): destination_b,
+                    },
+                },
+            )
+
+    thread = threading.Thread(target=request_preflight)
+    thread.start()
+    assert first_probe_started.wait(5), "first destination probe did not start"
+    with app.test_client() as client:
+        cancelled = client.post(
+            "/api/workspaces/active/local-folders/preflight/cancel",
+            json={"preflight_id": "probe-cancel"},
+        )
+    release_probe.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    assert cancelled.status_code == 200
+    assert cancelled.get_json() == {"cancelled": True}
+    assert result["response"].status_code == 409
+    assert result["response"].get_json()["error"] == (
+        "Folder size calculation was cancelled"
+    )
+    # The second destination is never probed — cancellation propagates
+    # through the loop between filesystem calls instead of forcing the
+    # obsolete handler to walk every remaining volume.
+    assert len(probe_paths) == 1
+
+
 def test_new_preflight_supersedes_old_scan(tmp_path, monkeypatch):
     from services.local_folder import LocalWorkspaceCancelled
 

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1,5 +1,6 @@
 """Folder-scoped Work Locally behavior and shared-workspace integration."""
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -634,6 +635,168 @@ def test_preflight_endpoint_returns_destination_probe_error(tmp_path, monkeypatc
 
     assert response.status_code == 409
     assert response.get_json()["error"] == "Could not inspect destination filesystem"
+
+
+def _cancellable_preflight_app(tmp_path, monkeypatch, fake_preflight):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+    from web import local_folder as local_folder_web
+
+    source = tmp_path / "nas" / "Photos"
+    source.mkdir(parents=True)
+    (source / "bird.raw").write_bytes(b"raw")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+    db = Database(db_path)
+    workspace_id = db.create_workspace("Cancellable preflight")
+    folder_id = db.add_folder(str(source), name="Photos", link_to_workspace=False)
+    db.add_workspace_folder(workspace_id, folder_id)
+    db.set_active_workspace(workspace_id)
+    db.close()
+
+    monkeypatch.setattr(local_folder_web, "local_copy_preflight", fake_preflight)
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={}
+        ).status_code == 200
+    return app, folder_id
+
+
+def test_preflight_cancel_endpoint_stops_matching_scan(tmp_path, monkeypatch):
+    from services.local_folder import LocalWorkspaceCancelled
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        started.set()
+        assert release.wait(5), "test did not release the fake preflight"
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("cancelled")
+        return {"folder_count": 1, "total_bytes": 0, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    result = {}
+
+    def request_preflight():
+        with app.test_client() as client:
+            result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={"folder_ids": [folder_id], "preflight_id": "dialog-one"},
+            )
+
+    thread = threading.Thread(target=request_preflight)
+    thread.start()
+    assert started.wait(5), "preflight did not start"
+    with app.test_client() as client:
+        cancelled = client.post(
+            "/api/workspaces/active/local-folders/preflight/cancel",
+            json={"preflight_id": "dialog-one"},
+        )
+    release.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    assert cancelled.status_code == 200
+    assert cancelled.get_json() == {"cancelled": True}
+    assert result["response"].status_code == 409
+    assert result["response"].get_json()["error"] == (
+        "Folder size calculation was cancelled"
+    )
+
+
+def test_preflight_cancel_can_arrive_before_scan_starts(tmp_path, monkeypatch):
+    from services.local_folder import LocalWorkspaceCancelled
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        if cancel_check and cancel_check():
+            raise LocalWorkspaceCancelled("cancelled before start")
+        return {"folder_count": 1, "total_bytes": 0, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    with app.test_client() as client:
+        cancel = client.post(
+            "/api/workspaces/active/local-folders/preflight/cancel",
+            json={"preflight_id": "late-request"},
+        )
+        preflight = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={"folder_ids": [folder_id], "preflight_id": "late-request"},
+        )
+
+    assert cancel.status_code == 200
+    assert cancel.get_json() == {"cancelled": False}
+    assert preflight.status_code == 409
+    assert preflight.get_json()["error"] == "Folder size calculation was cancelled"
+
+
+def test_new_preflight_supersedes_old_scan(tmp_path, monkeypatch):
+    from services.local_folder import LocalWorkspaceCancelled
+
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls_lock = threading.Lock()
+    calls = 0
+
+    def fake_preflight(
+        _db, _root_ids, _vireo_dir, *, destination_bases=None, cancel_check=None
+    ):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            first_started.set()
+            assert release_first.wait(5), "test did not release the first preflight"
+            if cancel_check and cancel_check():
+                raise LocalWorkspaceCancelled("superseded")
+        return {"folder_count": 1, "total_bytes": call_number, "can_copy": True,
+                "folders": [], "volumes": []}
+
+    app, folder_id = _cancellable_preflight_app(
+        tmp_path, monkeypatch, fake_preflight
+    )
+    first_result = {}
+
+    def request_first():
+        with app.test_client() as client:
+            first_result["response"] = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={"folder_ids": [folder_id], "preflight_id": "first"},
+            )
+
+    thread = threading.Thread(target=request_first)
+    thread.start()
+    assert first_started.wait(5), "first preflight did not start"
+    with app.test_client() as client:
+        second = client.post(
+            "/api/workspaces/active/local-folders/preflight",
+            json={"folder_ids": [folder_id], "preflight_id": "second"},
+        )
+    release_first.set()
+    thread.join(5)
+
+    assert not thread.is_alive()
+    assert second.status_code == 200
+    assert second.get_json()["total_bytes"] == 2
+    assert first_result["response"].status_code == 409
+    assert first_result["response"].get_json()["error"] == (
+        "Folder size calculation was cancelled"
+    )
 
 
 def test_local_root_under_folder_finds_descendant_session(tmp_path):

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -162,6 +162,29 @@ def test_walk_entries_cancels_after_root_stat_before_scandir(tmp_path, monkeypat
         )
 
 
+def test_walk_entries_converts_queued_directory_stat_race(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    child = source / "child"
+    child.mkdir(parents=True)
+    real_lstat = local_workspace.os.lstat
+    child_stats = 0
+
+    def disappearing_lstat(path):
+        nonlocal child_stats
+        if os.path.normpath(path) == os.path.normpath(child):
+            child_stats += 1
+            if child_stats == 2:
+                raise FileNotFoundError("queued directory disappeared")
+        return real_lstat(path)
+
+    monkeypatch.setattr(local_workspace.os, "lstat", disappearing_lstat)
+
+    with pytest.raises(LocalWorkspaceError, match="Could not read workspace directory"):
+        list(local_workspace._walk_entries(str(source)))
+
+    assert child_stats == 2
+
+
 @pytest.mark.skipif(os.name == "nt", reason="Windows test runners may not permit symlinks")
 def test_source_tree_size_does_not_follow_queued_directory_replaced_by_symlink(
     tmp_path, monkeypatch

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -136,6 +136,32 @@ def test_source_tree_size_cancels_between_scandir_entries(tmp_path, monkeypatch)
     assert enumerated == 2
 
 
+def test_walk_entries_cancels_after_root_stat_before_scandir(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    source.mkdir()
+    cancelled = threading.Event()
+    real_lstat = local_workspace.os.lstat
+
+    def cancelling_lstat(path):
+        result = real_lstat(path)
+        if os.path.normpath(path) == os.path.normpath(source):
+            cancelled.set()
+        return result
+
+    def unexpected_scandir(_path):
+        raise AssertionError("cancelled traversal must not start scandir")
+
+    monkeypatch.setattr(local_workspace.os, "lstat", cancelling_lstat)
+    monkeypatch.setattr(local_workspace.os, "scandir", unexpected_scandir)
+
+    with pytest.raises(LocalWorkspaceCancelled, match="Folder scan cancelled"):
+        list(
+            local_workspace._walk_entries(
+                str(source), cancel_check=cancelled.is_set
+            )
+        )
+
+
 @pytest.mark.skipif(os.name == "nt", reason="Windows test runners may not permit symlinks")
 def test_source_tree_size_does_not_follow_queued_directory_replaced_by_symlink(
     tmp_path, monkeypatch

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import shutil
 import threading
@@ -308,6 +309,42 @@ def test_source_tree_size_detects_child_swapped_to_symlink_before_open(
         local_workspace.source_tree_size(str(source))
 
     assert swap_done
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason="O_NOFOLLOW directory opens are only used on supported platforms",
+)
+def test_walk_entries_rejects_directory_after_transient_open_failure(
+    tmp_path, monkeypatch
+):
+    """A failed open followed by a directory lstat must not skip its subtree."""
+    source = tmp_path / "source"
+    child = source / "child"
+    child.mkdir(parents=True)
+    (child / "inside.raw").write_bytes(b"inside")
+
+    real_open = local_workspace.os.open
+    failed = False
+
+    def transient_open(path, flags, *args, **kwargs):
+        nonlocal failed
+        if (
+            not failed
+            and isinstance(path, (str, bytes, os.PathLike))
+            and os.path.normpath(os.fspath(path)) == os.path.normpath(child)
+            and flags & os.O_NOFOLLOW
+        ):
+            failed = True
+            raise FileNotFoundError(errno.ENOENT, "transient directory open", path)
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(local_workspace.os, "open", transient_open)
+
+    with pytest.raises(LocalWorkspaceError, match="Workspace directory changed"):
+        list(local_workspace._walk_entries(str(source)))
+
+    assert failed
 
 
 @pytest.mark.parametrize(

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -136,6 +136,28 @@ def test_source_tree_size_cancels_between_scandir_entries(tmp_path, monkeypatch)
     assert enumerated == 2
 
 
+@pytest.mark.parametrize(
+    "probe",
+    [
+        local_workspace.destination_disk_space,
+        local_workspace.destination_case_insensitive,
+    ],
+)
+def test_destination_probe_cancels_between_missing_ancestors(tmp_path, probe):
+    checks = 0
+
+    def cancel_check():
+        nonlocal checks
+        checks += 1
+        return checks == 2
+
+    destination = tmp_path / "missing" / "deep" / "photos"
+    with pytest.raises(LocalWorkspaceCancelled, match="Folder scan cancelled"):
+        probe(destination, cancel_check=cancel_check)
+
+    assert checks == 2
+
+
 def test_stage_modify_and_sync_back(local_workspace_env):
     env = local_workspace_env
     result = stage_workspace(env["db"], env["workspace_id"], str(env["vireo_dir"]))

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -72,6 +72,31 @@ def _source_fs_preserves_case(directory: Path) -> bool:
         probe.unlink()
 
 
+def _scandir_target_is(directory, scandir_arg) -> bool:
+    """Whether ``scandir_arg`` (path or fd) refers to ``directory``.
+
+    The walker now opens each directory with ``O_NOFOLLOW`` and passes the
+    resulting file descriptor to ``os.scandir``, so mocks that used to key on
+    the path argument must also recognise fd calls. Matching by (inode,
+    device) works for both a path and a directory descriptor.
+    """
+    try:
+        expected = os.stat(directory)
+    except OSError:
+        return False
+    if isinstance(scandir_arg, int):
+        try:
+            actual = os.fstat(scandir_arg)
+        except OSError:
+            return False
+    else:
+        try:
+            actual = os.stat(scandir_arg)
+        except OSError:
+            return False
+    return (actual.st_ino, actual.st_dev) == (expected.st_ino, expected.st_dev)
+
+
 def test_source_tree_size_converts_traversal_race_to_workspace_error(
     tmp_path, monkeypatch
 ):
@@ -122,7 +147,7 @@ def test_source_tree_size_cancels_between_scandir_entries(tmp_path, monkeypatch)
 
     def cancelling_scandir(path):
         entries = real_scandir(path)
-        if os.path.normpath(path) == os.path.normpath(source):
+        if _scandir_target_is(source, path):
             return CancellingIterator(entries)
         return entries
 
@@ -173,8 +198,7 @@ def test_walk_entries_converts_queued_directory_stat_race(tmp_path, monkeypatch)
         nonlocal child_stats
         if os.path.normpath(path) == os.path.normpath(child):
             child_stats += 1
-            if child_stats == 2:
-                raise FileNotFoundError("queued directory disappeared")
+            raise FileNotFoundError("queued directory disappeared")
         return real_lstat(path)
 
     monkeypatch.setattr(local_workspace.os, "lstat", disappearing_lstat)
@@ -182,7 +206,12 @@ def test_walk_entries_converts_queued_directory_stat_race(tmp_path, monkeypatch)
     with pytest.raises(LocalWorkspaceError, match="Could not read workspace directory"):
         list(local_workspace._walk_entries(str(source)))
 
-    assert child_stats == 2
+    # The walker no longer calls ``os.lstat`` inside the parent's scandir
+    # loop (per-entry stat now routes through ``DirEntry.stat`` on the
+    # parent fd), so the queued child is lstat'd exactly once — at the
+    # pop-and-revalidate boundary — and that is where the OSError must
+    # convert to a LocalWorkspaceError.
+    assert child_stats == 1
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Windows test runners may not permit symlinks")
@@ -227,10 +256,7 @@ def test_source_tree_size_does_not_follow_queued_directory_replaced_by_symlink(
 
     def swapping_scandir(path):
         entries = real_scandir(path)
-        if (
-            not isinstance(path, int)
-            and os.path.normpath(path) == os.path.normpath(source)
-        ):
+        if _scandir_target_is(source, path):
             return SwapOnExhaustion(entries)
         return entries
 
@@ -240,6 +266,48 @@ def test_source_tree_size_does_not_follow_queued_directory_replaced_by_symlink(
         local_workspace.source_tree_size(str(source))
 
     assert swapped
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason="O_NOFOLLOW swap protection is only wired on platforms that expose it",
+)
+def test_source_tree_size_detects_child_swapped_to_symlink_before_open(
+    tmp_path, monkeypatch
+):
+    """A child dir that becomes a symlink between the walker's fresh lstat
+    and its O_NOFOLLOW open must be re-lstat'd and yielded as a symlink
+    instead of letting the enumeration follow into an unrelated tree."""
+    source = tmp_path / "source"
+    child = source / "child"
+    child.mkdir(parents=True)
+    (child / "inside.raw").write_bytes(b"inside")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "outside.raw").write_bytes(b"outside")
+
+    real_open = local_workspace.os.open
+    swap_done = False
+
+    def swapping_open(path, flags, *args, **kwargs):
+        nonlocal swap_done
+        if (
+            not swap_done
+            and isinstance(path, (str, bytes, os.PathLike))
+            and os.path.normpath(os.fspath(path)) == os.path.normpath(child)
+            and flags & os.O_NOFOLLOW
+        ):
+            shutil.rmtree(child)
+            os.symlink(outside, child)
+            swap_done = True
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(local_workspace.os, "open", swapping_open)
+
+    with pytest.raises(LocalWorkspaceError, match="Symlink escapes"):
+        local_workspace.source_tree_size(str(source))
+
+    assert swap_done
 
 
 @pytest.mark.parametrize(
@@ -310,7 +378,7 @@ def test_stage_aborts_when_source_directory_cannot_be_read(local_workspace_env, 
     real_scandir = local_workspace.os.scandir
 
     def failing_scandir(path):
-        if os.path.normpath(path) == os.path.normpath(env["source"]):
+        if _scandir_target_is(env["source"], path):
             raise PermissionError("NAS directory denied")
         return real_scandir(path)
 

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -7,6 +7,7 @@ import pytest
 import services.local_workspace as local_workspace
 from db import Database
 from services.local_workspace import (
+    LocalWorkspaceCancelled,
     LocalWorkspaceConflict,
     LocalWorkspaceError,
     discard_local,
@@ -87,6 +88,54 @@ def test_source_tree_size_converts_traversal_race_to_workspace_error(
         local_workspace.source_tree_size(str(source))
 
 
+def test_source_tree_size_cancels_between_scandir_entries(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    source.mkdir()
+    for index in range(4):
+        (source / f"photo-{index}.raw").write_bytes(b"raw")
+
+    cancelled = threading.Event()
+    enumerated = 0
+    real_scandir = local_workspace.os.scandir
+
+    class CancellingIterator:
+        def __init__(self, entries):
+            self.entries = entries
+
+        def __enter__(self):
+            self.entries.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self.entries.__exit__(*args)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            nonlocal enumerated
+            entry = next(self.entries)
+            enumerated += 1
+            if enumerated == 2:
+                cancelled.set()
+            return entry
+
+    def cancelling_scandir(path):
+        entries = real_scandir(path)
+        if os.path.normpath(path) == os.path.normpath(source):
+            return CancellingIterator(entries)
+        return entries
+
+    monkeypatch.setattr(local_workspace.os, "scandir", cancelling_scandir)
+
+    with pytest.raises(LocalWorkspaceCancelled, match="Folder scan cancelled"):
+        local_workspace.source_tree_size(
+            str(source), cancel_check=cancelled.is_set
+        )
+
+    assert enumerated == 2
+
+
 def test_stage_modify_and_sync_back(local_workspace_env):
     env = local_workspace_env
     result = stage_workspace(env["db"], env["workspace_id"], str(env["vireo_dir"]))
@@ -130,14 +179,14 @@ def test_stage_modify_and_sync_back(local_workspace_env):
 
 def test_stage_aborts_when_source_directory_cannot_be_read(local_workspace_env, monkeypatch):
     env = local_workspace_env
-    real_walk = local_workspace.os.walk
+    real_scandir = local_workspace.os.scandir
 
-    def failing_walk(path, *args, **kwargs):
+    def failing_scandir(path):
         if os.path.normpath(path) == os.path.normpath(env["source"]):
-            kwargs["onerror"](PermissionError("NAS directory denied"))
-        return real_walk(path, *args, **kwargs)
+            raise PermissionError("NAS directory denied")
+        return real_scandir(path)
 
-    monkeypatch.setattr(local_workspace.os, "walk", failing_walk)
+    monkeypatch.setattr(local_workspace.os, "scandir", failing_scandir)
 
     with pytest.raises(LocalWorkspaceError, match="NAS directory denied"):
         stage_workspace(env["db"], env["workspace_id"], str(env["vireo_dir"]))

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -77,7 +77,7 @@ def test_source_tree_size_converts_traversal_race_to_workspace_error(
     source = tmp_path / "source"
     source.mkdir()
 
-    def raced_walk(_root):
+    def raced_walk(_root, *, cancel_check=None):
         raise FileNotFoundError("entry disappeared during traversal")
         yield
 
@@ -154,8 +154,8 @@ def test_staging_temp_file_cannot_overwrite_real_sibling(local_workspace_env, mo
     base.write_bytes(b"base contents")
     real_walk_entries = local_workspace._walk_entries
 
-    def sibling_first(root):
-        yield from sorted(real_walk_entries(root), reverse=True)
+    def sibling_first(root, *, cancel_check=None):
+        yield from sorted(real_walk_entries(root, cancel_check=cancel_check), reverse=True)
 
     monkeypatch.setattr(local_workspace, "_walk_entries", sibling_first)
     stage_workspace(env["db"], env["workspace_id"], str(env["vireo_dir"]))
@@ -225,8 +225,8 @@ def test_stage_rejects_source_swapped_to_symlink_before_copy(local_workspace_env
     real_walk_entries = local_workspace._walk_entries
     swapped = {"done": False}
 
-    def swap_after_walk(root):
-        for entry in real_walk_entries(root):
+    def swap_after_walk(root, *, cancel_check=None):
+        for entry in real_walk_entries(root, cancel_check=cancel_check):
             rel, full, _st = entry
             yield entry
             if not swapped["done"] and rel == os.path.join("2026", "bird.jpg"):
@@ -337,8 +337,8 @@ def test_stage_rejects_symlink_target_swapped_after_walk(local_workspace_env, tm
     real_walk_entries = local_workspace._walk_entries
     swapped = {"done": False}
 
-    def swap_after_walk(root):
-        for entry in real_walk_entries(root):
+    def swap_after_walk(root, *, cancel_check=None):
+        for entry in real_walk_entries(root, cancel_check=cancel_check):
             rel, full, _st = entry
             yield entry
             if not swapped["done"] and rel == "safe-link.jpg":

--- a/vireo/tests/test_local_workspace.py
+++ b/vireo/tests/test_local_workspace.py
@@ -136,6 +136,63 @@ def test_source_tree_size_cancels_between_scandir_entries(tmp_path, monkeypatch)
     assert enumerated == 2
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows test runners may not permit symlinks")
+def test_source_tree_size_does_not_follow_queued_directory_replaced_by_symlink(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "source"
+    child = source / "child"
+    child.mkdir(parents=True)
+    (child / "inside.raw").write_bytes(b"inside")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "outside.raw").write_bytes(b"outside")
+
+    real_scandir = local_workspace.os.scandir
+    swapped = False
+
+    class SwapOnExhaustion:
+        def __init__(self, entries):
+            self.entries = entries
+
+        def __enter__(self):
+            self.entries.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self.entries.__exit__(*args)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            nonlocal swapped
+            try:
+                return next(self.entries)
+            except StopIteration:
+                if not swapped:
+                    shutil.rmtree(child)
+                    os.symlink(outside, child)
+                    swapped = True
+                raise
+
+    def swapping_scandir(path):
+        entries = real_scandir(path)
+        if (
+            not isinstance(path, int)
+            and os.path.normpath(path) == os.path.normpath(source)
+        ):
+            return SwapOnExhaustion(entries)
+        return entries
+
+    monkeypatch.setattr(local_workspace.os, "scandir", swapping_scandir)
+
+    with pytest.raises(LocalWorkspaceError, match="Symlink escapes"):
+        local_workspace.source_tree_size(str(source))
+
+    assert swapped
+
+
 @pytest.mark.parametrize(
     "probe",
     [

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -47,6 +47,23 @@ def create_local_folder_blueprint(
     last_preflight_seq: dict[tuple[int, str | None], int] = {}
     max_preflight_sequences = 64
 
+    def _trim_preflight_sequences(protected_key=None):
+        while len(last_preflight_seq) > max_preflight_sequences:
+            inactive_key = next(
+                (
+                    key
+                    for key in last_preflight_seq
+                    if key not in active_preflights and key != protected_key
+                ),
+                None,
+            )
+            if inactive_key is None:
+                # The number of active scans is already constrained by server
+                # workers. Keep their ordering records until they finish, then
+                # trim from ``_finish_preflight`` below.
+                break
+            last_preflight_seq.pop(inactive_key, None)
+
     def _begin_preflight(
         workspace_id, preflight_id, preflight_client_id=None, preflight_seq=None
     ):
@@ -72,8 +89,7 @@ def create_local_folder_blueprint(
                 # browser pages rather than whichever key was first seen.
                 last_preflight_seq.pop(ordering_key, None)
                 last_preflight_seq[ordering_key] = preflight_seq
-                while len(last_preflight_seq) > max_preflight_sequences:
-                    last_preflight_seq.pop(next(iter(last_preflight_seq)))
+                _trim_preflight_sequences(ordering_key)
             if preflight_id is not None and cancellation_key in cancelled_preflight_ids:
                 # The cancel request can beat the original request to a free
                 # Waitress worker. Advance ordering above before consuming its
@@ -104,6 +120,7 @@ def create_local_folder_blueprint(
             current = active_preflights.get(active_key)
             if current == (preflight_id, cancelled):
                 active_preflights.pop(active_key, None)
+            _trim_preflight_sequences()
 
     def _cancel_preflight(workspace_id, preflight_id):
         with preflight_lock:

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -77,19 +77,32 @@ def create_local_folder_blueprint(
                 # The cancel request can beat the original request to a free
                 # Waitress worker. Advance ordering above before consuming its
                 # tombstone so an even older delayed request is still rejected.
+                # If that predecessor registered between the cancel and this
+                # request, stop it too; the dismissed page no longer needs
+                # either scan. Do not disrupt a scan from another browser page.
                 cancelled_preflight_ids.pop(cancellation_key, None)
+                previous = active_preflights.get(int(workspace_id))
+                if previous is not None and (
+                    preflight_client_id is None
+                    or previous[2] == preflight_client_id
+                ):
+                    previous[1].set()
                 cancelled.set()
                 return cancelled
             previous = active_preflights.get(int(workspace_id))
             if previous is not None:
                 previous[1].set()
-            active_preflights[int(workspace_id)] = (preflight_id, cancelled)
+            active_preflights[int(workspace_id)] = (
+                preflight_id,
+                cancelled,
+                preflight_client_id,
+            )
         return cancelled
 
     def _finish_preflight(workspace_id, preflight_id, cancelled):
         with preflight_lock:
             current = active_preflights.get(int(workspace_id))
-            if current == (preflight_id, cancelled):
+            if current is not None and current[:2] == (preflight_id, cancelled):
                 active_preflights.pop(int(workspace_id), None)
 
     def _cancel_preflight(workspace_id, preflight_id):

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -41,12 +41,14 @@ def create_local_folder_blueprint(
     active_preflights = {}
     cancelled_preflight_ids = {}
     max_cancelled_preflight_ids = 256
-    # Highest client-supplied ordering token seen per workspace. Registered
-    # under ``preflight_lock``; any request that arrives with a token less than
-    # or equal to this is rejected before it can supersede a newer scan.
-    last_preflight_seq: dict[int, int] = {}
+    # Highest ordering token seen per workspace and browser page. Scoping the
+    # high-water mark by client lets a refreshed page start its sequence at one
+    # without being rejected by the previous page's larger counter.
+    last_preflight_seq: dict[tuple[int, str | None], int] = {}
 
-    def _begin_preflight(workspace_id, preflight_id, preflight_seq=None):
+    def _begin_preflight(
+        workspace_id, preflight_id, preflight_client_id=None, preflight_seq=None
+    ):
         cancelled = threading.Event()
         with preflight_lock:
             cancellation_key = (int(workspace_id), preflight_id)
@@ -66,12 +68,12 @@ def create_local_folder_blueprint(
             # the client is stuck at 409 while the user's latest inputs never
             # get a size back. Reject the stale arrival instead.
             if preflight_seq is not None:
-                ws_key = int(workspace_id)
-                last_seen = last_preflight_seq.get(ws_key)
+                ordering_key = (int(workspace_id), preflight_client_id)
+                last_seen = last_preflight_seq.get(ordering_key)
                 if last_seen is not None and preflight_seq <= last_seen:
                     cancelled.set()
                     return cancelled
-                last_preflight_seq[ws_key] = preflight_seq
+                last_preflight_seq[ordering_key] = preflight_seq
             previous = active_preflights.get(int(workspace_id))
             if previous is not None:
                 previous[1].set()
@@ -329,6 +331,12 @@ def create_local_folder_blueprint(
         preflight_id = body.get("preflight_id")
         if not isinstance(preflight_id, str) or not preflight_id.strip():
             preflight_id = None
+        preflight_client_id = body.get("preflight_client_id")
+        if (
+            not isinstance(preflight_client_id, str)
+            or not preflight_client_id.strip()
+        ):
+            preflight_client_id = None
         raw_seq = body.get("preflight_seq")
         preflight_seq: int | None
         if isinstance(raw_seq, bool):
@@ -344,7 +352,12 @@ def create_local_folder_blueprint(
         # every destination volume has finished responding to
         # ``destination_case_insensitive`` — which can hang for seconds each on
         # an unavailable network mount.
-        cancelled = _begin_preflight(workspace_id, preflight_id, preflight_seq)
+        cancelled = _begin_preflight(
+            workspace_id,
+            preflight_id,
+            preflight_client_id,
+            preflight_seq,
+        )
         try:
             try:
                 destination_bases, destination_error = _stage_destinations(

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -41,8 +41,12 @@ def create_local_folder_blueprint(
     active_preflights = {}
     cancelled_preflight_ids = {}
     max_cancelled_preflight_ids = 256
+    # Highest client-supplied ordering token seen per workspace. Registered
+    # under ``preflight_lock``; any request that arrives with a token less than
+    # or equal to this is rejected before it can supersede a newer scan.
+    last_preflight_seq: dict[int, int] = {}
 
-    def _begin_preflight(workspace_id, preflight_id):
+    def _begin_preflight(workspace_id, preflight_id, preflight_seq=None):
         cancelled = threading.Event()
         with preflight_lock:
             cancellation_key = (int(workspace_id), preflight_id)
@@ -53,6 +57,21 @@ def create_local_folder_blueprint(
                 cancelled_preflight_ids.pop(cancellation_key, None)
                 cancelled.set()
                 return cancelled
+            # Client-provided monotonic ordering token. Waitress can deliver
+            # an older request after a newer one has already registered (the
+            # older one waited longer for a free worker, or its cancel signal
+            # never arrived). Without this check the older request would
+            # unconditionally cancel the newer scan and take over as active;
+            # a subsequent cancel for the older id then cancels it too, and
+            # the client is stuck at 409 while the user's latest inputs never
+            # get a size back. Reject the stale arrival instead.
+            if preflight_seq is not None:
+                ws_key = int(workspace_id)
+                last_seen = last_preflight_seq.get(ws_key)
+                if last_seen is not None and preflight_seq <= last_seen:
+                    cancelled.set()
+                    return cancelled
+                last_preflight_seq[ws_key] = preflight_seq
             previous = active_preflights.get(int(workspace_id))
             if previous is not None:
                 previous[1].set()
@@ -310,13 +329,22 @@ def create_local_folder_blueprint(
         preflight_id = body.get("preflight_id")
         if not isinstance(preflight_id, str) or not preflight_id.strip():
             preflight_id = None
+        raw_seq = body.get("preflight_seq")
+        preflight_seq: int | None
+        if isinstance(raw_seq, bool):
+            preflight_seq = None
+        else:
+            try:
+                preflight_seq = int(raw_seq) if raw_seq is not None else None
+            except (TypeError, ValueError):
+                preflight_seq = None
         # Register cancellation state before probing destinations so a concurrent
         # cancel request can flip the shared Event between filesystem calls,
         # rather than being reduced to a tombstone that only takes effect once
         # every destination volume has finished responding to
         # ``destination_case_insensitive`` — which can hang for seconds each on
         # an unavailable network mount.
-        cancelled = _begin_preflight(workspace_id, preflight_id)
+        cancelled = _begin_preflight(workspace_id, preflight_id, preflight_seq)
         try:
             try:
                 destination_bases, destination_error = _stage_destinations(

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -269,6 +269,13 @@ def create_local_folder_blueprint(
                 case_insensitive = destination_case_insensitive(
                     final_path, cancel_check=cancel_check
                 )
+            except LocalWorkspaceCancelled:
+                # ``LocalWorkspaceCancelled`` subclasses ``LocalWorkspaceError``.
+                # Let it propagate so the route-level handler returns the
+                # cancellation-specific error message instead of the generic
+                # 409 the destination probe returns for real filesystem
+                # failures.
+                raise
             except LocalWorkspaceError as exc:
                 return None, json_error(str(exc), 409)
             final_destinations.append(

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -187,7 +187,7 @@ def create_local_folder_blueprint(
             names[root_id] = os.path.basename(path.rstrip("/\\")) or "Folder"
         return names, paths
 
-    def _stage_destinations(body, root_ids, root_names, source_paths):
+    def _stage_destinations(body, root_ids, root_names, source_paths, *, cancel_check=None):
         raw_destinations = body.get("destination_bases") or {}
         if not isinstance(raw_destinations, dict):
             return None, json_error("destination_bases must be an object", 400)
@@ -206,6 +206,15 @@ def create_local_folder_blueprint(
             final_path = os.path.abspath(
                 local_path_for_base(destination, root_id, source_paths[root_id])
             )
+            # ``destination_case_insensitive`` probes the destination volume,
+            # which can block for seconds on a slow or unreachable network
+            # mount. Cooperate with cancellation between folders so a cancel
+            # request only has to wait for the current probe, not every
+            # remaining destination, before the request returns.
+            if cancel_check and cancel_check():
+                raise LocalWorkspaceCancelled(
+                    "Preflight cancelled during destination validation"
+                )
             try:
                 case_insensitive = destination_case_insensitive(final_path)
             except LocalWorkspaceError as exc:
@@ -298,27 +307,41 @@ def create_local_folder_blueprint(
                 409,
             )
         root_names, source_paths = _folder_names(db, root_ids)
-        destination_bases, destination_error = _stage_destinations(
-            body, root_ids, root_names, source_paths
-        )
-        if destination_error is not None:
-            return destination_error
         preflight_id = body.get("preflight_id")
         if not isinstance(preflight_id, str) or not preflight_id.strip():
             preflight_id = None
+        # Register cancellation state before probing destinations so a concurrent
+        # cancel request can flip the shared Event between filesystem calls,
+        # rather than being reduced to a tombstone that only takes effect once
+        # every destination volume has finished responding to
+        # ``destination_case_insensitive`` — which can hang for seconds each on
+        # an unavailable network mount.
         cancelled = _begin_preflight(workspace_id, preflight_id)
         try:
-            result = local_copy_preflight(
-                db,
-                root_ids,
-                vireo_dir,
-                destination_bases=destination_bases,
-                cancel_check=cancelled.is_set,
-            )
-        except LocalWorkspaceCancelled:
-            return json_error("Folder size calculation was cancelled", 409)
-        except LocalWorkspaceError as exc:
-            return json_error(str(exc), 409)
+            try:
+                destination_bases, destination_error = _stage_destinations(
+                    body,
+                    root_ids,
+                    root_names,
+                    source_paths,
+                    cancel_check=cancelled.is_set,
+                )
+            except LocalWorkspaceCancelled:
+                return json_error("Folder size calculation was cancelled", 409)
+            if destination_error is not None:
+                return destination_error
+            try:
+                result = local_copy_preflight(
+                    db,
+                    root_ids,
+                    vireo_dir,
+                    destination_bases=destination_bases,
+                    cancel_check=cancelled.is_set,
+                )
+            except LocalWorkspaceCancelled:
+                return json_error("Folder size calculation was cancelled", 409)
+            except LocalWorkspaceError as exc:
+                return json_error(str(exc), 409)
         finally:
             _finish_preflight(workspace_id, preflight_id, cancelled)
         return jsonify(result)

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -52,6 +52,7 @@ def create_local_folder_blueprint(
     ):
         cancelled = threading.Event()
         with preflight_lock:
+            active_key = (int(workspace_id), preflight_client_id)
             cancellation_key = (int(workspace_id), preflight_id)
             # Client-provided monotonic ordering token. Waitress can deliver
             # an older request after a newer one has already registered (the
@@ -81,29 +82,28 @@ def create_local_folder_blueprint(
                 # request, stop it too; the dismissed page no longer needs
                 # either scan. Do not disrupt a scan from another browser page.
                 cancelled_preflight_ids.pop(cancellation_key, None)
-                previous = active_preflights.get(int(workspace_id))
-                if previous is not None and (
-                    preflight_client_id is None
-                    or previous[2] == preflight_client_id
-                ):
+                previous = active_preflights.get(active_key)
+                if previous is not None:
                     previous[1].set()
                 cancelled.set()
                 return cancelled
-            previous = active_preflights.get(int(workspace_id))
+            previous = active_preflights.get(active_key)
             if previous is not None:
                 previous[1].set()
-            active_preflights[int(workspace_id)] = (
+            active_preflights[active_key] = (
                 preflight_id,
                 cancelled,
-                preflight_client_id,
             )
         return cancelled
 
-    def _finish_preflight(workspace_id, preflight_id, cancelled):
+    def _finish_preflight(
+        workspace_id, preflight_id, preflight_client_id, cancelled
+    ):
         with preflight_lock:
-            current = active_preflights.get(int(workspace_id))
-            if current is not None and current[:2] == (preflight_id, cancelled):
-                active_preflights.pop(int(workspace_id), None)
+            active_key = (int(workspace_id), preflight_client_id)
+            current = active_preflights.get(active_key)
+            if current == (preflight_id, cancelled):
+                active_preflights.pop(active_key, None)
 
     def _cancel_preflight(workspace_id, preflight_id):
         with preflight_lock:
@@ -111,11 +111,11 @@ def create_local_folder_blueprint(
             cancelled_preflight_ids[cancellation_key] = None
             while len(cancelled_preflight_ids) > max_cancelled_preflight_ids:
                 cancelled_preflight_ids.pop(next(iter(cancelled_preflight_ids)))
-            current = active_preflights.get(int(workspace_id))
-            if current is None or current[0] != preflight_id:
-                return False
-            current[1].set()
-            return True
+            for active_key, current in active_preflights.items():
+                if active_key[0] == int(workspace_id) and current[0] == preflight_id:
+                    current[1].set()
+                    return True
+            return False
 
     def _active_context():
         db = get_db()
@@ -406,7 +406,12 @@ def create_local_folder_blueprint(
             except LocalWorkspaceError as exc:
                 return json_error(str(exc), 409)
         finally:
-            _finish_preflight(workspace_id, preflight_id, cancelled)
+            _finish_preflight(
+                workspace_id,
+                preflight_id,
+                preflight_client_id,
+                cancelled,
+            )
         return jsonify(result)
 
     @blueprint.post("/api/workspaces/active/local-folders/preflight/cancel")

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -115,6 +115,13 @@ def create_local_folder_blueprint(
                 if active_key[0] == int(workspace_id) and current[0] == preflight_id:
                     current[1].set()
                     return True
+            # Preflight IDs are generated uniquely per browser request. This
+            # fallback handles workspace activation racing ahead of pagehide
+            # in older clients that did not include their originating id.
+            for current in active_preflights.values():
+                if current[0] == preflight_id:
+                    current[1].set()
+                    return True
             return False
 
     def _active_context():
@@ -469,8 +476,16 @@ def create_local_folder_blueprint(
         preflight_id = body.get("preflight_id")
         if not isinstance(preflight_id, str) or not preflight_id.strip():
             return json_error("preflight_id must be a non-empty string", 400)
+        cancel_workspace_id = body.get("workspace_id")
+        if isinstance(cancel_workspace_id, bool):
+            cancel_workspace_id = workspace_id
+        else:
+            try:
+                cancel_workspace_id = int(cancel_workspace_id)
+            except (TypeError, ValueError):
+                cancel_workspace_id = workspace_id
         return jsonify(
-            {"cancelled": _cancel_preflight(workspace_id, preflight_id)}
+            {"cancelled": _cancel_preflight(cancel_workspace_id, preflight_id)}
         )
 
     @blueprint.post("/api/workspaces/active/local-folders/stage")

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -131,6 +131,24 @@ def create_local_folder_blueprint(
             return None, None, json_error("No active workspace", 400)
         return db, int(workspace_id), None
 
+    def _preflight_context(body):
+        """Bind a queued preflight to the workspace that submitted it."""
+        raw_workspace_id = body.get("workspace_id")
+        if raw_workspace_id is None:
+            # Backward compatibility for clients loaded before workspace-bound
+            # preflights were introduced.
+            return _active_context()
+        if isinstance(raw_workspace_id, bool):
+            return None, None, json_error("workspace_id must be an integer", 400)
+        try:
+            workspace_id = int(raw_workspace_id)
+        except (TypeError, ValueError):
+            return None, None, json_error("workspace_id must be an integer", 400)
+        db = get_db()
+        if db.get_workspace(workspace_id) is None:
+            return None, None, json_error("Workspace not found", 404)
+        return db, workspace_id, None
+
     def _active_root_ids(db, workspace_id):
         return [int(row["id"]) for row in db.get_workspace_folder_roots(workspace_id)]
 
@@ -384,13 +402,13 @@ def create_local_folder_blueprint(
 
     @blueprint.post("/api/workspaces/active/local-folders/preflight")
     def preflight_local_folders():
-        db, workspace_id, error = _active_context()
+        body = request.get_json(silent=True) or {}
+        db, workspace_id, error = _preflight_context(body)
         if error:
             return error
         legacy_error = _legacy_error(db, workspace_id)
         if legacy_error is not None:
             return legacy_error
-        body = request.get_json(silent=True) or {}
         root_ids, request_error = _requested_roots(db, workspace_id, body)
         if request_error is not None:
             return request_error

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -45,6 +45,7 @@ def create_local_folder_blueprint(
     # high-water mark by client lets a refreshed page start its sequence at one
     # without being rejected by the previous page's larger counter.
     last_preflight_seq: dict[tuple[int, str | None], int] = {}
+    max_preflight_sequences = 64
 
     def _begin_preflight(
         workspace_id, preflight_id, preflight_client_id=None, preflight_seq=None
@@ -52,13 +53,6 @@ def create_local_folder_blueprint(
         cancelled = threading.Event()
         with preflight_lock:
             cancellation_key = (int(workspace_id), preflight_id)
-            if preflight_id is not None and cancellation_key in cancelled_preflight_ids:
-                # The cancel request can beat the original request to a free
-                # Waitress worker. Preserve it as a short-lived tombstone so a
-                # late obsolete scan cannot replace and cancel a newer one.
-                cancelled_preflight_ids.pop(cancellation_key, None)
-                cancelled.set()
-                return cancelled
             # Client-provided monotonic ordering token. Waitress can deliver
             # an older request after a newer one has already registered (the
             # older one waited longer for a free worker, or its cancel signal
@@ -73,7 +67,19 @@ def create_local_folder_blueprint(
                 if last_seen is not None and preflight_seq <= last_seen:
                     cancelled.set()
                     return cancelled
+                # Refresh insertion order so the bounded cache retains active
+                # browser pages rather than whichever key was first seen.
+                last_preflight_seq.pop(ordering_key, None)
                 last_preflight_seq[ordering_key] = preflight_seq
+                while len(last_preflight_seq) > max_preflight_sequences:
+                    last_preflight_seq.pop(next(iter(last_preflight_seq)))
+            if preflight_id is not None and cancellation_key in cancelled_preflight_ids:
+                # The cancel request can beat the original request to a free
+                # Waitress worker. Advance ordering above before consuming its
+                # tombstone so an even older delayed request is still rejected.
+                cancelled_preflight_ids.pop(cancellation_key, None)
+                cancelled.set()
+                return cancelled
             previous = active_preflights.get(int(workspace_id))
             if previous is not None:
                 previous[1].set()
@@ -337,6 +343,7 @@ def create_local_folder_blueprint(
         if (
             not isinstance(preflight_client_id, str)
             or not preflight_client_id.strip()
+            or len(preflight_client_id) > 128
         ):
             preflight_client_id = None
         raw_seq = body.get("preflight_seq")

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -237,7 +237,9 @@ def create_local_folder_blueprint(
                     "Preflight cancelled during destination validation"
                 )
             try:
-                case_insensitive = destination_case_insensitive(final_path)
+                case_insensitive = destination_case_insensitive(
+                    final_path, cancel_check=cancel_check
+                )
             except LocalWorkspaceError as exc:
                 return None, json_error(str(exc), 409)
             final_destinations.append(

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -9,6 +9,7 @@ import unicodedata
 from db import Database
 from flask import Blueprint, jsonify, request
 from services.local_folder import (
+    LocalWorkspaceCancelled,
     LocalWorkspaceError,
     affected_workspace_ids,
     discard_folder,
@@ -36,6 +37,45 @@ def create_local_folder_blueprint(
 ):
     blueprint = Blueprint("local_folder", __name__)
     transition_lock = threading.RLock()
+    preflight_lock = threading.Lock()
+    active_preflights = {}
+    cancelled_preflight_ids = {}
+    max_cancelled_preflight_ids = 256
+
+    def _begin_preflight(workspace_id, preflight_id):
+        cancelled = threading.Event()
+        with preflight_lock:
+            cancellation_key = (int(workspace_id), preflight_id)
+            if preflight_id is not None and cancellation_key in cancelled_preflight_ids:
+                # The cancel request can beat the original request to a free
+                # Waitress worker. Preserve it as a short-lived tombstone so a
+                # late obsolete scan cannot replace and cancel a newer one.
+                cancelled_preflight_ids.pop(cancellation_key, None)
+                cancelled.set()
+                return cancelled
+            previous = active_preflights.get(int(workspace_id))
+            if previous is not None:
+                previous[1].set()
+            active_preflights[int(workspace_id)] = (preflight_id, cancelled)
+        return cancelled
+
+    def _finish_preflight(workspace_id, preflight_id, cancelled):
+        with preflight_lock:
+            current = active_preflights.get(int(workspace_id))
+            if current == (preflight_id, cancelled):
+                active_preflights.pop(int(workspace_id), None)
+
+    def _cancel_preflight(workspace_id, preflight_id):
+        with preflight_lock:
+            cancellation_key = (int(workspace_id), preflight_id)
+            cancelled_preflight_ids[cancellation_key] = None
+            while len(cancelled_preflight_ids) > max_cancelled_preflight_ids:
+                cancelled_preflight_ids.pop(next(iter(cancelled_preflight_ids)))
+            current = active_preflights.get(int(workspace_id))
+            if current is None or current[0] != preflight_id:
+                return False
+            current[1].set()
+            return True
 
     def _active_context():
         db = get_db()
@@ -263,16 +303,38 @@ def create_local_folder_blueprint(
         )
         if destination_error is not None:
             return destination_error
+        preflight_id = body.get("preflight_id")
+        if not isinstance(preflight_id, str) or not preflight_id.strip():
+            preflight_id = None
+        cancelled = _begin_preflight(workspace_id, preflight_id)
         try:
             result = local_copy_preflight(
                 db,
                 root_ids,
                 vireo_dir,
                 destination_bases=destination_bases,
+                cancel_check=cancelled.is_set,
             )
+        except LocalWorkspaceCancelled:
+            return json_error("Folder size calculation was cancelled", 409)
         except LocalWorkspaceError as exc:
             return json_error(str(exc), 409)
+        finally:
+            _finish_preflight(workspace_id, preflight_id, cancelled)
         return jsonify(result)
+
+    @blueprint.post("/api/workspaces/active/local-folders/preflight/cancel")
+    def cancel_preflight_local_folders():
+        _db, workspace_id, error = _active_context()
+        if error:
+            return error
+        body = request.get_json(silent=True) or {}
+        preflight_id = body.get("preflight_id")
+        if not isinstance(preflight_id, str) or not preflight_id.strip():
+            return json_error("preflight_id must be a non-empty string", 400)
+        return jsonify(
+            {"cancelled": _cancel_preflight(workspace_id, preflight_id)}
+        )
 
     @blueprint.post("/api/workspaces/active/local-folders/stage")
     def stage_local_folders():


### PR DESCRIPTION
## Summary

Work Locally preflight requests now abort in the browser and notify the server when the dialog closes, the destination changes, or a newer preflight supersedes them.
The root cause was that the UI only ignored stale responses while synchronous directory walks continued consuming server threads and SMB I/O.
Server-side cancellation is cooperative between filesystem calls, deduplicates scans per workspace, and preserves early cancellation requests so request-order races cannot revive obsolete scans.
Validated with `node --check vireo/static/vireo-work-locally.js` and `pytest -q vireo/tests/test_local_folder.py vireo/tests/test_local_workspace.py` (104 passed, 3 skipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation support for local-folder preflight scans.
  * Starting a new scan automatically cancels the previous one.
  * Added an endpoint to cancel active preflight requests.

* **Bug Fixes**
  * Cancelled or outdated requests no longer display misleading errors.
  * Cancelled scans return a clear cancellation response and clean up correctly.
  * Improved filesystem scanning reliability when folders change during a preflight.
  * Prevented unsafe traversal through symbolic links during local-folder checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->