### PR TITLE
Cancel superseded duplicate preview work

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1230,6 +1230,76 @@ def test_import_duplicate_stream_result_ignored_after_controls_change(
     expect(page.locator("#destStructure")).to_be_hidden()
 
 
+def test_new_import_preview_aborts_superseded_duplicate_stream(
+    live_server, page
+):
+    """Starting a new preview must stop the old hash-heavy stream.
+
+    Sequence guards keep stale results off screen, but without transport
+    cancellation the server keeps reading every source file anyway.
+    """
+    page.goto(f"{live_server['url']}/import")
+    page.locator("#modeCopy").check()
+    page.locator("#destInput").fill("/archive")
+    page.evaluate(
+        """
+        () => {
+          clearScheduledImportPreview();
+          const originalFetch = window.fetch.bind(window);
+          window.__duplicateFetchCount = 0;
+          window.__firstDuplicateAborted = false;
+          window.fetch = (input, init = {}) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/import/folder-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                files: [{path: '/tmp/card-a/IMG_0001.jpg'}],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            if (target && target.indexOf('/api/import/check-duplicates') === 0) {
+              window.__duplicateFetchCount += 1;
+              if (window.__duplicateFetchCount === 1) {
+                return new Promise((_resolve, reject) => {
+                  init.signal.addEventListener('abort', () => {
+                    window.__firstDuplicateAborted = true;
+                    reject(new DOMException('Aborted', 'AbortError'));
+                  }, {once: true});
+                });
+              }
+              const frame = 'data: ' + JSON.stringify({
+                duplicates: [], recovered: [], checked: 1, total: 1,
+              }) + '\\n\\n' + 'data: ' + JSON.stringify({
+                done: true, duplicate_count: 0, recovered_count: 0,
+                checked: 1, total: 1,
+              }) + '\\n\\n';
+              return Promise.resolve(new Response(frame, {
+                status: 200,
+                headers: {'Content-Type': 'text/event-stream'},
+              }));
+            }
+            if (target && target.indexOf('/api/import/destination-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({folders: []}), {
+                status: 200,
+                headers: {'Content-Type': 'application/json'},
+              }));
+            }
+            return originalFetch(input, init);
+          };
+          addSourcePath('/tmp/card-a');
+          clearScheduledImportPreview();
+        }
+        """
+    )
+
+    page.locator("#btnPreview").click()
+    page.wait_for_function("window.__duplicateFetchCount === 1")
+    page.evaluate("() => { void previewImport(); }")
+
+    page.wait_for_function("window.__firstDuplicateAborted === true")
+    page.wait_for_function("window.__duplicateFetchCount === 2")
+    expect(page.locator("#btnPreview")).to_be_enabled()
+    expect(page.locator("#importError")).to_have_text("")
+
+
 def test_import_preview_older_response_does_not_clobber_newer_summary(
     live_server, page
 ):

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1300,6 +1300,76 @@ def test_new_import_preview_aborts_superseded_duplicate_stream(
     expect(page.locator("#importError")).to_have_text("")
 
 
+def test_removing_last_source_aborts_in_flight_duplicate_stream(
+    live_server, page
+):
+    """Removing the last source while a preview is running must stop the
+    server-side hash/EXIF work.
+
+    ``scheduleImportPreview()`` short-circuits on an empty source list, so
+    no successor ``previewImport()`` fires — and its own abort (which
+    lives at the top of ``previewImport``) never runs. Before the fix, the
+    UI cleared but the request kept scanning the removed card. The
+    scheduler now aborts the in-flight controller from the short-circuit
+    path itself.
+    """
+    page.goto(f"{live_server['url']}/import")
+    page.locator("#modeCopy").check()
+    page.locator("#destInput").fill("/archive")
+    page.evaluate(
+        """
+        () => {
+          clearScheduledImportPreview();
+          const originalFetch = window.fetch.bind(window);
+          window.__duplicateAborted = false;
+          window.__duplicateStarted = false;
+          window.fetch = (input, init = {}) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/import/folder-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                files: [{path: '/tmp/card-a/IMG_0001.jpg'}],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            if (target && target.indexOf('/api/import/check-duplicates') === 0) {
+              window.__duplicateStarted = true;
+              return new Promise((_resolve, reject) => {
+                init.signal.addEventListener('abort', () => {
+                  window.__duplicateAborted = true;
+                  reject(new DOMException('Aborted', 'AbortError'));
+                }, {once: true});
+              });
+            }
+            if (target && target.indexOf('/api/import/destination-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({folders: []}), {
+                status: 200,
+                headers: {'Content-Type': 'application/json'},
+              }));
+            }
+            return originalFetch(input, init);
+          };
+          addSourcePath('/tmp/card-a');
+          clearScheduledImportPreview();
+        }
+        """
+    )
+
+    page.locator("#btnPreview").click()
+    page.wait_for_function("window.__duplicateStarted === true")
+    # Drop the last source (mirrors the user clicking × on the only card
+    # while the duplicate stream is still running). Then invoke the same
+    # scheduler the click handler does — that is the code path the
+    # short-circuit lives in.
+    page.evaluate(
+        """
+        () => {
+          sources.splice(0, sources.length);
+          scheduleImportPreview();
+        }
+        """
+    )
+    page.wait_for_function("window.__duplicateAborted === true")
+
+
 def test_import_preview_older_response_does_not_clobber_newer_summary(
     live_server, page
 ):

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1370,6 +1370,101 @@ def test_removing_last_source_aborts_in_flight_duplicate_stream(
     page.wait_for_function("window.__duplicateAborted === true")
 
 
+def test_re_adding_the_last_source_after_abort_does_not_reuse_stale_paths(
+    live_server, page
+):
+    """Empty-source abort must retire the captured preview too, not just
+    the flight flags.
+
+    Removing the last source mid-stream aborts the in-flight request and
+    clears importPreviewInFlight / importDupStreamPending / importPreviewSeq.
+    Without this fix it left importPreviewCapturedSignature and
+    importPreviewedPaths behind: re-adding the same source inside the 350ms
+    debounce restored a matching signature over an empty grid, so
+    updateStartGate() found no reason to hold Start and lit it up as
+    "Start import (0 files)". Clicking that button then posted the
+    previously discovered paths as include_paths, silently importing every
+    file behind an empty screen.
+    """
+    page.goto(f"{live_server['url']}/import")
+    page.locator("#modeCopy").check()
+    page.locator("#destInput").fill("/archive")
+    page.evaluate(
+        """
+        () => {
+          clearScheduledImportPreview();
+          const originalFetch = window.fetch.bind(window);
+          window.__duplicateStarted = false;
+          window.fetch = (input, init = {}) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/import/folder-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                files: [{path: '/tmp/card-a/IMG_0001.jpg'},
+                        {path: '/tmp/card-a/IMG_0002.jpg'}],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            if (target && target.indexOf('/api/import/check-duplicates') === 0) {
+              window.__duplicateStarted = true;
+              return new Promise((_resolve, reject) => {
+                init.signal.addEventListener('abort', () => {
+                  reject(new DOMException('Aborted', 'AbortError'));
+                }, {once: true});
+              });
+            }
+            if (target && target.indexOf('/api/import/destination-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({folders: []}), {
+                status: 200,
+                headers: {'Content-Type': 'application/json'},
+              }));
+            }
+            return originalFetch(input, init);
+          };
+          addSourcePath('/tmp/card-a');
+          clearScheduledImportPreview();
+        }
+        """
+    )
+
+    page.locator("#btnPreview").click()
+    page.wait_for_function("window.__duplicateStarted === true")
+    # previewImport() captured the signature and previewed paths before
+    # the duplicate stream started. The bug hinges on those still being
+    # set at this point.
+    page.wait_for_function(
+        "() => importPreviewCapturedSignature !== null "
+        "&& importPreviewedPaths.length > 0"
+    )
+    # Remove the last source mid-stream. This is the empty-source abort
+    # branch inside scheduleImportPreview().
+    page.evaluate(
+        """
+        () => {
+          sources.splice(0, sources.length);
+          scheduleImportPreview();
+        }
+        """
+    )
+    # The fix retires the captured preview alongside the flight flags.
+    page.wait_for_function(
+        "() => importPreviewCapturedSignature === null "
+        "&& importPreviewedPaths.length === 0"
+    )
+    # Re-add the same source inside the 350ms debounce (no timer fired
+    # yet — clearScheduledImportPreview keeps it that way). Before the
+    # fix, updateStartGate() would light up Start with "0 files" here.
+    page.evaluate(
+        """
+        () => {
+          addSourcePath('/tmp/card-a');
+          clearScheduledImportPreview();
+        }
+        """
+    )
+    # Start must NOT read "Start import (0 files)" — the previously
+    # captured paths must not be resurrected against an empty grid.
+    expect(page.locator("#btnStart")).not_to_have_text("Start import (0 files)")
+
+
 def test_import_preview_older_response_does_not_clobber_newer_summary(
     live_server, page
 ):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3025,6 +3025,17 @@ def _life_list_alphabetical_key(name):
 # instead of one-per-file. Module-level so tests can override it.
 DUPLICATE_CHECK_FLUSH_INTERVAL_SECONDS = 0.1
 
+# Chunk size for the duplicate-check prep phase (EXIF batching and, in
+# verify_by_hash + recovery mode, source_capture_timestamps for folder
+# planning). Small enough that a superseded browser request cancels within
+# one chunk's worth of I/O — otherwise a card with tens of thousands of
+# files spends the entire prep phase reading metadata before the WSGI layer
+# ever gets a chance to observe the disconnect. Aligned with
+# metadata._BATCH_SIZE so an outer chunk maps to at most one ExifTool
+# subprocess for its leftovers, keeping subprocess overhead unchanged.
+# Module-level so tests can override it.
+DUPLICATE_CHECK_PREP_BATCH_SIZE = 100
+
 
 def create_app(db_path, thumb_cache_dir=None, api_token=None):
     """Create the Flask app for the Vireo photo browser.
@@ -18553,22 +18564,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             recovered_count = 0
             batch_duplicates = []
             batch_recovered = []
-            # Batch the EXIF header reads once up front (no-op in
-            # verify_by_hash mode). Intra-run duplicate tracking lives in
+            # Batch the EXIF header reads up front in bounded chunks (no-op
+            # in verify_by_hash mode). Intra-run duplicate tracking lives in
             # the checker: identical source files not yet in the DB are
             # reported as duplicates of each other, matching the actual
-            # import step.
-            checker.prepare([Path(p) for p in paths])
-            if recovery_base and verify_by_hash:
-                # prepare() skipped the EXIF batch (verify mode's identity
-                # is the hash), but recovery folder planning still needs
-                # capture times — resolve the whole request in one batch,
-                # not one lazy read per checked file.
-                recovery_times.update({
-                    str(f): dt
-                    for f, dt in source_capture_timestamps(
-                        [Path(p) for p in paths]).items()
-                })
+            # import step. Chunking with a yield between each chunk lets a
+            # superseded browser request stop this phase within one chunk's
+            # worth of I/O — a single upfront prepare() over tens of
+            # thousands of files would otherwise ignore the disconnect
+            # entirely until the per-file loop begins.
+            prep_paths = [Path(p) for p in paths]
+            prep_batch = DUPLICATE_CHECK_PREP_BATCH_SIZE
+            for prep_start in range(0, len(prep_paths), prep_batch):
+                chunk = prep_paths[prep_start:prep_start + prep_batch]
+                checker.prepare(chunk)
+                if recovery_base and verify_by_hash:
+                    # prepare() skipped the EXIF batch (verify mode's
+                    # identity is the hash), but recovery folder planning
+                    # still needs capture times — resolve them alongside
+                    # the same chunk so both prep paths share the same
+                    # cancellation cadence.
+                    recovery_times.update({
+                        str(f): dt
+                        for f, dt in source_capture_timestamps(chunk).items()
+                    })
+                # Cheap heartbeat frame the client can render as
+                # "preparing metadata…" and, more importantly, the yield
+                # that lets the WSGI server notice a disconnected client
+                # between chunks instead of after the entire prep phase.
+                prepared = prep_start + len(chunk)
+                yield f"data: {json.dumps({'preparing': prepared, 'total': total})}\n\n"
 
             last_flush = time.monotonic()
             for checked, path in enumerate(paths, 1):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18538,8 +18538,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     return True
                 counter += 1
 
-        BATCH_SIZE = 20
-
         def generate():
             total = len(paths)
             duplicate_count = 0
@@ -18594,10 +18592,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 except OSError:
                     pass  # Skip unreadable/missing files
 
-                if checked % BATCH_SIZE == 0 or checked == total:
-                    yield f"data: {json.dumps({'duplicates': batch_duplicates, 'recovered': batch_recovered, 'checked': checked, 'total': total})}\n\n"
-                    batch_duplicates = []
-                    batch_recovered = []
+                # Flush after every file. Besides making progress honest for
+                # byte-for-byte checks on slow cards / NAS volumes, each
+                # yield gives the WSGI server a chance to observe that a
+                # superseded browser request disconnected. The abandoned
+                # generator then closes after at most the current file
+                # instead of hashing another 20-file batch in the background.
+                yield f"data: {json.dumps({'duplicates': batch_duplicates, 'recovered': batch_recovered, 'checked': checked, 'total': total})}\n\n"
+                batch_duplicates = []
+                batch_recovered = []
 
             yield f"data: {json.dumps({'done': True, 'duplicate_count': duplicate_count, 'recovered_count': recovered_count, 'checked': total, 'total': total})}\n\n"
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3017,6 +3017,15 @@ def _life_list_alphabetical_key(name):
     return _LIFE_LIST_LEADING_APOSTROPHE_RE.sub("", str(name or "")).lower()
 
 
+# Adaptive flush cadence for the duplicate-check SSE stream. Byte-for-byte
+# hashes on slow cards spend far more than this per file, so each check ends
+# its own event and cancellation is bounded by one file. Metadata-only
+# checks on a 100k-file source blow through hundreds of files inside one
+# window and coalesce naturally, keeping event count in the low hundreds
+# instead of one-per-file. Module-level so tests can override it.
+DUPLICATE_CHECK_FLUSH_INTERVAL_SECONDS = 0.1
+
+
 def create_app(db_path, thumb_cache_dir=None, api_token=None):
     """Create the Flask app for the Vireo photo browser.
 
@@ -18561,6 +18570,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         [Path(p) for p in paths]).items()
                 })
 
+            last_flush = time.monotonic()
             for checked, path in enumerate(paths, 1):
                 # Zero-byte placeholders are non-duplicates (the checker
                 # gives them no identity), and unreadable/missing files
@@ -18592,15 +18602,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 except OSError:
                     pass  # Skip unreadable/missing files
 
-                # Flush after every file. Besides making progress honest for
-                # byte-for-byte checks on slow cards / NAS volumes, each
-                # yield gives the WSGI server a chance to observe that a
-                # superseded browser request disconnected. The abandoned
-                # generator then closes after at most the current file
-                # instead of hashing another 20-file batch in the background.
-                yield f"data: {json.dumps({'duplicates': batch_duplicates, 'recovered': batch_recovered, 'checked': checked, 'total': total})}\n\n"
-                batch_duplicates = []
-                batch_recovered = []
+                # The yield is both how the client learns progress and how
+                # the WSGI server notices that a superseded browser request
+                # disconnected — cheap checks may finish dozens of files
+                # inside one window (a single event covers them all), while
+                # a slow byte-for-byte hash spends longer than the window on
+                # one file (that file gets its own event and cancellation
+                # stops within the next check). ``checked == total``
+                # guarantees the last progress event always ships so the
+                # client sees ``checked == total`` before ``done``.
+                now = time.monotonic()
+                if (
+                    checked == total
+                    or now - last_flush
+                    >= DUPLICATE_CHECK_FLUSH_INTERVAL_SECONDS
+                ):
+                    yield f"data: {json.dumps({'duplicates': batch_duplicates, 'recovered': batch_recovered, 'checked': checked, 'total': total})}\n\n"
+                    batch_duplicates = []
+                    batch_recovered = []
+                    last_flush = now
 
             yield f"data: {json.dumps({'done': True, 'duplicate_count': duplicate_count, 'recovered_count': recovered_count, 'checked': total, 'total': total})}\n\n"
 

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -551,6 +551,10 @@ let destStructureSeq = 0;
 // results. Incremented at the top of previewImport().
 let importPreviewSeq = 0;
 let importPreviewTimer = null;
+// Own every request spawned by the active preview. Starting a new preview
+// aborts this controller so an obsolete byte-for-byte duplicate check does
+// not keep reading the card / archive in the background.
+let importPreviewAbort = null;
 let importThumbSchedulerCancel = null;
 // Last args passed to renderImportPreviewGrid, so the "Hide duplicates"
 // filter can re-render locally.
@@ -3074,7 +3078,7 @@ function importPreviewSignatureChanged(signature) {
 // the duplicate summary above is never clobbered. ``excludePaths`` are the
 // source files that will be skipped as duplicates — excluding them keeps the
 // new/existing folder counts matching the files that actually land.
-async function renderDestStructure(excludePaths) {
+async function renderDestStructure(excludePaths, signal) {
   // hideDestStructure() also drops the previous run's example folder names.
   // Unlike the move page — where the examples depend only on the selected
   // folder — an import's examples come from the set of source files that will
@@ -3094,6 +3098,7 @@ async function renderDestStructure(excludePaths) {
     const resp = await fetch('/api/import/destination-preview', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      signal: signal,
       body: JSON.stringify({
         sources: sources,
         destination: destination,
@@ -3216,6 +3221,14 @@ function endImportPreviewFlight(requestSeq) {
 }
 
 async function previewImport(opts) {
+  // Abort before advancing the sequence. abort() only schedules the rejected
+  // fetch continuation; this synchronous function advances importPreviewSeq
+  // before that continuation can run, so the old catch/finally paths already
+  // recognize that they no longer own the UI.
+  if (importPreviewAbort) {
+    importPreviewAbort.abort();
+    importPreviewAbort = null;
+  }
   clearScheduledImportPreview();
   showError('');
   hideDestStructure();
@@ -3258,6 +3271,8 @@ async function previewImport(opts) {
   const btnPreview = document.getElementById('btnPreview');
   if (btnPreview) btnPreview.disabled = true;
   summary.textContent = 'Discovering files…';
+  const previewAbort = new AbortController();
+  importPreviewAbort = previewAbort;
   try {
     const snapshotMode = newImagesSnapshotId !== null;
     const resp = await fetch(
@@ -3266,6 +3281,7 @@ async function previewImport(opts) {
         : '/api/import/folder-preview', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      signal: previewAbort.signal,
       body: JSON.stringify(snapshotMode ? {
         snapshot_id: newImagesSnapshotId,
       } : {
@@ -3361,7 +3377,7 @@ async function previewImport(opts) {
       if (!recoveryDestNoDedup) {
         summary.textContent = files.length +
           ' files found · duplicates will be copied';
-        const destData = await renderDestStructure([]);
+        const destData = await renderDestStructure([], previewAbort.signal);
         if (requestSeq !== importPreviewSeq) return;
         if (importPreviewSignatureChanged(requestSignature)) return;
         if (destData && destData.files) {
@@ -3379,6 +3395,7 @@ async function previewImport(opts) {
       const recResp = await fetch('/api/import/check-duplicates', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        signal: previewAbort.signal,
         body: JSON.stringify({
           paths: files.map(f => f.path),
           verify_by_hash: document.getElementById('chkVerifyByHash').checked,
@@ -3404,6 +3421,15 @@ async function previewImport(opts) {
           try {
             const d = JSON.parse(m[1]);
             if (d.recovered) recoveredPathsNoDedup.push(...d.recovered);
+            if (!d.done && requestSeq === importPreviewSeq &&
+                !importPreviewSignatureChanged(requestSignature) &&
+                Number.isFinite(Number(d.checked)) &&
+                Number.isFinite(Number(d.total))) {
+              summary.textContent = files.length +
+                ' files found — checking for interrupted-run leftovers… ' +
+                Number(d.checked).toLocaleString() + ' of ' +
+                Number(d.total).toLocaleString();
+            }
           } catch (e) { /* partial frame */ }
         }
       }
@@ -3418,7 +3444,7 @@ async function previewImport(opts) {
         ' to copy · duplicates will be copied';
       // No dedup gate, so every discovered file lands — pass no exclusions
       // so the folder-structure counts match the full copy set.
-      const destData = await renderDestStructure([]);
+      const destData = await renderDestStructure([], previewAbort.signal);
       if (requestSeq !== importPreviewSeq) return;
       if (importPreviewSignatureChanged(requestSignature)) return;
       if (destData && destData.files) renderImportPreviewGrid(files, [], destData.files);
@@ -3449,6 +3475,7 @@ async function previewImport(opts) {
     const dupResp = await fetch('/api/import/check-duplicates', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      signal: previewAbort.signal,
       body: JSON.stringify({
         paths: files.map(f => f.path),
         verify_by_hash: document.getElementById('chkVerifyByHash').checked,
@@ -3477,6 +3504,15 @@ async function previewImport(opts) {
           const d = JSON.parse(m[1]);
           if (d.duplicates) duplicatePaths.push(...d.duplicates);
           if (d.recovered) recoveredPaths.push(...d.recovered);
+          if (!d.done && requestSeq === importPreviewSeq &&
+              !importPreviewSignatureChanged(requestSignature) &&
+              Number.isFinite(Number(d.checked)) &&
+              Number.isFinite(Number(d.total))) {
+            summary.textContent = files.length +
+              ' files found — checking for duplicates… ' +
+              Number(d.checked).toLocaleString() + ' of ' +
+              Number(d.total).toLocaleString();
+          }
         } catch (e) { /* partial frame */ }
       }
     }
@@ -3511,11 +3547,16 @@ async function previewImport(opts) {
     // Skipped duplicates aren't copied, so exclude them from the
     // folder-structure preview — the new/existing folder counts must
     // reflect the files that will actually land in the archive.
-    const destData = await renderDestStructure(duplicatePaths);
+    const destData = await renderDestStructure(
+      duplicatePaths, previewAbort.signal);
     if (requestSeq !== importPreviewSeq) return;
     if (importPreviewSignatureChanged(requestSignature)) return;
     if (destData && destData.files) renderImportPreviewGrid(files, duplicatePaths, destData.files);
   } catch (e) {
+    // A superseding preview deliberately aborts every request owned by this
+    // run. Its successor owns the summary / error state, so cancellation is
+    // a normal lifecycle event rather than a user-facing failure.
+    if (e && e.name === 'AbortError') return;
     // Don't let a stale run's error clobber a newer preview's summary
     // or surface a stale error banner — the newer run owns the UI.
     if (requestSeq !== importPreviewSeq) return;
@@ -3527,6 +3568,7 @@ async function previewImport(opts) {
     // staleness check would call that "current". Say so explicitly.
     importPreviewFailed = true;
   } finally {
+    if (importPreviewAbort === previewAbort) importPreviewAbort = null;
     if (requestSeq === importPreviewSeq && btnPreview) {
       btnPreview.disabled = false;
     }

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2324,7 +2324,25 @@ function scheduleImportPreview() {
   // import. (wireDestStructureInvalidation also calls this directly; the
   // call is a pure recompute, so running it twice costs nothing.)
   updateStartGate();
-  if (!sources.length) return;
+  if (!sources.length) {
+    // No successor preview will run, so previewImport()'s own abort at
+    // the top of the next flight won't happen. If we don't cancel the
+    // in-flight request here, removing the last source leaves the server
+    // hashing that removed card until it finishes — exactly the resource
+    // contention the AbortController plumbing was added to prevent. The
+    // sequence bump makes the old run's staleness guards fail so its
+    // finally block can't re-enable Start or overwrite the summary.
+    if (importPreviewAbort) {
+      importPreviewAbort.abort();
+      importPreviewAbort = null;
+      importPreviewSeq += 1;
+      importPreviewInFlight = false;
+      importDupStreamPending = false;
+      importPreviewFailed = false;
+      updateStartGate();
+    }
+    return;
+  }
   importPreviewTimer = setTimeout(() => {
     importPreviewTimer = null;
     previewImport({ automatic: true });
@@ -3511,6 +3529,19 @@ async function previewImport(opts) {
             summary.textContent = files.length +
               ' files found — checking for duplicates… ' +
               Number(d.checked).toLocaleString() + ' of ' +
+              Number(d.total).toLocaleString();
+          } else if (!d.done && requestSeq === importPreviewSeq &&
+              !importPreviewSignatureChanged(requestSignature) &&
+              Number.isFinite(Number(d.preparing)) &&
+              Number.isFinite(Number(d.total))) {
+            // Heartbeat from the prep phase (batched EXIF/capture-time
+            // reads before per-file checks begin). Long cards used to
+            // sit on "Discovering files…" through all of prep — this
+            // shows the user work is happening AND surfaces a place the
+            // server pauses long enough to observe a client disconnect.
+            summary.textContent = files.length +
+              ' files found — preparing metadata… ' +
+              Number(d.preparing).toLocaleString() + ' of ' +
               Number(d.total).toLocaleString();
           }
         } catch (e) { /* partial frame */ }

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2339,6 +2339,20 @@ function scheduleImportPreview() {
       importPreviewInFlight = false;
       importDupStreamPending = false;
       importPreviewFailed = false;
+      // Retire the captured preview along with the flight. When discovery
+      // had already populated importPreviewCapturedSignature and
+      // importPreviewedPaths before the removal, leaving them behind lets a
+      // re-add of the same source within the 350ms debounce restore a
+      // matching signature over an empty grid: updateStartGate() finds no
+      // reason to hold Start (sig is not stale, dup stream is not pending,
+      // eligible count is zero so the "0 selected" gate never fires),
+      // enables it as "Start import (0 files)", and startImport() posts the
+      // retained importPreviewedPaths as include_paths — importing every
+      // previously-discovered file behind an empty screen. Collapse the
+      // state back to "no preview run" so the next preview owns the truth.
+      importPreviewCapturedSignature = null;
+      importPreviewedPaths = [];
+      updateImportSelectionUI();
       updateStartGate();
     }
     return;

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -86,7 +86,12 @@ def _shutdown_created_job_runners(monkeypatch):
     leaked = []
     shutdown_failures = 0
     for runner in reversed(created):
-        if runner.shutdown(timeout=5.0):
+        # Windows CI runners can stretch _persist_job's SQLite retries past
+        # a five-second budget when a worker enters its finally block just
+        # as the test releases the fixture. Give the shutdown enough slack
+        # that a legitimately-completing worker can drain, but keep it
+        # short enough that an actually leaked job still fails the test.
+        if runner.shutdown(timeout=30.0):
             continue
         shutdown_failures += 1
         leaked.extend(
@@ -210,7 +215,11 @@ def app_and_db(tmp_path, monkeypatch):
 
     app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="test-token-123")
     yield app, db
-    jobs_stopped = app._cleanup_app_resources(job_timeout=5.0)
+    # Windows CI runners can stretch _persist_job's SQLite retries past a
+    # tight teardown budget when a worker enters its finally block just as
+    # the test releases the fixture. Give the shutdown enough slack that a
+    # legitimately-completing worker can drain without racing teardown.
+    jobs_stopped = app._cleanup_app_resources(job_timeout=30.0)
     db.close()
     if not jobs_stopped:
         pytest.fail("app background jobs did not stop during fixture teardown")
@@ -261,7 +270,9 @@ def client_with_photo(tmp_path, monkeypatch):
 
     app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir), api_token="test-token-123")
     yield app, db, pid
-    jobs_stopped = app._cleanup_app_resources(job_timeout=5.0)
+    # Match app_and_db's more generous teardown budget so slow Windows CI
+    # runners don't flag a legitimately-completing worker as a leak.
+    jobs_stopped = app._cleanup_app_resources(job_timeout=30.0)
     db.close()
     if not jobs_stopped:
         pytest.fail("app background jobs did not stop during fixture teardown")

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -194,6 +194,37 @@ def test_check_duplicates_all_new(app_and_db, tmp_path):
     assert done[0]["duplicate_count"] == 0
 
 
+def test_check_duplicates_streams_progress_after_every_file(
+    app_and_db, tmp_path
+):
+    """Every completed file is an SSE flush boundary.
+
+    A client that aborts a superseded byte-for-byte preview can only make the
+    WSGI server notice at a yield. Per-file events therefore bound abandoned
+    work to the hash already in progress instead of the old 20-file batch.
+    """
+    app, _db, _fid = app_and_db
+
+    source = tmp_path / "source"
+    source.mkdir()
+    paths = []
+    for index, color in enumerate(("red", "green", "blue"), 1):
+        path = source / f"new{index}.jpg"
+        Image.new("RGB", (50, 50), color=color).save(str(path))
+        paths.append(str(path))
+
+    resp = app.test_client().post(
+        "/api/import/check-duplicates", json={"paths": paths}
+    )
+    progress = [
+        event for event in parse_sse_events(resp.data)
+        if not event.get("done")
+    ]
+
+    assert [event["checked"] for event in progress] == [1, 2, 3]
+    assert all(event["total"] == 3 for event in progress)
+
+
 def test_check_duplicates_ignores_zero_byte_images(app_and_db, tmp_path):
     """Empty image placeholders should not be reported as duplicate photos."""
     app, db, fid = app_and_db
@@ -248,7 +279,7 @@ def test_check_duplicates_missing_file_skipped(app_and_db, tmp_path):
 def test_check_duplicates_zero_byte_file_does_not_swallow_pending_batch(
     app_and_db, tmp_path
 ):
-    """A zero-byte path at end-of-list (or on a BATCH_SIZE boundary) must
+    """A zero-byte path at end-of-list must
     not eat already-queued ``batch_duplicates``. The pipeline UI only
     learns about duplicates from emitted ``data.duplicates`` events; if
     the end-of-list yield is skipped, ``duplicate_count`` reports the

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -194,15 +194,13 @@ def test_check_duplicates_all_new(app_and_db, tmp_path):
     assert done[0]["duplicate_count"] == 0
 
 
-def test_check_duplicates_streams_progress_after_every_file(
+def test_check_duplicates_progress_events_are_monotonic(
     app_and_db, tmp_path
 ):
-    """Every completed file is an SSE flush boundary.
-
-    A client that aborts a superseded byte-for-byte preview can only make the
-    WSGI server notice at a yield. Per-file events therefore bound abandoned
-    work to the hash already in progress instead of the old 20-file batch.
-    """
+    """Progress events report a strictly increasing ``checked`` and the
+    correct ``total`` on every event, and the final progress event lands on
+    ``checked == total`` before ``done`` (so the client's percentage never
+    regresses and always finishes at 100%)."""
     app, _db, _fid = app_and_db
 
     source = tmp_path / "source"
@@ -212,6 +210,48 @@ def test_check_duplicates_streams_progress_after_every_file(
         path = source / f"new{index}.jpg"
         Image.new("RGB", (50, 50), color=color).save(str(path))
         paths.append(str(path))
+
+    resp = app.test_client().post(
+        "/api/import/check-duplicates", json={"paths": paths}
+    )
+    events = parse_sse_events(resp.data)
+    progress = [event for event in events if not event.get("done")]
+
+    assert progress, "at least one progress event must precede done"
+    checked_values = [event["checked"] for event in progress]
+    assert checked_values == sorted(set(checked_values)), (
+        "checked must strictly increase across progress events"
+    )
+    assert all(event["total"] == 3 for event in progress)
+    assert progress[-1]["checked"] == 3, (
+        "the final progress event before done must always land on total"
+    )
+
+
+def test_check_duplicates_slow_check_yields_per_file(
+    app_and_db, tmp_path, monkeypatch
+):
+    """When a per-file check exceeds the flush window, each file gets its
+    own event so an aborted preview stops within one file's worth of work
+    (rather than draining a fixed batch first)."""
+    import app as vireo_app
+
+    app, _db, _fid = app_and_db
+
+    source = tmp_path / "source"
+    source.mkdir()
+    paths = []
+    for index, color in enumerate(("red", "green", "blue"), 1):
+        path = source / f"new{index}.jpg"
+        Image.new("RGB", (50, 50), color=color).save(str(path))
+        paths.append(str(path))
+
+    # Zero flush window → every completed file crosses the threshold and
+    # gets its own event, exercising the bounded-cancellation guarantee the
+    # SSE loop was designed for.
+    monkeypatch.setattr(
+        vireo_app, "DUPLICATE_CHECK_FLUSH_INTERVAL_SECONDS", 0.0
+    )
 
     resp = app.test_client().post(
         "/api/import/check-duplicates", json={"paths": paths}

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -215,7 +215,13 @@ def test_check_duplicates_progress_events_are_monotonic(
         "/api/import/check-duplicates", json={"paths": paths}
     )
     events = parse_sse_events(resp.data)
-    progress = [event for event in events if not event.get("done")]
+    # Prep-phase heartbeats carry ``preparing``/``total`` but no
+    # ``checked``; the per-file progress events are the ones this
+    # monotonicity contract is about, so filter to those.
+    progress = [
+        event for event in events
+        if not event.get("done") and "checked" in event
+    ]
 
     assert progress, "at least one progress event must precede done"
     checked_values = [event["checked"] for event in progress]
@@ -258,11 +264,65 @@ def test_check_duplicates_slow_check_yields_per_file(
     )
     progress = [
         event for event in parse_sse_events(resp.data)
-        if not event.get("done")
+        if not event.get("done") and "checked" in event
     ]
 
     assert [event["checked"] for event in progress] == [1, 2, 3]
     assert all(event["total"] == 3 for event in progress)
+
+
+def test_check_duplicates_prep_phase_yields_between_batches(
+    app_and_db, tmp_path, monkeypatch
+):
+    """Metadata prep runs in bounded batches with a heartbeat between
+    each. A single upfront prepare() would leave the WSGI layer unable
+    to notice a superseded browser request during the (potentially long)
+    EXIF-batching phase — chunking with a yield puts a cancellation
+    point every prep-batch worth of I/O."""
+    import app as vireo_app
+
+    app, _db, _fid = app_and_db
+
+    source = tmp_path / "source"
+    source.mkdir()
+    paths = []
+    for index in range(5):
+        path = source / f"card{index}.jpg"
+        Image.new("RGB", (50, 50), color="red").save(str(path))
+        paths.append(str(path))
+
+    # Force one path per prep chunk so the batching contract is visible
+    # even with a tiny test fixture.
+    monkeypatch.setattr(vireo_app, "DUPLICATE_CHECK_PREP_BATCH_SIZE", 1)
+
+    resp = app.test_client().post(
+        "/api/import/check-duplicates", json={"paths": paths}
+    )
+    events = parse_sse_events(resp.data)
+    preparing = [
+        event["preparing"] for event in events if "preparing" in event
+    ]
+    assert preparing == [1, 2, 3, 4, 5], (
+        f"expected one prep heartbeat per batch reaching total; got "
+        f"{preparing}"
+    )
+    # The prep events precede every per-file event — the checker only
+    # walks paths after all of prep is done, and the per-file loop is
+    # what emits ``checked``.
+    order = [
+        "preparing" if "preparing" in event
+        else ("checked" if "checked" in event and not event.get("done")
+              else "done" if event.get("done") else "other")
+        for event in events
+    ]
+    last_prep = max(i for i, tag in enumerate(order) if tag == "preparing")
+    first_checked = next(
+        (i for i, tag in enumerate(order) if tag == "checked"), None
+    )
+    if first_checked is not None:
+        assert last_prep < first_checked, (
+            "prep heartbeats must precede per-file checked events"
+        )
 
 
 def test_check_duplicates_ignores_zero_byte_images(app_and_db, tmp_path):


### PR DESCRIPTION
Import preview sequence guards ignored stale results but left the underlying SSE requests hashing card and archive files, allowing duplicate checks to stack and contend with automatic filesystem scans. Each preview now owns an AbortController propagated through discovery, duplicate, and destination requests, while the server flushes after every checked file so disconnects stop abandoned work promptly. The UI reports checked/total progress, and regression coverage verifies both transport cancellation and per-file SSE progress. Validated with 29 duplicate-check tests, four focused browser/app tests, Ruff, and git diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import previews now show live duplicate-check progress as files are processed.
  * Starting a new preview automatically cancels any previous preview activity.
* **Bug Fixes**
  * Prevented outdated preview requests from interfering with newer imports.
  * Improved handling of cancelled requests so expected cancellations do not display import errors.
  * Ensured the Start button is restored after preview completion or cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->