### PR TITLE
Import unification PR 4: remote derived-cache invalidation (spec decision 6)

### DIFF
--- a/docs/superpowers/plans/2026-08-08-import-unify-pr4-derived-cache.md
+++ b/docs/superpowers/plans/2026-08-08-import-unify-pr4-derived-cache.md
@@ -1,0 +1,152 @@
+# Import Unification PR 4: Remote Derived-Cache Invalidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the local import path's derived-cache invalidation (spec decision 6) to the remote path: `raw_companion_invalidations`, `pre_scan_hashes` capture + diff loop, and the `_sweep_untracked_previews_for_photos` call — so a remote import can no longer leave stale thumbnails/previews/working copies.
+
+**Architecture:** Fourth PR of the import-path-unification project (spec: `docs/superpowers/specs/2026-08-06-import-path-unification-design.md`). A 2026-08-08 reachability analysis (below) found the genuinely LIVE remote bug is the **companion geometry**: a JPEG landing beside a pre-cataloged RAW never invalidates the RAW's derived caches (scanner's `_pair_raw_jpeg_companions` only invalidates when an edit recipe transfers — `scanner.py:604-671`), so a stale RAW working copy survives and the deferred WC extraction skips the row. The direct-row diff loop is defense-in-depth on BOTH paths (both `scan()` calls pass `vireo_dir`, so `scanner.py:2525-2538` handles ordinary content changes) — ported for parity and legacy-row robustness, mirroring the local comment's own framing. Neither transport ever replaces bytes in place (local `copy_and_hash_verify` promotes no-overwrite; remote rsync runs `--ignore-existing` + suffix walk), so the geometry sets match.
+
+**Tech Stack:** pytest; existing local tests at `vireo/tests/test_import_job.py:3661-3903` are the templates; remote harness (`_remote_archive_for`, `_install_fake_remote_rsync`).
+
+---
+
+## Context for a zero-context engineer
+
+- Repo root: `/Users/julius/conductor/workspaces/vireo/nagoya`; branch `import-unify-pr4-derived-cache` (checked out, tracks origin/main at the PR-1433 merge `6553b214`). Run tests from repo root. Commit to this branch.
+- `vireo/import_job.py`: remote function `_run_remote_import_job` (~1235-3080), local body of `run_import_job` (~3100-4750). You are porting FROM the local catalog block TO the remote one. Line numbers below verified at `6553b214`.
+- **Local machinery being ported** (read all of it first):
+  - `pre_scan_hashes` capture: 4177-4203 (comment + loop querying each landed path's pre-scan photo row hash).
+  - `reclassified_landed_paths` (4243-4253) — local-only; remote does NOT need it for `landed` because remote rollbacks filter `landed` in place (`landed = [e for e in landed if e[0] != dest_path]` at 2627-2629, 2646-2648, 2727-2729, 2745-2747), so surviving `landed` is already the not-reclassified set.
+  - `raw_companion_invalidations` (4255-4273 decl; `.add(companion["id"])` at 4354 in the companion accept branch).
+  - Post-scan invalidation block 4426-4492: diff loop over `landed` (skip reclassified; skip paths with no pre-scan row; compare `pre_hash` vs copy-time hash; `_invalidate_derived_caches(db, params.vireo_dir, row["id"], thumb_cache_dir=params.thumb_cache_dir)`; collect `invalidated_photo_ids`), then the companion loop 4483-4492.
+  - `db.conn.commit()` 4494, then sweep 4496-4504 (`_sweep_untracked_previews_for_photos(db, params.vireo_dir, invalidated_photo_ids)` — runs AFTER the commit, only when non-empty).
+  - WC-override fill filtered by reclassified 4506-4532 — remote's fill (2892-2895) already gets this free via the filtered `landed`; nothing to port there.
+- **Scanner helpers** (`vireo/scanner.py`): `_invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None)` at 751-871 — deletes thumb/working/display/preview files, NULLs `thumb_path`/`working_copy_*`, deletes `preview_cache` rows for successfully-unlinked sizes; does NOT commit. `_sweep_untracked_previews_for_photos(db, vireo_dir, photo_ids)` at 874-936 — unlinks orphan `previews/{pid}_{size}.jpg` files with no `preview_cache` row; files only, no DB writes.
+- **Remote landing sites** (all in `_run_remote_import_job`):
+  - Batch-catalog guard 2488; `landed_paths`/`scan_files = landed_paths | set(adopted_paths.keys())` 2489-2494; `scan(...)` 2495-2514; scan-failure rollback 2515-2523.
+  - Catalog-stamping loop 2544-2747 (direct-row branch 2552-2657; companion branch 2658-2738 with accept at 2731-2738; not-cataloged fallthrough 2739-2747).
+  - Adopted-paths validation pass 2748-2889 (companion sub-branch `is_companion` 2791-2810; failure `continue`s at 2817-2825, 2866-2877, 2878-2888 which do NOT remove the key from `adopted_paths` — the one place remote needs reclassified-style tracking).
+  - `db.conn.commit()` 2890; `wc_source_paths` fill 2892-2895.
+- **Remote `landed` tuple** (5-tuple, decl 2263): `(dest_path, card_source, src_hash, src_size, src_mtime_ns)` — copy-time hash at `entry[2]`. Local's is a 6-tuple with hash at `entry[1]`. Remote adoptions live in `adopted_paths: {mount_path: (source_file, src_hash)}`, NOT in `landed` — so the pre-scan capture must iterate `scan_files`, not `landed`, or adoption coverage local has (adoptions are inside local `landed`) silently drops.
+- **Comparison semantics**: port local's diff comparison EXACTLY (no `EMPTY_FILE_SHA256`/None normalization — local's 4464 doesn't normalize; the degenerate zero-byte spurious-invalidation is a shared harmless quirk both paths will carry into PR 5 identically). Note it in a comment.
+- **Local test templates** (`vireo/tests/test_import_job.py`): `test_import_invalidates_derived_caches_on_content_change` (3661-3741; stale row + file deleted out-of-band, new bytes land at same path), `test_import_invalidates_derived_caches_when_pre_row_had_null_hash` (3744-3808), `test_import_invalidates_raw_caches_when_new_jpeg_pairs` (3811-3903; pre-cataloged NEF with seeded stale working copy, new JPEG lands and pairs). Remote harness: `_remote_archive_for` / `_remote_calls` / `_install_fake_remote_rsync` (~4245-4299). The behavior-case runners accept `params_kwargs={"vireo_dir": ..., "thumb_cache_dir": ...}` if convenient, but direct `run_import_job` calls mirroring the local tests' structure are fine and clearer here.
+- The dedupe/collision walk is untouched → the app.py preflight mirrors are unaffected (say so in the PR body).
+
+### Task 0: Branch sanity
+
+- [ ] `git branch --show-current` → `import-unify-pr4-derived-cache`; `git log --oneline -1` → `6553b214` or newer. Baseline: `python -m pytest vireo/tests/test_import_job.py -q` → 214 passed, 1 skipped.
+
+### Task 1: Companion invalidation (the live bug) — TDD
+
+**Files:**
+- Modify: `vireo/import_job.py` (remote: decl before 2544; adds at 2737 and in 2791-2810; invalidation loop + sweep between 2889 and 2892). Local: comment fix only (see Step 4).
+- Test: `vireo/tests/test_import_job.py`
+
+- [ ] **Step 1: Write the failing test** — `test_remote_import_invalidates_raw_caches_when_new_jpeg_pairs`, a faithful remote mirror of the local test at 3811-3903. Read that test line by line first. Geometry: a real `DSC_0800.NEF` on the MOUNT (not a local archive), cataloged with a bogus `file_hash` and a seeded stale `working_copy_path` file under `vireo_dir/working/`; the card holds a new `DSC_0800.jpg` (same capture date so it lands in the NEF's folder); run through `run_import_job` with `remote_target=ra`, `verify_by_hash=True`, `vireo_dir` set, fake rsync installed. Mirror the local test's assertions: `copied == 1`, the RAW row's `companion_path == "DSC_0800.jpg"`, the stale working-copy bytes do not survive (`working_copy_path` NULLed and/or the seeded file gone — match the local test's exact checks). Keep fixture geometry IDENTICAL to the local test apart from mount-vs-archive (this file's history has a memory of mirror tests with divergent geometry hiding bugs).
+
+- [ ] **Step 2: Verify red.** Run the single test. Expected: FAIL on the stale-working-copy assertion (the pairing happens — `companion_path` set — but the RAW's caches survive untouched, because scanner's pair-merge only invalidates on recipe transfer and the remote path has no `raw_companion_invalidations`). Any other failure shape: STOP, report.
+
+- [ ] **Step 3: Implement the port.** In `_run_remote_import_job`:
+
+(i) Before the stamping loop (~2544), declare, with local's comment adapted (and correct — see Step 4):
+
+```python
+            # RAW rows that gained a JPEG companion this batch. The
+            # scan's pair-merge only invalidates the RAW's derived
+            # caches when an edit recipe transfers, so a RAW whose
+            # working copy / thumb / previews were rendered RAW-only
+            # keeps serving them after pairing. Collect every such RAW
+            # id (transferred AND adopted JPEGs — adoption only proves
+            # the JPEG bytes pre-existed on the mount, not that the RAW
+            # already carried companion_path) and invalidate below.
+            # Mirrors the local path — spec decision 6.
+            raw_companion_invalidations = set()
+```
+
+(ii) In the companion accept branch, next to `imported_photo_ids.add(companion["id"])` (2737): `raw_companion_invalidations.add(companion["id"])`.
+
+(iii) In the adopted-paths `is_companion` accept flow (2791-2810): after the adopted companion row is accepted (where `imported_photo_ids.add(row_id)` runs for it at 2889-area — read the flow; the add must happen only for entries that survive validation), add `row_id` to `raw_companion_invalidations` when `is_companion` is true.
+
+(iv) Between the validation pass and `db.conn.commit()` (2890): the companion invalidation loop, then commit, then sweep — mirroring local 4483-4504:
+
+```python
+            invalidated_photo_ids = set()
+            if params.vireo_dir:
+                from scanner import _invalidate_derived_caches
+                for raw_id in raw_companion_invalidations:
+                    _invalidate_derived_caches(
+                        db, params.vireo_dir, raw_id,
+                        thumb_cache_dir=params.thumb_cache_dir,
+                    )
+                    invalidated_photo_ids.add(raw_id)
+            db.conn.commit()
+            if invalidated_photo_ids:
+                from scanner import _sweep_untracked_previews_for_photos
+                _sweep_untracked_previews_for_photos(
+                    db, params.vireo_dir, invalidated_photo_ids,
+                )
+```
+
+(The existing bare `db.conn.commit()` at 2890 is REPLACED by this sequence; Task 2 extends the same block with the diff loop. `invalidated_photo_ids` is declared here so Task 2 only inserts the diff loop above the companion loop.)
+
+- [ ] **Step 4: Fix the stale LOCAL comment** at 4268-4272: it says "Skip when the JPEG was adopted (`origin == "skipped_duplicate"`)" but the code (4331-4356) deliberately invalidates regardless of origin and says so. Rewrite the 4268-4272 comment to match the code (adoption only proves the JPEG bytes pre-existed, not that the RAW was already paired). One comment, no code change.
+
+- [ ] **Step 5: Verify green + sweep.** The new test passes; `python -m pytest vireo/tests/test_import_job.py -q -k "invalidates or companion or pairs"` all pass; full file → 215 passed, 1 skipped.
+
+- [ ] **Step 6: Commit** — `git add -A && git commit -m "Remote import invalidates RAW derived caches when a new JPEG pairs (spec decision 6)"`
+
+### Task 2: pre_scan_hashes capture + diff loop (defense-in-depth parity) — mirror tests
+
+**Files:**
+- Modify: `vireo/import_job.py` (remote: capture after 2494; failed-adopted tracking in the validation pass; diff loop inserted above Task 1's companion loop)
+- Test: `vireo/tests/test_import_job.py`
+
+- [ ] **Step 1: Write the two remote mirror tests** — `test_remote_import_invalidates_derived_caches_on_content_change` and `test_remote_import_invalidates_derived_caches_when_pre_row_had_null_hash`, faithful mirrors of the local tests at 3661-3741 and 3744-3808 (stale photo row whose file is GONE from the mount → the card lands new/real bytes at the same computed path). Identical geometry apart from mount-vs-archive; `skip_duplicates` setting must match each local template.
+
+- [ ] **Step 2: Run them.** EXPECTED: likely GREEN already — the remote `scan()` call passes `vireo_dir` (2511), and scanner's own `content_identity_changed` invalidation (`scanner.py:2525-2538`) covers the direct-row geometry. If green: these are parity pins, keep them and proceed (the diff loop being ported is defense-in-depth, same as local's own framing at 4177-4189 — legacy rows and codepath changes). If RED: report the failure shape before implementing — it means scanner coverage differs remotely, which is a finding.
+
+- [ ] **Step 3: Implement the capture + diff loop.**
+
+(i) After `scan_files` (2494), before the scan `try:`, capture over **`scan_files`** (NOT `landed` — remote adoptions live outside `landed`, and local's capture covers adoptions because they're inside its `landed`):
+
+```python
+            # Pre-scan snapshot of any photo row already cataloged at a
+            # path this batch will scan (landed AND adopted). Compared
+            # after the scan to invalidate derived caches for rows whose
+            # content identity changed. Defense-in-depth next to the
+            # scanner's own content_identity_changed invalidation, for
+            # rows/codepaths the scanner misses (legacy NULL-hash rows).
+            # Mirrors the local path — spec decision 6.
+            pre_scan_hashes = {}
+            for sp in scan_files:
+                row = db.conn.execute(
+                    """SELECT p.id, p.file_hash FROM photos p
+                       JOIN folders f ON f.id = p.folder_id
+                       WHERE f.path = ? AND p.filename = ?""",
+                    (os.path.dirname(sp), os.path.basename(sp)),
+                ).fetchone()
+                if row is not None:
+                    pre_scan_hashes[sp] = row["file_hash"]
+```
+
+(ii) Failed-adopted tracking: the adopted-validation failure `continue`s (2817-2825, 2866-2877, 2878-2888) leave their key in `adopted_paths`. Add `failed_adopted_paths = set()` (declared next to Task 1's `raw_companion_invalidations`) and `failed_adopted_paths.add(ap)` at each of the three failure sites (read each; `ap` is the loop's mount-path variable). Local needs no analogue for `landed` (its rollbacks keep entries → it filters via `reclassified_landed_paths`; remote's `landed` self-filters) — this set is the remote's one reclassified-style structure, scoped to adoptions.
+
+(iii) The diff loop, inserted ABOVE Task 1's companion loop (inside the same `if params.vireo_dir:`): iterate surviving `landed` entries (hash at `entry[2]`) AND surviving adoptions (`for ap, (adopt_source, a_hash) in adopted_paths.items()` skipping `failed_adopted_paths`; read the actual tuple shape at ~2178/2146 first). For each path: skip if not in `pre_scan_hashes`; compare `pre_scan_hashes[path]` vs the copy-time hash with local's EXACT semantics (no zero-byte normalization — add local's-parity comment noting the shared quirk); re-query the row id; `_invalidate_derived_caches(...)`; collect into `invalidated_photo_ids`. Mirror local 4441-4481's structure and comments.
+
+- [ ] **Step 4: Green + full file.** The two mirror tests still pass; the Task 1 test still passes; full file → 217 passed, 1 skipped.
+
+- [ ] **Step 5: Commit** — `"Remote import: pre-scan hash capture and derived-cache diff loop (spec decision 6)"`
+
+### Task 3: Sweep coverage pair (closes a gap on BOTH paths)
+
+Neither path currently tests `_sweep_untracked_previews_for_photos` from the import flow (an orphan `previews/{pid}_{size}.jpg` with NO `preview_cache` row survives `_invalidate_derived_caches`, which only deletes tracked sizes' files — the sweep exists for exactly these orphans).
+
+- [ ] **Step 1:** Extend ONE existing local invalidation test (the content-change one at 3661) and its new remote mirror: seed an orphan preview file `vireo_dir/previews/{photo_id}_512.jpg` (no `preview_cache` row) alongside the tracked state, and assert after the import that the orphan file is gone. Read `_sweep_untracked_previews_for_photos` (scanner.py 874-936) first to match its filename convention exactly.
+- [ ] **Step 2:** Run both; expected: both pass (local sweep wiring exists; remote gained it in Task 1). If the LOCAL one fails, that's a pre-existing local bug — STOP and report before touching production.
+- [ ] **Step 3:** Full file → 217 passed, 1 skipped. Commit — `"Test the untracked-preview sweep from both import paths"`
+
+### Task 4: Full verification + PR
+
+- [ ] **Step 1:** Full file (timeout 600000) → 217 passed, 1 skipped.
+- [ ] **Step 2:** Required suite (CLAUDE.md list, timeout 600000; known env failure `test_api_exiftool_status_reports_missing` ignored).
+- [ ] **Step 3:** Push; `gh pr create --base main --title "Import unification PR 4: remote derived-cache invalidation (spec decision 6)" --body "<BODY>"`. Body: spec/plan links; the live bug (remote JPEG-pairs-RAW left stale RAW caches; why scanner's pair-merge doesn't cover it) with the red test as evidence; the defense-in-depth diff loop with its capture-over-scan_files subtlety and the failed-adopted set; the sweep test pair; the local comment fix; the shared zero-byte comparison quirk noted for PR 5; preflight mirrors unaffected; exact counts. End with the Claude Code attribution line.

--- a/docs/superpowers/plans/2026-08-08-import-unify-pr4-derived-cache.md
+++ b/docs/superpowers/plans/2026-08-08-import-unify-pr4-derived-cache.md
@@ -89,7 +89,9 @@
 
 (The existing bare `db.conn.commit()` at 2890 is REPLACED by this sequence; Task 2 extends the same block with the diff loop. `invalidated_photo_ids` is declared here so Task 2 only inserts the diff loop above the companion loop.)
 
-- [ ] **Step 4: Fix the stale LOCAL comment** at 4268-4272: it says "Skip when the JPEG was adopted (`origin == "skipped_duplicate"`)" but the code (4331-4356) deliberately invalidates regardless of origin and says so. Rewrite the 4268-4272 comment to match the code (adoption only proves the JPEG bytes pre-existed, not that the RAW was already paired). One comment, no code change.
+- [ ] **Step 4: Fix TWO stale LOCAL comments** (comments only, no code change):
+  1. 4268-4272: says "Skip when the JPEG was adopted (`origin == "skipped_duplicate"`)" but the code (4331-4356) deliberately invalidates regardless of origin and says so. Rewrite to match the code (adoption only proves the JPEG bytes pre-existed, not that the RAW was already paired).
+  2. 4426-4439: says "The batch scan ran with `vireo_dir=None` ... scanner's own `_invalidate_derived_caches` ... was bypassed" — contradicting the actual scan call (4220 passes `vireo_dir`) and the newer comment at 4177-4189. Rewrite to the defense-in-depth framing (scanner's own invalidation fires; this loop covers legacy rows/codepath changes).
 
 - [ ] **Step 5: Verify green + sweep.** The new test passes; `python -m pytest vireo/tests/test_import_job.py -q -k "invalidates or companion or pairs"` all pass; full file → 215 passed, 1 skipped.
 
@@ -131,7 +133,7 @@
 
 (ii) Failed-adopted tracking: the adopted-validation failure `continue`s (2817-2825, 2866-2877, 2878-2888) leave their key in `adopted_paths`. Add `failed_adopted_paths = set()` (declared next to Task 1's `raw_companion_invalidations`) and `failed_adopted_paths.add(ap)` at each of the three failure sites (read each; `ap` is the loop's mount-path variable). Local needs no analogue for `landed` (its rollbacks keep entries → it filters via `reclassified_landed_paths`; remote's `landed` self-filters) — this set is the remote's one reclassified-style structure, scoped to adoptions.
 
-(iii) The diff loop, inserted ABOVE Task 1's companion loop (inside the same `if params.vireo_dir:`): iterate surviving `landed` entries (hash at `entry[2]`) AND surviving adoptions (`for ap, (adopt_source, a_hash) in adopted_paths.items()` skipping `failed_adopted_paths`; read the actual tuple shape at ~2178/2146 first). For each path: skip if not in `pre_scan_hashes`; compare `pre_scan_hashes[path]` vs the copy-time hash with local's EXACT semantics (no zero-byte normalization — add local's-parity comment noting the shared quirk); re-query the row id; `_invalidate_derived_caches(...)`; collect into `invalidated_photo_ids`. Mirror local 4441-4481's structure and comments.
+(iii) The diff loop, inserted ABOVE Task 1's companion loop (inside the same `if params.vireo_dir:`): iterate surviving `landed` entries (hash at `entry[2]`) AND surviving adoptions (`for ap, (adopt_source, a_hash) in adopted_paths.items()` skipping `failed_adopted_paths`; the population site is at ~2160 — read the actual tuple shape there first). For each path: skip if not in `pre_scan_hashes`; compare `pre_scan_hashes[path]` vs the copy-time hash with local's EXACT semantics (no zero-byte normalization — add local's-parity comment noting the shared quirk); re-query the row id; `_invalidate_derived_caches(...)`; collect into `invalidated_photo_ids`. Mirror local 4441-4481's structure and comments.
 
 - [ ] **Step 4: Green + full file.** The two mirror tests still pass; the Task 1 test still passes; full file → 217 passed, 1 skipped.
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2541,6 +2541,17 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # NULL hash_status/hash_checked_at (scan may set file_hash,
             # but we don't claim an integrity verdict we didn't
             # independently make).
+            #
+            # RAW rows that gained a JPEG companion this batch. The
+            # scan's pair-merge only invalidates the RAW's derived
+            # caches when an edit recipe transfers, so a RAW whose
+            # working copy / thumb / previews were rendered RAW-only
+            # keeps serving them after pairing. Collect every such RAW
+            # id (transferred AND adopted JPEGs — adoption only proves
+            # the JPEG bytes pre-existed on the mount, not that the RAW
+            # already carried companion_path) and invalidate below.
+            # Mirrors the local path — spec decision 6.
+            raw_companion_invalidations = set()
             for dest_path, _sf, src_hash, _sz, _mt in list(landed):
                 row = db.conn.execute(
                     """SELECT p.id, p.file_hash FROM photos p
@@ -2734,6 +2745,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # what the chaining hook should process, so its
                         # id joins ``imported_photo_ids``. See PR #1113
                         # review.
+                        raw_companion_invalidations.add(companion["id"])
                         imported_photo_ids.add(companion["id"])
                         continue
                     copied -= 1
@@ -2886,8 +2898,25 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         "stale or misconfigured)",
                     )
                     continue
+                if is_companion:
+                    raw_companion_invalidations.add(row_id)
                 imported_photo_ids.add(row_id)
+
+            invalidated_photo_ids = set()
+            if params.vireo_dir:
+                from scanner import _invalidate_derived_caches
+                for raw_id in raw_companion_invalidations:
+                    _invalidate_derived_caches(
+                        db, params.vireo_dir, raw_id,
+                        thumb_cache_dir=params.thumb_cache_dir,
+                    )
+                    invalidated_photo_ids.add(raw_id)
             db.conn.commit()
+            if invalidated_photo_ids:
+                from scanner import _sweep_untracked_previews_for_photos
+                _sweep_untracked_previews_for_photos(
+                    db, params.vireo_dir, invalidated_photo_ids,
+                )
 
             if params.vireo_dir:
                 for dest_path, sf, _sh, sz, mt in landed:
@@ -4265,11 +4294,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             # strategy), and the deferred ``_extract_working_copies``
             # skips rows whose ``working_copy_path IS NOT NULL``. Without
             # invalidation the UI keeps serving derived files for the
-            # previous companion state. Skip when the JPEG was adopted
-            # (``origin == "skipped_duplicate"``): its bytes were already
-            # at the archive path before this run, so any RAW cache
-            # derived from them is by construction consistent. See PR
-            # #1107 review.
+            # previous companion state. Collected regardless of origin —
+            # adoption (``origin == "skipped_duplicate"``) only proves
+            # the JPEG bytes were already at the archive path, NOT that
+            # the RAW row already carried ``companion_path`` for this
+            # JPEG (see the accept branch below). See PR #1107 review.
             raw_companion_invalidations = set()
 
             def _rehash_dest_or_none(path):
@@ -4424,17 +4453,17 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     reclassified_landed_paths.add(dest_path)
 
             # Invalidate derived caches for any landed row whose bytes
-            # differ from what was there pre-scan. The batch scan ran with
-            # ``vireo_dir=None`` (per-batch WC extraction would race
-            # RAW+JPEG pairing across batch boundaries), so scanner's own
-            # ``_invalidate_derived_caches`` on content change was
-            # bypassed. Do it here for the same set of rows the scanner
-            # would have caught: existing rows whose new hash differs from
-            # the pre-scan hash. Without this, imports that restore a
-            # replaced-then-deleted archive file leave stale
-            # ``working_copy_path``/thumb/preview files pointing at the
-            # previous bytes, and the deferred end-of-run
-            # ``_extract_working_copies`` skips rows whose
+            # differ from what was there pre-scan. The batch scan passes
+            # ``vireo_dir`` through, so scanner's own
+            # ``_invalidate_derived_caches`` already fires on rows it
+            # detects as content-changed; this loop is defense-in-depth
+            # for legacy rows and codepath changes the scanner misses
+            # (see the ``pre_scan_hashes`` capture comment above), and
+            # is idempotent with scanner's call. Without it, imports
+            # that restore a replaced-then-deleted archive file could
+            # leave stale ``working_copy_path``/thumb/preview files
+            # pointing at the previous bytes, and the deferred
+            # end-of-run ``_extract_working_copies`` skips rows whose
             # ``working_copy_path`` is already set — so the WC never
             # rebuilds against the new archive bytes. See PR #1107 review.
             invalidated_photo_ids = set()

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -3021,6 +3021,10 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     invalidated_photo_ids.add(raw_id)
             db.conn.commit()
             if invalidated_photo_ids:
+                # Mirror scanner.scan()'s post-loop untracked-preview
+                # sweep: orphan preview files with no preview_cache row
+                # would be lazy-adopted on the next request and served as
+                # stale bytes for the just-replaced mount file.
                 from scanner import _sweep_untracked_previews_for_photos
                 _sweep_untracked_previews_for_photos(
                     db, params.vireo_dir, invalidated_photo_ids,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2492,6 +2492,26 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # also what prevents a duplicate-only import from falling back
             # to a whole-directory discovery walk. See PR #1113 review.
             scan_files = landed_paths | set(adopted_paths.keys())
+            # Pre-scan snapshot of any photo row already cataloged at a
+            # path this batch will scan (landed AND adopted — remote
+            # adoptions live in ``adopted_paths``, outside ``landed``, so
+            # capturing over ``landed`` alone would drop the adoption
+            # coverage the local path gets for free). Compared after the
+            # scan to invalidate derived caches for rows whose content
+            # identity changed. Defense-in-depth next to the scanner's
+            # own ``content_identity_changed`` invalidation, for rows/
+            # codepaths the scanner misses (legacy NULL-hash rows).
+            # Mirrors the local path — spec decision 6.
+            pre_scan_hashes = {}
+            for sp in scan_files:
+                row = db.conn.execute(
+                    """SELECT p.id, p.file_hash FROM photos p
+                       JOIN folders f ON f.id = p.folder_id
+                       WHERE f.path = ? AND p.filename = ?""",
+                    (os.path.dirname(sp), os.path.basename(sp)),
+                ).fetchone()
+                if row is not None:
+                    pre_scan_hashes[sp] = row["file_hash"]
             try:
                 # A landed path is not necessarily uncataloged: a stale row
                 # can survive for a file deleted off the archive, and if
@@ -2552,6 +2572,14 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # already carried companion_path) and invalidate below.
             # Mirrors the local path — spec decision 6.
             raw_companion_invalidations = set()
+            # Adopted mount paths whose post-scan validation failed (the
+            # failure ``continue``s below leave the key in
+            # ``adopted_paths``, unlike ``landed`` which self-filters on
+            # failure). The diff loop below skips these — invalidating a
+            # row we just failed/rolled back would act on unproven bytes.
+            # The remote counterpart of the local path's
+            # ``reclassified_landed_paths``, scoped to adoptions.
+            failed_adopted_paths = set()
             for dest_path, _sf, src_hash, _sz, _mt in list(landed):
                 row = db.conn.execute(
                     """SELECT p.id, p.file_hash FROM photos p
@@ -2745,6 +2773,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # what the chaining hook should process, so its
                         # id joins ``imported_photo_ids``. See PR #1113
                         # review.
+                        # Collected for the post-validation invalidation
+                        # loop — see the raw_companion_invalidations decl.
                         raw_companion_invalidations.add(companion["id"])
                         imported_photo_ids.add(companion["id"])
                         continue
@@ -2835,6 +2865,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         "replaced before catalog scan (no photo row "
                         "and no companion row)",
                     )
+                    failed_adopted_paths.add(ap)
                     continue
                 src_h_norm = (
                     None if adopt_src_hash == EMPTY_FILE_SHA256
@@ -2886,6 +2917,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             "replaced or became unreadable between the "
                             "adopt-time hash check and catalog scan)",
                         )
+                        failed_adopted_paths.add(ap)
                         continue
                 elif scan_h != src_h_norm:
                     skipped_duplicate -= 1
@@ -2897,14 +2929,90 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         "with the source hash (mount base is likely "
                         "stale or misconfigured)",
                     )
+                    failed_adopted_paths.add(ap)
                     continue
                 if is_companion:
+                    # Collected for the post-validation invalidation
+                    # loop — see the raw_companion_invalidations decl.
                     raw_companion_invalidations.add(row_id)
                 imported_photo_ids.add(row_id)
 
+            # Invalidate derived caches for any landed/adopted row whose
+            # bytes differ from what was there pre-scan. The batch scan
+            # passes ``vireo_dir`` through, so scanner's own
+            # ``_invalidate_derived_caches`` already fires on rows it
+            # detects as content-changed; this loop is defense-in-depth
+            # for legacy rows and codepath changes the scanner misses
+            # (see the ``pre_scan_hashes`` capture comment above), and
+            # is idempotent with scanner's call. Without it, imports
+            # that restore a replaced-then-deleted mount file could
+            # leave stale ``working_copy_path``/thumb/preview files
+            # pointing at the previous bytes, and the deferred
+            # end-of-run ``_extract_working_copies`` skips rows whose
+            # ``working_copy_path`` is already set — so the WC never
+            # rebuilds against the new mount bytes. Mirrors the local
+            # path — spec decision 6.
             invalidated_photo_ids = set()
             if params.vireo_dir:
                 from scanner import _invalidate_derived_caches
+                # Surviving entries only: failed direct rows were
+                # filtered out of ``landed`` in place; failed adoptions
+                # are skipped via ``failed_adopted_paths``. Copy-time
+                # hash: ``landed`` carries it at index 2, adoptions at
+                # index 1 of their ``adopted_paths`` value tuple.
+                changed_candidates = [
+                    (entry[0], entry[2]) for entry in landed
+                ] + [
+                    (ap, a_hash)
+                    for ap, (_asrc, a_hash) in adopted_paths.items()
+                    if ap not in failed_adopted_paths
+                ]
+                for cand_path, copy_hash in changed_candidates:
+                    if cand_path not in pre_scan_hashes:
+                        # No pre-scan row (fresh insert) — no derived
+                        # caches exist for this photo yet.
+                        continue
+                    # A pre-scan row existed. Its ``file_hash`` may be
+                    # ``NULL`` (legacy row, or a prior scan that couldn't
+                    # read the file), and such a row can still carry
+                    # ``working_copy_path``/thumb/preview caches from
+                    # earlier processing. Scanner's own content-change
+                    # path treats ``NULL -> concrete hash`` as an
+                    # invalidating transition (see scanner.scan()'s
+                    # ``content_identity_changed`` block); mirror that
+                    # here so restoring a deleted mount file whose
+                    # legacy row lost its hash still clears the stale
+                    # derived caches. Compared raw, matching the local
+                    # path's diff loop exactly — deliberately NOT
+                    # normalizing the zero-byte convention (scan writes
+                    # NULL, copy-time hashing yields EMPTY_FILE_SHA256),
+                    # so a pre-existing zero-byte row is spuriously
+                    # invalidated. Harmless, and shared with local so
+                    # PR 5 unifies identical behavior.
+                    pre_hash = pre_scan_hashes[cand_path]
+                    if pre_hash == copy_hash:
+                        continue
+                    row = db.conn.execute(
+                        """SELECT p.id FROM photos p
+                           JOIN folders f ON f.id = p.folder_id
+                           WHERE f.path = ? AND p.filename = ?""",
+                        (
+                            os.path.dirname(cand_path),
+                            os.path.basename(cand_path),
+                        ),
+                    ).fetchone()
+                    if row is None:
+                        continue
+                    _invalidate_derived_caches(
+                        db, params.vireo_dir, row["id"],
+                        thumb_cache_dir=params.thumb_cache_dir,
+                    )
+                    invalidated_photo_ids.add(row["id"])
+
+                # RAW rows whose companion JPEG we just landed —
+                # covered by the same untracked-preview sweep below so
+                # orphaned preview files from the prior companion state
+                # don't get lazy-adopted on the next request.
                 for raw_id in raw_companion_invalidations:
                     _invalidate_derived_caches(
                         db, params.vireo_dir, raw_id,

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -3705,6 +3705,16 @@ def test_import_invalidates_derived_caches_on_content_change(tmp_path):
     ).lastrowid
     db.conn.commit()
 
+    # Orphan preview file: previews/{pid}_{size}.jpg with NO
+    # preview_cache row (legacy code path / interrupted insert).
+    # Row-driven ``_invalidate_derived_caches`` can't see it — only the
+    # post-loop untracked-preview sweep removes it before it can be
+    # lazy-adopted and served as stale pre-change bytes.
+    previews_dir = vireo_dir / "previews"
+    previews_dir.mkdir()
+    orphan_preview = previews_dir / f"{photo_id}_512.jpg"
+    orphan_preview.write_bytes(b"stale-orphan-preview-bytes")
+
     # Overwrite the archive file with DIFFERENT bytes (simulates: the
     # archive file was deleted/replaced between the prior scan and this
     # import, and the import restores the same filename with new bytes).
@@ -3738,6 +3748,12 @@ def test_import_invalidates_derived_caches_on_content_change(tmp_path):
     # The stale WC file was also unlinked from disk.
     assert not fake_wc.exists(), (
         "content change on a landed row must delete the stale WC file"
+    )
+    # The orphan preview (no preview_cache row) was removed by the
+    # untracked-preview sweep.
+    assert not orphan_preview.exists(), (
+        "untracked-preview sweep must remove orphan preview files for "
+        "invalidated photos"
     )
 
 
@@ -5262,6 +5278,16 @@ def test_remote_import_invalidates_derived_caches_on_content_change(
     ).lastrowid
     db.conn.commit()
 
+    # Orphan preview file: previews/{pid}_{size}.jpg with NO
+    # preview_cache row (legacy code path / interrupted insert).
+    # Row-driven ``_invalidate_derived_caches`` can't see it — only the
+    # post-loop untracked-preview sweep removes it before it can be
+    # lazy-adopted and served as stale pre-change bytes.
+    previews_dir = vireo_dir / "previews"
+    previews_dir.mkdir()
+    orphan_preview = previews_dir / f"{photo_id}_512.jpg"
+    orphan_preview.write_bytes(b"stale-orphan-preview-bytes")
+
     # Remove the mount file (simulates: the mount file was deleted/
     # replaced between the prior scan and this import, and the import
     # restores the same filename with new bytes).
@@ -5296,6 +5322,12 @@ def test_remote_import_invalidates_derived_caches_on_content_change(
     # The stale WC file was also unlinked from disk.
     assert not fake_wc.exists(), (
         "content change on a landed row must delete the stale WC file"
+    )
+    # The orphan preview (no preview_cache row) was removed by the
+    # untracked-preview sweep.
+    assert not orphan_preview.exists(), (
+        "untracked-preview sweep must remove orphan preview files for "
+        "invalidated photos"
     )
 
 

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5210,6 +5210,168 @@ def test_remote_import_accepts_paired_jpeg_companion_row(
     )
 
 
+def test_remote_import_invalidates_derived_caches_on_content_change(
+        tmp_path, monkeypatch):
+    """Remote mirror of
+    ``test_import_invalidates_derived_caches_on_content_change``: when a
+    rsynced file replaces bytes at a mount path whose catalog row already
+    has ``working_copy_path`` set (from a prior scan of an older mount
+    file at the same path), the import must invalidate that WC — the
+    deferred end-of-run ``_extract_working_copies`` skips rows with
+    ``working_copy_path IS NOT NULL``, so without invalidation the WC
+    persists pointing at bytes the mount no longer holds. Spec decision 6.
+    """
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+    # A stale mount file present before the import; its catalog row
+    # captures its OLD hash + a fake WC path (as if a prior scan
+    # extracted a WC for it).
+    stale_mount = os.path.join(mount_dir, "DSC_0700.jpg")
+    Image.new("RGB", (16, 16), "blue").save(stale_mount)
+    stale_hash = compute_file_hash(stale_mount)
+
+    vireo_dir = tmp_path / "vireo_data"
+    (vireo_dir / "working").mkdir(parents=True)
+    fake_wc = vireo_dir / "working" / "1.jpg"
+    Image.new("RGB", (8, 8), "yellow").save(str(fake_wc))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (mount_dir, os.path.basename(mount_dir)),
+    ).lastrowid
+    photo_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash, working_copy_path) VALUES (?, ?, '.jpg', ?, ?, ?)",
+        (
+            fid,
+            "DSC_0700.jpg",
+            os.path.getsize(stale_mount),
+            stale_hash,
+            str(fake_wc),
+        ),
+    ).lastrowid
+    db.conn.commit()
+
+    # Remove the mount file (simulates: the mount file was deleted/
+    # replaced between the prior scan and this import, and the import
+    # restores the same filename with new bytes).
+    os.unlink(stale_mount)
+
+    # Card holds the NEW bytes at the same filename/date, which will land
+    # at the same mount path.
+    card = _make_card(tmp_path, [
+        ("DSC_0700.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+    # Force skip_duplicates False so the card's new bytes actually get
+    # copied over even though the stale row's hash still exists.
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=ra["mount_base"],
+                                         remote_target=ra,
+                                         verify_by_hash=True,
+                                         skip_duplicates=False,
+                                         vireo_dir=str(vireo_dir)))
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+
+    # The row's WC path was cleared so the deferred extractor / later
+    # backfill can rebuild against the new mount bytes.
+    row = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id = ?", (photo_id,),
+    ).fetchone()
+    assert row["working_copy_path"] is None, (
+        "content change on a landed row must clear working_copy_path so "
+        "the deferred WC pass rebuilds it against the new mount bytes"
+    )
+    # The stale WC file was also unlinked from disk.
+    assert not fake_wc.exists(), (
+        "content change on a landed row must delete the stale WC file"
+    )
+
+
+def test_remote_import_invalidates_derived_caches_when_pre_row_had_null_hash(
+        tmp_path, monkeypatch):
+    """Remote mirror of
+    ``test_import_invalidates_derived_caches_when_pre_row_had_null_hash``:
+    a pre-scan row with ``file_hash IS NULL`` can still carry
+    ``working_copy_path``/thumb/preview caches from earlier processing.
+    Scanner's own content-change path treats ``NULL -> concrete hash`` as
+    an invalidating transition; the remote per-batch invalidation must
+    mirror that, or restoring a deleted mount file at that path leaves
+    stale WC/thumb bytes cached against the fresh hash. Spec decision 6.
+    """
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+
+    vireo_dir = tmp_path / "vireo_data"
+    (vireo_dir / "working").mkdir(parents=True)
+    fake_wc = vireo_dir / "working" / "1.jpg"
+    Image.new("RGB", (8, 8), "yellow").save(str(fake_wc))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (mount_dir, os.path.basename(mount_dir)),
+    ).lastrowid
+    # Legacy-shaped row: no file on the mount, ``file_hash IS NULL``, but
+    # a stale ``working_copy_path`` from an earlier processing pass.
+    photo_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash, working_copy_path) VALUES (?, ?, '.jpg', ?, NULL, ?)",
+        (fid, "DSC_0701.jpg", 12345, str(fake_wc)),
+    ).lastrowid
+    db.conn.commit()
+
+    # Card holds the NEW bytes at the same filename/date — the import
+    # will land them at the mount path whose row currently has
+    # ``file_hash IS NULL`` + a stale WC.
+    card = _make_card(tmp_path, [
+        ("DSC_0701.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=ra["mount_base"],
+                                         remote_target=ra,
+                                         verify_by_hash=True,
+                                         skip_duplicates=False,
+                                         vireo_dir=str(vireo_dir)))
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+
+    # The row's WC path was cleared: NULL -> concrete hash is a real
+    # content change, and the deferred extractor / later backfill must be
+    # allowed to rebuild the WC against the just-imported mount bytes.
+    row = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id = ?", (photo_id,),
+    ).fetchone()
+    assert row["working_copy_path"] is None, (
+        "NULL-hash pre-scan row must invalidate its stale derived caches "
+        "when the import stamps a concrete hash (mirrors scanner.scan()'s "
+        "content-change path)"
+    )
+    assert not fake_wc.exists(), (
+        "NULL-hash pre-scan row must have its stale WC file unlinked"
+    )
+
+
 def test_remote_import_invalidates_raw_caches_when_new_jpeg_pairs(
         tmp_path, monkeypatch):
     """RAW+JPEG companion restore, remote mirror of
@@ -5238,7 +5400,7 @@ def test_remote_import_invalidates_raw_caches_when_new_jpeg_pairs(
     os.makedirs(mount_dir, exist_ok=True)
     raw_seed = os.path.join(mount_dir, "_seed.jpg")
     Image.new("RGB", (16, 16), "red").save(raw_seed)
-    raw_bytes = open(raw_seed, "rb").read() + b"RAW-SENSOR-DATA"
+    raw_bytes = Path(raw_seed).read_bytes() + b"RAW-SENSOR-DATA"
     os.unlink(raw_seed)
     raw_archive = os.path.join(mount_dir, "DSC_0800.NEF")
     with open(raw_archive, "wb") as f:
@@ -5311,6 +5473,108 @@ def test_remote_import_invalidates_raw_caches_when_new_jpeg_pairs(
             "RAW's stale WC bytes must not survive the import — either "
             "the file is unlinked or overwritten with a fresh WC from "
             "the verified companion JPEG"
+        )
+
+
+def test_remote_import_invalidates_raw_caches_when_adopted_jpeg_pairs(
+        tmp_path, monkeypatch):
+    """Adopted-branch variant of
+    ``test_remote_import_invalidates_raw_caches_when_new_jpeg_pairs``:
+    the card's JPEG is ALREADY on the mount byte-identical (crash-
+    recovery/resume geometry), so the collision loop adopts it
+    (``skipped_duplicate``, no rsync) instead of transferring. Adoption
+    only proves the JPEG bytes pre-existed on the mount — NOT that the
+    RAW row already carried ``companion_path`` or that its derived
+    caches reflect the paired state — so the adopted companion accept
+    branch must invalidate the RAW's stale caches just like the
+    transferred branch. Spec decision 6.
+    """
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    vireo_dir = tmp_path / "vireo_data"
+    (vireo_dir / "working").mkdir(parents=True)
+
+    # Pre-existing RAW file at the MOUNT path, cataloged standalone
+    # with a stale working_copy_path from a prior RAW-only extraction.
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+    raw_seed = os.path.join(mount_dir, "_seed.jpg")
+    Image.new("RGB", (16, 16), "red").save(raw_seed)
+    raw_bytes = Path(raw_seed).read_bytes() + b"RAW-SENSOR-DATA"
+    os.unlink(raw_seed)
+    raw_archive = os.path.join(mount_dir, "DSC_0800.NEF")
+    with open(raw_archive, "wb") as f:
+        f.write(raw_bytes)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (mount_dir, os.path.basename(mount_dir)),
+    ).lastrowid
+    # WC file must live at working/{photo_id}.jpg — that's the layout
+    # _invalidate_derived_caches unlinks.
+    raw_photo_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash, working_copy_path) VALUES (?, ?, '.nef', ?, ?, 'placeholder')",
+        (fid, "DSC_0800.NEF", len(raw_bytes),
+         "deadbeef" * 8),
+    ).lastrowid
+    fake_wc = vireo_dir / "working" / f"{raw_photo_id}.jpg"
+    Image.new("RGB", (8, 8), "orange").save(str(fake_wc))
+    stale_wc_bytes = fake_wc.read_bytes()
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path = ? WHERE id = ?",
+        (str(fake_wc), raw_photo_id),
+    )
+    db.conn.commit()
+
+    # Card holds the JPEG — and the SAME bytes are already at the
+    # template mount path, uncataloged, so the collision loop adopts
+    # rather than rsyncs.
+    card = _make_card(tmp_path, [
+        ("DSC_0800.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+    import shutil
+    shutil.copy2(str(card / "DSC_0800.jpg"),
+                 os.path.join(mount_dir, "DSC_0800.jpg"))
+
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=ra["mount_base"],
+                                         remote_target=ra,
+                                         verify_by_hash=True,
+                                         skip_duplicates=False,
+                                         vireo_dir=str(vireo_dir)))
+    # The JPEG was adopted on-disk, not transferred.
+    assert result["copied"] == 0
+    assert result["failed"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert calls["rsync"] == [], (
+        "byte-identical mount file must be adopted without an rsync"
+    )
+
+    # Pairing still happened via the batch scan of the adopted path,
+    # and the adopted-companion accept branch invalidated the RAW's
+    # stale derived caches.
+    row = db.conn.execute(
+        "SELECT working_copy_path, companion_path FROM photos WHERE id = ?",
+        (raw_photo_id,),
+    ).fetchone()
+    assert row["companion_path"] == "DSC_0800.jpg", (
+        "pair-merge must record the adopted JPEG as the RAW's "
+        "companion_path"
+    )
+    if fake_wc.exists():
+        assert fake_wc.read_bytes() != stale_wc_bytes, (
+            "RAW's stale WC bytes must not survive the import — either "
+            "the file is unlinked or overwritten with a fresh WC from "
+            "the adopted companion JPEG"
         )
 
 

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5210,6 +5210,110 @@ def test_remote_import_accepts_paired_jpeg_companion_row(
     )
 
 
+def test_remote_import_invalidates_raw_caches_when_new_jpeg_pairs(
+        tmp_path, monkeypatch):
+    """RAW+JPEG companion restore, remote mirror of
+    ``test_import_invalidates_raw_caches_when_new_jpeg_pairs``: when a
+    freshly rsynced JPEG lands as companion to an existing RAW row
+    (pair-merge deletes the JPEG's own row), the RAW row's derived
+    caches may reflect the pre-pair state (RAW-only preview, or a
+    deleted/replaced prior companion). The hash-stamping loop treats
+    ``row is None`` as a fresh insert with no diff to invalidate, so
+    without an explicit companion-invalidation pass the deferred WC
+    pass skips the RAW (working_copy_path is set) and the UI keeps
+    serving stale derived files. Spec decision 6.
+    """
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    vireo_dir = tmp_path / "vireo_data"
+    (vireo_dir / "working").mkdir(parents=True)
+
+    # Pre-existing RAW file at the MOUNT path, cataloged standalone
+    # with a stale working_copy_path from a prior RAW-only extraction.
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+    raw_seed = os.path.join(mount_dir, "_seed.jpg")
+    Image.new("RGB", (16, 16), "red").save(raw_seed)
+    raw_bytes = open(raw_seed, "rb").read() + b"RAW-SENSOR-DATA"
+    os.unlink(raw_seed)
+    raw_archive = os.path.join(mount_dir, "DSC_0800.NEF")
+    with open(raw_archive, "wb") as f:
+        f.write(raw_bytes)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (mount_dir, os.path.basename(mount_dir)),
+    ).lastrowid
+    # WC file must live at working/{photo_id}.jpg — that's the layout
+    # _invalidate_derived_caches unlinks.
+    raw_photo_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash, working_copy_path) VALUES (?, ?, '.nef', ?, ?, 'placeholder')",
+        (fid, "DSC_0800.NEF", len(raw_bytes),
+         "deadbeef" * 8),
+    ).lastrowid
+    fake_wc = vireo_dir / "working" / f"{raw_photo_id}.jpg"
+    Image.new("RGB", (8, 8), "orange").save(str(fake_wc))
+    stale_wc_bytes = fake_wc.read_bytes()
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path = ? WHERE id = ?",
+        (str(fake_wc), raw_photo_id),
+    )
+    db.conn.commit()
+
+    # Card holds a NEW JPEG that will land at DSC_0800.jpg and pair with
+    # the existing RAW during the batch scan.
+    card = _make_card(tmp_path, [
+        ("DSC_0800.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=ra["mount_base"],
+                                         remote_target=ra,
+                                         verify_by_hash=True,
+                                         skip_duplicates=False,
+                                         vireo_dir=str(vireo_dir)))
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+
+    # The RAW row's stale WC path was cleared (invalidation ran) and
+    # the on-disk stale WC file was unlinked. The deferred end-of-run
+    # ``_extract_working_copies`` then either succeeds with a fresh WC
+    # (path differs from the stale one) or leaves working_copy_path
+    # NULL for the scanner's later backfill; either way the row no
+    # longer points at the pre-pair bytes.
+    row = db.conn.execute(
+        "SELECT working_copy_path, companion_path FROM photos WHERE id = ?",
+        (raw_photo_id,),
+    ).fetchone()
+    assert row["companion_path"] == "DSC_0800.jpg", (
+        "pair-merge must record the newly landed JPEG as the RAW's "
+        "companion_path"
+    )
+    # If invalidation didn't run the row would still point at the
+    # pre-pair WC path (which the extractor's candidate predicate would
+    # then skip, since working_copy_path is set). Invalidation resets
+    # the path, and the deferred WC pass rebuilds fresh: even when the
+    # extractor happens to reuse the same on-disk slot
+    # (``working/{id}.jpg``), the bytes at that path must differ from
+    # the stale orange placeholder we seeded, because the WC now comes
+    # from the just-verified companion JPEG.
+    if fake_wc.exists():
+        assert fake_wc.read_bytes() != stale_wc_bytes, (
+            "RAW's stale WC bytes must not survive the import — either "
+            "the file is unlinked or overwritten with a fresh WC from "
+            "the verified companion JPEG"
+        )
+
+
 def test_remote_import_paired_jpeg_verify_fails_on_mount_hash_mismatch(
         tmp_path, monkeypatch):
     """Cross-check parity: when the paired JPEG's mount bytes disagree

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -3707,9 +3707,13 @@ def test_import_invalidates_derived_caches_on_content_change(tmp_path):
 
     # Orphan preview file: previews/{pid}_{size}.jpg with NO
     # preview_cache row (legacy code path / interrupted insert).
-    # Row-driven ``_invalidate_derived_caches`` can't see it — only the
-    # post-loop untracked-preview sweep removes it before it can be
-    # lazy-adopted and served as stale pre-change bytes.
+    # Row-driven ``_invalidate_derived_caches`` can't see it; an
+    # untracked-preview sweep removes it before it can be lazy-adopted
+    # and served as stale pre-change bytes. In this content-change
+    # geometry EITHER sweep suffices — scan()'s own internal sweep also
+    # covers it — so this asserts "some sweep ran"; the pairing tests
+    # isolate the import job's sweep call with a geometry scan()'s
+    # sweep set never contains.
     previews_dir = vireo_dir / "previews"
     previews_dir.mkdir()
     orphan_preview = previews_dir / f"{photo_id}_512.jpg"
@@ -3875,6 +3879,17 @@ def test_import_invalidates_raw_caches_when_new_jpeg_pairs(tmp_path):
     )
     db.conn.commit()
 
+    # Orphan preview file for the RAW: previews/{raw_photo_id}_512.jpg
+    # with NO preview_cache row. In this companion-pair geometry the
+    # RAW's id never enters scan()'s own internal sweep set (pairing is
+    # not a content change), so ONLY the import job's post-batch
+    # ``_sweep_untracked_previews_for_photos`` call can remove it —
+    # this seed isolates that call site.
+    previews_dir = vireo_dir / "previews"
+    previews_dir.mkdir()
+    orphan_preview = previews_dir / f"{raw_photo_id}_512.jpg"
+    orphan_preview.write_bytes(b"stale-orphan-preview-bytes")
+
     # Card holds a NEW JPEG that will land at DSC_0800.jpg and pair with
     # the existing RAW during the batch scan.
     card = _make_card(tmp_path, [
@@ -3917,6 +3932,13 @@ def test_import_invalidates_raw_caches_when_new_jpeg_pairs(tmp_path):
             "the file is unlinked or overwritten with a fresh WC from "
             "the verified companion JPEG"
         )
+    # The RAW's orphan preview (no preview_cache row) is gone. Scan()'s
+    # internal sweep never sees companion-paired RAW ids, so only the
+    # import job's own sweep call can have removed it.
+    assert not orphan_preview.exists(), (
+        "the import-path untracked-preview sweep must remove the paired "
+        "RAW's orphan preview files"
+    )
 
 
 def test_key_duplicate_links_only_byte_verified_twin_folder(tmp_path):
@@ -5280,9 +5302,13 @@ def test_remote_import_invalidates_derived_caches_on_content_change(
 
     # Orphan preview file: previews/{pid}_{size}.jpg with NO
     # preview_cache row (legacy code path / interrupted insert).
-    # Row-driven ``_invalidate_derived_caches`` can't see it — only the
-    # post-loop untracked-preview sweep removes it before it can be
-    # lazy-adopted and served as stale pre-change bytes.
+    # Row-driven ``_invalidate_derived_caches`` can't see it; an
+    # untracked-preview sweep removes it before it can be lazy-adopted
+    # and served as stale pre-change bytes. In this content-change
+    # geometry EITHER sweep suffices — scan()'s own internal sweep also
+    # covers it — so this asserts "some sweep ran"; the pairing tests
+    # isolate the import job's sweep call with a geometry scan()'s
+    # sweep set never contains.
     previews_dir = vireo_dir / "previews"
     previews_dir.mkdir()
     orphan_preview = previews_dir / f"{photo_id}_512.jpg"
@@ -5462,6 +5488,17 @@ def test_remote_import_invalidates_raw_caches_when_new_jpeg_pairs(
     )
     db.conn.commit()
 
+    # Orphan preview file for the RAW: previews/{raw_photo_id}_512.jpg
+    # with NO preview_cache row. In this companion-pair geometry the
+    # RAW's id never enters scan()'s own internal sweep set (pairing is
+    # not a content change), so ONLY the import job's post-batch
+    # ``_sweep_untracked_previews_for_photos`` call can remove it —
+    # this seed isolates that call site.
+    previews_dir = vireo_dir / "previews"
+    previews_dir.mkdir()
+    orphan_preview = previews_dir / f"{raw_photo_id}_512.jpg"
+    orphan_preview.write_bytes(b"stale-orphan-preview-bytes")
+
     # Card holds a NEW JPEG that will land at DSC_0800.jpg and pair with
     # the existing RAW during the batch scan.
     card = _make_card(tmp_path, [
@@ -5506,6 +5543,13 @@ def test_remote_import_invalidates_raw_caches_when_new_jpeg_pairs(
             "the file is unlinked or overwritten with a fresh WC from "
             "the verified companion JPEG"
         )
+    # The RAW's orphan preview (no preview_cache row) is gone. Scan()'s
+    # internal sweep never sees companion-paired RAW ids, so only the
+    # import job's own sweep call can have removed it.
+    assert not orphan_preview.exists(), (
+        "the import-path untracked-preview sweep must remove the paired "
+        "RAW's orphan preview files"
+    )
 
 
 def test_remote_import_invalidates_raw_caches_when_adopted_jpeg_pairs(


### PR DESCRIPTION
## What this is

PR 4 of the import-path-unification project (spec: `docs/superpowers/specs/2026-08-06-import-path-unification-design.md`; plan: `docs/superpowers/plans/2026-08-08-import-unify-pr4-derived-cache.md`, included in this PR). This is the last behavior-alignment PR before the structural phase.

## The live bug (fixed, TDD red)

A remote import landing a JPEG beside a pre-cataloged RAW paired them but never invalidated the RAW's derived caches — the scanner's pair-merge only invalidates when an edit recipe transfers — so a stale RAW-only working copy/thumb/previews kept being served, and the deferred WC extraction skipped the row. The new mirror test failed exactly there pre-fix (companion_path set, stale WC surviving). Now: `raw_companion_invalidations` collected from transferred AND adopted JPEG pairings, invalidated before the batch commit, swept after.

## Defense-in-depth diff loop

`pre_scan_hashes` captured over `scan_files` (landed + adopted — remote adoptions live outside `landed`, unlike local), `failed_adopted_paths` tracking at the three validation-failure sites, comparison semantics byte-matched to local (including the shared harmless zero-byte quirk, commented for PR 5). The two direct-row remote mirror tests were GREEN before the change — the scanner's own content-identity invalidation covers that geometry on both paths (both scan calls pass vireo_dir) — and are kept as parity pins.

## Sweep isolation (found during review)

The content-change orphan-preview assertions are satisfiable by scan()'s internal sweep, so the import-path sweep call is only load-bearing for companion-paired RAW ids (which never enter scan's sweep set). The transferred-pairing tests now seed orphans that ONLY the import-path sweep can remove — verified by neutralization in both directions.

## Also

Two stale local comments fixed (the "skip when adopted" claim contradicting the code; the "scan ran with vireo_dir=None" claim contradicting the actual call); test-hygiene polish.

## Notes for the PR 5 merger

- Capture iterates `scan_files` (remote) vs `landed` (local).
- Failure tracking conventions differ: `reclassified_landed_paths` vs self-filtering `landed` + `failed_adopted_paths`.
- Copy-time hash lives at `entry[1]` local vs `entry[2]` remote.
- The batch-catalog guard keeps the `or adopted_paths` arm.
- The unused `p.id` in both capture queries is a cleanup candidate.
- The remote-side comments are the more accurate surviving text.
- Deliberate deviations: the remote mirrors run `verify_by_hash=True` (remote-harness norm; the pinned invariants are verify-independent); the `failed_adopted_paths` diff-loop skip is untested (guards an already-failed row).

## Scope

Dedupe/collision walk untouched, so the app.py preflight mirrors are unaffected.

## Test results

- `vireo/tests/test_import_job.py`: 218 passed, 1 skipped.
- Required suite (`tests/test_workspaces.py`, `vireo/tests/test_db.py`, `vireo/tests/test_app.py`, `vireo/tests/test_photos_api.py`, `vireo/tests/test_edits_api.py`, `vireo/tests/test_jobs_api.py`, `vireo/tests/test_darktable_api.py`, `vireo/tests/test_config.py`): 2077 passed, 14 skipped, 1 failed — the failure is the known environment-only `test_api_exiftool_status_reports_missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote imports now invalidate stale working copies, thumbnails, and previews when file content changes.
  * Cache invalidation now handles newly added or adopted JPEG companions for RAW photos.
  * Orphaned previews are removed during local and remote cache cleanup.
  * Imports with previously missing file hashes now correctly refresh derived data.

* **Tests**
  * Added coverage for content replacement, missing hashes, companion pairing, adoption, and orphan preview cleanup.

* **Documentation**
  * Added an implementation plan for remote derived-cache invalidation during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
