### PR TITLE
Load SSH archive destinations before import readiness

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1355,6 +1355,48 @@ def test_import_dest_structure_invalidation_survives_slow_startup(live_server, p
     expect(page.locator("#destStructure")).to_be_hidden()
 
 
+def test_import_remote_targets_load_while_readiness_is_slow(live_server, page):
+    """A catalog-wide metadata check must not hide configured SSH targets.
+
+    Import readiness can take minutes for a large library.  The destination
+    picker is independent of that check, so populate it while readiness is
+    still in flight instead of leaving only the static local-path option.
+    """
+    url = live_server["url"]
+
+    def readiness(route):
+        # Never fulfill: this models the slow catalog scan without blocking
+        # Playwright's event loop, so independent requests can still finish.
+        pass
+
+    def remote_targets(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "rsync_available": True,
+                "ssh_available": True,
+                "targets": [{
+                    "id": "nas1",
+                    "name": "Photo NAS",
+                    "user": "photo",
+                    "host": "nas.local",
+                    "remote_path": "/volume1/Photography",
+                    "mount_path": "/Volumes/Photography",
+                }],
+            }),
+        )
+
+    page.route("**/api/import/readiness", readiness)
+    page.route("**/api/remote-targets", remote_targets)
+    page.goto(f"{url}/import", wait_until="domcontentloaded")
+
+    expect(page.locator("#destMode option")).to_have_count(2)
+    expect(page.locator("#destMode option").nth(1)).to_have_text(
+        "Photo NAS — direct transfer over SSH"
+    )
+
+
 def test_import_remote_destination_requires_visible_folder_inside_nas(
     live_server, page,
 ):

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1389,8 +1389,10 @@ def test_import_remote_targets_load_while_readiness_is_slow(live_server, page):
 
     page.route("**/api/import/readiness", readiness)
     page.route("**/api/remote-targets", remote_targets)
-    page.goto(f"{url}/import", wait_until="domcontentloaded")
+    with page.expect_request("**/api/import/readiness") as readiness_request:
+        page.goto(f"{url}/import", wait_until="domcontentloaded")
 
+    assert readiness_request.value.url.endswith("/api/import/readiness")
     expect(page.locator("#destMode option")).to_have_count(2)
     expect(page.locator("#destMode option").nth(1)).to_have_text(
         "Photo NAS — direct transfer over SSH"

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -4078,6 +4078,11 @@ async function initImportPage() {
   // being invalidated.
   wireDestStructureInvalidation();
   wireImportSelectAll();
+  // Remote targets are independent of import readiness.  In a large catalog
+  // the metadata-repair count below can take a long time, and starting the
+  // target request afterward used to leave the destination picker with only
+  // its static local-path option for the entire scan.
+  loadImportRemoteTargets();
   await loadImportReadiness();
   // Native menu deep link: File > Import Folder... routes here as
   // /import?mode=copy&pick=source so it lands in Copy-to-archive with the
@@ -4195,7 +4200,6 @@ async function initImportPage() {
   // dropdown value.
   _afterImportConfigLoaded = cfgOk && overridesOk;
   updateAdvancedImportOptions();
-  loadImportRemoteTargets();
   loadOrphanedStaging();
   updateImportMode();
   const newImagesDeepLink = menuParams.get('new_images');

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -86,13 +86,7 @@ def _shutdown_created_job_runners(monkeypatch):
     leaked = []
     shutdown_failures = 0
     for runner in reversed(created):
-        # 15s (not 5s): a worker whose HTTP-visible status just went
-        # terminal can still be inside _run_job's finally block draining
-        # the sleep-inhibitor, persisting to job_history, and flushing
-        # logs. Windows CI under xdist load has been observed to run
-        # past 5s there, tripping this shutdown even though the job
-        # actually finished.
-        if runner.shutdown(timeout=15.0):
+        if runner.shutdown(timeout=5.0):
             continue
         shutdown_failures += 1
         leaked.extend(
@@ -216,14 +210,7 @@ def app_and_db(tmp_path, monkeypatch):
 
     app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test-token-123")
     yield app, db
-    # 15s (not 5s): a scan job that raises returns terminal status to the
-    # HTTP poll before its worker's finally block finishes, and that block
-    # on Windows can take several seconds — SleepBlocker.release() joins the
-    # sleep-inhibitor thread with its own 5s timeout, then SQLite job-history
-    # persist and log flushes still have to run. 5s isn't enough headroom on
-    # a loaded xdist Windows runner and the shutdown times out with the
-    # worker mid-finalize.
-    jobs_stopped = app._cleanup_app_resources(job_timeout=15.0)
+    jobs_stopped = app._cleanup_app_resources(job_timeout=5.0)
     db.close()
     if not jobs_stopped:
         pytest.fail("app background jobs did not stop during fixture teardown")
@@ -274,10 +261,7 @@ def client_with_photo(tmp_path, monkeypatch):
 
     app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="test-token-123")
     yield app, db, pid
-    # See app_and_db for why 15s: Windows worker finalize (sleep-inhibitor
-    # join + SQLite persist + log flushes) can outrun a 5s budget under
-    # xdist load, even after the HTTP-visible status already went terminal.
-    jobs_stopped = app._cleanup_app_resources(job_timeout=15.0)
+    jobs_stopped = app._cleanup_app_resources(job_timeout=5.0)
     db.close()
     if not jobs_stopped:
         pytest.fail("app background jobs did not stop during fixture teardown")

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -86,7 +86,13 @@ def _shutdown_created_job_runners(monkeypatch):
     leaked = []
     shutdown_failures = 0
     for runner in reversed(created):
-        if runner.shutdown(timeout=5.0):
+        # 15s (not 5s): a worker whose HTTP-visible status just went
+        # terminal can still be inside _run_job's finally block draining
+        # the sleep-inhibitor, persisting to job_history, and flushing
+        # logs. Windows CI under xdist load has been observed to run
+        # past 5s there, tripping this shutdown even though the job
+        # actually finished.
+        if runner.shutdown(timeout=15.0):
             continue
         shutdown_failures += 1
         leaked.extend(
@@ -210,7 +216,14 @@ def app_and_db(tmp_path, monkeypatch):
 
     app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test-token-123")
     yield app, db
-    jobs_stopped = app._cleanup_app_resources(job_timeout=5.0)
+    # 15s (not 5s): a scan job that raises returns terminal status to the
+    # HTTP poll before its worker's finally block finishes, and that block
+    # on Windows can take several seconds — SleepBlocker.release() joins the
+    # sleep-inhibitor thread with its own 5s timeout, then SQLite job-history
+    # persist and log flushes still have to run. 5s isn't enough headroom on
+    # a loaded xdist Windows runner and the shutdown times out with the
+    # worker mid-finalize.
+    jobs_stopped = app._cleanup_app_resources(job_timeout=15.0)
     db.close()
     if not jobs_stopped:
         pytest.fail("app background jobs did not stop during fixture teardown")
@@ -261,7 +274,10 @@ def client_with_photo(tmp_path, monkeypatch):
 
     app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="test-token-123")
     yield app, db, pid
-    jobs_stopped = app._cleanup_app_resources(job_timeout=5.0)
+    # See app_and_db for why 15s: Windows worker finalize (sleep-inhibitor
+    # join + SQLite persist + log flushes) can outrun a 5s budget under
+    # xdist load, even after the HTTP-visible status already went terminal.
+    jobs_stopped = app._cleanup_app_resources(job_timeout=15.0)
     db.close()
     if not jobs_stopped:
         pytest.fail("app background jobs did not stop during fixture teardown")


### PR DESCRIPTION
## Summary

- Load configured remote targets as soon as Import initialization begins so a slow metadata-readiness scan cannot hide SSH archive choices.
- Preserve the existing readiness gate and add Playwright coverage for an indefinitely slow readiness request.

## Tests

- `python -m pytest tests/e2e/test_import_page.py::test_import_dest_structure_invalidation_survives_slow_startup tests/e2e/test_import_page.py::test_import_remote_targets_load_while_readiness_is_slow tests/e2e/test_import_page.py::test_import_remote_destination_requires_visible_folder_inside_nas tests/e2e/test_import_page.py::test_import_copy_start_sends_restored_options -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote destination options now appear in the import destination picker while readiness checks are still in progress.

* **Bug Fixes**
  * Improved import page responsiveness by starting remote target loading immediately, preventing destination options from being unnecessarily delayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->