### PR TITLE
Import-incident follow-ups: honest duplicate preview after a cancelled run, resilient SSH target loading

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18313,10 +18313,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         Optional {"destination": abs path, "folder_template": str} turns on
         destination-recovery detection: non-duplicate files whose planned
-        destination folder already holds a same-named same-sized file are
-        streamed as ``recovered`` (with a final ``recovered_count``). Those
-        are the files a cancelled/crashed prior run left at the destination
-        — the import adopts them via crash recovery (verify + catalog, no
+        destination folder already holds a size-matching file at the
+        primary name — or at a numeric-suffix slot the run would adopt
+        (``name_1.ext``, ``name_2.ext``, ...) — are streamed as
+        ``recovered`` (with a final ``recovered_count``). Those are the
+        files a cancelled/crashed prior run left at the destination —
+        the import adopts them via crash recovery (verify + catalog, no
         re-copy), so counting them "to copy" overstates the transfer. Size
         is a cheap proxy for the run's byte-verification: a same-size file
         may still fail the hash check and be suffix-copied, so the UI must
@@ -18375,9 +18377,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return dir_listings[folder]
 
         def _recovery_candidate(path):
-            """True when the planned destination already holds a same-named
-            same-sized file — mirrors the run's adopt precondition (which
-            then byte-verifies before adopting)."""
+            """True when the planned destination already holds a size-matching
+            file at the primary name OR at any suffix slot the run would
+            adopt — mirrors ``import_job``'s adopt precondition (which then
+            byte-verifies). Size is a cheap proxy: the run may still hash-
+            mismatch and land at a further suffix, so the preview shares
+            that same optimism as the primary check."""
             if not recovery_base:
                 return False
             source_file = Path(path)
@@ -18413,8 +18418,33 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 recovery_base if rel_folder in ("", ".")
                 else os.path.join(recovery_base, rel_folder)
             )
-            return _planned_folder_listing(folder).get(
-                source_file.name) == size
+            listing = _planned_folder_listing(folder)
+            primary_name = source_file.name
+            primary_size = listing.get(primary_name)
+            if primary_size == size:
+                return True
+            if primary_size is None:
+                # No collision on the primary name — the run copies to the
+                # primary slot without walking suffixes.
+                return False
+            # Primary slot is taken by a different-sized file. Mirror
+            # import_job's collision walk (``name_1.ext``, ``name_2.ext``,
+            # ...): stop at the first free slot (the run would land a
+            # fresh copy there — not recovered), or claim recovery at the
+            # first size-matching candidate (the run would byte-verify and
+            # adopt it — same size-as-proxy semantics as the primary
+            # check above). Non-matching sizes advance the counter, just
+            # as a hash mismatch does in the run.
+            stem, suffix_ext = os.path.splitext(primary_name)
+            counter = 1
+            while True:
+                candidate = f"{stem}_{counter}{suffix_ext}"
+                cand_size = listing.get(candidate)
+                if cand_size is None:
+                    return False
+                if cand_size == size:
+                    return True
+                counter += 1
 
         BATCH_SIZE = 20
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18328,10 +18328,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         the walk the same way ``import_job`` does on a hash mismatch —
         otherwise the preview would tell the user "not re-copied" for a
         file the run is about to suffix-copy under a numbered name.
+
+        Optional {"skip_duplicates": false} matches the import job's own
+        gate: when the run has duplicate skipping off, the library-dedup
+        checker isn't consulted (library duplicates get copied anyway),
+        but crash-recovery adoption of byte-identical files at the
+        destination still fires. Passing skip_duplicates=false here
+        mirrors that: no ``duplicates`` are streamed, but ``recovered``
+        still is — so the retry preview after a cancelled dedup-off run
+        doesn't overstate the transfer.
         """
         body = request.get_json(silent=True) or {}
         paths = body.get("paths", [])
         verify_by_hash = bool(body.get("verify_by_hash"))
+        # Default True is the import job's default and preserves the
+        # pre-existing endpoint contract; only the dedup-off preview
+        # branch passes False.
+        skip_duplicates = bool(body.get("skip_duplicates", True))
         if not paths:
             return json_error("paths required", 400)
 
@@ -18354,6 +18367,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "or backslashes", 400)
 
         db = _get_db()
+        # The checker still runs when skip_duplicates=False, but only for
+        # its EXIF-batching side effect (needed by _recovery_candidate in
+        # default mode). check_and_record() is skipped in the generator
+        # below so no library-dedup verdict is produced — matching the
+        # import job, which doesn't create the checker at all in that
+        # mode.
         checker = DuplicateChecker(
             CatalogIndex.from_db(db), verify_by_hash=verify_by_hash,
         )
@@ -18519,7 +18538,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # landed on the last path or on a batch boundary, leaving
                 # the UI unable to deselect those known dupes.
                 try:
-                    if checker.check_and_record(Path(path)):
+                    # When skip_duplicates=False, the import run doesn't
+                    # consult the library-dedup checker at all — every
+                    # source file goes on to the recovery/adopt gate. Skip
+                    # check_and_record() here so a cataloged twin that
+                    # also sits at the destination is streamed as
+                    # ``recovered`` (matching what the run will actually
+                    # do) instead of ``duplicates`` (which the client
+                    # would then not subtract from the transfer count).
+                    if skip_duplicates and checker.check_and_record(
+                            Path(path)):
                         batch_duplicates.append(path)
                         duplicate_count += 1
                     elif _recovery_candidate(path):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18313,16 +18313,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         Optional {"destination": abs path, "folder_template": str} turns on
         destination-recovery detection: non-duplicate files whose planned
-        destination folder already holds a size-matching file at the
+        destination folder already holds a byte-identical file at the
         primary name — or at a numeric-suffix slot the run would adopt
         (``name_1.ext``, ``name_2.ext``, ...) — are streamed as
         ``recovered`` (with a final ``recovered_count``). Those are the
         files a cancelled/crashed prior run left at the destination —
         the import adopts them via crash recovery (verify + catalog, no
-        re-copy), so counting them "to copy" overstates the transfer. Size
-        is a cheap proxy for the run's byte-verification: a same-size file
-        may still fail the hash check and be suffix-copied, so the UI must
-        phrase this as "verified & adopted on import", never "done".
+        re-copy), so counting them "to copy" overstates the transfer.
+
+        A size match is the cheap gate: same-size candidates are the only
+        ones the run would even byte-verify, so hashing is scoped to that
+        subset (rare in a fresh import; proportional to actual collisions
+        in a retry). A same-size candidate whose bytes disagree advances
+        the walk the same way ``import_job`` does on a hash mismatch —
+        otherwise the preview would tell the user "not re-copied" for a
+        file the run is about to suffix-copy under a numbered name.
         """
         body = request.get_json(silent=True) or {}
         paths = body.get("paths", [])
@@ -18331,9 +18336,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("paths required", 400)
 
         from import_dedup import (
-            CatalogIndex, DuplicateChecker, source_capture_timestamps,
+            CatalogIndex,
+            DuplicateChecker,
+            source_capture_timestamps,
         )
         from ingest import _is_unsafe_path, build_destination_path
+        from scanner import compute_file_hash
 
         recovery_base = (body.get("destination") or "").strip()
         folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
@@ -18377,12 +18385,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return dir_listings[folder]
 
         def _recovery_candidate(path):
-            """True when the planned destination already holds a size-matching
-            file at the primary name OR at any suffix slot the run would
-            adopt — mirrors ``import_job``'s adopt precondition (which then
-            byte-verifies). Size is a cheap proxy: the run may still hash-
-            mismatch and land at a further suffix, so the preview shares
-            that same optimism as the primary check."""
+            """True when the planned destination already holds a byte-
+            identical file at the primary name OR at any suffix slot the
+            run would adopt — mirrors ``import_job``'s adopt precondition
+            (size match then byte-verify). A size-matching candidate whose
+            bytes disagree advances the walk the same way a hash mismatch
+            does in the run: otherwise the preview would subtract the
+            file from "to copy" and promise "not re-copied" for a file
+            the run will suffix-copy under a numbered name."""
             if not recovery_base:
                 return False
             source_file = Path(path)
@@ -18420,21 +18430,49 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             listing = _planned_folder_listing(folder)
             primary_name = source_file.name
+
+            # Lazy source-hash: only computed once, and only if we hit a
+            # size-matching candidate that needs verifying. A typical
+            # fresh import has no size collisions and skips hashing
+            # entirely.
+            src_hash_cache = []
+
+            def _src_hash():
+                if not src_hash_cache:
+                    try:
+                        src_hash_cache.append(compute_file_hash(
+                            str(source_file)))
+                    except OSError:
+                        src_hash_cache.append(None)
+                return src_hash_cache[0]
+
+            def _bytes_match(cand_path):
+                sh = _src_hash()
+                if sh is None:
+                    return False
+                try:
+                    return compute_file_hash(cand_path) == sh
+                except OSError:
+                    return False
+
             primary_size = listing.get(primary_name)
             if primary_size == size:
-                return True
-            if primary_size is None:
+                if _bytes_match(os.path.join(folder, primary_name)):
+                    return True
+                # Same size, different bytes at the primary slot: the run
+                # will hash-mismatch and advance to the suffix walk.
+            elif primary_size is None:
                 # No collision on the primary name — the run copies to the
                 # primary slot without walking suffixes.
                 return False
-            # Primary slot is taken by a different-sized file. Mirror
-            # import_job's collision walk (``name_1.ext``, ``name_2.ext``,
-            # ...): stop at the first free slot (the run would land a
-            # fresh copy there — not recovered), or claim recovery at the
-            # first size-matching candidate (the run would byte-verify and
-            # adopt it — same size-as-proxy semantics as the primary
-            # check above). Non-matching sizes advance the counter, just
-            # as a hash mismatch does in the run.
+            # Primary slot is taken by a different-sized (or same-sized-
+            # different-bytes) file. Mirror import_job's collision walk
+            # (``name_1.ext``, ``name_2.ext``, ...): stop at the first
+            # free slot (the run would land a fresh copy there — not
+            # recovered), or claim recovery at the first byte-identical
+            # candidate (the run would adopt it). Size-mismatched slots
+            # advance the counter; same-size-different-bytes slots also
+            # advance, mirroring the run's hash-mismatch skip.
             stem, suffix_ext = os.path.splitext(primary_name)
             counter = 1
             while True:
@@ -18442,7 +18480,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 cand_size = listing.get(candidate)
                 if cand_size is None:
                     return False
-                if cand_size == size:
+                if cand_size == size and _bytes_match(
+                        os.path.join(folder, candidate)):
                     return True
                 counter += 1
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18465,7 +18465,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         src_hash_cache.append(None)
                 return src_hash_cache[0]
 
+            def _is_source(cand_path):
+                # Reject destination candidates that ARE the source file
+                # itself — the run rejects that self-copy overlap
+                # (destination is an ancestor of the source AND the
+                # folder template renders back onto the source folder,
+                # e.g. importing /archive/2026/2026-07-03/IMG.jpg into
+                # /archive with %Y/%Y-%m-%d) rather than adopting it, so
+                # the preview must not promise "verified & adopted, not
+                # re-copied" and subtract it from "to copy" for a file
+                # the run will fail. Mirrors import_job's samefile guard
+                # with the same normalized-path fallback for paths that
+                # can't be stat'd.
+                try:
+                    return (
+                        os.path.exists(cand_path)
+                        and os.path.samefile(str(source_file), cand_path)
+                    )
+                except OSError:
+                    return (
+                        os.path.normpath(str(source_file))
+                        == os.path.normpath(cand_path)
+                    )
+
             def _bytes_match(cand_path):
+                if _is_source(cand_path):
+                    return False
                 sh = _src_hash()
                 if sh is None:
                     return False
@@ -18475,8 +18500,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     return False
 
             primary_size = listing.get(primary_name)
+            primary_path = os.path.join(folder, primary_name)
+            if primary_size == size and _is_source(primary_path):
+                # Destination candidate at the primary slot IS the
+                # source file. The run fails this file entirely rather
+                # than walking suffixes; report as not recovered instead
+                # of falling through to the suffix walk (which could
+                # find a coincidental byte-identical sibling in the
+                # source folder and wrongly claim adoption).
+                return False
             if primary_size == size:
-                if _bytes_match(os.path.join(folder, primary_name)):
+                if _bytes_match(primary_path):
                     return True
                 # Same size, different bytes at the primary slot: the run
                 # will hash-mismatch and advance to the suffix walk.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18310,6 +18310,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         fallback by default, hash-everything when verify_by_hash — so the
         preview's DUPLICATE badges and count are exactly the files the
         import step will skip.
+
+        Optional {"destination": abs path, "folder_template": str} turns on
+        destination-recovery detection: non-duplicate files whose planned
+        destination folder already holds a same-named same-sized file are
+        streamed as ``recovered`` (with a final ``recovered_count``). Those
+        are the files a cancelled/crashed prior run left at the destination
+        — the import adopts them via crash recovery (verify + catalog, no
+        re-copy), so counting them "to copy" overstates the transfer. Size
+        is a cheap proxy for the run's byte-verification: a same-size file
+        may still fail the hash check and be suffix-copied, so the UI must
+        phrase this as "verified & adopted on import", never "done".
         """
         body = request.get_json(silent=True) or {}
         paths = body.get("paths", [])
@@ -18317,25 +18328,118 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not paths:
             return json_error("paths required", 400)
 
-        from import_dedup import CatalogIndex, DuplicateChecker
+        from import_dedup import (
+            CatalogIndex, DuplicateChecker, source_capture_timestamps,
+        )
+        from ingest import _is_unsafe_path, build_destination_path
+
+        recovery_base = (body.get("destination") or "").strip()
+        folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
+        if recovery_base and not os.path.isabs(recovery_base):
+            return json_error("destination must be an absolute path", 400)
+        if recovery_base and folder_template and _is_unsafe_path(
+                folder_template):
+            return json_error(
+                "folder_template must be a relative path without '..' "
+                "or backslashes", 400)
 
         db = _get_db()
         checker = DuplicateChecker(
             CatalogIndex.from_db(db), verify_by_hash=verify_by_hash,
         )
 
+        # str(path) -> capture datetime for recovery folder planning when
+        # verify_by_hash disables the checker's own EXIF batching.
+        recovery_times = {}
+
+        # name -> size per planned destination folder, one scandir each —
+        # the destination may be a network mount, so listings are batched
+        # rather than stat'ing per candidate file (count round trips).
+        dir_listings = {}
+
+        def _planned_folder_listing(folder):
+            if folder not in dir_listings:
+                entries = {}
+                try:
+                    with os.scandir(folder) as it:
+                        for entry in it:
+                            try:
+                                if entry.is_file(follow_symlinks=False):
+                                    entries[entry.name] = entry.stat(
+                                        follow_symlinks=False).st_size
+                            except OSError:
+                                continue
+                except OSError:
+                    pass  # missing/unreadable folder -> nothing to adopt
+                dir_listings[folder] = entries
+            return dir_listings[folder]
+
+        def _recovery_candidate(path):
+            """True when the planned destination already holds a same-named
+            same-sized file — mirrors the run's adopt precondition (which
+            then byte-verifies before adopting)."""
+            if not recovery_base:
+                return False
+            source_file = Path(path)
+            try:
+                size = source_file.stat().st_size
+            except OSError:
+                return False
+            if size == 0:
+                # Zero-byte placeholders match any empty file by size;
+                # don't claim adoption for them (the duplicate checker
+                # gives them no identity either).
+                return False
+            # Folder planning mirrors ingest._source_file_timestamps:
+            # EXIF capture time falling back to file mtime. In the default
+            # mode checker.prepare() already batched the EXIF reads and
+            # capture_time() is a cache hit; in verify mode prepare() is a
+            # no-op, so the times come from this request's own batch
+            # (below) — never resolved lazily one file at a time.
+            if verify_by_hash:
+                ts = recovery_times.get(str(source_file))
+            else:
+                ts = checker.capture_time(source_file)
+            if ts is None:
+                with contextlib.suppress(OSError, ValueError,
+                                         OverflowError):
+                    ts = datetime.fromtimestamp(
+                        source_file.stat().st_mtime)
+            try:
+                rel_folder = build_destination_path(ts, folder_template)
+            except ValueError:
+                return False
+            folder = (
+                recovery_base if rel_folder in ("", ".")
+                else os.path.join(recovery_base, rel_folder)
+            )
+            return _planned_folder_listing(folder).get(
+                source_file.name) == size
+
         BATCH_SIZE = 20
 
         def generate():
             total = len(paths)
             duplicate_count = 0
+            recovered_count = 0
             batch_duplicates = []
+            batch_recovered = []
             # Batch the EXIF header reads once up front (no-op in
             # verify_by_hash mode). Intra-run duplicate tracking lives in
             # the checker: identical source files not yet in the DB are
             # reported as duplicates of each other, matching the actual
             # import step.
             checker.prepare([Path(p) for p in paths])
+            if recovery_base and verify_by_hash:
+                # prepare() skipped the EXIF batch (verify mode's identity
+                # is the hash), but recovery folder planning still needs
+                # capture times — resolve the whole request in one batch,
+                # not one lazy read per checked file.
+                recovery_times.update({
+                    str(f): dt
+                    for f, dt in source_capture_timestamps(
+                        [Path(p) for p in paths]).items()
+                })
 
             for checked, path in enumerate(paths, 1):
                 # Zero-byte placeholders are non-duplicates (the checker
@@ -18349,14 +18453,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     if checker.check_and_record(Path(path)):
                         batch_duplicates.append(path)
                         duplicate_count += 1
+                    elif _recovery_candidate(path):
+                        # Duplicate gate first, recovery second — same
+                        # order as the import run, so a cataloged twin
+                        # that also sits at the destination stays a
+                        # duplicate here and a skip there.
+                        batch_recovered.append(path)
+                        recovered_count += 1
                 except OSError:
                     pass  # Skip unreadable/missing files
 
                 if checked % BATCH_SIZE == 0 or checked == total:
-                    yield f"data: {json.dumps({'duplicates': batch_duplicates, 'checked': checked, 'total': total})}\n\n"
+                    yield f"data: {json.dumps({'duplicates': batch_duplicates, 'recovered': batch_recovered, 'checked': checked, 'total': total})}\n\n"
                     batch_duplicates = []
+                    batch_recovered = []
 
-            yield f"data: {json.dumps({'done': True, 'duplicate_count': duplicate_count, 'checked': total, 'total': total})}\n\n"
+            yield f"data: {json.dumps({'done': True, 'duplicate_count': duplicate_count, 'recovered_count': recovered_count, 'checked': total, 'total': total})}\n\n"
 
         return Response(
             generate(),

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -3340,7 +3340,82 @@ async function previewImport(opts) {
       renderImportPreviewGrid(files, [], null);
       updateImportSelectionUI();
       retireHideDuplicatesOptIn();
-      summary.textContent = files.length + ' files found · duplicates will be copied';
+      // With duplicate-skipping OFF the run doesn't consult the library
+      // checker, but crash-recovery adoption of byte-identical files at
+      // the destination still fires unconditionally in import_job — so
+      // the honest transfer count still depends on how many of the
+      // discovered files are already sitting at their planned destination
+      // from an interrupted prior run. Fetch recovery-only (paths a
+      // resumed run would adopt without transferring) whenever the
+      // destination is resolvable; the summary subtracts them from
+      // "to copy" the same way the dedup-on branch does. Nothing else in
+      // the UI changes: recovered files stay selected and land in the
+      // preview grid without a badge, because the run still processes
+      // them (verify + catalog) — they're just not re-copied.
+      //
+      // No destination resolvable (in-place preview, or the remote
+      // dropdown hasn't populated yet) → skip the request and show the
+      // count with the old wording. A subsequent preview run after the
+      // form settles will re-check.
+      const recoveryDestNoDedup = resolvedCopyDestination();
+      if (!recoveryDestNoDedup) {
+        summary.textContent = files.length +
+          ' files found · duplicates will be copied';
+        const destData = await renderDestStructure([]);
+        if (requestSeq !== importPreviewSeq) return;
+        if (importPreviewSignatureChanged(requestSignature)) return;
+        if (destData && destData.files) {
+          renderImportPreviewGrid(files, [], destData.files);
+        }
+        return;
+      }
+      summary.textContent = files.length +
+        ' files found — checking for interrupted-run leftovers…';
+      // Reuse the check-duplicates SSE endpoint with skip_duplicates:
+      // false — the server matches the import job's own gate and streams
+      // only ``recovered`` (no ``duplicates``) in this mode. Same
+      // race-condition guards as the dedup-on branch below: a newer
+      // preview cancels this one via requestSeq / signature checks.
+      const recResp = await fetch('/api/import/check-duplicates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          paths: files.map(f => f.path),
+          verify_by_hash: document.getElementById('chkVerifyByHash').checked,
+          skip_duplicates: false,
+          destination: recoveryDestNoDedup,
+          folder_template: selectedFolderTemplate(),
+        }),
+      });
+      if (!recResp.ok) throw new Error('recovery check failed');
+      const recReader = recResp.body.getReader();
+      const recDecoder = new TextDecoder();
+      let recBuffer = '';
+      const recoveredPathsNoDedup = [];
+      for (;;) {
+        const r = await recReader.read();
+        if (r.done) break;
+        recBuffer += recDecoder.decode(r.value, { stream: true });
+        const parts = recBuffer.split('\n\n');
+        recBuffer = parts.pop();
+        for (const part of parts) {
+          const m = part.match(/^data: (.+)$/m);
+          if (!m) continue;
+          try {
+            const d = JSON.parse(m[1]);
+            if (d.recovered) recoveredPathsNoDedup.push(...d.recovered);
+          } catch (e) { /* partial frame */ }
+        }
+      }
+      if (requestSeq !== importPreviewSeq) return;
+      if (importPreviewSignatureChanged(requestSignature)) return;
+      const recCountNoDedup = recoveredPathsNoDedup.length;
+      summary.textContent = files.length + ' files found · ' +
+        (recCountNoDedup ? recCountNoDedup +
+          ' already at destination from an interrupted import' +
+          ' (verified & adopted on import, not re-copied) · ' : '') +
+        (files.length - recCountNoDedup) +
+        ' to copy · duplicates will be copied';
       // No dedup gate, so every discovered file lands — pass no exclusions
       // so the folder-structure counts match the full copy set.
       const destData = await renderDestStructure([]);

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -3418,10 +3418,11 @@ async function previewImport(opts) {
     // Recovered files stay selected — the import must still process them
     // to verify and catalog the copies already at the destination — but
     // they are not part of the transfer, so "to copy" must not count
-    // them. "verified & adopted on import" is a promise about the run,
-    // hedged on purpose: the preview matched name + size, the run's
-    // byte-check has the final word (a mismatch is re-copied under a
-    // numbered suffix).
+    // them. The preview already byte-verified each size-matching
+    // candidate against its source, so the "not re-copied" promise
+    // matches what the run will do; a same-size-different-bytes
+    // collision would have been advanced past on the server and
+    // reappeared in the "to copy" count.
     const recCount = recoveredPaths.length;
     summary.textContent = files.length + ' files found · ' + dupCount +
       ' already in your library (will be skipped) · ' +

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -50,6 +50,10 @@ body { display: flex; flex-direction: column; height: 100vh; }
   color: var(--danger); font-size: 12px; font-weight: 600;
 }
 .field-error.visible { display: block; }
+.field-error .retry-link {
+  background: none; border: none; padding: 0; cursor: pointer;
+  color: inherit; font: inherit; text-decoration: underline;
+}
 .input-invalid { border-color: var(--danger) !important; }
 .destination-mode-hint {
   font-size: 11px; color: var(--text-secondary); margin: -2px 0 10px;
@@ -366,6 +370,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div class="destination-mode-hint" id="destModeHint">
         Use this for folders on this Mac and NAS volumes mounted in Finder.
       </div>
+      <div class="field-error" id="remoteTargetsError" role="alert"></div>
       <div id="destLocalRows">
       <div class="row">
         <button class="btn btn-primary" id="btnBrowseDestination" data-testid="import-destination-browse-btn" onclick="browseForDestination()">Browse...</button>
@@ -1132,20 +1137,57 @@ function onImportDestModeChange() {
 }
 
 async function loadImportRemoteTargets() {
+  // A failure here used to silently wipe the SSH options and leave a
+  // local-only dropdown with no explanation — and a HUNG endpoint (e.g.
+  // the server blocked on a stale SMB mount) never settled this promise
+  // at all, so the dropdown just never grew its SSH entries. Bound the
+  // wait, say what happened, offer a retry, and keep the last known
+  // target list rather than discarding a working option over a transient
+  // failure.
+  let failed = false;
   try {
-    const resp = await fetch('/api/remote-targets');
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 10000);
+    let resp;
+    try {
+      resp = await fetch('/api/remote-targets', { signal: ctrl.signal });
+    } finally {
+      clearTimeout(timer);
+    }
     if (!resp.ok) throw new Error('remote targets unavailable');
     const data = await resp.json();
     importRemoteTargets = (data && data.targets) || [];
     importRsyncAvailable = !!(data && data.rsync_available);
     importSshAvailable = !!(data && data.ssh_available);
   } catch (e) {
-    importRemoteTargets = [];
-    importRsyncAvailable = false;
-    importSshAvailable = false;
+    failed = true;
+  }
+  const errEl = document.getElementById('remoteTargetsError');
+  if (errEl) {
+    errEl.textContent = '';
+    errEl.classList.toggle('visible', failed);
+    if (failed) {
+      errEl.append(
+        'Couldn’t load the SSH archive destinations — the ' +
+        'server didn’t answer. ' +
+        (importRemoteTargets.length
+          ? 'Showing the last known list. '
+          : 'Only local or mounted destinations are shown. '));
+      const retry = document.createElement('button');
+      retry.type = 'button';
+      retry.className = 'retry-link';
+      retry.textContent = 'Retry';
+      retry.addEventListener('click', () => loadImportRemoteTargets());
+      errEl.appendChild(retry);
+    }
   }
   const sel = document.getElementById('destMode');
   if (!sel) return;
+  // Rebuilding removes the selected option, which silently flips the form
+  // back to "Local" — put the selection back if its target survived the
+  // reload (matters for the Retry link: a filled-in remote form must not
+  // reset itself when the retry succeeds).
+  const prevValue = sel.value;
   while (sel.options.length > 1) sel.remove(1);
   importRemoteTargets.forEach((t) => {
     const opt = document.createElement('option');
@@ -1153,6 +1195,9 @@ async function loadImportRemoteTargets() {
     opt.textContent = t.name + ' — direct transfer over SSH';
     sel.appendChild(opt);
   });
+  if (Array.prototype.some.call(sel.options, (o) => o.value === prevValue)) {
+    sel.value = prevValue;
+  }
   onImportDestModeChange();
   updateAfterMoveUI();
 }
@@ -3008,6 +3053,13 @@ function importPreviewSignature() {
     skip_duplicates: document.getElementById('chkSkipDuplicates').checked,
     verify_by_hash: document.getElementById('chkVerifyByHash').checked,
     trust_likely_duplicates: document.getElementById('chkTrustLikelyDuplicates').checked,
+    // The dup stream's "already at destination" verdicts are computed
+    // against the planned destination folders, so the preview no longer
+    // describes the form once the destination or template changes —
+    // without these fields a mid-debounce destination edit could let a
+    // stale recovery count render (or Start submit against it).
+    destination: copyMode ? resolvedCopyDestination() : '',
+    folder_template: copyMode ? selectedFolderTemplate() : '',
   });
 }
 
@@ -3312,12 +3364,23 @@ async function previewImport(opts) {
     // Pass verify_by_hash so the preview and the import agree on which files
     // are duplicates — otherwise a renamed/metadata-colliding file counted
     // as "to copy" in the preview would be skipped by the hash-based import.
+    // Pass the destination + template (same values startImport sends) so the
+    // server can also flag files a cancelled/crashed prior run already left
+    // at their planned destination folder — the run adopts those via crash
+    // recovery instead of re-copying, and counting them "to copy" here
+    // overstated the transfer after every mid-run Stop. An unresolved
+    // destination (incomplete remote form) just skips that check.
+    const recoveryDestination = resolvedCopyDestination();
     const dupResp = await fetch('/api/import/check-duplicates', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         paths: files.map(f => f.path),
         verify_by_hash: document.getElementById('chkVerifyByHash').checked,
+        ...(recoveryDestination ? {
+          destination: recoveryDestination,
+          folder_template: selectedFolderTemplate(),
+        } : {}),
       }),
     });
     if (!dupResp.ok) throw new Error('duplicate check failed');
@@ -3325,6 +3388,7 @@ async function previewImport(opts) {
     const decoder = new TextDecoder();
     let buffer = '';
     const duplicatePaths = [];
+    const recoveredPaths = [];
     for (;;) {
       const r = await reader.read();
       if (r.done) break;
@@ -3337,6 +3401,7 @@ async function previewImport(opts) {
         try {
           const d = JSON.parse(m[1]);
           if (d.duplicates) duplicatePaths.push(...d.duplicates);
+          if (d.recovered) recoveredPaths.push(...d.recovered);
         } catch (e) { /* partial frame */ }
       }
     }
@@ -3350,9 +3415,20 @@ async function previewImport(opts) {
     const dupCount = duplicatePaths.length;
     // The check ran to completion, so this count is final.
     if (dupCount === 0) retireHideDuplicatesOptIn();
+    // Recovered files stay selected — the import must still process them
+    // to verify and catalog the copies already at the destination — but
+    // they are not part of the transfer, so "to copy" must not count
+    // them. "verified & adopted on import" is a promise about the run,
+    // hedged on purpose: the preview matched name + size, the run's
+    // byte-check has the final word (a mismatch is re-copied under a
+    // numbered suffix).
+    const recCount = recoveredPaths.length;
     summary.textContent = files.length + ' files found · ' + dupCount +
       ' already in your library (will be skipped) · ' +
-      (files.length - dupCount) + ' to copy';
+      (recCount ? recCount +
+        ' already at destination from an interrupted import' +
+        ' (verified & adopted on import, not re-copied) · ' : '') +
+      (files.length - dupCount - recCount) + ' to copy';
     importDupStreamPending = false;
     renderImportPreviewGrid(files, duplicatePaths, null);
     updateImportSelectionUI();

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -14403,6 +14403,22 @@ def test_import_page_returns_200(app_and_db):
     assert "res.unverified_duplicates_only" in html
     assert 'id="safeToFormatPill"' in html
     assert "/api/jobs/import-in-place" in html
+
+
+def test_import_page_surfaces_remote_target_load_failure(app_and_db):
+    """The Archive Destination dropdown must never lose its SSH options
+    silently: when /api/remote-targets fails or hangs, the page shows a
+    visible error with a Retry control instead of a local-only dropdown
+    that looks complete (import-incident follow-up)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    html = client.get("/import").data.decode()
+    assert 'id="remoteTargetsError"' in html
+    # The loader bounds the fetch (a hung endpoint used to leave the
+    # dropdown local-only with no error at all) and offers a retry.
+    assert "AbortController" in html
+    assert "retry-link" in html
+    assert "Couldn\u2019t load the SSH archive destinations" in html
     assert "/api/jobs/import-photos" in html
 
 

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -290,3 +290,235 @@ def test_check_duplicates_zero_byte_file_does_not_swallow_pending_batch(
         "the duplicate.jpg path needs to surface in a data.duplicates "
         "event so the import UI can deselect it."
     )
+
+
+# --------------------------------------------------------------------------
+# Destination recovery awareness. A cancelled/crashed run leaves files at
+# the planned destination that are not yet cataloged; the import run adopts
+# them via crash recovery (verify + catalog, no re-copy). The preview must
+# say so instead of counting them "to copy" — a catalog-only check reads
+# "5,523 to copy / 0 duplicates" while 9 files already sit on the NAS.
+# --------------------------------------------------------------------------
+
+def _make_dated_source(tmp_path, name="IMG_0100.jpg", color="red"):
+    """A source file whose mtime (no EXIF) plans it into 2026/2026-07-03."""
+    from datetime import datetime
+
+    source = tmp_path / "source"
+    source.mkdir(exist_ok=True)
+    path = source / name
+    Image.new("RGB", (50, 50), color=color).save(str(path))
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(path), (ts, ts))
+    return path
+
+
+def _recovered_paths(events):
+    out = []
+    for e in events:
+        out.extend(e.get("recovered") or [])
+    return out
+
+
+def test_check_duplicates_reports_files_already_at_destination(
+    app_and_db, tmp_path
+):
+    """Same name + same size at the planned destination folder → streamed
+    as ``recovered``, not counted as duplicate or left in "to copy"."""
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+    import shutil
+    shutil.copy2(str(src), str(planned / src.name))
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    assert resp.status_code == 200
+
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert len(done) == 1
+    assert done[0]["duplicate_count"] == 0
+    assert done[0]["recovered_count"] == 1
+    assert str(src) in _recovered_paths(events)
+
+
+def test_check_duplicates_recovery_requires_size_match(app_and_db, tmp_path):
+    """A same-named file with different bytes at the destination is NOT a
+    recovery candidate — the run would suffix-copy the source instead."""
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+    (planned / src.name).write_bytes(b"different bytes entirely")
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 0
+    assert _recovered_paths(events) == []
+
+
+def test_check_duplicates_catalog_duplicate_wins_over_recovery(
+    app_and_db, tmp_path
+):
+    """A file that is both cataloged (library twin) and present at the
+    planned destination counts as a duplicate — mirroring the run, whose
+    duplicate gate runs before the crash-recovery adopt."""
+    app, db, fid = app_and_db
+
+    library_dir = tmp_path / "library"
+    library_dir.mkdir(exist_ok=True)
+    src = _make_dated_source(tmp_path)
+    import shutil
+    shutil.copy2(str(src), str(library_dir / src.name))
+    from scanner import scan
+    scan(str(library_dir), db)
+
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+    shutil.copy2(str(src), str(planned / src.name))
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["duplicate_count"] == 1
+    assert done[0]["recovered_count"] == 0
+    assert _recovered_paths(events) == []
+
+
+def test_check_duplicates_no_destination_reports_no_recovery(
+    app_and_db, tmp_path
+):
+    """Without a destination in the request the endpoint behaves exactly
+    as before — zero recovered, no errors."""
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+    })
+    assert resp.status_code == 200
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0].get("recovered_count", 0) == 0
+    assert _recovered_paths(events) == []
+
+
+def test_check_duplicates_zero_byte_source_never_recovered(
+    app_and_db, tmp_path
+):
+    """Zero-byte placeholders match any empty destination file by size;
+    don't claim adoption for them (the checker gives them no identity
+    either)."""
+    from datetime import datetime
+
+    app, db, fid = app_and_db
+
+    source = tmp_path / "source"
+    source.mkdir(exist_ok=True)
+    src = source / "DSC_0001.NEF"
+    src.write_bytes(b"")
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(src), (ts, ts))
+
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+    (planned / "DSC_0001.NEF").write_bytes(b"")
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 0
+
+
+def test_check_duplicates_rejects_relative_destination(app_and_db, tmp_path):
+    app, db, fid = app_and_db
+    src = _make_dated_source(tmp_path)
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": "relative/archive",
+    })
+    assert resp.status_code == 400
+
+
+def test_check_duplicates_rejects_unsafe_template(app_and_db, tmp_path):
+    app, db, fid = app_and_db
+    src = _make_dated_source(tmp_path)
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(tmp_path / "archive"),
+        "folder_template": "../escape",
+    })
+    assert resp.status_code == 400
+
+
+def test_check_duplicates_recovery_batches_exif_reads_in_verify_mode(
+    app_and_db, tmp_path, monkeypatch
+):
+    """verify_by_hash makes checker.prepare() a no-op, so the recovery
+    check must batch its own capture-time resolution — one call for the
+    whole request, not one lazy ExifTool spawn per file."""
+    app, db, fid = app_and_db
+
+    srcs = [
+        _make_dated_source(tmp_path, name=f"IMG_010{i}.jpg", color=c)
+        for i, c in enumerate(["red", "green", "blue"])
+    ]
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+    import shutil
+    shutil.copy2(str(srcs[0]), str(planned / srcs[0].name))
+
+    import import_dedup
+    real = import_dedup.source_capture_timestamps
+    calls = []
+
+    def _counting(files, *a, **kw):
+        calls.append(list(files))
+        return real(files, *a, **kw)
+
+    monkeypatch.setattr(
+        import_dedup, "source_capture_timestamps", _counting)
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(s) for s in srcs],
+        "verify_by_hash": True,
+        "destination": str(dest),
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 1
+    assert str(srcs[0]) in _recovered_paths(events)
+    assert len(calls) == 1, (
+        f"expected one batched capture-time resolution, got {len(calls)}: "
+        f"{[len(c) for c in calls]}"
+    )

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -729,3 +729,143 @@ def test_check_duplicates_recovery_batches_exif_reads_in_verify_mode(
         f"expected one batched capture-time resolution, got {len(calls)}: "
         f"{[len(c) for c in calls]}"
     )
+
+
+# --------------------------------------------------------------------------
+# skip_duplicates=False mirrors the import job's dedup-off mode:
+# library-dedup checker isn't consulted, but crash-recovery adoption of
+# byte-identical files at the destination still fires. The retry preview
+# after a cancelled dedup-off run has to reflect that, or "to copy" would
+# double-count the files a resumed run will adopt without transferring.
+# --------------------------------------------------------------------------
+
+def test_check_duplicates_skip_false_suppresses_duplicate_verdicts(
+    app_and_db, tmp_path
+):
+    """With ``skip_duplicates: false`` no cataloged file is reported as a
+    duplicate — matching the import run's dedup-off mode, which doesn't
+    consult the library checker at all."""
+    app, db, fid = app_and_db
+
+    library_dir = tmp_path / "library"
+    library_dir.mkdir(exist_ok=True)
+    src = _make_dated_source(tmp_path)
+    import shutil
+    shutil.copy2(str(src), str(library_dir / src.name))
+    from scanner import scan
+    scan(str(library_dir), db)
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "skip_duplicates": False,
+    })
+    assert resp.status_code == 200
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert len(done) == 1
+    assert done[0]["duplicate_count"] == 0
+    # No ``duplicates`` batches at all — nothing to subtract from "to copy".
+    for e in events:
+        assert not e.get("duplicates")
+
+
+def test_check_duplicates_skip_false_still_reports_recovery(
+    app_and_db, tmp_path
+):
+    """With ``skip_duplicates: false`` the recovery gate still fires:
+    a byte-identical file at the planned destination is streamed as
+    ``recovered`` so the dedup-off retry preview subtracts it from the
+    transfer count, matching the run's unconditional crash-recovery."""
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+    import shutil
+    shutil.copy2(str(src), str(planned / src.name))
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "skip_duplicates": False,
+        "destination": str(dest),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["duplicate_count"] == 0
+    assert done[0]["recovered_count"] == 1
+    assert str(src) in _recovered_paths(events)
+
+
+def test_check_duplicates_skip_false_reports_cataloged_twin_as_recovered(
+    app_and_db, tmp_path
+):
+    """A file that is BOTH a library twin AND already at the destination:
+    with ``skip_duplicates: false`` it must be streamed as ``recovered``
+    (matching what the dedup-off run does — it doesn't consult the
+    checker, then crash-recovery adopts the on-disk copy). Without this
+    the preview would emit no verdict for it and it would stay counted in
+    "to copy", overstating the transfer after a cancelled dedup-off run
+    of a batch that happened to contain a library duplicate."""
+    app, db, fid = app_and_db
+
+    library_dir = tmp_path / "library"
+    library_dir.mkdir(exist_ok=True)
+    src = _make_dated_source(tmp_path)
+    import shutil
+    shutil.copy2(str(src), str(library_dir / src.name))
+    from scanner import scan
+    scan(str(library_dir), db)
+
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+    shutil.copy2(str(src), str(planned / src.name))
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "skip_duplicates": False,
+        "destination": str(dest),
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["duplicate_count"] == 0
+    assert done[0]["recovered_count"] == 1
+    assert str(src) in _recovered_paths(events)
+
+
+def test_check_duplicates_skip_true_by_default_preserves_contract(
+    app_and_db, tmp_path
+):
+    """Omitting ``skip_duplicates`` defaults to True — the pre-existing
+    endpoint contract. A cataloged twin at the destination stays reported
+    as a duplicate (duplicate gate wins over recovery), just like before
+    the flag was introduced."""
+    app, db, fid = app_and_db
+
+    library_dir = tmp_path / "library"
+    library_dir.mkdir(exist_ok=True)
+    src = _make_dated_source(tmp_path)
+    import shutil
+    shutil.copy2(str(src), str(library_dir / src.name))
+    from scanner import scan
+    scan(str(library_dir), db)
+
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+    shutil.copy2(str(src), str(planned / src.name))
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["duplicate_count"] == 1
+    assert done[0]["recovered_count"] == 0

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -479,6 +479,106 @@ def test_check_duplicates_rejects_unsafe_template(app_and_db, tmp_path):
     assert resp.status_code == 400
 
 
+def test_check_duplicates_recovery_walks_suffix_slots(app_and_db, tmp_path):
+    """When the primary name is taken by a different file (crash left a
+    colliding placeholder), the run walks ``name_1.ext``/``name_2.ext``
+    and adopts the first byte-identical suffix. Preview must mirror that
+    walk with size-as-proxy — otherwise a collision-retry reports files
+    as "to copy" even though Start hashes and adopts them without
+    transfer."""
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+
+    # Primary slot is occupied by a same-named but different-sized file
+    # (e.g. an unrelated existing archive photo). The interrupted run's
+    # previous copy of THIS source landed at IMG_0100_1.jpg — same size
+    # as source, byte-identical (size is the preview's stand-in for that).
+    (planned / src.name).write_bytes(b"different sized existing photo")
+    import shutil
+    shutil.copy2(str(src), str(planned / "IMG_0100_1.jpg"))
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert len(done) == 1
+    assert done[0]["recovered_count"] == 1
+    assert str(src) in _recovered_paths(events)
+
+
+def test_check_duplicates_recovery_stops_at_first_free_suffix(
+    app_and_db, tmp_path
+):
+    """Primary taken by a different-sized file, and every existing suffix
+    slot also differs in size — the run would copy the source to the
+    first free slot (e.g. ``IMG_0100_2.jpg``), so the preview must NOT
+    call this a recovery."""
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+
+    (planned / src.name).write_bytes(b"different-sized primary")
+    # IMG_0100_1.jpg exists but is a different size — the run would hash-
+    # skip it and advance to IMG_0100_2.jpg (a free slot), meaning a real
+    # copy happens.
+    (planned / "IMG_0100_1.jpg").write_bytes(
+        b"another different-sized colliding file"
+    )
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 0
+    assert _recovered_paths(events) == []
+
+
+def test_check_duplicates_recovery_skips_size_mismatched_suffixes(
+    app_and_db, tmp_path
+):
+    """The walk must advance past size-mismatched suffix slots — mirroring
+    the run's hash-mismatch skip — before adopting a further slot that
+    does size-match. A one-slot-only check would miss the adoption."""
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+
+    (planned / src.name).write_bytes(b"different-sized primary")
+    (planned / "IMG_0100_1.jpg").write_bytes(b"another different-sized file")
+    import shutil
+    # IMG_0100_2.jpg is the adopted-from-crash copy of this source.
+    shutil.copy2(str(src), str(planned / "IMG_0100_2.jpg"))
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 1
+    assert str(src) in _recovered_paths(events)
+
+
 def test_check_duplicates_recovery_batches_exif_reads_in_verify_mode(
     app_and_db, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -869,3 +869,84 @@ def test_check_duplicates_skip_true_by_default_preserves_contract(
     done = [e for e in events if e.get("done")]
     assert done[0]["duplicate_count"] == 1
     assert done[0]["recovered_count"] == 0
+
+
+def test_check_duplicates_recovery_skipped_when_candidate_is_source(
+    app_and_db, tmp_path
+):
+    """The destination-folder template renders the planned destination
+    back onto the source folder (e.g. importing
+    /archive/2026/2026-07-03/IMG.jpg with destination /archive and
+    template %Y/%Y-%m-%d), so the primary candidate IS the source file
+    itself. The run rejects that self-copy overlap and fails the file;
+    the preview must NOT promise "verified & adopted, not re-copied"
+    and subtract it from "to copy". Mirrors import_job's samefile guard.
+    """
+    from datetime import datetime
+
+    # Source lives INSIDE what will become the planned destination
+    # folder — archive/2026/2026-07-03 renders back onto itself.
+    archive = tmp_path / "archive"
+    src_folder = archive / "2026" / "2026-07-03"
+    src_folder.mkdir(parents=True)
+    src = src_folder / "IMG_0100.jpg"
+    Image.new("RGB", (50, 50), color="red").save(str(src))
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(src), (ts, ts))
+
+    app, db, fid = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(archive),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    assert resp.status_code == 200
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 0
+    assert _recovered_paths(events) == []
+
+
+def test_check_duplicates_recovery_skipped_for_source_via_symlink(
+    app_and_db, tmp_path
+):
+    """Source path and planned-destination candidate resolve to the
+    same inode via a symlinked source directory. os.path.samefile
+    catches it even when the literal paths differ, matching
+    import_job's guard: the run fails the file, so the preview must
+    report not-recovered."""
+    from datetime import datetime
+
+    archive = tmp_path / "archive"
+    real_folder = archive / "2026" / "2026-07-03"
+    real_folder.mkdir(parents=True)
+    real_src = real_folder / "IMG_0200.jpg"
+    Image.new("RGB", (50, 50), color="blue").save(str(real_src))
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(real_src), (ts, ts))
+
+    # A symlink to the real source folder. Passing the file via the
+    # symlink path makes the literal source string differ from the
+    # planned destination path, but both stat to the same inode.
+    link_folder = tmp_path / "card_link"
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlinks unavailable")
+    try:
+        os.symlink(str(real_folder), str(link_folder))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted")
+    src_via_link = link_folder / "IMG_0200.jpg"
+
+    app, db, fid = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src_via_link)],
+        "destination": str(archive),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    assert resp.status_code == 200
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 0
+    assert _recovered_paths(events) == []

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -579,6 +579,113 @@ def test_check_duplicates_recovery_skips_size_mismatched_suffixes(
     assert str(src) in _recovered_paths(events)
 
 
+def test_check_duplicates_recovery_rejects_same_size_different_bytes(
+    app_and_db, tmp_path
+):
+    """A destination file with the same name and byte size but different
+    contents (e.g. a corrupt partial file, or an unrelated coincidence)
+    must NOT be reported as recovered. The import path hashes the
+    candidate and suffix-copies on a mismatch, so the preview would
+    otherwise subtract the file from ``to copy`` and promise "not
+    re-copied" for a file the run will re-copy under a numbered suffix.
+    """
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+
+    # Land a same-name same-size but different-content file at the
+    # primary slot. Padded to exactly match the source size.
+    src_size = os.path.getsize(str(src))
+    (planned / src.name).write_bytes(b"X" * src_size)
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert len(done) == 1
+    assert done[0]["recovered_count"] == 0
+    assert _recovered_paths(events) == []
+
+
+def test_check_duplicates_recovery_walks_past_same_size_mismatch_to_adopt(
+    app_and_db, tmp_path
+):
+    """Primary slot has same size but different bytes → the run advances
+    the walk (via hash mismatch) and adopts a further byte-identical
+    suffix. The preview must mirror that walk: advance past same-size-
+    different-bytes slots, adopt the first byte-identical candidate.
+    """
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    planned = dest / "2026" / "2026-07-03"
+    planned.mkdir(parents=True)
+
+    # Primary slot: same size, different bytes (must not be adopted).
+    src_size = os.path.getsize(str(src))
+    (planned / src.name).write_bytes(b"Y" * src_size)
+    # IMG_0100_1.jpg: byte-identical to source (the run's actual adopt).
+    import shutil
+    shutil.copy2(str(src), str(planned / "IMG_0100_1.jpg"))
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 1
+    assert str(src) in _recovered_paths(events)
+
+
+def test_check_duplicates_recovery_skips_hashing_when_no_collision(
+    app_and_db, tmp_path, monkeypatch
+):
+    """No size collision at the destination → the preview must not hash
+    the source. Fresh imports (the common case) stay cheap; hashing is
+    scoped to actual collision candidates."""
+    app, db, fid = app_and_db
+
+    src = _make_dated_source(tmp_path)
+    dest = tmp_path / "archive"
+    # Planned folder is empty — no candidate at the primary slot at all.
+    (dest / "2026" / "2026-07-03").mkdir(parents=True)
+
+    import scanner
+    hash_calls = []
+    real_hash = scanner.compute_file_hash
+
+    def _counting_hash(path, *a, **kw):
+        hash_calls.append(path)
+        return real_hash(path, *a, **kw)
+
+    monkeypatch.setattr(scanner, "compute_file_hash", _counting_hash)
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(src)],
+        "destination": str(dest),
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["recovered_count"] == 0
+    assert hash_calls == [], (
+        f"expected no content hashing without a size collision, got "
+        f"{len(hash_calls)} hash call(s): {hash_calls}"
+    )
+
+
 def test_check_duplicates_recovery_batches_exif_reads_in_verify_mode(
     app_and_db, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Follow-ups from the 2026-08-04 import incident (slow-VPN NAS import, cancelled mid-batch). Companion to #1421 (merged) and #1423; complementary to #1424, which starts the remote-targets request earlier in init — this PR bounds and surfaces the request itself, so both are needed and their hunks don't overlap.

## 1. Duplicate preview now accounts for files an interrupted run left at the destination

The preview checked only cataloged library records, so after a cancelled run the retry showed "5,523 to copy · 0 duplicates" while 9 files already sat on the NAS (uncataloged — cancellation happened before the batch scan). The import run adopts those via crash recovery, so the preview overstated the transfer.

- `/api/import/check-duplicates` optionally accepts `destination` + `folder_template` (the exact values `startImport` sends, same empty-string semantics as the job route) and streams a new `recovered` category: non-duplicate files whose planned destination folder already holds a same-named same-sized file. Duplicate gate runs first, recovery second — same order as the run, so verdicts can't disagree.
- Summary line becomes: `N files found · D already in your library (will be skipped) · R already at destination from an interrupted import (verified & adopted on import, not re-copied) · K to copy` (recovery clause omitted when zero). Size match is a cheap proxy for the run's byte-verification, so the wording promises adoption *on import*, not completion.
- SMB-friendly: one `scandir` per planned destination folder (name→size map), never a per-file stat; capture times are batch-resolved even in `verify_by_hash` mode, where `checker.prepare()` is a no-op (a test pins one batched resolution per request — the lazy path was one ExifTool spawn per RAW).
- `importPreviewSignature()` now includes destination + template, so a mid-debounce destination edit invalidates the preview instead of rendering or submitting against stale recovery counts.

## 2. SSH archive destinations can no longer vanish silently

`loadImportRemoteTargets()` swallowed failures and wiped the target list; a *hung* `/api/remote-targets` (server blocked on a stale SMB mount — the incident case) never settled the fetch at all, leaving a local-only dropdown with no explanation.

- Fetch bounded at 10s via `AbortController`.
- Failure shows a visible error under the dropdown ("Couldn't load the SSH archive destinations — the server didn't answer…") with a Retry control, instead of silence.
- The last known target list is kept on failure rather than discarded, and the dropdown rebuild restores a still-valid remote selection instead of silently flipping the form back to "Local".

## Tests

- 8 new tests in `vireo/tests/test_check_duplicates.py` (recovery detection, size-mismatch rejection, duplicate-gate precedence, no-destination back-compat, zero-byte exclusion, relative-destination and unsafe-template 400s, batched EXIF resolution) — written first, watched fail, then implemented. All 16 in the file pass.
- 1 new test in `vireo/tests/test_app.py` locking the visible-error/retry affordance on the import page.
- Required suites: `tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_check_duplicates.py` → 2093 passed, 14 skipped, 1 failed (`test_api_exiftool_status_reports_missing` — fails identically on untouched `main` on this machine; known environment baseline, not a regression).
- Inline JS of `import.html` extracted and passed `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Import previews now support destination and folder-template selection.
  - Interrupted imports can recover already-copied files, including duplicate and suffixed destination files.
  - Preview results and progress updates report recovered files and counts.
  - Duplicate checking can be disabled while destination recovery remains active.

- **Bug Fixes**
  - Remote destination loading now has a timeout, preserves existing selections, and provides a visible retry option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->