### PR TITLE
Make Stop kill the in-flight import rsync and report honest transfer progress

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2182,8 +2182,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     rc, stderr, timed_out = _do_rsync(
                         [str(sf) for sf, _bn, _sh in flat], rsync_target, True,
                         extra_args,
-                        progress_cb=lambda done, _tot, name, _label:
-                            _emit_transfer(rel, done, batch_size, name))
+                        progress_cb=lambda done, _tot, name, _label,
+                        _rel=rel, _bs=batch_size:
+                            _emit_transfer(_rel, done, _bs, name))
                     if timed_out:
                         for sf, _bn, _sh in flat:
                             _fail(rel, sf, "rsync stalled (no progress)")

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2145,7 +2145,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             # can otherwise pin "cancelling" for hours,
                             # since cancellation is only observed at file/
                             # batch boundaries the transfer never yields.
-                            cancel_check=lambda: runner.is_cancelled(
+                            # Non-blocking probe: this fires from the rsync
+                            # watchdog thread, and ``is_cancelled`` would
+                            # park it inside ``wait_if_paused`` on Pause,
+                            # disabling both stall detection and Stop until
+                            # the user resumes. Pause is handled at the
+                            # existing batch-boundary check below.
+                            cancel_check=lambda: runner.cancellation_requested(
                                 job["id"]),
                         )
                         return rc, stderr, timed_out
@@ -2160,7 +2166,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # run, and whatever rsync landed before the kill is
                     # adopted by crash-recovery like any mid-batch stop
                     # (--partial-dir preserves the interrupted file).
-                    return rc != 0 and runner.is_cancelled(job["id"])
+                    # Non-blocking probe matches the watchdog above; the
+                    # batch-boundary ``is_cancelled`` further down is where
+                    # pause is actually observed.
+                    return rc != 0 and runner.cancellation_requested(
+                        job["id"])
 
                 transferred = []   # (sf, dest_basename, src_hash, nas_full_path)
                 batch_size = len(to_transfer)

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -31,7 +31,11 @@ Reconnaissance notes (Task 2.0, verified 2026-07-04):
 3. Cancellation mirrors the scan job: the work function polls
    ``runner.is_cancelled(job_id)`` at batch boundaries and passes
    ``cancel_check`` into ``scan()``; the runner flips the job status to
-   "cancelled" when the work function returns after a Stop.
+   "cancelled" when the work function returns after a Stop. The remote
+   path additionally passes ``cancel_check`` into the per-batch rsync so
+   Stop kills the subprocess mid-transfer instead of waiting out the
+   batch — the interrupted batch is cancelled work (nothing failed,
+   nothing cataloged), recovered like a mid-batch crash.
 4. Batch unit: files grouped by destination (template) folder,
    processed in template order, chunked to at most
    ``IMPORT_BATCH_SIZE`` files per scan call. Restricted scans only
@@ -118,6 +122,17 @@ def _invalidate_new_images(db, root):
 IMPORT_BATCH_SIZE = 200
 _IMPORT_ETA_PROGRESS_KEYS = (
     "eta_state", "eta_settled", "eta_seconds", "eta_rate_per_min",
+)
+
+# Batch-scoped truth counters for the remote path: how many files of the
+# current per-batch rsync have actually crossed the network, next to the
+# ordinary ``current``/``total`` which advances while files are merely
+# inspected and queued. Uses the same sub-phase progress keys the scanner
+# emits (``phase_current``/``phase_total``/``phase_label``) so the bottom
+# panel's ``bpActiveProgress`` renders the batch counter without changes.
+# Cleared on every ordinary emit so they never outlive their batch.
+_IMPORT_TRANSFER_PROGRESS_KEYS = (
+    "phase_current", "phase_total", "phase_label",
 )
 
 
@@ -1265,7 +1280,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         job["progress"]["current"] = current
         job["progress"]["total"] = total
         job["progress"]["current_file"] = current_file
-        for key in _IMPORT_ETA_PROGRESS_KEYS:
+        for key in _IMPORT_ETA_PROGRESS_KEYS + _IMPORT_TRANSFER_PROGRESS_KEYS:
             job["progress"].pop(key, None)
         job["progress"].update(eta_fields)
         runner.update_step(
@@ -1279,6 +1294,43 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             job["id"], "progress",
             progress_event(
                 phase, current, total, current_file, **eta_fields,
+            ),
+        )
+
+    def _emit_transfer(rel, transfer_current, transfer_total, current_file):
+        """Report one actually-transferred file of the current batch rsync.
+
+        Leaves ``current``/``total`` (and the ETA fields derived from them)
+        exactly as the last ordinary ``_emit`` set them: this is the truth
+        channel next to the prepared-files counter, not a second driver of
+        it. ``_emit`` clears the transfer keys, so they exist only while a
+        batch is on the wire.
+        """
+        extra = {
+            "phase_current": transfer_current,
+            "phase_total": transfer_total,
+            "phase_label": "Transferring batch",
+            **{k: job["progress"][k] for k in _IMPORT_ETA_PROGRESS_KEYS
+               if k in job["progress"]},
+        }
+        job["progress"]["phase_current"] = transfer_current
+        job["progress"]["phase_total"] = transfer_total
+        job["progress"]["phase_label"] = "Transferring batch"
+        job["progress"]["current_file"] = current_file
+        runner.update_step(
+            job["id"], "import",
+            current_file=current_file,
+            progress={
+                "current": job["progress"]["current"],
+                "total": job["progress"]["total"], **extra,
+            },
+        )
+        runner.push_event(
+            job["id"], "progress",
+            progress_event(
+                f"{rel}: transferring",
+                job["progress"]["current"], job["progress"]["total"],
+                current_file, **extra,
             ),
         )
 
@@ -2081,27 +2133,52 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     if bn != sf.name
                 ]
 
-                def _do_rsync(src_specs, target, dest_is_dir, extra_args):
+                def _do_rsync(src_specs, target, dest_is_dir, extra_args,
+                              progress_cb=None):
                     try:
                         rc, stderr, timed_out = move_mod._run_rsync_streamed(
-                            None, target, [], len(src_specs), None,
+                            None, target, [], len(src_specs), progress_cb,
                             rsync_bin=rsync_bin, extra_args=extra_args,
                             src_specs=src_specs,
                             src_specs_dest_is_dir=dest_is_dir,
+                            # Stop must reach the subprocess: a slow batch
+                            # can otherwise pin "cancelling" for hours,
+                            # since cancellation is only observed at file/
+                            # batch boundaries the transfer never yields.
+                            cancel_check=lambda: runner.is_cancelled(
+                                job["id"]),
                         )
                         return rc, stderr, timed_out
                     except OSError as exc:
                         return 1, str(exc), False
 
+                def _rsync_cancelled(rc):
+                    # A Stop mid-transfer kills the subprocess via the
+                    # cancel_check above and surfaces as a nonzero exit.
+                    # That is cancelled work, not a pile of per-file
+                    # failures: queued files stay on the card for the next
+                    # run, and whatever rsync landed before the kill is
+                    # adopted by crash-recovery like any mid-batch stop
+                    # (--partial-dir preserves the interrupted file).
+                    return rc != 0 and runner.is_cancelled(job["id"])
+
                 transferred = []   # (sf, dest_basename, src_hash, nas_full_path)
-                # Flat batch: one rsync into the dir.
+                batch_size = len(to_transfer)
+                # Flat batch: one rsync into the dir. rsync names each file
+                # as it lands; forward that as the batch's honest
+                # actually-crossed-the-network counter next to the
+                # prepared-files counter (which already reads ``emitted``).
                 if flat:
                     rc, stderr, timed_out = _do_rsync(
                         [str(sf) for sf, _bn, _sh in flat], rsync_target, True,
-                        extra_args)
+                        extra_args,
+                        progress_cb=lambda done, _tot, name, _label:
+                            _emit_transfer(rel, done, batch_size, name))
                     if timed_out:
                         for sf, _bn, _sh in flat:
                             _fail(rel, sf, "rsync stalled (no progress)")
+                    elif _rsync_cancelled(rc):
+                        cancelled = True
                     elif rc != 0:
                         for sf, _bn, _sh in flat:
                             _fail(rel, sf, f"rsync failed: {stderr.strip()}")
@@ -2112,6 +2189,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 # Renamed files: one rsync each to the explicit NAS file
                 # path (rsync <card> user@host:/dir/DSC_0001_1.jpg).
                 for sf, bn, sh in renamed:
+                    if cancelled or runner.is_cancelled(job["id"]):
+                        cancelled = True
+                        break
                     nas_full = posixpath.join(ssh_dest, bn)
                     rc, stderr, timed_out = _do_rsync(
                         [str(sf)],
@@ -2119,10 +2199,17 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         extra_args)
                     if timed_out:
                         _fail(rel, sf, "rsync stalled (no progress)")
+                    elif _rsync_cancelled(rc):
+                        cancelled = True
+                        break
                     elif rc != 0:
                         _fail(rel, sf, f"rsync failed: {stderr.strip()}")
                     else:
                         transferred.append((sf, bn, sh, nas_full))
+                        # ``len(transferred)`` counts only files that truly
+                        # landed, so a failed flat batch can't inflate the
+                        # renamed files' transfer counter.
+                        _emit_transfer(rel, len(transferred), batch_size, bn)
 
                 for sf, bn, src_hash, nas_full in transferred:
                     dest_path = os.path.join(dest_folder, bn)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -779,7 +779,7 @@ def remote_verify_files(rsync_bin, src_specs, rsync_target, remote,
 def _run_rsync_streamed(src_path, dest_spec, rsync_flags, total_files,
                         progress_cb, rsync_bin="rsync", extra_args=None,
                         stall_timeout=RSYNC_STALL_TIMEOUT, src_specs=None,
-                        src_specs_dest_is_dir=True):
+                        src_specs_dest_is_dir=True, cancel_check=None):
     """Run rsync, reporting each transferred file through progress_cb.
 
     rsync's ``--out-format=%n`` prints the relative name of every item it
@@ -810,9 +810,15 @@ def _run_rsync_streamed(src_path, dest_spec, rsync_flags, total_files,
     killed. This is a STALL watchdog rather than a total-runtime cap: a
     healthy but slow transfer (e.g. thousands of RAW files over a network
     share) runs for as long as it keeps moving data, while a genuinely wedged
-    rsync — which the job's cancel path can't reach, since it never sees the
-    subprocess — still gets reaped. The clock resets on every transferred
-    file and on stderr activity, so only true silence trips it.
+    rsync still gets reaped. The clock resets on every transferred file and
+    on stderr activity, so only true silence trips it.
+
+    ``cancel_check`` (optional callable -> bool) is the caller's Stop
+    signal: when it returns True the subprocess is killed within a couple
+    of seconds instead of draining the batch. The kill surfaces as an
+    ordinary nonzero returncode with ``timed_out`` False — the caller
+    already holds the cancel flag it passed in, so it can tell a
+    cancellation from a transfer failure without a fourth return value.
 
     stdout is attached to a pty, not a pipe, wherever the platform allows.
     Apple's openrsync block-buffers stdout when it's a pipe, so its
@@ -866,8 +872,14 @@ def _run_rsync_streamed(src_path, dest_spec, rsync_flags, total_files,
 
     def _watchdog():
         # Poll well below stall_timeout so a stall is detected promptly once
-        # the window elapses, without busy-waiting.
-        while not done.wait(min(stall_timeout, 30)):
+        # the window elapses, without busy-waiting. With a cancel_check the
+        # poll drops to 1s: Stop has to kill the subprocess within a couple
+        # of seconds, not at the stall watchdog's leisurely interval.
+        poll = 1.0 if cancel_check is not None else min(stall_timeout, 30)
+        while not done.wait(poll):
+            if cancel_check is not None and cancel_check():
+                proc.kill()
+                return
             if time.monotonic() - last_activity["t"] > stall_timeout:
                 state["timed_out"] = True
                 proc.kill()

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -3557,8 +3557,18 @@ function watchJob(jobId) {
 }
 
 function renderProgress(data) {
-  document.getElementById('progressPhase').textContent =
+  let phaseText =
     (data.phase || '') + (data.current_file ? ' · ' + data.current_file : '');
+  // Remote imports report the current batch's actual network transfer as
+  // sub-phase progress. Show it next to the prepared-files counter — the
+  // main bar advances while files are merely inspected and queued, so
+  // without this line "200 / 5,523" reads as 200 files safely copied
+  // while the batch is still crossing the network.
+  if (data.phase_total > 0 && data.phase_label) {
+    phaseText += ' · ' + data.phase_label + ' ' +
+      (data.phase_current || 0) + ' / ' + data.phase_total;
+  }
+  document.getElementById('progressPhase').textContent = phaseText;
   const pct = data.total ? Math.round(100 * data.current / data.total) : 0;
   document.getElementById('progressFill').style.width = pct + '%';
   if (data.folders && Object.keys(data.folders).length) {

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -6780,6 +6780,167 @@ def test_remote_import_cancel_mid_batch_does_not_start_rsync(
     )
 
 
+def test_remote_import_stop_kills_in_flight_rsync_batch(
+        tmp_path, monkeypatch):
+    """Stop must reach a running per-batch rsync. The job passes the
+    runner's cancel signal into ``_run_rsync_streamed`` as ``cancel_check``
+    (so the watchdog can kill the subprocess), and when the killed rsync
+    returns nonzero the batch is treated as cancelled work — its files are
+    NOT reported as per-file failures. Queued files stay on the card for
+    the next run; whatever rsync landed before the kill is adopted by
+    crash-recovery, exactly like a mid-batch crash."""
+    import shutil
+
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 10, 5, 0), "green"),
+    ])
+
+    runner = FakeRunner()
+    job = _make_job()
+    seen = {"cancel_check": None, "cancel_check_result": None}
+
+    def killed_rsync(src_path, dest_spec, rsync_flags, total_files,
+                     progress_cb, rsync_bin="rsync", extra_args=None,
+                     src_specs=None, src_specs_dest_is_dir=True, **kw):
+        seen["cancel_check"] = kw.get("cancel_check")
+        # Stop arrives mid-transfer: flip the runner's cancel flag, land
+        # only the first file (the kill interrupted the rest), and return
+        # the killed subprocess's nonzero exit with timed_out=False.
+        runner.cancelled_ids.add(job["id"])
+        if seen["cancel_check"] is not None:
+            seen["cancel_check_result"] = seen["cancel_check"]()
+        ssh_path = dest_spec.split(":", 1)[1]
+        rel = os.path.relpath(ssh_path, calls["_ssh_base"])
+        mount_dir = os.path.join(calls["_mount_base"], rel)
+        os.makedirs(mount_dir, exist_ok=True)
+        shutil.copy2(
+            src_specs[0],
+            os.path.join(mount_dir, os.path.basename(src_specs[0])))
+        return (-9, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", killed_rsync)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    result = run_import_job(
+        job, runner, db_path, db._active_workspace_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # The transfer received a live cancel_check wired to the runner.
+    assert seen["cancel_check"] is not None, (
+        "the per-batch rsync was started without a cancel_check — Stop "
+        "cannot reach the subprocess")
+    assert seen["cancel_check_result"] is True
+
+    assert result["cancelled"] is True, result
+    # A killed batch is cancelled work, not a pile of per-file failures.
+    assert result["failed"] == 0, result
+    assert not any(
+        "rsync" in u["reason"] for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+    # Nothing was verified/cataloged from the interrupted batch, and a
+    # cancelled run never claims the card is safe to erase.
+    assert result["copied"] == 0, result
+    assert result["safe_to_format"] is False, result
+
+
+def test_remote_import_reports_per_file_transfer_progress(
+        tmp_path, monkeypatch):
+    """The per-batch rsync streams each transferred file; the job must
+    surface that as sub-phase progress (``phase_current``/``phase_total``/
+    ``phase_label`` — the same keys the scanner's metadata phase uses, so
+    the bottom panel renders them as-is) instead of discarding the
+    callback. The prepared-files counter (``current``/``total``) alone
+    reads as "files completed" while the batch is still crossing the
+    network — the UI transparency rule requires the real transfer count
+    alongside it. The prep counter itself must NOT move during the
+    transfer, and the transfer fields must not outlive the batch in
+    ``job["progress"]``."""
+    import shutil
+
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Two sources carrying the SAME basename with different capture times
+    # in the same date folder: the second queues as a collision-renamed
+    # single-file rsync (DSC_0001_1.jpg), so the transfer counter must
+    # span the flat batch AND the renamed transfer.
+    card1 = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ], card_name="card1")
+    card2 = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 5, 0), "green"),
+    ], card_name="card2")
+
+    real_fake = _move._run_rsync_streamed  # landing behavior from the seam
+
+    def streaming_rsync(src_path, dest_spec, rsync_flags, total_files,
+                        progress_cb, rsync_bin="rsync", extra_args=None,
+                        src_specs=None, src_specs_dest_is_dir=True, **kw):
+        rc, stderr, timed_out = real_fake(
+            src_path, dest_spec, rsync_flags, total_files, None,
+            rsync_bin=rsync_bin, extra_args=extra_args, src_specs=src_specs,
+            src_specs_dest_is_dir=src_specs_dest_is_dir)
+        if progress_cb is not None:
+            for i, s in enumerate(src_specs, 1):
+                progress_cb(i, total_files, os.path.basename(s),
+                            "Copying files")
+        return rc, stderr, timed_out
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", streaming_rsync)
+
+    runner = FakeRunner()
+    job = _make_job()
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    result = run_import_job(
+        job, runner, db_path, db._active_workspace_id,
+        ImportParams(
+            sources=[str(card1), str(card2)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+    assert result["failed"] == 0, result
+    assert result["copied"] == 2, result
+
+    transfer_events = [
+        data for _jid, etype, data in runner.events
+        if etype == "progress" and "phase_current" in data
+    ]
+    assert transfer_events, (
+        "no transfer progress events — the batch rsync's per-file stream "
+        "is being discarded")
+    for ev in transfer_events:
+        assert ev["phase"].endswith(": transferring"), ev
+        assert ev["phase_label"] == "Transferring batch", ev
+        assert ev["phase_total"] == 2, ev
+        # The prepared-files counter must not be inflated or reset by
+        # transfer reporting.
+        assert ev["current"] == 2 and ev["total"] == 2, ev
+    # Both the flat batch file and the collision-renamed file reported.
+    assert max(ev["phase_current"] for ev in transfer_events) == 2
+    # Transfer fields are batch-scoped: cleared once the batch settles.
+    assert "phase_current" not in job["progress"], job["progress"]
+    assert "phase_total" not in job["progress"], job["progress"]
+    assert "phase_label" not in job["progress"], job["progress"]
+
+
 def test_include_paths_imports_only_selected_files(tmp_path):
     """include_paths restricts the copy set; discovered still counts the card."""
     from import_job import ImportParams

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -30,6 +30,9 @@ class FakeRunner:
     def is_cancelled(self, job_id):
         return job_id in self.cancelled_ids
 
+    def cancellation_requested(self, job_id):
+        return job_id in self.cancelled_ids
+
 
 def _make_job(job_id="import-test-1"):
     return {
@@ -6854,6 +6857,91 @@ def test_remote_import_stop_kills_in_flight_rsync_batch(
     # cancelled run never claims the card is safe to erase.
     assert result["copied"] == 0, result
     assert result["safe_to_format"] is False, result
+
+
+def test_remote_import_rsync_watchdog_does_not_block_on_pause(
+        tmp_path, monkeypatch):
+    """The rsync watchdog thread's cancel_check must be a non-blocking
+    probe. Import jobs run pausable, and ``runner.is_cancelled()`` parks
+    the caller inside ``wait_if_paused`` when a Pause is pending. Wiring
+    the watchdog to that pause-aware method would silently disable both
+    the stall watchdog and Stop while paused — rsync would keep copying
+    at 50 KB/s until Resume/Cancel. Use ``cancellation_requested()``
+    instead; pause is observed at the existing batch-boundary check."""
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    class PauseAwareRunner(FakeRunner):
+        """Mirror JobRunner's pause behaviour: is_cancelled blocks while
+        paused; cancellation_requested does not."""
+
+        def __init__(self):
+            super().__init__()
+            self.paused_ids = set()
+
+        def is_cancelled(self, job_id):
+            if job_id in self.paused_ids and job_id not in self.cancelled_ids:
+                raise AssertionError(
+                    "watchdog called the pause-aware is_cancelled and would "
+                    "have blocked the stall/cancel watchdog thread during "
+                    "Pause")
+            return job_id in self.cancelled_ids
+
+        def cancellation_requested(self, job_id):
+            return job_id in self.cancelled_ids
+
+    runner = PauseAwareRunner()
+    job = _make_job()
+    seen = {"probe_during_pause": None}
+
+    def paused_rsync(src_path, dest_spec, rsync_flags, total_files,
+                    progress_cb, rsync_bin="rsync", extra_args=None,
+                    src_specs=None, src_specs_dest_is_dir=True, **kw):
+        # A Pause arrives mid-transfer. The watchdog's cancel_check must
+        # still be safe to call in that state — a blocking call here is
+        # the exact defect the fix guards against.
+        runner.paused_ids.add(job["id"])
+        cancel_check = kw.get("cancel_check")
+        if cancel_check is not None:
+            seen["probe_during_pause"] = cancel_check()
+        # Simulate a healthy (uncancelled) transfer completing normally.
+        import shutil
+        ssh_path = dest_spec.split(":", 1)[1]
+        rel = os.path.relpath(ssh_path, calls["_ssh_base"])
+        mount_dir = os.path.join(calls["_mount_base"], rel)
+        os.makedirs(mount_dir, exist_ok=True)
+        shutil.copy2(
+            src_specs[0],
+            os.path.join(mount_dir, os.path.basename(src_specs[0])))
+        return (0, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", paused_rsync)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    # No exception ⇒ watchdog probed cancellation without blocking on the
+    # pause request. The transfer completes on its own since nothing was
+    # cancelled.
+    result = run_import_job(
+        job, runner, db_path, db._active_workspace_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=False,
+        ),
+    )
+
+    assert seen["probe_during_pause"] is False, (
+        "watchdog's cancel_check returned something other than a "
+        "non-blocking False during Pause")
+    assert result["copied"] == 1, result
 
 
 def test_remote_import_reports_per_file_transfer_progress(

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -6956,8 +6956,6 @@ def test_remote_import_reports_per_file_transfer_progress(
     alongside it. The prep counter itself must NOT move during the
     transfer, and the transfer fields must not outlive the batch in
     ``job["progress"]``."""
-    import shutil
-
     import move as _move
     from import_job import ImportParams, run_import_job
 

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -5573,6 +5573,63 @@ def test_rsync_streamed_runs_as_long_as_it_progresses(monkeypatch):
     assert len(seen) == 12  # progress reported for every transferred file
 
 
+def test_rsync_streamed_cancel_check_kills_transfer(monkeypatch):
+    """When ``cancel_check`` flips true the in-flight rsync subprocess is
+    killed promptly instead of running to batch completion — Stop must reach
+    the transfer, not wait hours for a slow 200-file batch to drain. The
+    kill is reported as an ordinary nonzero exit, NOT as a stall
+    (timed_out stays False): the caller distinguishes cancellation by its
+    own cancel flag."""
+    import move as move_mod
+
+    proc_holder = {}
+
+    def _fake_popen(*_a, **_k):
+        proc = _FakeProc.__new__(_FakeProc)
+        proc.killed = threading.Event()
+        proc.stdout = _SilentStdout(proc.killed)
+        proc.stderr = _FakeStderr()
+        proc.returncode = 0
+        proc_holder["proc"] = proc
+        return proc
+
+    monkeypatch.setattr(move_mod.subprocess, "Popen", _fake_popen)
+
+    start = time.monotonic()
+    rc, stderr, timed_out = move_mod._run_rsync_streamed(
+        "/src", "/dst", [], 10, None, stall_timeout=60.0,
+        cancel_check=lambda: True,
+    )
+    elapsed = time.monotonic() - start
+    assert proc_holder["proc"].killed.is_set()
+    assert timed_out is False
+    assert rc != 0
+    # Killed on the fast cancel poll, not the 30s watchdog interval and
+    # not the 60s stall window. Generous bound for slow CI schedulers.
+    assert elapsed < 20, f"cancel took {elapsed:.1f}s to kill rsync"
+
+
+def test_rsync_streamed_cancel_check_false_leaves_transfer_alone(monkeypatch):
+    """A cancel_check that stays false must not disturb a healthy transfer:
+    every file streams through progress_cb and rsync exits normally."""
+    import move as move_mod
+
+    monkeypatch.setattr(
+        move_mod.subprocess, "Popen",
+        lambda *_a, **_k: _FakeProc(_StreamingStdout(n=5, gap=0.05)),
+    )
+
+    seen = []
+    rc, stderr, timed_out = move_mod._run_rsync_streamed(
+        "/src", "/dst", [], 5,
+        lambda cur, tot, name, phase: seen.append(name),
+        stall_timeout=60.0, cancel_check=lambda: False,
+    )
+    assert rc == 0
+    assert timed_out is False
+    assert len(seen) == 5
+
+
 @pytest.mark.skipif(not hasattr(os, "openpty"), reason="pty is POSIX-only")
 def test_rsync_streamed_survives_block_buffered_rsync(tmp_path):
     """A real child that block-buffers stdout (as Apple's openrsync does when


### PR DESCRIPTION
## What changed

Two fixes for the remote import path, both hit during a real 5,523-file import over a slow Tailscale link (see the session where a Stop request sat in "cancelling" while a 200-file batch crawled at ~50 KB/s, and the progress bar showed "200 / 5,523" with 8 files actually on the NAS).

### 1. Stop now kills the in-flight per-batch rsync

`_run_rsync_streamed` (vireo/move.py) accepts an optional `cancel_check` callable. The existing stall-watchdog thread polls it every 1s and kills the subprocess when it flips true — reusing the exact kill path the stall timeout already exercises. The kill surfaces as an ordinary nonzero exit with `timed_out=False`; no fourth return value, so the move job and all existing callers are unchanged.

The remote import job passes `runner.is_cancelled(job_id)` as `cancel_check` and classifies a killed rsync as **cancelled work**: no per-file "rsync failed" entries, nothing cataloged from the interrupted batch, `safe_to_format=False`. Files rsync landed before the kill are adopted by the existing crash-recovery on the next run (`--partial-dir` preserves the interrupted file). Previously cancellation was only observed between batches, so Stop could wait hours for a slow batch to drain.

### 2. Honest transfer progress next to the prepared-files counter

The per-batch rsync already streams each transferred filename (`--out-format=%n`), but the import job discarded it (`progress_cb=None`). The counter users see advances while files are merely inspected and queued, so it overstates completion by up to a whole batch (CORE_PHILOSOPHY: status text must answer the question users read it as).

The stream is now forwarded as sub-phase progress using the established `phase_current`/`phase_total`/`phase_label` keys (same convention as the scanner's metadata phase), so:

- the Import page phase line shows `2026/08-03: transferring · DSC_0123.NEF · Transferring batch 8 / 200`
- the Jobs page and bottom panel render the batch counter with **zero changes** (`bpActiveProgress` already prefers these keys)

Collision-renamed single-file transfers count into the same batch counter via files-actually-landed. `current`/`total` semantics and the `_ImportEtaEstimator` are untouched; the transfer keys are batch-scoped and popped on every ordinary emit.

This is a remote-path-only fix: the local path copies each file inline in the loop, so its counter is already honest.

## Tests

TDD — all four new tests written first and watched fail:

- `test_rsync_streamed_cancel_check_kills_transfer` — cancel kills the subprocess promptly; not misreported as a stall
- `test_rsync_streamed_cancel_check_false_leaves_transfer_alone` — healthy transfers undisturbed
- `test_remote_import_stop_kills_in_flight_rsync_batch` — cancel_check is wired to the runner; killed batch reports cancelled, `failed == 0`, `safe_to_format=False`, nothing cataloged
- `test_remote_import_reports_per_file_transfer_progress` — `phase_current`/`phase_total`/`phase_label` events emitted for flat + collision-renamed transfers; prep counter unchanged; keys cleared after the batch

Results:
- `vireo/tests/test_move.py` + `test_move_remote.py` + `test_move_api.py`: **227 passed** (3 consecutive runs)
- `vireo/tests/test_import_job.py`: **181 passed**
- CLAUDE.md required set (workspaces, db, app, photos/edits/jobs/darktable APIs, config): **2076 passed**, 1 failure (`test_api_exiftool_status_reports_missing`) confirmed pre-existing on a clean tree — ExifTool is installed on this machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote imports can now be stopped while files are actively transferring.
  * Transfer progress displays per-batch file counts alongside existing progress and ETA information.
  * Progress accurately reflects flat and renamed file transfers.

* **Bug Fixes**
  * Cancelled transfers are correctly classified as cancelled rather than failed.
  * Renamed transfers no longer start when cancellation has already been requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->