### PR TITLE
Use standard sleep phrasing

### DIFF
--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -292,7 +292,7 @@
          the lid still sleeps the machine and will still kill the job. -->
     <div class="jobs-awake-note" id="keepingAwakeNote" style="display:none;"
          title="Long jobs die if the machine sleeps — a network share often does not survive it.">
-      Keeping this computer awake while jobs run. Closing the lid will still sleep it.
+      Keeping this computer awake while jobs run. Closing the lid will still put it to sleep.
     </div>
     <div class="jobs-list-content" id="jobListContent">
       <div style="padding:24px;text-align:center;color:var(--text-ghost);font-size:13px;">Loading...</div>


### PR DESCRIPTION
## Summary

- replace the awkward transitive use of “sleep” in the jobs awake notice
- use the standard phrase “put it to sleep” for clearer English

## Impact

The notice shown while jobs keep the computer awake now reads naturally and remains behaviorally unchanged.

## Validation

- `pytest -q vireo/tests/test_app.py::test_templates_jinja_free_except_includes`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the awake-status message to indicate that closing the lid puts the computer to sleep.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->