### PR TITLE
Explain when processing blocks Work Locally

### DIFF
--- a/tests/e2e/test_workspace.py
+++ b/tests/e2e/test_workspace.py
@@ -48,6 +48,54 @@ def test_work_locally_full_cycle(live_server, page, tmp_path):
     assert restored == str(source)
 
 
+def test_work_locally_explains_processing_blocker(live_server, page, tmp_path):
+    """A running pipeline disables local-copy controls with a visible reason."""
+    import threading
+
+    db = live_server["db"]
+    source = tmp_path / "nas-blocked"
+    source.mkdir()
+    (source / "bird.jpg").write_bytes(b"original-bytes")
+    workspace_id = db.create_workspace("Processing")
+    db.set_active_workspace(workspace_id)
+    db.add_folder(str(source), name="nas-blocked")
+
+    assert page.request.post(
+        f"{live_server['url']}/api/workspaces/{workspace_id}/activate"
+    ).ok
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def processing(_job):
+        started.set()
+        assert release.wait(timeout=10)
+        return {"ok": True}
+
+    job_id = live_server["app"]._job_runner.start(
+        "pipeline", processing, workspace_id=workspace_id
+    )
+    try:
+        assert started.wait(timeout=2)
+        page.goto(f"{live_server['url']}/workspace", timeout=5000)
+
+        panel = page.locator("#localWorkspaceContent")
+        expect(panel).to_contain_text(
+            "Pipeline is running. Work Locally will be available when it finishes or is cancelled.",
+            timeout=5000,
+        )
+        expect(panel.get_by_role("link", name="View Jobs")).to_be_visible()
+        folder_action = page.get_by_role("button", name="Work Locally", exact=True)
+        expect(folder_action).to_be_disabled()
+
+        release.set()
+        expect(folder_action).to_be_enabled(timeout=10000)
+        expect(panel).not_to_contain_text("Pipeline is running", timeout=10000)
+    finally:
+        release.set()
+        live_server["app"]._job_runner.cancel_job(job_id)
+
+
 def test_workspace_page_lists_all_workspaces(live_server, page):
     """Workspace page shows both Default and Field Work workspaces."""
     url = live_server["url"]

--- a/tests/e2e/test_workspace.py
+++ b/tests/e2e/test_workspace.py
@@ -113,6 +113,55 @@ def test_work_locally_explains_processing_blocker(live_server, page, tmp_path):
         live_server["app"]._job_runner.cancel_job(job_id)
 
 
+def test_open_work_locally_dialog_disables_when_processing_starts(
+    live_server, page, tmp_path
+):
+    """A blocker discovered after preflight disables the open copy dialog."""
+    import threading
+
+    db = live_server["db"]
+    source = tmp_path / "nas-late-blocker"
+    source.mkdir()
+    (source / "bird.jpg").write_bytes(b"original-bytes")
+    workspace_id = db.create_workspace("Late Processing")
+    db.set_active_workspace(workspace_id)
+    db.add_folder(str(source), name="nas-late-blocker")
+    assert page.request.post(
+        f"{live_server['url']}/api/workspaces/{workspace_id}/activate"
+    ).ok
+
+    page.goto(f"{live_server['url']}/workspace", timeout=5000)
+    page.get_by_role("button", name="Work Locally", exact=True).click()
+    modal = page.locator("#stageLocalFoldersModal")
+    copy_button = modal.get_by_role("button", name="Copy Locally", exact=True)
+    expect(copy_button).to_be_enabled(timeout=5000)
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def processing(_job):
+        started.set()
+        assert release.wait(timeout=10)
+        return {"ok": True}
+
+    job_id = live_server["app"]._job_runner.start(
+        "pipeline", processing, workspace_id=workspace_id
+    )
+    try:
+        assert started.wait(timeout=2)
+        page.evaluate("() => window.vireoLocalFolders.load()")
+        expect(copy_button).to_be_disabled()
+        expect(modal.locator("#stageLocalFoldersError")).to_contain_text(
+            "Pipeline is running. Work Locally will be available when it finishes or is cancelled."
+        )
+
+        release.set()
+        expect(copy_button).to_be_enabled(timeout=10000)
+    finally:
+        release.set()
+        live_server["app"]._job_runner.cancel_job(job_id)
+
+
 def test_workspace_page_lists_all_workspaces(live_server, page):
     """Workspace page shows both Default and Field Work workspaces."""
     url = live_server["url"]

--- a/tests/e2e/test_workspace.py
+++ b/tests/e2e/test_workspace.py
@@ -52,13 +52,27 @@ def test_work_locally_explains_processing_blocker(live_server, page, tmp_path):
     """A running pipeline disables local-copy controls with a visible reason."""
     import threading
 
+    from services.local_folder import stage_folder
+
     db = live_server["db"]
     source = tmp_path / "nas-blocked"
     source.mkdir()
     (source / "bird.jpg").write_bytes(b"original-bytes")
+    recovery_source = tmp_path / "nas-recovery"
+    recovery_source.mkdir()
+    (recovery_source / "fox.jpg").write_bytes(b"original-bytes")
     workspace_id = db.create_workspace("Processing")
     db.set_active_workspace(workspace_id)
     db.add_folder(str(source), name="nas-blocked")
+    recovery_folder_id = db.add_folder(
+        str(recovery_source), name="nas-recovery"
+    )
+    stage_folder(db, recovery_folder_id, str(tmp_path))
+    db.conn.execute(
+        "UPDATE local_folders SET state='staging' WHERE root_folder_id=?",
+        (recovery_folder_id,),
+    )
+    db.conn.commit()
 
     assert page.request.post(
         f"{live_server['url']}/api/workspaces/{workspace_id}/activate"
@@ -86,10 +100,13 @@ def test_work_locally_explains_processing_blocker(live_server, page, tmp_path):
         )
         expect(panel.get_by_role("link", name="View Jobs")).to_be_visible()
         folder_action = page.get_by_role("button", name="Work Locally", exact=True)
+        cleanup_action = page.get_by_role("button", name="Clean Up", exact=True)
         expect(folder_action).to_be_disabled()
+        expect(cleanup_action).to_be_disabled()
 
         release.set()
         expect(folder_action).to_be_enabled(timeout=10000)
+        expect(cleanup_action).to_be_enabled(timeout=10000)
         expect(panel).not_to_contain_text("Pipeline is running", timeout=10000)
     finally:
         release.set()

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -25,11 +25,15 @@
   function scheduleBlockingJobRefresh() {
     if (blockingJobTimer) clearTimeout(blockingJobTimer);
     blockingJobTimer = null;
-    if (!data || !data.blocking_job) return;
+    if (!data) return;
+    // Fast refresh while a block is active so the UI re-enables promptly,
+    // slow keep-alive otherwise so a scan/pipeline started in another tab
+    // becomes visible without a page reload.
+    var delay = data.blocking_job ? 3000 : 15000;
     blockingJobTimer = setTimeout(function() {
       blockingJobTimer = null;
       load();
-    }, 3000);
+    }, delay);
   }
 
   function selectedItems(folderIds, localOnly) {
@@ -256,10 +260,17 @@
       container.innerHTML = '<span style="color:var(--text-ghost);font-size:13px;">Migrating the previous local session...</span>';
       return;
     }
+    var blocked = !!(data && data.blocking_job);
+    var blockerHtml = blocked
+      ? '<div role="status" style="font-size:12px;color:var(--warning);line-height:1.5;margin-bottom:12px;">' +
+          escapeHtml(blockingJobMessage()) + ' <a href="/jobs" style="color:inherit;text-decoration:underline;">View Jobs</a></div>'
+      : '';
+    var disabledAttrs = blocked ? ' disabled style="opacity:.5;"' : '';
     if (legacy.state === 'staging') {
       container.innerHTML =
         '<div style="font-size:13px;color:var(--warning);margin-bottom:10px;">An older workspace copy was interrupted before activation.</div>' +
-        '<button class="btn btn-secondary" data-legacy-action="discard">Clean Up Incomplete Copy</button>';
+        blockerHtml +
+        '<button class="btn btn-secondary" data-legacy-action="discard"' + disabledAttrs + '>Clean Up Incomplete Copy</button>';
       return;
     }
     var changes = legacy.changes || {created: 0, modified: 0, deleted: 0};
@@ -270,9 +281,10 @@
       '</div>' +
       '<div style="font-size:11px;color:var(--text-dim);margin-bottom:12px;">' +
         changes.created + ' new · ' + changes.modified + ' modified · ' + changes.deleted + ' deleted</div>' +
+      blockerHtml +
       '<div style="display:flex;gap:8px;flex-wrap:wrap;">' +
-        '<button class="btn btn-secondary" data-legacy-action="sync">' + (recovery ? 'Finish Sync-back' : 'Finish and Sync Back') + '</button>' +
-        '<button class="btn btn-secondary" style="color:var(--danger);" data-legacy-action="discard">Discard Local Changes</button>' +
+        '<button class="btn btn-secondary" data-legacy-action="sync"' + disabledAttrs + '>' + (recovery ? 'Finish Sync-back' : 'Finish and Sync Back') + '</button>' +
+        '<button class="btn btn-secondary" style="color:var(--danger);" data-legacy-action="discard"' + disabledAttrs + '>Discard Local Changes</button>' +
       '</div>';
   }
 
@@ -554,6 +566,10 @@
 
   async function legacyAction(action) {
     if (!data || !data.legacy || actionInFlight || activeJob) return;
+    if (data.blocking_job) {
+      showToast(blockingJobMessage(), 'warning');
+      return;
+    }
     var legacy = data.legacy;
     var endpoint = action === 'sync' ? 'sync' : 'discard';
     var body;

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -8,6 +8,29 @@
   var stagePreflightGeneration = 0;
   var stagePreflightTimer = null;
   var stagePreflightSignature = null;
+  var blockingJobTimer = null;
+
+  function blockingJobMessage() {
+    var job = data && data.blocking_job;
+    if (!job) return '';
+    var label = typeof window.formatJobType === 'function'
+      ? window.formatJobType(job.type)
+      : String(job.type || 'Processing').replace(/[-_]+/g, ' ');
+    var status = ['queued', 'running', 'pausing', 'paused'].indexOf(job.status) >= 0
+      ? job.status
+      : 'running';
+    return label + ' is ' + status + '. Work Locally will be available when it finishes or is cancelled.';
+  }
+
+  function scheduleBlockingJobRefresh() {
+    if (blockingJobTimer) clearTimeout(blockingJobTimer);
+    blockingJobTimer = null;
+    if (!data || !data.blocking_job) return;
+    blockingJobTimer = setTimeout(function() {
+      blockingJobTimer = null;
+      load();
+    }, 3000);
+  }
 
   function selectedItems(folderIds, localOnly) {
     var wanted = folderIds && folderIds.length
@@ -164,6 +187,10 @@
 
   function openStageDialog(folderIds) {
     if (actionInFlight || activeJob) return;
+    if (data && data.blocking_job) {
+      showToast(blockingJobMessage(), 'warning');
+      return;
+    }
     var items = selectedItems(folderIds, false).filter(function(item) {
       return item.state === 'remote';
     });
@@ -282,6 +309,7 @@
     var shared = localItems.filter(function(item) {
       return (item.workspace_ids || []).length > 1;
     }).length;
+    var blocked = !!data.blocking_job;
 
     var summary = local === 0
       ? 'All ' + total + ' folder' + (total === 1 ? ' is' : 's are') + ' using source storage.'
@@ -294,13 +322,20 @@
         (local ? changes.created + ' new · ' + changes.modified + ' modified · ' + changes.deleted + ' deleted' :
           'Local copies speed up work on network or slower storage.') +
         (shared ? ' · ' + shared + ' shared local folder' + (shared === 1 ? '' : 's') : '') +
-      '</div><div style="display:flex;gap:8px;flex-wrap:wrap;">';
+      '</div>';
+    if (blocked) {
+      html += '<div role="status" style="font-size:12px;color:var(--warning);line-height:1.5;margin-bottom:12px;">' +
+        escapeHtml(blockingJobMessage()) + ' <a href="/jobs" style="color:inherit;text-decoration:underline;">View Jobs</a></div>';
+    }
+    html += '<div style="display:flex;gap:8px;flex-wrap:wrap;">';
     if (local < total) {
-      html += '<button class="btn btn-secondary" data-local-folders-action="stage-all">' +
+      html += '<button class="btn btn-secondary" data-local-folders-action="stage-all"' +
+        (blocked ? ' disabled style="opacity:.5;"' : '') + '>' +
         (local ? 'Make All Folders Local' : 'Work Entire Workspace Locally') + '</button>';
     }
     if (local) {
-      html += '<button class="btn btn-secondary" data-local-folders-action="manage">Finish Local Work...</button>';
+      html += '<button class="btn btn-secondary" data-local-folders-action="manage"' +
+        (blocked ? ' disabled style="opacity:.5;"' : '') + '>Finish Local Work...</button>';
     }
     html += '</div>';
     container.innerHTML = html;
@@ -362,6 +397,7 @@
       window.vireoLocalFolderData = data;
       render();
       if (typeof loadWsFolders === 'function') loadWsFolders();
+      scheduleBlockingJobRefresh();
       return data;
     } catch (error) {
       var container = document.getElementById('localWorkspaceContent');
@@ -624,6 +660,8 @@
   window.vireoLocalFolders = {
     load: load,
     statusFor: statusFor,
+    blockingJob: function() { return data && data.blocking_job; },
+    blockingMessage: blockingJobMessage,
     stage: stageFromAnywhere,
     sync: function(folderId) { return sync([Number(folderId)]); },
     discard: function(folderId) { return discard([Number(folderId)]); }

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -9,9 +9,10 @@
   var stagePreflightTimer = null;
   var stagePreflightSignature = null;
   var blockingJobTimer = null;
+  var stageBlockedByJob = false;
 
-  function blockingJobMessage() {
-    var job = data && data.blocking_job;
+  function blockingJobMessage(job) {
+    job = job || (data && data.blocking_job);
     if (!job) return '';
     var label = typeof window.formatJobType === 'function'
       ? window.formatJobType(job.type)
@@ -22,9 +23,27 @@
     return label + ' is ' + status + '. Work Locally will be available when it finishes or is cancelled.';
   }
 
-  function blockerSignature(job) {
-    if (!job) return '';
-    return String(job.id) + ':' + String(job.status || '');
+  function blockingJobForFolder(folderId) {
+    var jobs = (data && data.folder_blocking_jobs) || {};
+    return jobs[String(Number(folderId))] || null;
+  }
+
+  function blockingJobForSelection(folderIds) {
+    if (!data) return null;
+    if (!folderIds || !folderIds.length) return data.blocking_job || null;
+    for (var index = 0; index < folderIds.length; index += 1) {
+      var job = blockingJobForFolder(folderIds[index]);
+      if (job) return job;
+    }
+    return null;
+  }
+
+  function blockerSignature(payload) {
+    if (!payload) return '';
+    return JSON.stringify({
+      blocking_job: payload.blocking_job || null,
+      folder_blocking_jobs: payload.folder_blocking_jobs || {}
+    });
   }
 
   async function refreshBlockingJob() {
@@ -38,8 +57,8 @@
       var payload = await Vireo.api.json(
         '/api/workspaces/active/local-folders/blocker', {}, {toast: false}
       );
-      var previous = blockerSignature(data.blocking_job);
-      var next = blockerSignature(payload.blocking_job);
+      var previous = blockerSignature(data);
+      var next = blockerSignature(payload);
       if (previous !== next) {
         await load();
       }
@@ -117,6 +136,31 @@
         destination_bases: destinationBases
       }
     };
+  }
+
+  function updateStageDialogBlocker() {
+    var modal = document.getElementById('stageLocalFoldersModal');
+    if (!modal || !modal.classList.contains('open') || !pendingStageItems.length) return;
+    var folderIds = pendingStageItems.map(function(item) {
+      return item.requested_folder_id;
+    });
+    var blocker = blockingJobForSelection(folderIds);
+    var button = document.getElementById('confirmStageLocalFolders');
+    var error = document.getElementById('stageLocalFoldersError');
+    if (blocker) {
+      stageBlockedByJob = true;
+      stagePreflightGeneration += 1;
+      stagePreflightSignature = null;
+      if (stagePreflightTimer) clearTimeout(stagePreflightTimer);
+      stagePreflightTimer = null;
+      if (button) button.disabled = true;
+      if (error) error.textContent = blockingJobMessage(blocker);
+      return;
+    }
+    if (!stageBlockedByJob) return;
+    stageBlockedByJob = false;
+    if (error) error.textContent = '';
+    scheduleStagePreflight(0);
   }
 
   function renderStagePreflight(preflight) {
@@ -213,6 +257,7 @@
     if (modal) modal.classList.remove('open');
     stagePreflightGeneration += 1;
     stagePreflightSignature = null;
+    stageBlockedByJob = false;
     if (stagePreflightTimer) clearTimeout(stagePreflightTimer);
     stagePreflightTimer = null;
     pendingStageItems = [];
@@ -220,8 +265,9 @@
 
   function openStageDialog(folderIds) {
     if (actionInFlight || activeJob) return;
-    if (data && data.blocking_job) {
-      showToast(blockingJobMessage(), 'warning');
+    var blocker = blockingJobForSelection(folderIds);
+    if (blocker) {
+      showToast(blockingJobMessage(blocker), 'warning');
       return;
     }
     var items = selectedItems(folderIds, false).filter(function(item) {
@@ -233,6 +279,7 @@
     var error = document.getElementById('stageLocalFoldersError');
     var modal = document.getElementById('stageLocalFoldersModal');
     if (!container || !modal) return;
+    stageBlockedByJob = false;
     if (error) error.textContent = '';
     container.innerHTML = items.map(function(item) {
       var id = Number(item.requested_folder_id);
@@ -438,6 +485,7 @@
       window.vireoLocalFolderData = data;
       render();
       if (typeof loadWsFolders === 'function') loadWsFolders();
+      updateStageDialogBlocker();
       scheduleBlockingJobRefresh();
       return data;
     } catch (error) {
@@ -452,6 +500,13 @@
     var error = document.getElementById('stageLocalFoldersError');
     var button = document.getElementById('confirmStageLocalFolders');
     var request = stageRequestBody();
+    var blocker = blockingJobForSelection(request.body.folder_ids);
+    if (blocker) {
+      stageBlockedByJob = true;
+      if (button) button.disabled = true;
+      if (error) error.textContent = blockingJobMessage(blocker);
+      return;
+    }
     if (!request.complete || stagePreflightSignature !== JSON.stringify(request.body)) {
       if (error) error.textContent = 'Wait for the size and free-space check to finish.';
       scheduleStagePreflight(0);
@@ -482,8 +537,9 @@
     if (actionInFlight || activeJob) return;
     await load();
     if (activeJob) return;
-    if (data && data.blocking_job) {
-      showToast(blockingJobMessage(), 'warning');
+    var blocker = blockingJobForSelection(folderIds);
+    if (blocker) {
+      showToast(blockingJobMessage(blocker), 'warning');
       return;
     }
     var items = selectedItems(folderIds, true);
@@ -533,8 +589,9 @@
     if (actionInFlight || activeJob) return;
     await load();
     if (activeJob) return;
-    if (data && data.blocking_job) {
-      showToast(blockingJobMessage(), 'warning');
+    var blocker = blockingJobForSelection(folderIds);
+    if (blocker) {
+      showToast(blockingJobMessage(blocker), 'warning');
       return;
     }
     var items = selectedItems(folderIds, true);
@@ -714,6 +771,7 @@
     load: load,
     statusFor: statusFor,
     blockingJob: function() { return data && data.blocking_job; },
+    blockingJobFor: blockingJobForFolder,
     blockingMessage: blockingJobMessage,
     stage: stageFromAnywhere,
     sync: function(folderId) { return sync([Number(folderId)]); },

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -22,6 +22,35 @@
     return label + ' is ' + status + '. Work Locally will be available when it finishes or is cancelled.';
   }
 
+  function blockerSignature(job) {
+    if (!job) return '';
+    return String(job.id) + ':' + String(job.status || '');
+  }
+
+  async function refreshBlockingJob() {
+    // Poll only the lightweight blocker endpoint. The full /local-folders
+    // payload walks every managed local tree, so hitting it on a keep-alive
+    // timer while nothing is happening would keep the disk busy for large
+    // libraries. Trigger a full load() only when the blocker state actually
+    // changes so the panel re-renders enabled/disabled controls.
+    if (!data) return;
+    try {
+      var payload = await Vireo.api.json(
+        '/api/workspaces/active/local-folders/blocker', {}, {toast: false}
+      );
+      var previous = blockerSignature(data.blocking_job);
+      var next = blockerSignature(payload.blocking_job);
+      if (previous !== next) {
+        await load();
+      }
+    } catch (_error) {
+      // Swallow — the next tick will retry, and any hard error already
+      // surfaces through the full-load code path.
+    } finally {
+      scheduleBlockingJobRefresh();
+    }
+  }
+
   function scheduleBlockingJobRefresh() {
     if (blockingJobTimer) clearTimeout(blockingJobTimer);
     blockingJobTimer = null;
@@ -32,7 +61,7 @@
     var delay = data.blocking_job ? 3000 : 15000;
     blockingJobTimer = setTimeout(function() {
       blockingJobTimer = null;
-      load();
+      refreshBlockingJob();
     }, delay);
   }
 
@@ -453,6 +482,10 @@
     if (actionInFlight || activeJob) return;
     await load();
     if (activeJob) return;
+    if (data && data.blocking_job) {
+      showToast(blockingJobMessage(), 'warning');
+      return;
+    }
     var items = selectedItems(folderIds, true);
     if (!items.length) return;
     if (items.some(function(item) {
@@ -500,6 +533,10 @@
     if (actionInFlight || activeJob) return;
     await load();
     if (activeJob) return;
+    if (data && data.blocking_job) {
+      showToast(blockingJobMessage(), 'warning');
+      return;
+    }
     var items = selectedItems(folderIds, true);
     if (!items.length) return;
     var affected = new Set();

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -263,7 +263,9 @@
     pendingStageItems = [];
   }
 
-  function openStageDialog(folderIds) {
+  async function openStageDialog(folderIds) {
+    if (actionInFlight || activeJob) return;
+    await load();
     if (actionInFlight || activeJob) return;
     var blocker = blockingJobForSelection(folderIds);
     if (blocker) {
@@ -659,6 +661,8 @@
   }
 
   async function legacyAction(action) {
+    if (!data || !data.legacy || actionInFlight || activeJob) return;
+    await load();
     if (!data || !data.legacy || actionInFlight || activeJob) return;
     if (data.blocking_job) {
       showToast(blockingJobMessage(), 'warning');

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -203,6 +203,8 @@ async function loadWsFolders() {
       ws.folders.forEach(function(f) {
         _wsFoldersById[f.id] = f;
         var local = window.vireoLocalFolders ? window.vireoLocalFolders.statusFor(f.id) : null;
+        var localBlocked = window.vireoLocalFolders && window.vireoLocalFolders.blockingJob();
+        var localBlockedMessage = localBlocked ? window.vireoLocalFolders.blockingMessage() : '';
         var displayPath = local && local.display_path ? local.display_path : f.path;
         var hasLocalActions = local && local.state !== 'remote' && local.state !== 'staging' &&
           !(local.state === 'recovery' && local.recovery_kind !== 'sync');
@@ -216,7 +218,9 @@ async function loadWsFolders() {
         html += '</label>';
         if (local) {
           if (local.state === 'remote') {
-            html += '<button onclick="vireoLocalFolders.stage(' + f.id + ')" class="btn btn-secondary" style="padding:4px 9px;font-size:11px;">Work Locally</button>';
+            html += '<button onclick="vireoLocalFolders.stage(' + f.id + ')" class="btn btn-secondary"' +
+              (localBlocked ? ' disabled title="' + escapeAttr(localBlockedMessage) + '"' : '') +
+              ' style="padding:4px 9px;font-size:11px;' + (localBlocked ? 'opacity:.5;' : '') + '">Work Locally</button>';
           } else if (local.state === 'staging') {
             html += '<span style="font-size:11px;color:var(--warning);">Copying...</span>';
           } else if (local.state === 'recovery' && local.recovery_kind !== 'sync') {
@@ -232,8 +236,12 @@ async function loadWsFolders() {
           html += '<span style="font-size:10px;color:var(--accent);background:rgba(36,229,202,0.1);padding:2px 7px;border-radius:3px;" title="' +
             (sharedCount > 1 ? 'Shared by ' + sharedCount + ' workspaces' : 'Using managed local storage') + '">Local' +
             (sharedCount > 1 ? ' · ' + sharedCount + ' workspaces' : '') + '</span>';
-          html += '<button onclick="vireoLocalFolders.sync(' + f.id + ')" class="btn btn-secondary" style="padding:4px 9px;font-size:11px;">Sync Back</button>';
-          html += '<button onclick="vireoLocalFolders.discard(' + f.id + ')" class="btn btn-secondary" style="padding:4px 9px;font-size:11px;color:var(--danger);">Discard</button>';
+          html += '<button onclick="vireoLocalFolders.sync(' + f.id + ')" class="btn btn-secondary"' +
+            (localBlocked ? ' disabled title="' + escapeAttr(localBlockedMessage) + '"' : '') +
+            ' style="padding:4px 9px;font-size:11px;' + (localBlocked ? 'opacity:.5;' : '') + '">Sync Back</button>';
+          html += '<button onclick="vireoLocalFolders.discard(' + f.id + ')" class="btn btn-secondary"' +
+            (localBlocked ? ' disabled title="' + escapeAttr(localBlockedMessage) + '"' : '') +
+            ' style="padding:4px 9px;font-size:11px;color:var(--danger);' + (localBlocked ? 'opacity:.5;' : '') + '">Discard</button>';
           html += '</div>';
         }
         html += '</div>';

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -225,7 +225,9 @@ async function loadWsFolders() {
             html += '<span style="font-size:11px;color:var(--warning);">Copying...</span>';
           } else if (local.state === 'recovery' && local.recovery_kind !== 'sync') {
             html += '<span style="font-size:11px;color:var(--warning);">Local copy needs cleanup</span>';
-            html += '<button onclick="vireoLocalFolders.discard(' + f.id + ')" class="btn btn-secondary" style="padding:4px 9px;font-size:11px;color:var(--danger);">Clean Up</button>';
+            html += '<button onclick="vireoLocalFolders.discard(' + f.id + ')" class="btn btn-secondary"' +
+              (localBlocked ? ' disabled title="' + escapeAttr(localBlockedMessage) + '"' : '') +
+              ' style="padding:4px 9px;font-size:11px;color:var(--danger);' + (localBlocked ? 'opacity:.5;' : '') + '">Clean Up</button>';
           }
         }
         html += '<button onclick="removeFolderFromWs(' + ws.id + ', ' + f.id + ')" style="background:none;border:none;color:var(--danger);cursor:pointer;font-size:16px;" title="Remove from workspace">&times;</button>';

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -203,8 +203,8 @@ async function loadWsFolders() {
       ws.folders.forEach(function(f) {
         _wsFoldersById[f.id] = f;
         var local = window.vireoLocalFolders ? window.vireoLocalFolders.statusFor(f.id) : null;
-        var localBlocked = window.vireoLocalFolders && window.vireoLocalFolders.blockingJob();
-        var localBlockedMessage = localBlocked ? window.vireoLocalFolders.blockingMessage() : '';
+        var localBlocked = window.vireoLocalFolders && window.vireoLocalFolders.blockingJobFor(f.id);
+        var localBlockedMessage = localBlocked ? window.vireoLocalFolders.blockingMessage(localBlocked) : '';
         var displayPath = local && local.display_path ? local.display_path : f.path;
         var hasLocalActions = local && local.state !== 'remote' && local.state !== 'staging' &&
           !(local.state === 'recovery' && local.recovery_kind !== 'sync');

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -149,6 +149,7 @@ GET          /api/workspaces/<int:ws_id>/folders
 GET          /api/workspaces/active
 GET          /api/workspaces/active/config
 GET          /api/workspaces/active/local-folders
+GET          /api/workspaces/active/local-folders/blocker
 GET          /api/workspaces/active/local-workspace
 GET          /api/workspaces/active/new-images
 GET          /api/workspaces/active/new-images/snapshot/<int:snapshot_id>

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1671,6 +1671,70 @@ def test_local_folder_blockers_are_scoped_to_affected_roots(tmp_path, monkeypatc
         assert wait_for_job_via_client(client, job_id)["status"] == "completed"
 
 
+def test_local_folder_blockers_include_descendant_sessions(tmp_path, monkeypatch):
+    """Every local-session row surfaced by workspace status gets a blocker."""
+    import threading
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+
+    parent_source = tmp_path / "nas" / "parent"
+    child_source = parent_source / "child"
+    child_source.mkdir(parents=True)
+    (child_source / "bird.jpg").write_bytes(b"original")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    parent_workspace = db.create_workspace("Parent")
+    child_workspace = db.create_workspace("Child")
+    parent_id = db.add_folder(
+        str(parent_source), name="parent", link_to_workspace=False
+    )
+    child_id = db.add_folder(
+        str(child_source),
+        name="child",
+        parent_id=parent_id,
+        link_to_workspace=False,
+    )
+    db.add_workspace_folder(parent_workspace, parent_id)
+    db.add_workspace_folder(child_workspace, child_id)
+    stage_folder(db, child_id, str(vireo_dir))
+    db.close()
+
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    started = threading.Event()
+    release = threading.Event()
+
+    def processing(_job):
+        started.set()
+        assert release.wait(timeout=10)
+        return {"ok": True}
+
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{parent_workspace}/activate", json={}
+        ).status_code == 200
+        job_id = app._job_runner.start(
+            "pipeline", processing, workspace_id=child_workspace
+        )
+        try:
+            assert started.wait(timeout=2)
+            blocker = client.get(
+                "/api/workspaces/active/local-folders/blocker"
+            ).get_json()
+            assert blocker["blocking_job"]["id"] == job_id
+            assert blocker["folder_blocking_jobs"] == {
+                str(child_id): blocker["blocking_job"],
+            }
+        finally:
+            release.set()
+        assert wait_for_job_via_client(client, job_id)["status"] == "completed"
+
+
 def test_folder_sync_proceeds_while_observational_job_runs(tmp_path, monkeypatch):
     """An automatic read-only probe must not hold local work hostage.
 

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1494,6 +1494,98 @@ def test_local_folder_status_exposes_blocking_job_and_preflight_stops_early(
         assert wait_for_job_via_client(client, job_id)["status"] == "completed"
 
 
+def test_local_folder_blocker_endpoint_avoids_source_walk(tmp_path, monkeypatch):
+    """The lightweight blocker endpoint must not walk managed local trees.
+
+    The Work Locally panel polls this endpoint on a keep-alive timer to notice
+    scans/pipelines started from other tabs. The full ``/local-folders``
+    payload recursively walks every managed local tree via ``folder_status``
+    to compute a change summary, so hitting it every few seconds on a large
+    library would keep the disk continuously busy.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import web.local_folder as local_folder_web
+    from app import create_app
+
+    source = tmp_path / "nas" / "photos"
+    source.mkdir(parents=True)
+    (source / "bird.jpg").write_bytes(b"original")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    workspace_id = db.create_workspace("Owner")
+    folder_id = db.add_folder(str(source), name="photos", link_to_workspace=False)
+    db.add_workspace_folder(workspace_id, folder_id)
+    db.set_active_workspace(workspace_id)
+    db.close()
+
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+
+    def unexpected_status(*_args, **_kwargs):
+        raise AssertionError("blocker endpoint must not walk local trees")
+
+    # web.local_folder rebinds workspace_status via `from services.local_folder
+    # import workspace_status`, so patch that name on the consuming module.
+    monkeypatch.setattr(local_folder_web, "workspace_status", unexpected_status)
+
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={}
+        ).status_code == 200
+        # No blocker → empty payload, without walking storage.
+        response = client.get("/api/workspaces/active/local-folders/blocker")
+        assert response.status_code == 200
+        assert response.get_json() == {"blocking_job": None}
+
+    import threading
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def processing(_job):
+        started.set()
+        assert release.wait(timeout=10)
+        return {"ok": True}
+
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={}
+        ).status_code == 200
+        job_id = app._job_runner.start(
+            "pipeline", processing, workspace_id=workspace_id
+        )
+        try:
+            assert started.wait(timeout=2)
+            response = client.get("/api/workspaces/active/local-folders/blocker")
+            assert response.status_code == 200
+            assert response.get_json() == {
+                "blocking_job": {
+                    "id": job_id,
+                    "type": "pipeline",
+                    "status": "running",
+                }
+            }
+        finally:
+            release.set()
+        assert wait_for_job_via_client(client, job_id)["status"] == "completed"
+
+    # Once the pipeline finishes the endpoint should report an empty blocker
+    # again, still without hitting workspace_status.
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={}
+        ).status_code == 200
+        response = client.get("/api/workspaces/active/local-folders/blocker")
+        assert response.status_code == 200
+        assert response.get_json() == {"blocking_job": None}
+    # Silence unused-variable warning when folder_id isn't referenced.
+    assert folder_id
+
+
 def test_folder_sync_proceeds_while_observational_job_runs(tmp_path, monkeypatch):
     """An automatic read-only probe must not hold local work hostage.
 

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1420,6 +1420,80 @@ def test_folder_stage_endpoint_refuses_while_scan_is_paused(tmp_path, monkeypatc
         wait_for_job_via_client(client, job_id)
 
 
+def test_local_folder_status_exposes_blocking_job_and_preflight_stops_early(
+    tmp_path, monkeypatch
+):
+    """The UI should know a transition is unavailable before scanning storage.
+
+    The capacity preflight can take a long time on a network volume.  If a
+    pipeline already makes Work Locally unsafe, report that job in status and
+    reject preflight without walking the source tree.
+    """
+    import threading
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import web.local_folder as local_folder_web
+    from app import create_app
+
+    source = tmp_path / "nas" / "photos"
+    source.mkdir(parents=True)
+    (source / "bird.jpg").write_bytes(b"original")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    workspace_id = db.create_workspace("Owner")
+    folder_id = db.add_folder(str(source), name="photos", link_to_workspace=False)
+    db.add_workspace_folder(workspace_id, folder_id)
+    db.set_active_workspace(workspace_id)
+    db.close()
+
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    started = threading.Event()
+    release = threading.Event()
+
+    def processing(_job):
+        started.set()
+        assert release.wait(timeout=10)
+        return {"ok": True}
+
+    def unexpected_preflight(*_args, **_kwargs):
+        raise AssertionError("blocked preflight must not scan source storage")
+
+    monkeypatch.setattr(local_folder_web, "local_copy_preflight", unexpected_preflight)
+
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{workspace_id}/activate", json={}
+        ).status_code == 200
+        job_id = app._job_runner.start(
+            "pipeline", processing, workspace_id=workspace_id
+        )
+        try:
+            assert started.wait(timeout=2)
+            status = client.get(
+                "/api/workspaces/active/local-folders"
+            ).get_json()
+            assert status["blocking_job"] == {
+                "id": job_id,
+                "type": "pipeline",
+                "status": "running",
+            }
+
+            preflight = client.post(
+                "/api/workspaces/active/local-folders/preflight",
+                json={"folder_ids": [folder_id]},
+            )
+            assert preflight.status_code == 409
+            assert "pipeline" in preflight.get_json()["error"]
+        finally:
+            release.set()
+        assert wait_for_job_via_client(client, job_id)["status"] == "completed"
+
+
 def test_folder_sync_proceeds_while_observational_job_runs(tmp_path, monkeypatch):
     """An automatic read-only probe must not hold local work hostage.
 

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -1539,7 +1539,10 @@ def test_local_folder_blocker_endpoint_avoids_source_walk(tmp_path, monkeypatch)
         # No blocker → empty payload, without walking storage.
         response = client.get("/api/workspaces/active/local-folders/blocker")
         assert response.status_code == 200
-        assert response.get_json() == {"blocking_job": None}
+        assert response.get_json() == {
+            "blocking_job": None,
+            "folder_blocking_jobs": {},
+        }
 
     import threading
 
@@ -1567,7 +1570,14 @@ def test_local_folder_blocker_endpoint_avoids_source_walk(tmp_path, monkeypatch)
                     "id": job_id,
                     "type": "pipeline",
                     "status": "running",
-                }
+                },
+                "folder_blocking_jobs": {
+                    str(folder_id): {
+                        "id": job_id,
+                        "type": "pipeline",
+                        "status": "running",
+                    }
+                },
             }
         finally:
             release.set()
@@ -1581,9 +1591,84 @@ def test_local_folder_blocker_endpoint_avoids_source_walk(tmp_path, monkeypatch)
         ).status_code == 200
         response = client.get("/api/workspaces/active/local-folders/blocker")
         assert response.status_code == 200
-        assert response.get_json() == {"blocking_job": None}
+        assert response.get_json() == {
+            "blocking_job": None,
+            "folder_blocking_jobs": {},
+        }
     # Silence unused-variable warning when folder_id isn't referenced.
     assert folder_id
+
+
+def test_local_folder_blockers_are_scoped_to_affected_roots(tmp_path, monkeypatch):
+    """A shared-root job must not disable an unrelated root in the workspace."""
+    import threading
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+
+    shared_source = tmp_path / "nas" / "shared"
+    unrelated_source = tmp_path / "nas" / "unrelated"
+    shared_source.mkdir(parents=True)
+    unrelated_source.mkdir(parents=True)
+    (shared_source / "bird.jpg").write_bytes(b"shared")
+    (unrelated_source / "fox.jpg").write_bytes(b"unrelated")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    first_workspace = db.create_workspace("First")
+    second_workspace = db.create_workspace("Second")
+    shared_id = db.add_folder(
+        str(shared_source), name="shared", link_to_workspace=False
+    )
+    unrelated_id = db.add_folder(
+        str(unrelated_source), name="unrelated", link_to_workspace=False
+    )
+    db.add_workspace_folder(first_workspace, shared_id)
+    db.add_workspace_folder(first_workspace, unrelated_id)
+    db.add_workspace_folder(second_workspace, shared_id)
+    db.close()
+
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    started = threading.Event()
+    release = threading.Event()
+
+    def processing(_job):
+        started.set()
+        assert release.wait(timeout=10)
+        return {"ok": True}
+
+    with app.test_client() as client:
+        assert client.post(
+            f"/api/workspaces/{first_workspace}/activate", json={}
+        ).status_code == 200
+        job_id = app._job_runner.start(
+            "pipeline", processing, workspace_id=second_workspace
+        )
+        try:
+            assert started.wait(timeout=2)
+            blocker = client.get(
+                "/api/workspaces/active/local-folders/blocker"
+            ).get_json()
+            assert blocker["blocking_job"]["id"] == job_id
+            assert blocker["folder_blocking_jobs"] == {
+                str(shared_id): blocker["blocking_job"]
+            }
+
+            stage = client.post(
+                "/api/workspaces/active/local-folders/stage",
+                json={"folder_ids": [unrelated_id]},
+            )
+            assert stage.status_code == 202, stage.get_json()
+            assert wait_for_job_via_client(
+                client, stage.get_json()["job_id"]
+            )["status"] == "completed"
+        finally:
+            release.set()
+        assert wait_for_job_via_client(client, job_id)["status"] == "completed"
 
 
 def test_folder_sync_proceeds_while_observational_job_runs(tmp_path, monkeypatch):

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -212,14 +212,17 @@ def create_local_folder_blueprint(
 
     def _blocking_status_payload(db, workspace_id):
         root_ids = _active_root_ids(db, workspace_id)
+        selectable_root_ids = set(root_ids) | set(
+            workspace_local_root_ids(db, workspace_id)
+        )
         folder_blocking_jobs = {}
-        for root_id in root_ids:
+        for root_id in selectable_root_ids:
             blocking_job = _busy_job(db, [root_id], workspace_id)
             if blocking_job is not None:
                 folder_blocking_jobs[str(root_id)] = _job_payload(blocking_job)
         return {
             "blocking_job": _job_payload(
-                _busy_job(db, root_ids, workspace_id)
+                _busy_job(db, selectable_root_ids, workspace_id)
             ),
             "folder_blocking_jobs": folder_blocking_jobs,
         }

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -121,6 +121,9 @@ def create_local_folder_blueprint(
                 return job
         return None
 
+    def _busy_job_error(job):
+        return f"Wait for the {job['type']} job to finish before working locally"
+
     def _legacy_error(db, workspace_id):
         if legacy_local_state(db, workspace_id):
             return json_error(
@@ -209,6 +212,17 @@ def create_local_folder_blueprint(
             return json_error(str(exc), 409)
         payload["legacy_workspace_session"] = bool(legacy_local_state(db, workspace_id))
 
+        blocking_job = _busy_job(db, _active_root_ids(db, workspace_id), workspace_id)
+        payload["blocking_job"] = (
+            {
+                "id": blocking_job["id"],
+                "type": blocking_job["type"],
+                "status": blocking_job["status"],
+            }
+            if blocking_job is not None
+            else None
+        )
+
         jobs = []
         active_roots = set(_active_root_ids(db, workspace_id))
         # Include descendant local sessions (workspace A links /parent while
@@ -257,6 +271,9 @@ def create_local_folder_blueprint(
                 "The selected folders are already local or contain a folder working locally",
                 409,
             )
+        busy = _busy_job(db, root_ids, workspace_id)
+        if busy:
+            return json_error(_busy_job_error(busy), 409)
         root_names, source_paths = _folder_names(db, root_ids)
         destination_bases, destination_error = _stage_destinations(
             body, root_ids, root_names, source_paths
@@ -374,9 +391,7 @@ def create_local_folder_blueprint(
         with transition_lock:
             busy = _busy_job(db, root_ids, workspace_id)
             if busy:
-                return json_error(
-                    f"Wait for the {busy['type']} job to finish before working locally", 409
-                )
+                return json_error(_busy_job_error(busy), 409)
             # Recheck residency inside the same registration boundary so two
             # simultaneous requests cannot both report 202 for one folder.
             if any(local_root_for_folder(db, root_id) is not None for root_id in root_ids):

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -201,14 +201,27 @@ def create_local_folder_blueprint(
                     )
         return destination_bases, None
 
-    def _blocking_job_payload(db, workspace_id):
-        blocking_job = _busy_job(db, _active_root_ids(db, workspace_id), workspace_id)
-        if blocking_job is None:
+    def _job_payload(job):
+        if job is None:
             return None
         return {
-            "id": blocking_job["id"],
-            "type": blocking_job["type"],
-            "status": blocking_job["status"],
+            "id": job["id"],
+            "type": job["type"],
+            "status": job["status"],
+        }
+
+    def _blocking_status_payload(db, workspace_id):
+        root_ids = _active_root_ids(db, workspace_id)
+        folder_blocking_jobs = {}
+        for root_id in root_ids:
+            blocking_job = _busy_job(db, [root_id], workspace_id)
+            if blocking_job is not None:
+                folder_blocking_jobs[str(root_id)] = _job_payload(blocking_job)
+        return {
+            "blocking_job": _job_payload(
+                _busy_job(db, root_ids, workspace_id)
+            ),
+            "folder_blocking_jobs": folder_blocking_jobs,
         }
 
     @blueprint.get("/api/workspaces/active/local-folders/blocker")
@@ -221,7 +234,7 @@ def create_local_folder_blueprint(
         db, workspace_id, error = _active_context()
         if error:
             return error
-        return jsonify({"blocking_job": _blocking_job_payload(db, workspace_id)})
+        return jsonify(_blocking_status_payload(db, workspace_id))
 
     @blueprint.get("/api/workspaces/active/local-folders")
     def local_folder_status():
@@ -234,7 +247,7 @@ def create_local_folder_blueprint(
             return json_error(str(exc), 409)
         payload["legacy_workspace_session"] = bool(legacy_local_state(db, workspace_id))
 
-        payload["blocking_job"] = _blocking_job_payload(db, workspace_id)
+        payload.update(_blocking_status_payload(db, workspace_id))
 
         jobs = []
         active_roots = set(_active_root_ids(db, workspace_id))

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -201,6 +201,28 @@ def create_local_folder_blueprint(
                     )
         return destination_bases, None
 
+    def _blocking_job_payload(db, workspace_id):
+        blocking_job = _busy_job(db, _active_root_ids(db, workspace_id), workspace_id)
+        if blocking_job is None:
+            return None
+        return {
+            "id": blocking_job["id"],
+            "type": blocking_job["type"],
+            "status": blocking_job["status"],
+        }
+
+    @blueprint.get("/api/workspaces/active/local-folders/blocker")
+    def local_folder_blocker():
+        # The full /local-folders payload recursively walks every managed local
+        # tree to compute a change summary, so polling it every few seconds to
+        # detect newly started jobs keeps the disk busy for large libraries.
+        # This endpoint returns only what the UI needs to enable or disable
+        # Work Locally controls, so it can safely be polled instead.
+        db, workspace_id, error = _active_context()
+        if error:
+            return error
+        return jsonify({"blocking_job": _blocking_job_payload(db, workspace_id)})
+
     @blueprint.get("/api/workspaces/active/local-folders")
     def local_folder_status():
         db, workspace_id, error = _active_context()
@@ -212,16 +234,7 @@ def create_local_folder_blueprint(
             return json_error(str(exc), 409)
         payload["legacy_workspace_session"] = bool(legacy_local_state(db, workspace_id))
 
-        blocking_job = _busy_job(db, _active_root_ids(db, workspace_id), workspace_id)
-        payload["blocking_job"] = (
-            {
-                "id": blocking_job["id"],
-                "type": blocking_job["type"],
-                "status": blocking_job["status"],
-            }
-            if blocking_job is not None
-            else None
-        )
+        payload["blocking_job"] = _blocking_job_payload(db, workspace_id)
 
         jobs = []
         active_roots = set(_active_root_ids(db, workspace_id))


### PR DESCRIPTION
Surface the active blocking job in Work Locally status and skip expensive copy preflights when a local transition cannot start.

Disable local-copy, sync, and discard controls with a clear explanation and Jobs link, then poll until processing finishes so the controls re-enable automatically.

Tests: `ruff check vireo/web/local_folder.py vireo/tests/test_local_folder.py tests/e2e/test_workspace.py`; `pytest -q vireo/tests/test_local_folder.py`; `pytest -q tests/e2e/test_workspace.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status messaging when workspace actions are blocked by an active job.
  * Added a “View Jobs” link to help monitor the blocking job.
  * Added automatic status updates while jobs are queued or running.

* **Bug Fixes**
  * Prevented Work Locally, Clean Up, Sync Back, and Discard actions from starting during conflicting operations.
  * Controls now automatically re-enable when the blocking job completes or is cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->