### PR TITLE
Bound destination hash reads so Stop can interrupt a dead SMB mount

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -35,7 +35,12 @@ Reconnaissance notes (Task 2.0, verified 2026-07-04):
    path additionally passes ``cancel_check`` into the per-batch rsync so
    Stop kills the subprocess mid-transfer instead of waiting out the
    batch — the interrupted batch is cancelled work (nothing failed,
-   nothing cataloged), recovered like a mid-batch crash.
+   nothing cataloged), recovered like a mid-batch crash. Destination-side
+   hash reads (duplicate gate, crash-recovery adopt, post-scan re-checks)
+   go through ``_hash_dest_file``, which watches the same Stop signal and
+   a stall watchdog — a read blocked on a dead SMB mount can otherwise
+   pin the worker for the mount's own multi-minute timeout per file while
+   cancellation goes unobserved.
 4. Batch unit: files grouped by destination (template) folder,
    processed in template order, chunked to at most
    ``IMPORT_BATCH_SIZE`` files per scan call. Restricted scans only
@@ -58,6 +63,7 @@ import os
 import posixpath
 import shutil
 import sys
+import threading
 import time
 import uuid
 from dataclasses import dataclass
@@ -741,6 +747,85 @@ def _fs_lacks_hardlinks(err):
     return getattr(err, "errno", None) in _HARDLINK_UNSUPPORTED_ERRNOS
 
 
+# Seconds a destination-side hash read may go without producing a single
+# chunk before it is declared stalled. Same philosophy as the rsync stall
+# watchdog in move.py: bound silence, not total runtime — a slow but moving
+# mount read never trips this, a wedged SMB session does.
+DEST_HASH_STALL_TIMEOUT = 120.0
+
+
+class DestReadCancelled(OSError):
+    """Stop arrived while a destination-side read was in flight.
+
+    Subclasses OSError so any call site without explicit cancel handling
+    treats it as an ordinary unreadable-file result (safe by default),
+    while the sites that would otherwise record a failure catch it first
+    and convert it into the job's normal cancelled exit.
+    """
+
+
+def _hash_dest_file(path, cancel_check, *,
+                    stall_timeout=DEST_HASH_STALL_TIMEOUT):
+    """SHA-256 a destination/mount-side file without letting a sick
+    network mount hold cancellation hostage.
+
+    ``compute_file_hash`` is a plain blocking read: against a stale SMB
+    mount a single file can pin the worker for the mount's own timeout
+    (tens of minutes on macOS) per read while Stop goes unobserved —
+    cancellation is only polled between files, so the job sits in
+    "cancelling" for hours. Run the chunked read in a watcher-supervised
+    daemon thread instead:
+
+    - ``cancel_check()`` returns True → ``DestReadCancelled`` within a
+      second, even mid-read.
+    - no chunk lands for ``stall_timeout`` → plain ``OSError``, the same
+      shape an unreadable file already produces at every call site.
+
+    The abandoned worker cannot be killed — the read is stuck in an
+    uninterruptible kernel call — so it is orphaned: a daemon thread that
+    exits when the mount finally returns, never blocking shutdown.
+    """
+    if cancel_check():
+        # The open() itself blocks on a dead mount; don't even touch it.
+        raise DestReadCancelled(f"import cancelled before reading {path}")
+
+    result = {}
+    activity = {"t": time.monotonic()}
+    done = threading.Event()
+
+    def _worker():
+        h = hashlib.sha256()
+        try:
+            with open(path, "rb") as f:
+                while True:
+                    chunk = f.read(65536)
+                    activity["t"] = time.monotonic()
+                    if not chunk:
+                        break
+                    h.update(chunk)
+            result["hash"] = h.hexdigest()
+        except BaseException as exc:  # surfaced on the caller's thread
+            result["exc"] = exc
+        finally:
+            done.set()
+
+    worker = threading.Thread(
+        target=_worker, daemon=True, name="import-dest-hash",
+    )
+    worker.start()
+    while not done.wait(0.5):
+        if cancel_check():
+            raise DestReadCancelled(
+                f"import cancelled while reading {path}")
+        if time.monotonic() - activity["t"] > stall_timeout:
+            raise OSError(
+                f"read of {path} stalled (no data for "
+                f"{stall_timeout:.0f}s; the mount is likely dead)")
+    if "exc" in result:
+        raise result["exc"]
+    return result["hash"]
+
+
 def _key_twin_rows(db, key):
     """Catalog rows whose stored identity equals a source metadata key.
 
@@ -1420,6 +1505,12 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     folder_counts = {}
     emitted = 0
     cancelled = False
+
+    def _stop_requested():
+        # Threaded through every destination-side hash read so a Stop can
+        # interrupt a read blocked on a dead mount (see _hash_dest_file).
+        return runner.is_cancelled(job["id"])
+
     wc_source_paths = {}
     wc_dest_folders = set()
     # Photo rows this run created or landed bytes into: fresh copies whose
@@ -1843,7 +1934,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             if _path_under_any_source(twin_path):
                                 continue
                             try:
-                                twin_hash = compute_file_hash(twin_path)
+                                twin_hash = _hash_dest_file(
+                                    twin_path, _stop_requested)
+                            except DestReadCancelled:
+                                cancelled = True
+                                break
                             except OSError:
                                 continue
                             if twin_hash is not None and twin_hash == src_hash:
@@ -1858,6 +1953,12 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                 # Mirrors the local path's collect-then-
                                 # link pattern. See PR #1113 review.
                                 verified_twin_rows.append(twin)
+                    if cancelled:
+                        # Stop interrupted a twin hash above. Don't let
+                        # this file fall through to the collision checks
+                        # and the transfer queue — every further step
+                        # touches the same (possibly dead) mount.
+                        break
                     if accept:
                         skipped_duplicate += 1
                         dup_skipped += 1
@@ -1968,7 +2069,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # Already on disk (crash-recovery/resume). Byte-identical
                     # -> skip; different -> advance to the next suffix.
                     try:
-                        on_disk = compute_file_hash(cand_mount)
+                        on_disk = _hash_dest_file(
+                            cand_mount, _stop_requested)
+                    except DestReadCancelled:
+                        cancelled = True
+                        on_disk = None
                     except OSError:
                         on_disk = None
                     if on_disk is not None and on_disk == src_hash:
@@ -2386,7 +2491,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # fallback. See PR #1113 review.
                     if scan_h is None and src_h_norm is not None:
                         try:
-                            mount_hash = compute_file_hash(dest_path)
+                            mount_hash = _hash_dest_file(
+                                dest_path, _stop_requested)
+                        except DestReadCancelled:
+                            cancelled = True
+                            break
                         except OSError:
                             mount_hash = None
                         mount_norm = (
@@ -2477,7 +2586,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # gated behind ``verify_by_hash``. See PR #1113
                         # review.
                         try:
-                            mount_hash = compute_file_hash(dest_path)
+                            mount_hash = _hash_dest_file(
+                                dest_path, _stop_requested)
+                        except DestReadCancelled:
+                            cancelled = True
+                            break
                         except OSError:
                             mount_hash = None
                         src_h_norm = (
@@ -2633,7 +2746,10 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # both sides) is still accepted.
                     read_failed = False
                     try:
-                        mount_hash = compute_file_hash(ap)
+                        mount_hash = _hash_dest_file(ap, _stop_requested)
+                    except DestReadCancelled:
+                        cancelled = True
+                        break
                     except OSError:
                         mount_hash = None
                         read_failed = True
@@ -3130,6 +3246,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     emitted = 0
     cancelled = False
 
+    def _stop_requested():
+        # Threaded through every destination-side hash read so a Stop can
+        # interrupt a read blocked on a dead mount (see _hash_dest_file).
+        return runner.is_cancelled(job["id"])
+
     # Working-copy extraction is DEFERRED to the end of the whole import
     # run (not per-batch). Rationale: a folder that receives more than
     # ``IMPORT_BATCH_SIZE`` files splits across multiple batches; a
@@ -3564,7 +3685,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             if _path_under_any_source(twin_path):
                                 continue
                             try:
-                                twin_hash = compute_file_hash(twin_path)
+                                twin_hash = _hash_dest_file(
+                                    twin_path, _stop_requested)
+                            except DestReadCancelled:
+                                cancelled = True
+                                break
                             except OSError:
                                 continue
                             if twin_hash is not None and twin_hash == src_hash:
@@ -3584,6 +3709,12 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 # the on-disk bytes). See PR #1107
                                 # review.
                                 verified_twin_rows.append(twin)
+                    if cancelled:
+                        # Stop interrupted a twin hash above. Don't let
+                        # this file fall through to the adopt/copy path —
+                        # every further step touches the same (possibly
+                        # dead) mount.
+                        break
                     if accept:
                         skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
@@ -3713,7 +3844,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         # case without walking the rest of the directory.
                         adopted_dest = (dest_file, EMPTY_FILE_SHA256)
                     elif src_size == dest_size:
-                        dest_hash = compute_file_hash(dest_file)
+                        dest_hash = _hash_dest_file(
+                            dest_file, _stop_requested)
                         src_h = _src_hash_cached()
                         if src_h is not None and src_h == dest_hash:
                             # Byte-identical file already at the destination
@@ -3750,7 +3882,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             except OSError:
                                 cand_size = -1
                             if cand_size == src_size:
-                                cand_hash = compute_file_hash(candidate)
+                                cand_hash = _hash_dest_file(
+                                    candidate, _stop_requested)
                                 src_h = _src_hash_cached()
                                 if (
                                     cand_hash is not None
@@ -3780,6 +3913,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 ok, file_hash = copy_and_hash_verify(
                     str(source_file), dest_file, src_hash=src_hash,
                 )
+            except DestReadCancelled:
+                # Stop arrived mid-read against the destination (adopt/
+                # collision hashing above). The file is neither copied nor
+                # failed — it stays on the card for the next run, like any
+                # file the cancel got to before its batch.
+                cancelled = True
+                break
             except OSError as e:
                 _fail(rel, source_file, str(e))
                 continue
@@ -3980,7 +4120,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 accepted as success.
                 """
                 try:
-                    return compute_file_hash(path)
+                    return _hash_dest_file(path, _stop_requested)
+                except DestReadCancelled:
+                    raise
                 except OSError:
                     return None
 
@@ -4016,7 +4158,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         ),
                     ).fetchone()
                     if companion is not None:
-                        actual = _rehash_dest_or_none(dest_path)
+                        try:
+                            actual = _rehash_dest_or_none(dest_path)
+                        except DestReadCancelled:
+                            cancelled = True
+                            break
                         if actual is not None and actual == verified_hash:
                             # Landed JPEG paired with an existing RAW
                             # row. Invalidate the RAW's derived caches
@@ -4085,7 +4231,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         # — if that also fails or disagrees with our
                         # copy-time hash, reclassify to failed instead of
                         # stamping a stale value. See PR #1107 review.
-                        actual = _rehash_dest_or_none(dest_path)
+                        try:
+                            actual = _rehash_dest_or_none(dest_path)
+                        except DestReadCancelled:
+                            cancelled = True
+                            break
                         if actual is not None and actual == verified_hash:
                             db.update_photo_hash_check(
                                 row["id"], "ok", file_hash=verified_hash,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1509,7 +1509,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     def _stop_requested():
         # Threaded through every destination-side hash read so a Stop can
         # interrupt a read blocked on a dead mount (see _hash_dest_file).
-        return runner.is_cancelled(job["id"])
+        # Nonblocking probe — ``is_cancelled`` would park in
+        # ``wait_if_paused`` for a pausable import, freezing the watchdog
+        # loop itself and stopping the 120s stall timer from running while
+        # the daemon reader can keep touching the archive even though the
+        # UI says the job is paused. Mirrors the rsync watchdog's use of
+        # ``cancellation_requested`` for the same reason.
+        return runner.cancellation_requested(job["id"])
 
     wc_source_paths = {}
     wc_dest_folders = set()
@@ -3275,7 +3281,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     def _stop_requested():
         # Threaded through every destination-side hash read so a Stop can
         # interrupt a read blocked on a dead mount (see _hash_dest_file).
-        return runner.is_cancelled(job["id"])
+        # Nonblocking probe — ``is_cancelled`` would park in
+        # ``wait_if_paused`` for a pausable import, freezing the watchdog
+        # loop itself and stopping the 120s stall timer from running while
+        # the daemon reader can keep touching the archive even though the
+        # UI says the job is paused. Mirrors the rsync watchdog's use of
+        # ``cancellation_requested`` for the same reason.
+        return runner.cancellation_requested(job["id"])
 
     # Working-copy extraction is DEFERRED to the end of the whole import
     # run (not per-batch). Rationale: a folder that receives more than

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2164,15 +2164,23 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # help: a detach after it races the transfer and catalog scan,
         # which no amount of probing can prevent.
         #
-        # Skip the probe when the per-file loop above already broke on
-        # cancellation. That break ran because Stop interrupted a
-        # destination-side hash on a possibly-dead mount; probing that
-        # same mount here can block for the mount's own timeout and put
-        # the job right back in the long "cancelling" state this fix set
-        # out to avoid. The rsync path below is already gated on
-        # ``cancelled``, so skipping the probe changes no downstream
-        # decision.
-        if not mount_lost and not cancelled:
+        # Skip the probe ONLY when the per-file loop above broke because
+        # a destination-side hash was interrupted mid-read
+        # (``dest_read_cancelled``): that signal means the mount itself
+        # is misbehaving, so probing it here would block for the mount's
+        # own timeout and put the job right back in the long
+        # "cancelling" state this fix set out to avoid.
+        #
+        # Do NOT skip on a plain-Stop ``cancelled`` (observed by
+        # ``runner.is_cancelled`` at the top of the source-file loop).
+        # An earlier file in this same batch may have been accepted as an
+        # adopted/duplicate claim before the user hit Stop, and if the
+        # share detached between that mount read and the Stop the only
+        # remaining chance to notice — and to roll ``dup_skips`` /
+        # ``adopted_paths`` back so the catalog block below doesn't
+        # trust a local shadow — is this probe. See PR #1423 review
+        # (Codex P2 r3716581282).
+        if not mount_lost and not dest_read_cancelled:
             mount_lost = _unmounted_since_baseline(mount_baseline)
 
         # A detach invalidates every accepted "already present" claim in
@@ -4032,15 +4040,23 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # it does guarantee is that nothing is booked as archived without
         # a mount check on both sides of every copy in the batch.
         #
-        # Skip the probe when the per-file loop above already broke on
-        # cancellation. That break ran because Stop interrupted a
-        # destination-side hash on a possibly-dead mount; probing that
-        # same mount here can block for the mount's own timeout and put
-        # the job right back in the long "cancelling" state this fix set
-        # out to avoid. Nothing is left to copy on a cancelled batch, so
-        # skipping the probe changes no downstream decision. Mirrors the
-        # remote path's gate above.
-        if not mount_lost and not cancelled:
+        # Skip the probe ONLY when the per-file loop above broke because
+        # a destination-side hash was interrupted mid-read
+        # (``dest_read_cancelled``): that signal means the mount itself
+        # is misbehaving, so probing it here would block for the mount's
+        # own timeout and put the job right back in the long
+        # "cancelling" state this fix set out to avoid.
+        #
+        # Do NOT skip on a plain-Stop ``cancelled`` (observed by
+        # ``runner.is_cancelled`` at the top of the source-file loop).
+        # An earlier file in this same batch may have been copied or
+        # adopted before the user hit Stop, and if the archive mount
+        # dropped during that just-finished operation the only remaining
+        # chance to notice — and to roll ``landed`` / ``dup_skips`` back
+        # so the catalog block below doesn't scan a local shadow — is
+        # this probe. Mirrors the remote path's gate above. See PR #1423
+        # review (Codex P2 r3716581283).
+        if not mount_lost and not dest_read_cancelled:
             mount_lost = _unmounted_since_baseline(mount_baseline)
 
         # Accepted duplicate skips rest on a twin that may live in the

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2072,8 +2072,18 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         on_disk = _hash_dest_file(
                             cand_mount, _stop_requested)
                     except DestReadCancelled:
+                        # Stop arrived mid-read against a candidate on the
+                        # (possibly dead) mount. Advancing to the next
+                        # suffix would immediately call os.path.exists /
+                        # getsize / _hash_dest_file on the same mount and
+                        # can pin cancelling for the mount's own timeout,
+                        # exactly like the twin-hash branch above. Exit the
+                        # candidate loop; the outer check below then exits
+                        # the source-file loop so nothing else in this
+                        # batch touches the mount. The interrupted file
+                        # stays on the card for the next run.
                         cancelled = True
-                        on_disk = None
+                        break
                     except OSError:
                         on_disk = None
                     if on_disk is not None and on_disk == src_hash:
@@ -2097,6 +2107,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     counter += 1
                     continue
                 dest_basename = candidate
+                break
+            if cancelled:
+                # Stop interrupted a collision hash above (mirrors the
+                # twin-hash branch's post-loop check). Don't let this file
+                # (or the rest of the batch) fall through to the queue /
+                # rsync path — every further step touches the same
+                # (possibly dead) mount.
                 break
             if adopted:
                 continue
@@ -2126,7 +2143,16 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # covered. As on the local path this is the last probe that can
         # help: a detach after it races the transfer and catalog scan,
         # which no amount of probing can prevent.
-        if not mount_lost:
+        #
+        # Skip the probe when the per-file loop above already broke on
+        # cancellation. That break ran because Stop interrupted a
+        # destination-side hash on a possibly-dead mount; probing that
+        # same mount here can block for the mount's own timeout and put
+        # the job right back in the long "cancelling" state this fix set
+        # out to avoid. The rsync path below is already gated on
+        # ``cancelled``, so skipping the probe changes no downstream
+        # decision.
+        if not mount_lost and not cancelled:
             mount_lost = _unmounted_since_baseline(mount_baseline)
 
         # A detach invalidates every accepted "already present" claim in
@@ -3951,7 +3977,16 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # can make a network filesystem stay mounted across a write. What
         # it does guarantee is that nothing is booked as archived without
         # a mount check on both sides of every copy in the batch.
-        if not mount_lost:
+        #
+        # Skip the probe when the per-file loop above already broke on
+        # cancellation. That break ran because Stop interrupted a
+        # destination-side hash on a possibly-dead mount; probing that
+        # same mount here can block for the mount's own timeout and put
+        # the job right back in the long "cancelling" state this fix set
+        # out to avoid. Nothing is left to copy on a cancelled batch, so
+        # skipping the probe changes no downstream decision. Mirrors the
+        # remote path's gate above.
+        if not mount_lost and not cancelled:
             mount_lost = _unmounted_since_baseline(mount_baseline)
 
         # Accepted duplicate skips rest on a twin that may live in the

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1834,6 +1834,18 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # decisions above happen per file and each one reads the mount —
         # so the mount has to be re-checked at that granularity too.
         mount_lost = None
+        # Sticky signal that a destination-side hash in the per-file loop
+        # below was cancelled mid-read (``DestReadCancelled``). Any such
+        # cancel is evidence the mount is misbehaving, so the post-loop
+        # catalog block MUST skip its ``scan()`` / ``_hash_dest_file``
+        # calls on the same paths — they would hit the same wedged mount
+        # and pin the job in "cancelling" for the mount's own timeout,
+        # exactly the failure mode this PR set out to eliminate. A plain
+        # user Stop on a healthy mount leaves this False (the catalog
+        # runs normally so partially-landed batches stay cataloged the
+        # way ``test_cancel_leaves_valid_partial_catalog`` expects).
+        # See PR #1423 review (Codex P2 r3716433824).
+        dest_read_cancelled = False
         for source_file in batch:
             if runner.is_cancelled(job["id"]):
                 cancelled = True
@@ -1944,6 +1956,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                     twin_path, _stop_requested)
                             except DestReadCancelled:
                                 cancelled = True
+                                dest_read_cancelled = True
                                 break
                             except OSError:
                                 continue
@@ -2089,6 +2102,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # batch touches the mount. The interrupted file
                         # stays on the card for the next run.
                         cancelled = True
+                        dest_read_cancelled = True
                         break
                     except OSError:
                         on_disk = None
@@ -2411,7 +2425,20 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # uncataloged mount-side collision. Cataloged duplicate twins are
         # linked directly below; scanning a duplicate-only destination would
         # enumerate/stat the entire mounted NAS folder for no new rows.
-        if landed or adopted_paths:
+        #
+        # Skip when a destination-side hash in the per-file loop above
+        # cancelled mid-read. That signal means the mount is misbehaving,
+        # and ``scan()`` here — plus the ``_hash_dest_file`` re-checks below
+        # for landed and adopted paths — would touch the same mounted
+        # directory and pin the job in "cancelling" for the mount's own
+        # timeout. Already-rsync'd landings and adopted-on-disk paths are
+        # picked up by the next run's crash-recovery adoption (byte-
+        # identical files match by hash and count as ``skipped_duplicate``).
+        # A plain user Stop on a healthy mount leaves
+        # ``dest_read_cancelled`` False, so partially-landed batches keep
+        # cataloging like before. See PR #1423 review (Codex P2
+        # r3716433824).
+        if (landed or adopted_paths) and not dest_read_cancelled:
             landed_paths = {entry[0] for entry in landed}
             # Include collision-loop adopted mount paths so their photo rows
             # get created by the restricted scan. The explicit file set is
@@ -3592,6 +3619,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # keeps the blast radius at one file instead of a whole folder.
         # One ismount call is nothing next to copying and hashing a RAW.
         mount_lost = None
+        # Sticky signal that a destination-side hash in the per-file loop
+        # below was cancelled mid-read (``DestReadCancelled``). Any such
+        # cancel is evidence the mount is misbehaving, so the post-loop
+        # catalog block MUST skip its ``scan()`` / ``_rehash_dest_or_none``
+        # calls on the same paths — they would hit the same wedged mount
+        # and pin the job in "cancelling" for the mount's own timeout,
+        # exactly the failure mode this PR set out to eliminate. A plain
+        # user Stop on a healthy mount leaves this False (the catalog
+        # runs normally so partially-landed batches stay cataloged the
+        # way ``test_cancel_leaves_valid_partial_catalog`` expects).
+        # Mirrors the remote path. See PR #1423 review (Codex P2
+        # r3716433830).
+        dest_read_cancelled = False
 
         for source_file in batch:
             if runner.is_cancelled(job["id"]):
@@ -3727,6 +3767,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                     twin_path, _stop_requested)
                             except DestReadCancelled:
                                 cancelled = True
+                                dest_read_cancelled = True
                                 break
                             except OSError:
                                 continue
@@ -3957,6 +3998,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # failed — it stays on the card for the next run, like any
                 # file the cancel got to before its batch.
                 cancelled = True
+                dest_read_cancelled = True
                 break
             except OSError as e:
                 _fail(rel, source_file, str(e))
@@ -4054,7 +4096,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # landed on disk must be cataloged before we stop, so every
         # stopping point is a valid catalog state). Bounded by the batch
         # size, so no cancel_check is passed — it runs to completion.
-        if landed:
+        #
+        # Skip when a destination-side hash in the per-file loop above
+        # cancelled mid-read. That signal means the mount is misbehaving,
+        # and ``scan()`` here — plus the ``_rehash_dest_or_none``
+        # re-checks below — would touch the same wedged mount and pin the
+        # job in "cancelling" for the mount's own timeout. Already-copied
+        # landings are picked up by the next run's crash-recovery
+        # adoption (byte-identical files match by hash and count as
+        # ``skipped_duplicate``). A plain user Stop on a healthy mount
+        # leaves ``dest_read_cancelled`` False, so partially-landed
+        # batches keep cataloging like before. Mirrors the remote path.
+        # See PR #1423 review (Codex P2 r3716433830).
+        if landed and not dest_read_cancelled:
             landed_paths = {entry[0] for entry in landed}
             # Capture the pre-scan (photo_id, file_hash) for every landed
             # dest_path. Scanner's own ``_invalidate_derived_caches``

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -4,6 +4,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from db import Database
@@ -9927,11 +9929,13 @@ def test_dest_read_cancelled_is_an_oserror():
     assert issubclass(DestReadCancelled, OSError)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
 def test_hash_dest_file_cancel_interrupts_blocked_read(tmp_path):
     import threading
     import time
-
-    import pytest
 
     from import_job import DestReadCancelled, _hash_dest_file
 
@@ -9952,12 +9956,14 @@ def test_hash_dest_file_cancel_interrupts_blocked_read(tmp_path):
         _release_fifo(fifo)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
 def test_hash_dest_file_cancel_pending_never_opens(tmp_path):
     """Stop already requested → raise before touching the file at all: on
     a dead mount the ``open()`` itself blocks, so returning at all proves
     the open was skipped (a FIFO reader with no writer never returns)."""
-    import pytest
-
     from import_job import DestReadCancelled, _hash_dest_file
 
     fifo = tmp_path / "stuck.NEF"
@@ -9966,12 +9972,14 @@ def test_hash_dest_file_cancel_pending_never_opens(tmp_path):
         _hash_dest_file(str(fifo), lambda: True)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
 def test_hash_dest_file_stall_raises_plain_oserror(tmp_path):
     """No Stop in flight — a read that produces no data for stall_timeout
     is an unreadable file, the same OSError shape every call site already
     handles (NOT a cancellation)."""
-    import pytest
-
     from import_job import DestReadCancelled, _hash_dest_file
 
     fifo = tmp_path / "stuck.NEF"
@@ -9997,6 +10005,10 @@ def _catalog_twin_row(db, dest_dir, filename, size, file_hash):
     db.conn.commit()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
 def test_local_import_cancel_interrupts_stuck_twin_hash(tmp_path):
     """Stop must not wait out a duplicate-gate hash read blocked on a dead
     mount. The cataloged twin here is a FIFO: hashing it blocks forever
@@ -10004,7 +10016,6 @@ def test_local_import_cancel_interrupts_stuck_twin_hash(tmp_path):
     cancel and exit — with the interrupted file neither copied nor
     counted as failed (it stays on the card for the next run)."""
     import threading
-    import time
 
     from import_dedup import compute_file_hash
     from import_job import ImportParams, run_import_job
@@ -10056,6 +10067,10 @@ def test_local_import_cancel_interrupts_stuck_twin_hash(tmp_path):
     assert result["copied"] == 0, result
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
 def test_remote_import_cancel_interrupts_stuck_twin_hash(
         tmp_path, monkeypatch):
     """Remote-path mirror of the local stuck-twin-hash cancel test — the
@@ -10120,6 +10135,10 @@ def test_remote_import_cancel_interrupts_stuck_twin_hash(
     assert calls["rsync"] == [], calls["rsync"]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
 def test_remote_import_cancel_interrupts_stuck_collision_hash(
         tmp_path, monkeypatch):
     """Remote-path mirror of the twin-hash cancel, but for the OTHER
@@ -10233,6 +10252,10 @@ def test_remote_import_cancel_interrupts_stuck_collision_hash(
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
 def test_remote_import_cancel_skips_post_loop_mount_probe(
         tmp_path, monkeypatch):
     """After Stop interrupts a destination-side hash on the remote path,
@@ -10315,6 +10338,10 @@ def test_remote_import_cancel_skips_post_loop_mount_probe(
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
 def test_local_import_cancel_skips_post_loop_mount_probe(
         tmp_path, monkeypatch):
     """Local-path mirror of the remote skip-post-loop-mount-probe test.

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -9872,3 +9872,249 @@ def test_remote_import_mount_loss_is_sticky_across_batches(
     # No rsync happened either — both batches short-circuited before the
     # transfer step.
     assert calls["rsync"] == [], calls["rsync"]
+
+
+# --------------------------------------------------------------------------
+# Destination-side hashing must not hold cancellation hostage. On a stale
+# SMB mount a single blocking read can pin the worker for tens of minutes
+# while Stop goes unobserved (cancellation is only polled between files).
+# ``_hash_dest_file`` bounds every mount-side hash read with the job's Stop
+# signal and a stall watchdog. The FIFOs below stand in for a dead network
+# mount — opening one for reading blocks until a writer appears, exactly
+# like a read against a wedged SMB session.
+# --------------------------------------------------------------------------
+
+def _release_fifo(fifo):
+    """Unblock any reader stuck on the FIFO (open the writer side, close →
+    the reader sees EOF). Best-effort cleanup so an abandoned hash worker
+    doesn't outlive its test."""
+    import contextlib
+    with contextlib.suppress(OSError):
+        fd = os.open(str(fifo), os.O_WRONLY | os.O_NONBLOCK)
+        os.close(fd)
+
+
+class CancelOnImportingRunner(FakeRunner):
+    """Flips to cancelled the moment the per-file "importing" progress
+    emit lands — i.e. after the loop-top cancellation check has already
+    passed for that file, right before the duplicate gate's destination
+    reads."""
+
+    def push_event(self, job_id, event_type, data):
+        super().push_event(job_id, event_type, data)
+        if (
+            event_type == "progress"
+            and ": importing" in (data.get("phase") or "")
+        ):
+            self.cancelled_ids.add(job_id)
+
+
+def test_hash_dest_file_matches_compute_file_hash(tmp_path):
+    from import_dedup import compute_file_hash
+    from import_job import _hash_dest_file
+
+    f = tmp_path / "a.jpg"
+    f.write_bytes(b"some destination bytes" * 1000)
+    assert _hash_dest_file(str(f), lambda: False) == \
+        compute_file_hash(str(f))
+
+
+def test_dest_read_cancelled_is_an_oserror():
+    """Call sites without explicit cancel handling catch OSError and treat
+    the file as unreadable — safe-by-default for any unwired site."""
+    from import_job import DestReadCancelled
+
+    assert issubclass(DestReadCancelled, OSError)
+
+
+def test_hash_dest_file_cancel_interrupts_blocked_read(tmp_path):
+    import threading
+    import time
+
+    import pytest
+
+    from import_job import DestReadCancelled, _hash_dest_file
+
+    fifo = tmp_path / "stuck.NEF"
+    os.mkfifo(str(fifo))
+    cancel = threading.Event()
+    timer = threading.Timer(0.3, cancel.set)
+    timer.start()
+    start = time.monotonic()
+    try:
+        with pytest.raises(DestReadCancelled):
+            _hash_dest_file(str(fifo), cancel.is_set)
+        assert time.monotonic() - start < 5.0, (
+            "cancellation took too long to interrupt the blocked read"
+        )
+    finally:
+        timer.cancel()
+        _release_fifo(fifo)
+
+
+def test_hash_dest_file_cancel_pending_never_opens(tmp_path):
+    """Stop already requested → raise before touching the file at all: on
+    a dead mount the ``open()`` itself blocks, so returning at all proves
+    the open was skipped (a FIFO reader with no writer never returns)."""
+    import pytest
+
+    from import_job import DestReadCancelled, _hash_dest_file
+
+    fifo = tmp_path / "stuck.NEF"
+    os.mkfifo(str(fifo))
+    with pytest.raises(DestReadCancelled):
+        _hash_dest_file(str(fifo), lambda: True)
+
+
+def test_hash_dest_file_stall_raises_plain_oserror(tmp_path):
+    """No Stop in flight — a read that produces no data for stall_timeout
+    is an unreadable file, the same OSError shape every call site already
+    handles (NOT a cancellation)."""
+    import pytest
+
+    from import_job import DestReadCancelled, _hash_dest_file
+
+    fifo = tmp_path / "stuck.NEF"
+    os.mkfifo(str(fifo))
+    try:
+        with pytest.raises(OSError) as exc_info:
+            _hash_dest_file(str(fifo), lambda: False, stall_timeout=0.5)
+        assert not isinstance(exc_info.value, DestReadCancelled)
+    finally:
+        _release_fifo(fifo)
+
+
+def _catalog_twin_row(db, dest_dir, filename, size, file_hash):
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), os.path.basename(str(dest_dir))),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, ?, ?, ?)",
+        (fid, filename, os.path.splitext(filename)[1], size, file_hash),
+    )
+    db.conn.commit()
+
+
+def test_local_import_cancel_interrupts_stuck_twin_hash(tmp_path):
+    """Stop must not wait out a duplicate-gate hash read blocked on a dead
+    mount. The cataloged twin here is a FIFO: hashing it blocks forever
+    until released, like a stale SMB session. The job must notice the
+    cancel and exit — with the interrupted file neither copied nor
+    counted as failed (it stays on the card for the next run)."""
+    import threading
+    import time
+
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(card_file))
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "old"
+    dest_dir.mkdir(parents=True)
+    twin = dest_dir / "IMG_0300.jpg"
+    os.mkfifo(str(twin))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _catalog_twin_row(
+        db, dest_dir, "IMG_0300.jpg",
+        os.path.getsize(str(card_file)), compute_file_hash(str(card_file)),
+    )
+
+    runner = CancelOnImportingRunner()
+    job = _make_job()
+    result_box = {}
+
+    def _run():
+        result_box["result"] = run_import_job(
+            job, runner, db_path, ws_id,
+            ImportParams(sources=[str(card)], destination=str(archive)),
+        )
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    try:
+        worker.join(timeout=15.0)
+        assert not worker.is_alive(), (
+            "Stop did not interrupt the destination hash read blocked on "
+            "the dead-mount twin"
+        )
+    finally:
+        _release_fifo(twin)
+        worker.join(timeout=5.0)
+
+    result = result_box["result"]
+    assert result["cancelled"] is True
+    assert result["failed"] == 0, result
+    assert result["copied"] == 0, result
+
+
+def test_remote_import_cancel_interrupts_stuck_twin_hash(
+        tmp_path, monkeypatch):
+    """Remote-path mirror of the local stuck-twin-hash cancel test — the
+    remote duplicate gate hashes cataloged twins through the SMB mount
+    too, and must observe Stop the same way. Nothing may reach rsync."""
+    import threading
+
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(card_file))
+
+    dest_dir = Path(ra["mount_base"]) / "2026" / "2026-01-01"
+    dest_dir.mkdir(parents=True)
+    twin = dest_dir / "IMG_0300.jpg"
+    os.mkfifo(str(twin))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _catalog_twin_row(
+        db, dest_dir, "IMG_0300.jpg",
+        os.path.getsize(str(card_file)), compute_file_hash(str(card_file)),
+    )
+
+    runner = CancelOnImportingRunner()
+    job = _make_job()
+    result_box = {}
+
+    def _run():
+        result_box["result"] = run_import_job(
+            job, runner, db_path, ws_id,
+            ImportParams(
+                sources=[str(card)], destination=ra["mount_base"],
+                remote_target=ra, verify_by_hash=True,
+            ),
+        )
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    try:
+        worker.join(timeout=15.0)
+        assert not worker.is_alive(), (
+            "Stop did not interrupt the destination hash read blocked on "
+            "the dead-mount twin"
+        )
+    finally:
+        _release_fifo(twin)
+        worker.join(timeout=5.0)
+
+    result = result_box["result"]
+    assert result["cancelled"] is True
+    assert result["failed"] == 0, result
+    assert result["copied"] == 0, result
+    assert calls["rsync"] == [], calls["rsync"]

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -10408,3 +10408,158 @@ def test_local_import_cancel_skips_post_loop_mount_probe(
         f"post-loop mount probe was not suppressed on cancel "
         f"({probe_calls['count']} calls)"
     )
+
+
+# --------------------------------------------------------------------------
+# The ``_stop_requested`` closures threaded into ``_hash_dest_file`` supervise
+# the watchdog thread that bounds every mount-side hash read. Import jobs are
+# pausable, so ``runner.is_cancelled()`` parks inside ``wait_if_paused`` when
+# a Pause is pending — wiring the watchdog to that pause-aware method would
+# freeze the watchdog loop itself, stopping the 120s stall timer from running
+# while the daemon reader can keep touching the archive at kernel-read speed.
+# Mirrors the rsync watchdog's use of ``cancellation_requested`` for the same
+# reason (see ``test_remote_import_rsync_watchdog_does_not_block_on_pause``).
+# --------------------------------------------------------------------------
+
+
+class _PauseWhileHashingRunner(FakeRunner):
+    """FakeRunner with real JobRunner-shaped pause semantics: is_cancelled
+    blocks during a pending Pause; cancellation_requested does not.
+
+    Raises on the blocking call so a broken closure fails the test loudly
+    instead of hanging the worker thread past its join timeout.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.paused_ids = set()
+
+    def is_cancelled(self, job_id):
+        if job_id in self.paused_ids and job_id not in self.cancelled_ids:
+            raise AssertionError(
+                "hash watchdog called the pause-aware is_cancelled and "
+                "would have blocked the stall/cancel watchdog thread "
+                "during Pause"
+            )
+        return job_id in self.cancelled_ids
+
+    def cancellation_requested(self, job_id):
+        return job_id in self.cancelled_ids
+
+
+def test_local_import_hash_watchdog_does_not_block_on_pause(
+        tmp_path, monkeypatch):
+    """Local-path duplicate-gate: the ``_stop_requested`` closure threaded
+    into ``_hash_dest_file`` must probe cancellation without parking in
+    ``wait_if_paused``. Without the fix, a Pause during a twin hash would
+    freeze the watchdog loop itself — stall timer disabled, Stop unobserved
+    — and the daemon reader keeps hitting the archive."""
+    import import_job as _ij
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(card_file))
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "twins"
+    dest_dir.mkdir(parents=True)
+    # Real byte-identical twin (not a FIFO) — the duplicate gate hashes
+    # it through ``_hash_dest_file`` to confirm the on-disk bytes match.
+    twin_file = dest_dir / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(twin_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _catalog_twin_row(
+        db, dest_dir, "IMG_0300.jpg",
+        os.path.getsize(str(twin_file)),
+        compute_file_hash(str(twin_file)),
+    )
+
+    runner = _PauseWhileHashingRunner()
+    job = _make_job()
+
+    # Mark the job paused for exactly the window in which the watchdog's
+    # ``cancel_check`` runs. Covers both the pre-open probe (line 788) and
+    # every mid-read chunk boundary (line 817).
+    real_hash_dest_file = _ij._hash_dest_file
+
+    def spy_hash_dest_file(path, cancel_check, **kw):
+        runner.paused_ids.add(job["id"])
+        try:
+            return real_hash_dest_file(path, cancel_check, **kw)
+        finally:
+            runner.paused_ids.discard(job["id"])
+
+    monkeypatch.setattr(_ij, "_hash_dest_file", spy_hash_dest_file)
+
+    # No AssertionError ⇒ the closure probed with the nonblocking method.
+    # The twin's real bytes hash cleanly so the import lands the file as
+    # ``skipped_duplicate``.
+    result = run_import_job(
+        job, runner, db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+    assert result["skipped_duplicate"] == 1, result
+    assert result["failed"] == 0, result
+
+
+def test_remote_import_hash_watchdog_does_not_block_on_pause(
+        tmp_path, monkeypatch):
+    """Remote-path mirror of the local hash-watchdog pause test — the
+    remote ``_stop_requested`` closure has to use ``cancellation_requested``
+    too. Each fix lands twice (see PR description)."""
+    import import_job as _ij
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(card_file))
+
+    dest_dir = Path(ra["mount_base"]) / "2026" / "2026-01-01"
+    dest_dir.mkdir(parents=True)
+    twin_file = dest_dir / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(twin_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _catalog_twin_row(
+        db, dest_dir, "IMG_0300.jpg",
+        os.path.getsize(str(twin_file)),
+        compute_file_hash(str(twin_file)),
+    )
+
+    runner = _PauseWhileHashingRunner()
+    job = _make_job()
+
+    real_hash_dest_file = _ij._hash_dest_file
+
+    def spy_hash_dest_file(path, cancel_check, **kw):
+        runner.paused_ids.add(job["id"])
+        try:
+            return real_hash_dest_file(path, cancel_check, **kw)
+        finally:
+            runner.paused_ids.discard(job["id"])
+
+    monkeypatch.setattr(_ij, "_hash_dest_file", spy_hash_dest_file)
+
+    result = run_import_job(
+        job, runner, db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+    assert result["skipped_duplicate"] == 1, result
+    assert result["failed"] == 0, result

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -10413,6 +10413,137 @@ def test_local_import_cancel_skips_post_loop_mount_probe(
 
 
 # --------------------------------------------------------------------------
+# On a PLAIN Stop (user-hit cancel observed by ``runner.is_cancelled`` at the
+# top of the source-file loop) the mount is not necessarily wedged; an
+# earlier file in the same batch may have been copied or adopted while the
+# archive was still healthy, and the share could then have detached in the
+# gap between that operation and the Stop. The post-loop mount probe is the
+# last chance to catch that detach — without it ``landed`` / ``dup_skips``
+# stay accepted and the catalog block trusts a local shadow. See PR #1423
+# review (Codex P2 r3716581282 / r3716581283).
+# --------------------------------------------------------------------------
+
+
+def test_local_import_plain_stop_still_runs_post_loop_mount_probe(
+        tmp_path, monkeypatch):
+    """A plain Stop (not a wedged-mount ``DestReadCancelled``) MUST NOT
+    suppress the post-loop mount probe. If the archive detaches after an
+    earlier file in the batch landed, only this probe can roll it back
+    before the catalog block scans a local shadow."""
+    import pipeline_job as _pj
+    from import_job import ImportParams
+
+    # Two files, one batch (same date -> same destination folder). File
+    # one gets to land; file two's loop-top cancel check breaks.
+    card = _make_card(tmp_path, [
+        ("DSC_0100.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0101.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+    archive = tmp_path / "archive"
+
+    probe_calls = {"count": 0}
+
+    def spy_unmounted(baseline):
+        probe_calls["count"] += 1
+        # Detach only appears on the post-loop probe: pre-batch (call 1)
+        # and per-file file-one (call 2) must return healthy so file one
+        # successfully lands. On the third call — post-loop — return a
+        # truthy mount root so the ``if mount_lost and landed`` rollback
+        # is exercised.
+        if probe_calls["count"] >= 3:
+            return "/Volumes/NAS"
+        return None
+
+    monkeypatch.setattr(_pj, "_unmounted_since_baseline", spy_unmounted)
+
+    runner = CancelOnImportingRunner()
+    db, ws_id, result = _run_import(
+        tmp_path,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+        runner=runner,
+    )
+
+    assert result["cancelled"] is True
+    # Post-loop probe MUST fire on plain Stop: pre-batch (1) + per-file
+    # for the one file that entered the loop body (2) + post-loop (3).
+    # If the gate ever regresses to ``not cancelled``, the third call
+    # disappears and the rollback below silently stops running.
+    assert probe_calls["count"] == 3, (
+        f"expected 3 mount probes (pre-batch + per-file + post-loop) "
+        f"but got {probe_calls['count']}"
+    )
+    # File one was copied but must be rolled back to failed once the
+    # post-loop probe sees the detach — the archive holds a local shadow
+    # of that file, not the real bytes, so booking it as copied would
+    # let ``safe_to_format`` go green over a card that still holds the
+    # only copy.
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "detached" in u["reason"] and "local shadow" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+
+def test_remote_import_plain_stop_still_runs_post_loop_mount_probe(
+        tmp_path, monkeypatch):
+    """Remote-path mirror of the local plain-Stop probe-firing test.
+    An earlier file in the same batch was queued for rsync as a fresh
+    copy; the share then detaches; a plain Stop breaks the loop. The
+    post-loop probe MUST fire so ``to_transfer`` is rolled back rather
+    than trusted."""
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0100.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0101.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    probe_calls = {"count": 0}
+
+    def spy_unmounted(baseline):
+        probe_calls["count"] += 1
+        if probe_calls["count"] >= 3:
+            return "/Volumes/NAS"
+        return None
+
+    monkeypatch.setattr(_pj, "_unmounted_since_baseline", spy_unmounted)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), CancelOnImportingRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra,
+        ),
+    )
+
+    assert result["cancelled"] is True
+    assert probe_calls["count"] == 3, (
+        f"expected 3 mount probes (pre-batch + per-file + post-loop) "
+        f"but got {probe_calls['count']}"
+    )
+    # File one was queued for rsync; the post-loop probe must roll it
+    # back to failed. rsync itself is gated on ``not cancelled`` and so
+    # never runs (``copied == 0`` alone doesn't prove the probe fired;
+    # the failed-with-detach reason does).
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "detached" in u["reason"] for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+
+# --------------------------------------------------------------------------
 # The ``_stop_requested`` closures threaded into ``_hash_dest_file`` supervise
 # the watchdog thread that bounds every mount-side hash read. Import jobs are
 # pausable, so ``runner.is_cancelled()`` parks inside ``wait_if_paused`` when

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -10118,3 +10118,266 @@ def test_remote_import_cancel_interrupts_stuck_twin_hash(
     assert result["failed"] == 0, result
     assert result["copied"] == 0, result
     assert calls["rsync"] == [], calls["rsync"]
+
+
+def test_remote_import_cancel_interrupts_stuck_collision_hash(
+        tmp_path, monkeypatch):
+    """Remote-path mirror of the twin-hash cancel, but for the OTHER
+    destination-side hash on this path: the collision/adopt loop.
+
+    Scenario: a file already sits at the collision candidate path on the
+    mount (crash-recovery shape — landed by an earlier run before catalog)
+    but is NOT cataloged, so the twin-hash branch above finds nothing and
+    execution reaches the ``os.path.exists(cand_mount)`` -> ``_hash_dest_file``
+    branch. That mount is wedged (FIFO). Before the fix, ``DestReadCancelled``
+    was swallowed as ``on_disk = None`` and the ``while True`` loop advanced
+    to the next suffix, calling ``os.path.exists`` / ``_hash_dest_file`` on
+    the same dead mount again. Stop must now leave both the candidate loop
+    and the source-file loop the moment cancellation is observed, so nothing
+    reaches rsync and no further mount work happens."""
+    import threading
+    from datetime import datetime
+
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(card_file))
+    # Pin the card file's mtime so the folder-template resolves to a
+    # deterministic dest_folder. Fixed local-time date so the collision
+    # FIFO below sits at the exact ``cand_mount`` path the import job
+    # computes for this file.
+    fixed_dt = datetime(2026, 1, 15, 12, 0, 0)
+    ts = fixed_dt.timestamp()
+    os.utime(str(card_file), (ts, ts))
+
+    dest_dir = Path(ra["mount_base"]) / fixed_dt.strftime("%Y") / \
+        fixed_dt.strftime("%Y-%m-%d")
+    dest_dir.mkdir(parents=True)
+    # Two NOT-cataloged mount files at consecutive suffixes — the primary
+    # candidate blocks the collision hash; the second exists so that
+    # advancing past the primary would re-enter ``os.path.exists`` /
+    # ``_hash_dest_file`` on the same wedged mount. This is the "next
+    # iteration" behavior Codex flagged — leaving the candidate loop on
+    # cancel means the second suffix is never touched.
+    collision = dest_dir / "IMG_0300.jpg"
+    os.mkfifo(str(collision))
+    next_collision = dest_dir / "IMG_0300_1.jpg"
+    os.mkfifo(str(next_collision))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Spy on the collision-candidate probe. ``os.path.exists`` gets called
+    # once per candidate iteration, so without the inner break Codex asked
+    # for, cancelling on the primary FIFO's hash would fall through to the
+    # counter+=1/continue path and probe (then hash) the second FIFO on
+    # the same dead mount before the outer ``if cancelled: break`` check
+    # fires.
+    import import_job as _ij
+    real_hash_dest_file = _ij._hash_dest_file
+    hashed_paths = []
+
+    def spy_hash_dest_file(path, cancel_check, **kw):
+        hashed_paths.append(path)
+        return real_hash_dest_file(path, cancel_check, **kw)
+
+    monkeypatch.setattr(_ij, "_hash_dest_file", spy_hash_dest_file)
+
+    runner = CancelOnImportingRunner()
+    job = _make_job()
+    result_box = {}
+
+    def _run():
+        result_box["result"] = run_import_job(
+            job, runner, db_path, ws_id,
+            ImportParams(
+                sources=[str(card)], destination=ra["mount_base"],
+                remote_target=ra, verify_by_hash=True,
+            ),
+        )
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    try:
+        worker.join(timeout=15.0)
+        assert not worker.is_alive(), (
+            "Stop did not interrupt the collision hash read blocked on "
+            "the dead-mount candidate"
+        )
+    finally:
+        _release_fifo(collision)
+        _release_fifo(next_collision)
+        worker.join(timeout=5.0)
+
+    result = result_box["result"]
+    assert result["cancelled"] is True
+    assert result["failed"] == 0, result
+    assert result["copied"] == 0, result
+    assert calls["rsync"] == [], calls["rsync"]
+    # After the primary candidate's hash raised DestReadCancelled, the
+    # inner break must exit the candidate loop — no second dead-mount
+    # candidate should have been hashed. Without the fix, the code would
+    # advance to ``IMG_0300_1.jpg`` and hash it too before observing
+    # cancellation at the outer batch boundary.
+    dest_hashes = [p for p in hashed_paths if str(dest_dir) in str(p)]
+    assert len(dest_hashes) <= 1, (
+        f"collision loop hashed multiple dead-mount candidates on cancel: "
+        f"{dest_hashes}"
+    )
+
+
+def test_remote_import_cancel_skips_post_loop_mount_probe(
+        tmp_path, monkeypatch):
+    """After Stop interrupts a destination-side hash on the remote path,
+    the post-loop ``_unmounted_since_baseline`` probe MUST NOT fire. On a
+    real wedged mount that probe would block for the mount's own timeout,
+    pinning the job in "cancelling" — exactly the behavior this PR set out
+    to eliminate.
+
+    Spy on the probe: it may run once (the per-file check that ran before
+    the twin-hash cancel), but the second call — post-loop — must be
+    suppressed by the ``not cancelled`` gate."""
+    import threading
+
+    import pipeline_job as _pj
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(card_file))
+
+    dest_dir = Path(ra["mount_base"]) / "2026" / "2026-01-01"
+    dest_dir.mkdir(parents=True)
+    twin = dest_dir / "IMG_0300.jpg"
+    os.mkfifo(str(twin))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _catalog_twin_row(
+        db, dest_dir, "IMG_0300.jpg",
+        os.path.getsize(str(card_file)), compute_file_hash(str(card_file)),
+    )
+
+    probe_calls = {"count": 0}
+
+    def spy_unmounted(baseline):
+        probe_calls["count"] += 1
+        return None
+
+    monkeypatch.setattr(_pj, "_unmounted_since_baseline", spy_unmounted)
+
+    runner = CancelOnImportingRunner()
+    job = _make_job()
+    result_box = {}
+
+    def _run():
+        result_box["result"] = run_import_job(
+            job, runner, db_path, ws_id,
+            ImportParams(
+                sources=[str(card)], destination=ra["mount_base"],
+                remote_target=ra, verify_by_hash=True,
+            ),
+        )
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    try:
+        worker.join(timeout=15.0)
+        assert not worker.is_alive()
+    finally:
+        _release_fifo(twin)
+        worker.join(timeout=5.0)
+
+    result = result_box["result"]
+    assert result["cancelled"] is True
+    # Two calls are expected on the healthy cancel path: pre-batch (once
+    # per batch, before the for-source_file loop) + per-file (once at the
+    # top of the loop, before the twin-hash break). The post-loop probe
+    # (unconditional before the fix) must be suppressed once ``cancelled``
+    # is set — so a third call would signal a regression.
+    assert probe_calls["count"] <= 2, (
+        f"post-loop mount probe was not suppressed on cancel "
+        f"({probe_calls['count']} calls)"
+    )
+
+
+def test_local_import_cancel_skips_post_loop_mount_probe(
+        tmp_path, monkeypatch):
+    """Local-path mirror of the remote skip-post-loop-mount-probe test.
+    The local path has the same unconditional post-loop probe and the same
+    dead-mount hang risk on a wedged twin hash."""
+    import threading
+
+    import pipeline_job as _pj
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(card_file))
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "old"
+    dest_dir.mkdir(parents=True)
+    twin = dest_dir / "IMG_0300.jpg"
+    os.mkfifo(str(twin))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _catalog_twin_row(
+        db, dest_dir, "IMG_0300.jpg",
+        os.path.getsize(str(card_file)), compute_file_hash(str(card_file)),
+    )
+
+    probe_calls = {"count": 0}
+
+    def spy_unmounted(baseline):
+        probe_calls["count"] += 1
+        return None
+
+    monkeypatch.setattr(_pj, "_unmounted_since_baseline", spy_unmounted)
+
+    runner = CancelOnImportingRunner()
+    job = _make_job()
+    result_box = {}
+
+    def _run():
+        result_box["result"] = run_import_job(
+            job, runner, db_path, ws_id,
+            ImportParams(sources=[str(card)], destination=str(archive)),
+        )
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    try:
+        worker.join(timeout=15.0)
+        assert not worker.is_alive()
+    finally:
+        _release_fifo(twin)
+        worker.join(timeout=5.0)
+
+    result = result_box["result"]
+    assert result["cancelled"] is True
+    # As on the remote path: two calls are expected (pre-batch +
+    # per-file, before the twin-hash cancel). A third would mean the
+    # post-loop probe (unconditional before the fix) fired.
+    assert probe_calls["count"] <= 2, (
+        f"post-loop mount probe was not suppressed on cancel "
+        f"({probe_calls['count']} calls)"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -10327,14 +10327,16 @@ def test_remote_import_cancel_skips_post_loop_mount_probe(
 
     result = result_box["result"]
     assert result["cancelled"] is True
-    # Two calls are expected on the healthy cancel path: pre-batch (once
-    # per batch, before the for-source_file loop) + per-file (once at the
-    # top of the loop, before the twin-hash break). The post-loop probe
-    # (unconditional before the fix) must be suppressed once ``cancelled``
-    # is set — so a third call would signal a regression.
-    assert probe_calls["count"] <= 2, (
-        f"post-loop mount probe was not suppressed on cancel "
-        f"({probe_calls['count']} calls)"
+    # Exactly two calls are expected on this single-file, single-batch
+    # cancel path: pre-batch (once per batch, before the for-source_file
+    # loop) + per-file (once at the top of the loop, before the twin-hash
+    # break). ``== 2`` catches BOTH regressions: a third call would mean
+    # the post-loop probe fired (unconditional before this PR's fix), and
+    # a count below 2 would mean the per-file or pre-batch probe was
+    # accidentally removed.
+    assert probe_calls["count"] == 2, (
+        f"expected exactly 2 mount probes (pre-batch + per-file) but got "
+        f"{probe_calls['count']}"
     )
 
 
@@ -10401,12 +10403,12 @@ def test_local_import_cancel_skips_post_loop_mount_probe(
 
     result = result_box["result"]
     assert result["cancelled"] is True
-    # As on the remote path: two calls are expected (pre-batch +
-    # per-file, before the twin-hash cancel). A third would mean the
-    # post-loop probe (unconditional before the fix) fired.
-    assert probe_calls["count"] <= 2, (
-        f"post-loop mount probe was not suppressed on cancel "
-        f"({probe_calls['count']} calls)"
+    # As on the remote path: exactly two calls are expected (pre-batch +
+    # per-file, before the twin-hash cancel). ``== 2`` catches BOTH a
+    # third call (post-loop probe not suppressed) and a missing probe.
+    assert probe_calls["count"] == 2, (
+        f"expected exactly 2 mount probes (pre-batch + per-file) but got "
+        f"{probe_calls['count']}"
     )
 
 
@@ -10563,3 +10565,250 @@ def test_remote_import_hash_watchdog_does_not_block_on_pause(
     )
     assert result["skipped_duplicate"] == 1, result
     assert result["failed"] == 0, result
+
+
+# --------------------------------------------------------------------------
+# When a destination-side hash cancels mid-read (``DestReadCancelled``), the
+# mount is misbehaving. The post-loop catalog block MUST NOT run: ``scan()``
+# and its ``_hash_dest_file`` re-checks would touch the same wedged mount
+# and pin the job in "cancelling" for the mount's own timeout — the exact
+# failure mode this PR set out to eliminate. Already-landed bytes are picked
+# up by the next run's crash-recovery adoption. A plain user Stop on a
+# healthy mount leaves ``dest_read_cancelled`` False so partially-landed
+# batches keep cataloging like before.
+# --------------------------------------------------------------------------
+
+
+class CancelOnFileImportingRunner(FakeRunner):
+    """Flips to cancelled the moment the "importing" progress emit lands
+    for a specific card filename — so an earlier file in the same batch can
+    complete normally (populating ``landed``/``adopted_paths``) before Stop
+    trips on the target file's destination-side hash."""
+
+    def __init__(self, filename):
+        super().__init__()
+        self.filename = filename
+
+    def push_event(self, job_id, event_type, data):
+        super().push_event(job_id, event_type, data)
+        if (
+            event_type == "progress"
+            and ": importing" in (data.get("phase") or "")
+            and data.get("current_file") == self.filename
+        ):
+            self.cancelled_ids.add(job_id)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
+def test_local_import_dest_read_cancel_skips_catalog_scan(
+        tmp_path, monkeypatch):
+    """Local path: an earlier file in the batch fresh-copies and lands.
+    The next file's twin is a FIFO — twin-hash blocks, cancel fires, and
+    ``DestReadCancelled`` trips ``dest_read_cancelled``. The post-loop
+    ``if landed:`` catalog block MUST be skipped: ``scan()`` and the
+    ``_rehash_dest_or_none`` re-checks below would touch the same wedged
+    mount and pin the job in "cancelling"."""
+    import threading
+
+    import import_job as _ij
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    card = tmp_path / "card"
+    card.mkdir()
+    a_file = card / "A.jpg"
+    b_file = card / "B.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(a_file))
+    Image.new("RGB", (16, 16), "blue").save(str(b_file))
+
+    archive = tmp_path / "archive"
+    twin_folder = archive / "old"
+    twin_folder.mkdir(parents=True)
+    # Only B has a cataloged twin — A fresh-copies. The twin file is a
+    # FIFO so its hash read blocks forever until released (stands in for
+    # a wedged SMB session).
+    fifo = twin_folder / "B.jpg"
+    os.mkfifo(str(fifo))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _catalog_twin_row(
+        db, twin_folder, "B.jpg",
+        os.path.getsize(str(b_file)), compute_file_hash(str(b_file)),
+    )
+
+    scan_calls = []
+    real_scan = _ij.scan if hasattr(_ij, "scan") else None
+
+    def spy_scan(*args, **kwargs):
+        scan_calls.append((args, kwargs))
+        if real_scan is not None:
+            return real_scan(*args, **kwargs)
+        return None
+
+    # Both local and remote paths do ``from scanner import scan`` inside
+    # ``run_import_job``; patch at the scanner module so the fresh import
+    # binds the spy.
+    import scanner
+    monkeypatch.setattr(scanner, "scan", spy_scan)
+
+    runner = CancelOnFileImportingRunner("B.jpg")
+    job = _make_job()
+    result_box = {}
+
+    def _run():
+        result_box["result"] = run_import_job(
+            job, runner, db_path, ws_id,
+            ImportParams(sources=[str(card)], destination=str(archive)),
+        )
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    try:
+        worker.join(timeout=15.0)
+        assert not worker.is_alive(), (
+            "Stop did not interrupt the destination hash read blocked on "
+            "the dead-mount twin"
+        )
+    finally:
+        _release_fifo(fifo)
+        worker.join(timeout=5.0)
+
+    result = result_box["result"]
+    assert result["cancelled"] is True
+    assert result["failed"] == 0, result
+    # A landed on disk (fresh copy completed before B's cancel), so the
+    # unfixed code would call ``scan()`` here — hitting the same wedged
+    # mount and hanging. The gate on ``dest_read_cancelled`` must suppress
+    # every catalog-block scan.
+    assert scan_calls == [], (
+        f"catalog scan() fired on a cancelled batch after "
+        f"DestReadCancelled — would hang on the wedged mount: "
+        f"{len(scan_calls)} calls"
+    )
+    # A's bytes are still on disk somewhere under the archive, ready for
+    # the next run's crash-recovery adoption. Anywhere under the archive
+    # is fine — the folder-template date depends on system tz, so don't
+    # pin the exact subfolder.
+    assert list(archive.rglob("A.jpg")), (
+        "A's fresh copy should be on disk for the next run to adopt"
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.mkfifo is POSIX-only; FIFO stands in for a dead SMB mount.",
+)
+def test_remote_import_dest_read_cancel_skips_catalog_scan(
+        tmp_path, monkeypatch):
+    """Remote path mirror. An earlier file in the batch is adopted from
+    an already-on-disk (crash-recovery) mount copy, populating
+    ``adopted_paths``. The next file's cataloged twin is a FIFO — twin-
+    hash blocks, cancel fires, ``DestReadCancelled`` trips
+    ``dest_read_cancelled``. The post-loop
+    ``if landed or adopted_paths:`` catalog block MUST be skipped."""
+    import threading
+    from datetime import datetime
+
+    import import_job as _ij
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    a_file = card / "A.jpg"
+    b_file = card / "B.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(a_file))
+    Image.new("RGB", (16, 16), "blue").save(str(b_file))
+    # Pin both card files' mtimes to the same date so the folder-template
+    # resolves to a single deterministic dest_folder — the adopted-on-disk
+    # A candidate and the FIFO twin for B must live in that same folder
+    # for the intra-batch cancel-after-adopt scenario to fire.
+    fixed_dt = datetime(2026, 1, 15, 12, 0, 0)
+    ts = fixed_dt.timestamp()
+    os.utime(str(a_file), (ts, ts))
+    os.utime(str(b_file), (ts, ts))
+
+    dest_dir = Path(ra["mount_base"]) / fixed_dt.strftime("%Y") / \
+        fixed_dt.strftime("%Y-%m-%d")
+    dest_dir.mkdir(parents=True)
+    # A is already on the mount as byte-identical (crash-recovery shape):
+    # the collision loop hashes it, matches, and adopts it into
+    # ``adopted_paths`` without going through rsync.
+    (dest_dir / "A.jpg").write_bytes(a_file.read_bytes())
+
+    # B has a cataloged twin (different folder from ``dest_dir``) whose
+    # on-disk file is a FIFO — twin-hash blocks and Stop trips
+    # DestReadCancelled.
+    twin_folder = Path(ra["mount_base"]) / "old"
+    twin_folder.mkdir()
+    fifo = twin_folder / "B.jpg"
+    os.mkfifo(str(fifo))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _catalog_twin_row(
+        db, twin_folder, "B.jpg",
+        os.path.getsize(str(b_file)), compute_file_hash(str(b_file)),
+    )
+
+    scan_calls = []
+    real_scan = _ij.scan if hasattr(_ij, "scan") else None
+
+    def spy_scan(*args, **kwargs):
+        scan_calls.append((args, kwargs))
+        if real_scan is not None:
+            return real_scan(*args, **kwargs)
+        return None
+
+    import scanner
+    monkeypatch.setattr(scanner, "scan", spy_scan)
+
+    runner = CancelOnFileImportingRunner("B.jpg")
+    job = _make_job()
+    result_box = {}
+
+    def _run():
+        result_box["result"] = run_import_job(
+            job, runner, db_path, ws_id,
+            ImportParams(
+                sources=[str(card)], destination=ra["mount_base"],
+                remote_target=ra, verify_by_hash=True,
+            ),
+        )
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    try:
+        worker.join(timeout=15.0)
+        assert not worker.is_alive(), (
+            "Stop did not interrupt the destination hash read blocked on "
+            "the dead-mount twin"
+        )
+    finally:
+        _release_fifo(fifo)
+        worker.join(timeout=5.0)
+
+    result = result_box["result"]
+    assert result["cancelled"] is True
+    assert result["failed"] == 0, result
+    # A was adopted from the mount before B's cancel, so
+    # ``adopted_paths`` is non-empty. The unfixed code would call
+    # ``scan()`` here — hitting the wedged mount and hanging. The gate on
+    # ``dest_read_cancelled`` must suppress every catalog-block scan.
+    assert scan_calls == [], (
+        f"catalog scan() fired on a cancelled remote batch after "
+        f"DestReadCancelled — would hang on the wedged mount: "
+        f"{len(scan_calls)} calls"
+    )
+    # Nothing rsync'd either — Stop must reach the transfer gate too.
+    assert calls["rsync"] == [], calls["rsync"]


### PR DESCRIPTION
## What

Follow-up to #1421 (which made Stop kill the in-flight rsync). This fixes the other stuck-cancel mechanism from the same incident: cancellation was only polled between files, and every destination-side hash read — duplicate-gate twin verification, crash-recovery adoption, and the post-scan re-checks — was a plain blocking `compute_file_hash()` read. Against a stale SMB mount a single file pins the worker for the mount's own timeout (~22 minutes per file observed on macOS), so a Stop sat in "cancelling" for hours.

## How

New `_hash_dest_file(path, cancel_check)` runs the chunked read in a supervised daemon thread:

- Stop interrupts within ~a second, even mid-read, raising `DestReadCancelled`.
- A read producing no data for `DEST_HASH_STALL_TIMEOUT` (120s) raises a plain `OSError` — the same unreadable-file shape every call site already handles. Same stall-not-total-runtime philosophy as the rsync watchdog in `move.py`.
- `DestReadCancelled` subclasses `OSError`, so any unwired call site degrades safely to "file unreadable" rather than misbehaving.
- The blocked worker thread can't be killed (uninterruptible kernel read); it's orphaned as a daemon and exits when the mount finally returns.

All destination-side hash sites in **both** the local and remote import paths are wired through it (the two paths are hand-mirrored, so each fix lands twice). Sites that would otherwise record a spurious failure on cancel (post-scan verification, adopted-file re-checks) instead convert to the job's normal cancelled exit: the interrupted file is neither copied nor failed — it stays on the card for the next run. After a cancel interrupts a twin hash, the file no longer falls through to the collision/adopt/copy steps, which touch the same possibly-dead mount.

Known residual (deliberately out of scope): bare stat-type calls (`os.path.exists`/`getsize`) and `copy_and_hash_verify`'s own reads can still block on a dead mount, but they're single metadata round-trips or accompany an equally-blocking copy — the multi-minute-per-file hash reads were the long pole.

## Tests

TDD: all new tests were written first and observed failing (the integration tests hang exactly like the real bug, timing out after 15s with the job thread stuck).

- Unit: digest parity with `compute_file_hash`, mid-read cancel on a blocked FIFO (< 5s), cancel-pending-never-opens, stall raises plain `OSError` (not `DestReadCancelled`), subclass contract.
- Integration (local + remote paths): a cataloged twin whose on-disk file is a FIFO (stand-in for a wedged SMB session) blocks the duplicate gate; Stop still lands promptly with `cancelled=True`, 0 copied, 0 failed, and (remote) nothing reaching rsync.

`vireo/tests/test_import_job.py` + `test_move.py`: 327 passed, 5 skipped. Full local suite (workspaces/db/app/photos/edits/jobs/darktable/config): 2076 passed, 1 pre-existing environmental failure (`test_api_exiftool_status_reports_missing` — exiftool is installed on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Import jobs now stop promptly when cancelled, including during destination verification and hashing.
  * Prevented queued transfers and unnecessary mount checks from starting after cancellation.
  * Interrupted files are preserved so imports can be retried safely.
  * Improved handling of stalled or unavailable destinations without hanging job shutdown.
  * Duplicate detection, collision checks, and catalog verification now respond reliably to cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->