### PR TITLE
Stop releases from silently re-resolving every Rust dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+# Rust dependency updates arrive as reviewed PRs instead of being silently
+# re-resolved by scripts/release.sh at tag time. Every PR that touches
+# src-tauri/ runs the `rust` job in test.yml (clippy --all-targets on macOS and
+# Windows), so a crate that does not compile is caught before merge rather than
+# 20 minutes into a tagged release build.
+updates:
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: deps
+    groups:
+      # One PR per month for the routine churn; majors stay separate so a
+      # breaking change is reviewed and bisectable on its own.
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,9 +46,30 @@ echo ""
 # --- Sync version across all manifests ---
 echo "==> Syncing version..."
 python scripts/sync_version.py "$NEW_VERSION"
-echo "==> Updating Cargo.lock..."
-(cd src-tauri && cargo generate-lockfile)
+# `--workspace` rewrites only the `vireo` entry in Cargo.lock so it matches the
+# version sync_version.py just wrote to Cargo.toml. Do NOT use
+# `cargo generate-lockfile` here: it re-resolves every third-party crate to the
+# newest compatible version, so a release silently ships dependency bumps that
+# no CI run has ever compiled. That is how v0.32.3 picked up zune-core 0.5.2 —
+# published three hours earlier, broken, yanked shortly after — and failed the
+# macOS build. Dependency updates belong in reviewed Dependabot PRs; see
+# .github/dependabot.yml.
+echo "==> Updating Cargo.lock (workspace version only)..."
+(cd src-tauri && cargo update --workspace)
 echo ""
+
+# --- Verify the Rust dependency graph compiles (publish path only) ---
+# The publish path never builds locally — CI does that, but only *after* the tag
+# is pushed, so a dependency that does not compile is discovered 20 minutes into
+# a tagged build with the tag already public. `cargo check --locked` compiles
+# every dependency for this host in a couple of minutes and also asserts that
+# Cargo.lock is complete and in sync with Cargo.toml. The non-publish path skips
+# this because the full local build below already covers it.
+if $PUBLISH; then
+    echo "==> Checking Rust dependency graph..."
+    (cd src-tauri && cargo check --locked)
+    echo ""
+fi
 
 # --- Run E2E tests ---
 echo "==> Running E2E tests..."

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6000,9 +6000,9 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98651bd6fa7814a351eb5e988ee9feadfc6aeb5fdbebfa4ad63ed5000c0bd97d"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-jpeg"

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,67 @@
+"""Guards on the release process.
+
+Both tests exist because of the v0.32.3 release failure: `scripts/release.sh`
+ran `cargo generate-lockfile`, which re-resolved every third-party crate to the
+newest compatible version. That pulled in zune-core 0.5.2 — published three
+hours earlier, broken, and yanked 35 minutes later — and the macOS build failed
+after the tag had already been pushed.
+"""
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+RELEASE_SH = REPO_ROOT / "scripts" / "release.sh"
+CARGO_LOCK = REPO_ROOT / "src-tauri" / "Cargo.lock"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _uncommented_lines(text):
+    return [
+        line for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_release_does_not_regenerate_the_whole_lockfile():
+    """The version bump must not re-resolve third-party crates.
+
+    `cargo update --workspace` rewrites only the `vireo` entry;
+    `cargo generate-lockfile` rewrites everything.
+    """
+    code = _uncommented_lines(RELEASE_SH.read_text())
+    offenders = [line for line in code if "cargo generate-lockfile" in line]
+    assert not offenders, (
+        "scripts/release.sh must not run `cargo generate-lockfile` — it bumps "
+        "every dependency to the newest compatible version at tag time, with no "
+        "CI run in between. Use `cargo update --workspace`. Offending lines: "
+        f"{offenders}"
+    )
+    assert any("cargo update --workspace" in line for line in code), (
+        "scripts/release.sh must sync the workspace version into Cargo.lock "
+        "with `cargo update --workspace`"
+    )
+
+
+def test_release_compiles_dependencies_before_tagging():
+    """The publish path builds nothing locally, so it needs a compile gate."""
+    code = _uncommented_lines(RELEASE_SH.read_text())
+    assert any("cargo check --locked" in line for line in code), (
+        "scripts/release.sh must run `cargo check --locked` before tagging so a "
+        "dependency that does not compile is caught before the tag is pushed"
+    )
+
+
+def test_cargo_lock_version_matches_pyproject():
+    """A stale Cargo.lock means CI has to re-resolve during a tagged build."""
+    expected = tomllib.loads(PYPROJECT.read_text())["project"]["version"]
+
+    lock = CARGO_LOCK.read_text()
+    match = re.search(
+        r'\[\[package\]\]\nname = "vireo"\nversion = "([^"]+)"', lock
+    )
+    assert match, "no `vireo` package entry found in src-tauri/Cargo.lock"
+    assert match.group(1) == expected, (
+        f"src-tauri/Cargo.lock has vireo v{match.group(1)} but pyproject.toml "
+        f"has {expected}. Run `cd src-tauri && cargo update --workspace`."
+    )

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,10 +1,15 @@
 """Guards on the release process.
 
-Both tests exist because of the v0.32.3 release failure: `scripts/release.sh`
+These tests exist because of the v0.32.3 release failure: `scripts/release.sh`
 ran `cargo generate-lockfile`, which re-resolved every third-party crate to the
 newest compatible version. That pulled in zune-core 0.5.2 — published three
 hours earlier, broken, and yanked 35 minutes later — and the macOS build failed
 after the tag had already been pushed.
+
+The ordering assertions matter as much as the presence ones. A compile gate that
+runs *after* `git tag` protects nothing: the tag is the point of no return, so a
+guard that only checked for the command's existence would still pass while the
+protection it describes had been silently lost.
 """
 import re
 import tomllib
@@ -15,12 +20,53 @@ RELEASE_SH = REPO_ROOT / "scripts" / "release.sh"
 CARGO_LOCK = REPO_ROOT / "src-tauri" / "Cargo.lock"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 
+LOCKFILE_SYNC = r"^\s*\(cd src-tauri && cargo update --workspace\)"
+DEPENDENCY_CHECK = r"^\s*\(cd src-tauri && cargo check --locked\)"
+TAG_COMMAND = r'^\s*git tag "'
+PUBLISH_GUARD = r"^if\s+\$PUBLISH\s*;\s*then\s*$"
 
-def _uncommented_lines(text):
+
+def _code_lines():
+    """release.sh with comments and blanks blanked out, line indices preserved.
+
+    Blanking rather than dropping keeps index comparisons meaningful, and stops
+    a command named in a comment from satisfying a presence assertion.
+    """
     return [
-        line for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
+        "" if (not line.strip() or line.lstrip().startswith("#")) else line
+        for line in RELEASE_SH.read_text().splitlines()
     ]
+
+
+def _sole_index(lines, pattern):
+    """Index of the one line matching `pattern`, asserting it is unambiguous."""
+    hits = [i for i, line in enumerate(lines) if re.search(pattern, line)]
+    assert len(hits) == 1, (
+        f"expected exactly one line in scripts/release.sh matching {pattern!r}, "
+        f"found {len(hits)} (lines {[i + 1 for i in hits]})"
+    )
+    return hits[0]
+
+
+def _publish_block_ranges(lines):
+    """(start, end) index pairs for each `if $PUBLISH; then ... fi` block.
+
+    Tracks if/fi nesting so a `$PUBLISH` block containing inner conditionals
+    still resolves to its own `fi` rather than the first one encountered.
+    """
+    ranges = []
+    open_blocks = []
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if re.match(r"^if\s", stripped):
+            open_blocks.append((i, line))
+        elif stripped == "fi":
+            assert open_blocks, f"unbalanced `fi` at scripts/release.sh:{i + 1}"
+            start, opener = open_blocks.pop()
+            if re.match(PUBLISH_GUARD, opener):
+                ranges.append((start, i))
+    assert not open_blocks, "unbalanced `if` in scripts/release.sh"
+    return ranges
 
 
 def test_release_does_not_regenerate_the_whole_lockfile():
@@ -29,26 +75,48 @@ def test_release_does_not_regenerate_the_whole_lockfile():
     `cargo update --workspace` rewrites only the `vireo` entry;
     `cargo generate-lockfile` rewrites everything.
     """
-    code = _uncommented_lines(RELEASE_SH.read_text())
-    offenders = [line for line in code if "cargo generate-lockfile" in line]
+    lines = _code_lines()
+    offenders = [
+        i + 1 for i, line in enumerate(lines) if "cargo generate-lockfile" in line
+    ]
     assert not offenders, (
         "scripts/release.sh must not run `cargo generate-lockfile` — it bumps "
         "every dependency to the newest compatible version at tag time, with no "
-        "CI run in between. Use `cargo update --workspace`. Offending lines: "
-        f"{offenders}"
+        f"CI run in between. Use `cargo update --workspace`. Lines: {offenders}"
     )
-    assert any("cargo update --workspace" in line for line in code), (
-        "scripts/release.sh must sync the workspace version into Cargo.lock "
-        "with `cargo update --workspace`"
+    _sole_index(lines, LOCKFILE_SYNC)
+
+
+def test_lockfile_sync_runs_before_tagging():
+    """A lock synced after tagging would not be in the tagged commit."""
+    lines = _code_lines()
+    assert _sole_index(lines, LOCKFILE_SYNC) < _sole_index(lines, TAG_COMMAND), (
+        "`cargo update --workspace` must run before `git tag` so the tagged "
+        "commit contains the synced Cargo.lock"
     )
 
 
-def test_release_compiles_dependencies_before_tagging():
-    """The publish path builds nothing locally, so it needs a compile gate."""
-    code = _uncommented_lines(RELEASE_SH.read_text())
-    assert any("cargo check --locked" in line for line in code), (
-        "scripts/release.sh must run `cargo check --locked` before tagging so a "
-        "dependency that does not compile is caught before the tag is pushed"
+def test_dependency_check_gates_the_tag():
+    """The compile gate is worthless unless it can still stop the tag.
+
+    The publish path builds nothing locally, so this is the only thing standing
+    between a broken dependency and a pushed tag.
+    """
+    lines = _code_lines()
+    check = _sole_index(lines, DEPENDENCY_CHECK)
+    tag = _sole_index(lines, TAG_COMMAND)
+
+    assert check < tag, (
+        "`cargo check --locked` must run before `git tag` — after the tag is "
+        "pushed it cannot prevent a broken release, which is the whole point"
+    )
+
+    blocks = _publish_block_ranges(lines)
+    assert blocks, "no `if $PUBLISH; then` block found in scripts/release.sh"
+    assert any(start < check < end for start, end in blocks), (
+        "`cargo check --locked` must sit inside an `if $PUBLISH; then` block. "
+        "The non-publish path already does a full local build, so running it "
+        "unconditionally just duplicates that compile."
     )
 
 


### PR DESCRIPTION
## Why v0.32.3 failed

The macOS ARM64 build in [run 31215463711](https://github.com/jss367/vireo/actions/runs/31215463711) failed compiling `zune-jpeg` 0.5.15:

```
error: macro expansion ends with an incomplete expression: expected expression
  --> zune-jpeg-0.5.15/src/mcu_prog.rs:463:17
      warn!("RST marker was not found, where expected, image may be garbled")
```

`zune-core` 0.5.2's no-op `warn!` (when the `log` feature is off) expanded to *nothing*, so the tail-position call became an incomplete expression.

| Time (UTC, 2026-08-07) | Event |
|---|---|
| 17:22 | `zune-core` 0.5.2 published (broken) |
| 20:20 | `release: v0.32.3` commit + tag pushed |
| 20:42 | macOS build fails |
| 20:55 | `zune-core` 0.5.3 published, **0.5.2 yanked** |

Linux and Windows passed because `zune-jpeg` only enters the dependency graph on macOS (`arboard` → `image` → `tiff` → `zune-jpeg`); neither job has a "Compiling zune-jpeg" line. `release` and `update-website` never ran, so `v0.32.3` is a tag with no published release.

## Root cause

`scripts/release.sh` ran `cargo generate-lockfile`, which re-resolves **every** third-party crate to the newest compatible version. The `release: v0.32.3` commit bumped six unrelated crates alongside the version — none of which any CI run had ever compiled. And with `--publish` the script skips the local build (`if ! $PUBLISH`), so nothing compiled the new lockfile before the tag was pushed.

## Changes

**1. `Cargo.lock`: `zune-core` 0.5.2 → 0.5.3** — the immediate unblock, a 2-line diff.

**2. `release.sh`: `cargo generate-lockfile` → `cargo update --workspace`** — rewrites only the `vireo` entry so it matches the version `sync_version.py` just wrote, without touching third-party crates. This is the root-cause fix.

**3. `release.sh`: `cargo check --locked` before commit/tag on the publish path** — the publish path compiled nothing locally, so the first compile of a new lockfile was 20 minutes into a tagged CI build, tag already public. This compiles every dependency for the host in ~2 min and asserts the lock is complete. Skipped on the non-publish path, which already does a full build.

**4. `.github/dependabot.yml`** — removing the release-time update means Rust deps would otherwise freeze forever. Monthly grouped cargo PRs keep them moving through review and CI instead. Any PR touching `src-tauri/` triggers the `rust` job in `test.yml` (`clippy --all-targets` on macOS + Windows), which would have caught this exact break at PR time. Requires Dependabot to be enabled in repo settings.

**5. `tests/test_release_script.py`** — guards that `release.sh` never regains `cargo generate-lockfile`, that it keeps the compile gate, and that the committed `Cargo.lock` version matches `pyproject.toml`.

## Verification

- `cargo check --locked` passes in `src-tauri`. After `cargo clean -p zune-jpeg -p zune-core`, both recompile clean against 0.5.3.
- `cargo update --workspace` on a 0.32.3 → 0.32.4 bump produces a lock diff of exactly the version line — no third-party churn.
- `tests/test_release_script.py`: 3 passed. Both new guards confirmed **failing** against the pre-fix `release.sh`.
- Full CLAUDE.md suite: **2077 passed, 1 failed, 14 skipped**. The failure is the pre-existing environmental `test_api_exiftool_status_reports_missing` (monkeypatches `shutil.which` to `None` but a bundled ExifTool is found anyway) — unrelated to these files.

## Re-releasing

After merge, `./scripts/release.sh patch --publish` cuts **v0.32.4**. Cleaner than force-moving the public `v0.32.3` tag, and the new `cargo check` gate runs before the tag is created.

## Known gap (not addressed)

A build failure on Windows or Linux still leaves a dangling tag — the local gate only covers the release machine's host target (macOS). Auto-deleting the tag on build failure would close that, but it's a riskier behavior change and separable from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved release validation to confirm dependency integrity before publishing.
  * Updated version handling to preserve existing dependency lock information during releases.

* **Maintenance**
  * Added automated dependency update scheduling for Rust components, with grouped minor and patch updates.

* **Tests**
  * Added regression coverage for lockfile handling, version consistency, and pre-release compilation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->