### PR TITLE
Free up card space: verified card cleanup (scan → preview → delete)

### DIFF
--- a/docs/superpowers/plans/2026-08-08-card-cleanup.md
+++ b/docs/superpowers/plans/2026-08-08-card-cleanup.md
@@ -1,0 +1,1655 @@
+# Free Up Card Space (Card Cleanup) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete files from a memory card only after verifying — per file, at the moment of deletion — that the identical bytes were checksum-verified into the archive and the archive copy is metadata-unchanged since.
+
+**Architecture:** Two new background jobs (`card-cleanup-scan`, `card-cleanup-delete`) run through the existing `JobRunner`, sharing one archive-side qualifying test in a new `vireo/card_cleanup.py` module. The scan walks the card, hashes every candidate once, matches by content hash against the global catalog, and writes an atomic on-disk manifest; the delete job re-validates both sides (card re-hash, fresh archive stat) immediately before every `os.remove`. The import endpoint's case-aware containment guard is extracted to a shared `vireo/path_guard.py` so the overlap guard uses identical decisions.
+
+**Tech Stack:** Python 3 / Flask, SQLite (`vireo/db.py` `Database`), `JobRunner` SSE jobs, pytest with tmp_path fixtures, vanilla JS in `vireo/templates/import.html`.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-card-cleanup-design.md` — read the "Safety invariant" section before starting. Every gate in this plan traces to it.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| Create `vireo/path_guard.py` | Filesystem-aware path containment (case-insensitivity hardened), extracted from the import endpoint's PR #1107 guard. No Vireo imports — pure `os`/`sys`. |
+| Create `vireo/card_cleanup.py` | Manifest IO + validation, card walk/classify, the archive-side qualifying test, `scan_card()`, `delete_verified()`. Imports `image_loader`, `scanner`, `path_guard`. Never imports Flask. |
+| Modify `vireo/app.py` | Rewire the import destination guard to `path_guard` (behavior-preserving); add `POST /api/card-cleanup/scan`, `POST /api/card-cleanup/delete`, `GET /api/card-cleanup/<scan_job_id>/manifest`. |
+| Modify `vireo/templates/import.html` | "Free up card space" UI section. |
+| Create `vireo/tests/test_path_guard.py` | Unit tests for containment helper. |
+| Create `vireo/tests/test_card_cleanup.py` | Unit tests for manifest IO, classify, qualify, scan, delete. |
+| Create `vireo/tests/test_card_cleanup_api.py` | Endpoint tests (fixture mirrors `app_and_db` from `vireo/tests/test_jobs_api.py`). |
+
+Existing symbols you will reuse (verify each exists before writing code that calls it):
+
+- `vireo/image_loader.py:33-35` — `RAW_EXTENSIONS`, `IMAGE_EXTENSIONS`, `SUPPORTED_EXTENSIONS`; `:73` `is_excluded_scan_path`; `:243` `safe_iter_dir`; `:288` `safe_scan_walk`.
+- `vireo/scanner.py:105` — `compute_file_hash(file_path)` → sha256 hex digest.
+- `vireo/ingest.py:286` — `discover_source_files(source_dir, file_types, recursive, onerror)` (parity target only — do not modify).
+- `vireo/db.py:5242` — `Database.add_photo(folder_id, filename, extension, file_size, file_mtime, ..., file_hash=None)`; `:3238` `add_folder(path, ...)`; `:3527` `update_photo_hash_check(photo_id, status, file_hash=None, ...)`.
+- `vireo/app.py` ~25641–25750 — the inline `_case_insensitive_platform` / `_casenorm` / `_fs_is_case_insensitive` block and the realpath containment loop you will extract.
+- `vireo/app.py` ~19010–19036 — the `verify-hashes` endpoint: the pattern to mirror for job work functions (thread `Database`, `set_active_workspace`, throttled `runner.push_event` progress, `runner.is_cancelled` cancel check, `runner.start(...)`).
+- `vireo/labels.py:288` — `_atomic_write_text`: the temp-file + `os.replace` pattern (copy the pattern; do not import labels).
+- `vireo/tests/test_jobs_api.py:7156-7250` — the PR #1107 guard tests (`test_import_photos_rejects_destination_inside_source`, `test_import_photos_inconclusive_case_probe_rejects_case_collision`). They must pass unchanged after Task 1.
+
+Conventions: sibling modules use flat imports (`from scanner import compute_file_hash`), matching the rest of the package. Tests run from the repo root.
+
+---
+
+### Task 1: Extract `path_guard.py` from the import endpoint (behavior-preserving)
+
+**Files:**
+- Create: `vireo/path_guard.py`
+- Create: `vireo/tests/test_path_guard.py`
+- Modify: `vireo/app.py` (~25641–25750, the destination-inside-source block)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `vireo/tests/test_path_guard.py`:
+
+```python
+"""Unit tests for the case-aware containment helper.
+
+Extracted from the import endpoint's destination-inside-source guard
+(PR #1107). The endpoint-level tests in test_jobs_api.py remain the
+behavior-preservation net; these pin the helper's own contract.
+"""
+import os
+import sys
+
+import pytest
+
+from path_guard import contains_resolved, fs_is_case_insensitive, path_contains
+
+
+def test_contains_equal_and_nested(tmp_path):
+    root = str(tmp_path / "card")
+    os.makedirs(root)
+    assert path_contains(root, root)
+    assert path_contains(root, os.path.join(root, "DCIM", "IMG_0001.NEF"))
+    assert not path_contains(root, str(tmp_path / "archive"))
+
+
+def test_contains_prefix_is_not_containment(tmp_path):
+    # /card-extra is NOT inside /card even though the string is a prefix.
+    root = str(tmp_path / "card")
+    os.makedirs(root)
+    assert not path_contains(root, str(tmp_path / "card-extra" / "x.jpg"))
+
+
+def test_contains_follows_symlinks(tmp_path):
+    root = tmp_path / "card"
+    root.mkdir()
+    link = tmp_path / "alias"
+    try:
+        os.symlink(str(root), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this filesystem")
+    assert path_contains(str(root), str(link / "IMG_0001.NEF"))
+
+
+@pytest.mark.skipif(
+    sys.platform in ("darwin", "win32"),
+    reason="Linux-only probe: darwin/win32 always case-fold",
+)
+def test_inconclusive_probe_casefolds(tmp_path):
+    # Numeric-only entries: the probe cannot case-swap, so it must fall
+    # back to case-insensitive (the strict direction) and the case-swapped
+    # child is treated as contained. Mirrors the PR #1107 endpoint test.
+    root = tmp_path / "Card-BAR"
+    root.mkdir()
+    (root / "100").mkdir()
+    assert fs_is_case_insensitive(str(root)) is True
+    assert contains_resolved(str(root), str(tmp_path / "card-bar" / "x"))
+
+
+@pytest.mark.skipif(
+    sys.platform in ("darwin", "win32"),
+    reason="Linux-only: needs a genuinely case-sensitive filesystem",
+)
+def test_case_sensitive_fs_distinguishes(tmp_path):
+    root = tmp_path / "CardABC"
+    root.mkdir()
+    (root / "alpha.txt").write_text("x")
+    if fs_is_case_insensitive(str(root)):
+        pytest.skip("tmp filesystem is case-insensitive")
+    assert not contains_resolved(str(root), str(tmp_path / "cardabc" / "x"))
+
+
+def test_darwin_always_casefolds(tmp_path):
+    if sys.platform not in ("darwin", "win32"):
+        pytest.skip("case-insensitive-platform path")
+    root = tmp_path / "Card"
+    root.mkdir()
+    swapped = str(tmp_path / "card" / "IMG.NEF")
+    assert contains_resolved(str(root), swapped)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_path_guard.py -v`
+Expected: FAIL/ERROR with `ModuleNotFoundError: No module named 'path_guard'`
+
+- [ ] **Step 3: Create `vireo/path_guard.py`**
+
+Move the logic verbatim from `vireo/app.py` — same comparisons, same fallbacks. Copy the two long explanatory comments (the platform rationale and the probe docstring) from app.py into this module; they cite PR #1107 and belong with the code:
+
+```python
+"""Filesystem-aware path containment.
+
+Extracted from the import endpoint's destination-inside-source guard
+(PR #1107) so the card-cleanup overlap guard makes identical decisions.
+``realpath`` alone is not enough: macOS/Windows default filesystems are
+case-insensitive but realpath does not case-normalize, and FAT/exFAT
+removable media on Linux are case-insensitive under a case-sensitive
+parent. Inconclusive probes fall back to case-folding — the strict
+direction for a containment guard.
+"""
+import os
+import sys
+
+
+def is_case_insensitive_platform():
+    return sys.platform in ("darwin", "win32")
+
+
+def fs_is_case_insensitive(path):
+    # (moved verbatim from app.py's _fs_is_case_insensitive, including
+    # its docstring)
+    ...
+
+
+def contains_resolved(root_real, child_real):
+    """True if ``child_real`` equals or lies inside ``root_real``.
+
+    Both arguments must already be realpath'd. Case sensitivity is
+    decided per root: unconditional case-fold on darwin/win32; on Linux,
+    probe the root's actual filesystem.
+    """
+    if is_case_insensitive_platform() or fs_is_case_insensitive(root_real):
+        root_cmp = root_real.casefold().rstrip(os.sep)
+        child_cmp = child_real.casefold()
+    else:
+        root_cmp = root_real.rstrip(os.sep)
+        child_cmp = child_real
+    return child_cmp == root_cmp or child_cmp.startswith(root_cmp + os.sep)
+
+
+def path_contains(root, child):
+    """realpath both sides, then ``contains_resolved``.
+
+    Unresolvable paths return True — for a guard that *disqualifies*
+    when contained, "can't tell" must be the strict direction.
+    """
+    try:
+        root_real = os.path.realpath(root)
+        child_real = os.path.realpath(child)
+    except OSError:
+        return True
+    return contains_resolved(root_real, child_real)
+```
+
+`fs_is_case_insensitive` is the app.py closure body unchanged (the `os.listdir` try/except returning True, the per-entry case-swap probe, `os.path.exists` → False, `os.path.samefile` → its result, OSError → True).
+
+Note the short-circuit preserves current behavior: on darwin/win32 the probe never runs, exactly like `_case_insensitive_platform or (...)` in app.py.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest vireo/tests/test_path_guard.py -v`
+Expected: PASS (platform-specific tests skip as marked)
+
+- [ ] **Step 5: Rewire app.py to use the helper**
+
+In the import-photos endpoint block (~25641), delete the inline `_case_insensitive_platform`, `_casenorm`, and `_fs_is_case_insensitive` definitions and replace the containment loop body so it reads:
+
+```python
+        try:
+            dest_real = os.path.realpath(destination)
+        except OSError as e:
+            return json_error(f"destination cannot be resolved: {e}")
+        for s in sources:
+            try:
+                source_real = os.path.realpath(s)
+            except OSError:
+                # Source unresolvable — the os.path.isdir check above
+                # already handled non-existent sources; nothing more to say.
+                continue
+            if path_guard.contains_resolved(source_real, dest_real):
+                return json_error(
+                    f"destination cannot be inside a source directory "
+                    f"(destination={destination!r}, source={s!r}); "
+                    f"formatting the card would erase the archive copy"
+                )
+```
+
+Add `import path_guard` with app.py's other top-level flat sibling imports. Keep the big explanatory comment above the loop (trim only what moved into path_guard's module docstring). If `_casenorm` or `_fs_is_case_insensitive` have any *other* call sites in app.py (grep first), point them at `path_guard` too.
+
+- [ ] **Step 6: Run the behavior-preservation net**
+
+Run: `python -m pytest vireo/tests/test_jobs_api.py -k "destination_inside_source or case_probe" -v && python -m pytest vireo/tests/test_path_guard.py -v`
+Expected: PASS — the endpoint tests unchanged, proving the extraction preserved guard decisions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add vireo/path_guard.py vireo/tests/test_path_guard.py vireo/app.py
+git commit -m "refactor: extract case-aware path containment into path_guard
+
+Behavior-preserving extraction of the import endpoint's PR #1107
+destination-inside-source guard, so card cleanup can share it."
+```
+
+---
+
+### Task 2: Manifest IO — atomic write, validated load, prune
+
+**Files:**
+- Create: `vireo/card_cleanup.py`
+- Create: `vireo/tests/test_card_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `vireo/tests/test_card_cleanup.py`:
+
+```python
+"""Unit tests for card cleanup: manifest IO, classification, and the
+scan/delete safety gates. Spec:
+docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+"""
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import card_cleanup
+from card_cleanup import (
+    ManifestError, load_manifest, prune_manifests, write_manifest,
+)
+
+
+def _manifest(tmp_path, **overrides):
+    m = {
+        "schema_version": card_cleanup.MANIFEST_SCHEMA_VERSION,
+        "scan_job_id": "scan-1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "source_root": str(tmp_path / "card"),
+        "recursive": True,
+        "entries": [],
+        "walk_errors": [],
+        "totals": {},
+    }
+    m.update(overrides)
+    return m
+
+
+def test_write_then_load_roundtrip(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    (tmp_path / "card").mkdir()
+    write_manifest(mdir, _manifest(tmp_path))
+    loaded = load_manifest(mdir, "scan-1")
+    assert loaded["scan_job_id"] == "scan-1"
+
+
+def test_write_is_atomic_no_leftover_tmp(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path))
+    names = os.listdir(mdir)
+    assert names == ["scan-1.json"]
+
+
+def test_load_missing_manifest_is_404(tmp_path):
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(str(tmp_path), "nope")
+    assert exc.value.http_status == 404
+
+
+def test_load_rejects_corrupt_json(tmp_path):
+    mdir = tmp_path / "manifests"
+    mdir.mkdir()
+    (mdir / "scan-1.json").write_text("{truncated")
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(str(mdir), "scan-1")
+    assert exc.value.http_status == 400
+
+
+def test_load_rejects_unknown_schema(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, schema_version=99))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def test_load_rejects_missing_source_root(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, source_root=""))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def test_load_rejects_deletable_entry_outside_source_root(tmp_path):
+    (tmp_path / "card").mkdir()
+    entry = {
+        "path": str(tmp_path / "elsewhere" / "x.nef"),
+        "size": 1, "mtime_ns": 1, "hash": "h", "bucket": "deletable",
+    }
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, entries=[entry]))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def test_load_rejects_expired_manifest_at_request_time(tmp_path):
+    (tmp_path / "card").mkdir()
+    old = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, created_at=old))
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(mdir, "scan-1")
+    assert exc.value.http_status == 404
+    assert "re-scan" in str(exc.value)
+
+
+def test_prune_removes_only_old_manifests(tmp_path):
+    mdir = tmp_path / "manifests"
+    mdir.mkdir()
+    old_file = mdir / "old.json"
+    new_file = mdir / "new.json"
+    old_file.write_text("{}")
+    new_file.write_text("{}")
+    eight_days = 8 * 86400
+    stale = os.stat(old_file).st_mtime - eight_days
+    os.utime(old_file, (stale, stale))
+    prune_manifests(str(mdir))
+    assert not old_file.exists()
+    assert new_file.exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'card_cleanup'`
+
+- [ ] **Step 3: Implement manifest IO in `vireo/card_cleanup.py`**
+
+```python
+"""Free up card space: verified scan → preview → delete for import sources.
+
+Spec: docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+
+The safety invariant, enforced immediately before every unlink:
+(1) the card file's re-hashed bytes equal the manifest hash, and
+(2) a fresh catalog query finds a row with hash_status='ok' whose
+    archive file is outside the source tree, is not the card file
+    itself (device+inode), and stats exactly at the cataloged
+    file_size/file_mtime baseline. Archive bytes are never re-read —
+    the archive lives on a VPN'd SMB mount, and a re-read of the whole
+    deletable set would cost more than the import this tool reclaims.
+"""
+import contextlib
+import errno
+import json
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import path_guard
+from image_loader import (
+    SUPPORTED_EXTENSIONS,
+    is_excluded_scan_path,
+    safe_iter_dir,
+    safe_scan_walk,
+)
+from scanner import compute_file_hash
+
+MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_MAX_AGE_DAYS = 7
+
+
+class ManifestError(Exception):
+    """Manifest missing, expired, or failing validation.
+
+    http_status lets the endpoint distinguish gone/expired (404,
+    "re-scan the card") from corrupt/invalid (400) without string
+    matching.
+    """
+
+    def __init__(self, message, http_status=400):
+        super().__init__(message)
+        self.http_status = http_status
+
+
+def manifest_path(manifest_dir, scan_job_id):
+    # Job ids are runner-generated, but basename() keeps a hostile id
+    # from escaping the manifest directory.
+    return os.path.join(
+        manifest_dir, f"{os.path.basename(str(scan_job_id))}.json"
+    )
+
+
+def write_manifest(manifest_dir, manifest):
+    """Atomic write (sibling temp + os.replace): a crash mid-scan can
+    never leave a truncated manifest that a later delete trusts."""
+    os.makedirs(manifest_dir, exist_ok=True)
+    path = manifest_path(manifest_dir, manifest["scan_job_id"])
+    fd, tmp = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.", suffix=".tmp",
+        dir=manifest_dir,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+    return path
+
+
+def prune_manifests(manifest_dir, max_age_days=MANIFEST_MAX_AGE_DAYS):
+    if not os.path.isdir(manifest_dir):
+        return
+    cutoff = time.time() - max_age_days * 86400
+    for name in os.listdir(manifest_dir):
+        if not name.endswith(".json"):
+            continue
+        full = os.path.join(manifest_dir, name)
+        with contextlib.suppress(OSError):
+            if os.path.getmtime(full) < cutoff:
+                os.unlink(full)
+
+
+def load_manifest(manifest_dir, scan_job_id,
+                  max_age_days=MANIFEST_MAX_AGE_DAYS):
+    """Load + validate. Everything here must pass before any delete."""
+    path = manifest_path(manifest_dir, scan_job_id)
+    if not os.path.exists(path):
+        raise ManifestError(
+            "manifest expired — re-scan the card", http_status=404)
+    try:
+        with open(path, encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, ValueError) as e:
+        raise ManifestError(f"manifest unreadable or corrupt: {e}") from e
+    if (not isinstance(manifest, dict)
+            or manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION):
+        raise ManifestError("manifest schema not recognized — re-scan the card")
+    source_root = manifest.get("source_root")
+    if not source_root or not os.path.isabs(str(source_root)):
+        raise ManifestError("manifest missing source root — re-scan the card")
+    try:
+        created = datetime.fromisoformat(manifest.get("created_at"))
+    except (TypeError, ValueError):
+        raise ManifestError("manifest missing timestamp — re-scan the card")
+    age = datetime.now(timezone.utc) - created
+    # Age is enforced here — at request time — not only by the
+    # scan-start prune.
+    if age.total_seconds() > max_age_days * 86400:
+        raise ManifestError(
+            "manifest expired — re-scan the card", http_status=404)
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        raise ManifestError("manifest entries malformed — re-scan the card")
+    for entry in entries:
+        if entry.get("bucket") != "deletable":
+            continue
+        if not path_guard.path_contains(source_root, str(entry.get("path", ""))):
+            raise ManifestError(
+                "manifest entry outside its source root — re-scan the card")
+    return manifest
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/card_cleanup.py vireo/tests/test_card_cleanup.py
+git commit -m "feat: card-cleanup manifest IO — atomic writes, validated load, expiry"
+```
+
+---
+
+### Task 3: Card walk + classification (with discovery parity)
+
+**Files:**
+- Modify: `vireo/card_cleanup.py`
+- Modify: `vireo/tests/test_card_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests** (append to `test_card_cleanup.py`)
+
+```python
+from card_cleanup import classify_source_files
+
+
+def _make_card(tmp_path):
+    card = tmp_path / "card"
+    (card / "DCIM" / "100").mkdir(parents=True)
+    (card / "DCIM" / "100" / "IMG_0001.NEF").write_bytes(b"raw-one")
+    (card / "DCIM" / "100" / "IMG_0002.JPG").write_bytes(b"jpg-two")
+    (card / "DCIM" / "100" / "IMG_0001.XMP").write_bytes(b"sidecar")
+    (card / "DCIM" / "100" / ".hidden.jpg").write_bytes(b"dot")
+    (card / "MISC" / "sub").mkdir(parents=True)
+    (card / "MISC" / "sub" / "firmware.bin").write_bytes(b"fw")
+    return card
+
+
+def test_classify_buckets(tmp_path):
+    card = _make_card(tmp_path)
+    candidates, ignored = classify_source_files(str(card))
+    cand_names = {p.name for p in candidates}
+    ign_names = {p.name for p in ignored}
+    assert cand_names == {"IMG_0001.NEF", "IMG_0002.JPG"}
+    assert ign_names == {"IMG_0001.XMP", ".hidden.jpg", "firmware.bin"}
+
+
+def test_classify_parity_with_discover_source_files(tmp_path):
+    # The deletable set may never exceed what an import would consider a
+    # photo — pin our filter to discovery's, byte for byte.
+    from ingest import discover_source_files
+    card = _make_card(tmp_path)
+    candidates, _ = classify_source_files(str(card), recursive=True)
+    assert candidates == discover_source_files(
+        str(card), file_types="both", recursive=True)
+    candidates_flat, _ = classify_source_files(str(card), recursive=False)
+    assert candidates_flat == discover_source_files(
+        str(card), file_types="both", recursive=False)
+
+
+def test_classify_missing_source_reports_onerror(tmp_path):
+    errors = []
+    candidates, ignored = classify_source_files(
+        str(tmp_path / "nope"), onerror=errors.append)
+    assert candidates == [] and ignored == []
+    assert len(errors) == 1 and isinstance(errors[0], OSError)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup.py -k classify -v`
+Expected: FAIL with `ImportError: cannot import name 'classify_source_files'`
+
+- [ ] **Step 3: Implement `classify_source_files`** (add to `card_cleanup.py`)
+
+This mirrors `discover_source_files` (`ingest.py:286`) — same excluded-bundle handling, same synthetic-OSError contract for unwalkable roots, same filter — but keeps the non-matching files instead of dropping them:
+
+```python
+def classify_source_files(source, recursive=True, onerror=None):
+    """One walk over the card; returns (candidates, ignored), both sorted.
+
+    Mirrors discover_source_files' file_types="both" filter exactly —
+    parity is pinned by a test — but also returns the non-photo files so
+    the preview can show an "ignored, never touched" bucket without a
+    second walk (discover_source_files drops them).
+    """
+    source_path = Path(source)
+    if is_excluded_scan_path(source_path):
+        if onerror is not None:
+            onerror(PermissionError(
+                errno.EACCES, "source is an excluded data bundle",
+                str(source_path)))
+        return [], []
+    if not source_path.is_dir():
+        if onerror is not None:
+            onerror(FileNotFoundError(
+                errno.ENOENT, "source is not an accessible directory",
+                str(source_path)))
+        return [], []
+    if recursive:
+        def _walk():
+            for dirpath, _dirnames, filenames in safe_scan_walk(
+                    str(source_path), onerror=onerror):
+                for name in filenames:
+                    yield Path(dirpath) / name
+        entries = _walk()
+    else:
+        entries = safe_iter_dir(str(source_path), onerror=onerror)
+    candidates, ignored = [], []
+    for f in entries:
+        if not f.is_file():
+            continue
+        if (f.suffix.lower() in SUPPORTED_EXTENSIONS
+                and not f.name.startswith(".")):
+            candidates.append(f)
+        else:
+            ignored.append(f)
+    return sorted(candidates), sorted(ignored)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/card_cleanup.py vireo/tests/test_card_cleanup.py
+git commit -m "feat: card-cleanup walk/classify with discovery filter parity"
+```
+
+---
+
+### Task 4: The archive-side qualifying test + `scan_card`
+
+**Files:**
+- Modify: `vireo/card_cleanup.py`
+- Modify: `vireo/tests/test_card_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests** (append to `test_card_cleanup.py`)
+
+These use a real `Database` on a temp file, with archive files on disk so stats work. The helper builds one cataloged, hash-verified archive photo whose bytes match a card file:
+
+```python
+from scanner import compute_file_hash as _sha
+
+
+# The `db` fixture comes from vireo/tests/conftest.py (~line 158) — a
+# Database on a temp file. Do not redefine it here.
+
+
+def _archive_photo(db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
+                   hash_status="ok", folder="archive/2026/2026-08-01"):
+    """Create an archive file on disk + its cataloged, verified row."""
+    folder_path = tmp_path / folder
+    folder_path.mkdir(parents=True, exist_ok=True)
+    f = folder_path / name
+    f.write_bytes(content)
+    st = os.stat(f)
+    fid = db.add_folder(str(folder_path))
+    pid = db.add_photo(
+        folder_id=fid, filename=name, extension=os.path.splitext(name)[1],
+        file_size=st.st_size, file_mtime=st.st_mtime,
+        file_hash=_sha(str(f)),
+    )
+    if hash_status is not None:
+        db.update_photo_hash_check(pid, hash_status)
+    return f, pid
+
+
+def _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one"):
+    card = tmp_path / "card" / "DCIM"
+    card.mkdir(parents=True, exist_ok=True)
+    f = card / name
+    f.write_bytes(content)
+    return f
+
+
+def _scan(db, tmp_path, **kwargs):
+    return card_cleanup.scan_card(
+        db, str(tmp_path / "card"), True,
+        str(tmp_path / "manifests"), "scan-1", **kwargs)
+
+
+def _entries(result, bucket):
+    return [e for e in result["entries"] if e["bucket"] == bucket]
+
+
+def test_scan_verified_file_is_deletable(db, tmp_path):
+    archive_file, _ = _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    deletable = _entries(result, "deletable")
+    assert len(deletable) == 1
+    assert deletable[0]["archive_path"] == str(archive_file)
+    assert result["totals"]["deletable"]["count"] == 1
+    # Manifest landed on disk and revalidates.
+    loaded = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    assert loaded["source_root"] == os.path.realpath(str(tmp_path / "card"))
+
+
+def test_scan_uncataloged_file_kept(db, tmp_path):
+    _card_file(tmp_path, content=b"never-imported")
+    result = _scan(db, tmp_path)
+    kept = _entries(result, "kept")
+    assert len(kept) == 1 and "not in catalog" in kept[0]["reason"]
+
+
+def test_scan_null_hash_status_kept_with_audit_remedy(db, tmp_path):
+    # Scan-cataloged archives: file_hash set, hash_status NULL. Kept —
+    # and the reason must point at the remedy, or the tool reads broken.
+    _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    kept = _entries(result, "kept")
+    assert len(kept) == 1
+    assert "integrity audit" in kept[0]["reason"]
+
+
+def test_scan_archive_file_missing_kept(db, tmp_path):
+    archive_file, _ = _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    os.unlink(archive_file)
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "kept")) == 1
+    assert len(_entries(result, "deletable")) == 0
+
+
+def test_scan_archive_mtime_off_baseline_kept(db, tmp_path):
+    # Exact equality, not the audit's 1s window: any drift keeps the file.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    st = os.stat(archive_file)
+    os.utime(archive_file, (st.st_atime, st.st_mtime + 0.5))
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "deletable")) == 0
+    assert "changed since verification" in _entries(result, "kept")[0]["reason"]
+
+
+def test_scan_self_match_inside_source_never_qualifies(db, tmp_path):
+    # The only catalog copy lives inside the selected source tree: the
+    # file must NOT be deletable (it would be deleting the archive copy).
+    _archive_photo(db, tmp_path, folder="card/DCIM")
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "deletable")) == 0
+    kept = _entries(result, "kept")
+    assert len(kept) == 1 and "inside the selected source" in kept[0]["reason"]
+
+
+def test_qualify_rejects_hardlink_alias_of_card_file(db, tmp_path):
+    # Mount-alias/samefile gate: the cataloged "archive copy" lives
+    # outside the source tree by path, but it's a hardlink to the card
+    # file itself — same dev+inode. Deleting the card file would leave
+    # the archive path as the only name for bytes we just proved existed
+    # twice; the spec says such a row never qualifies.
+    card = _card_file(tmp_path)
+    folder_path = tmp_path / "archive" / "2026"
+    folder_path.mkdir(parents=True)
+    alias = folder_path / "IMG_0001.NEF"
+    try:
+        os.link(card, alias)
+    except (OSError, NotImplementedError):
+        pytest.skip("hardlinks unsupported on this filesystem")
+    st = os.stat(alias)
+    fid = db.add_folder(str(folder_path))
+    pid = db.add_photo(
+        folder_id=fid, filename="IMG_0001.NEF", extension=".NEF",
+        file_size=st.st_size, file_mtime=st.st_mtime,
+        file_hash=_sha(str(alias)),
+    )
+    db.update_photo_hash_check(pid, "ok")
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "deletable")) == 0
+    kept = _entries(result, "kept")
+    assert len(kept) == 1 and "inside the selected source" in kept[0]["reason"]
+
+
+def test_scan_duplicate_card_files_both_deletable(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path, name="IMG_0001.NEF")
+    _card_file(tmp_path, name="IMG_0001_copy.NEF")
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "deletable")) == 2
+
+
+def test_scan_two_rows_one_qualifying_is_deletable(db, tmp_path):
+    # Same hash cataloged twice; only one row passes → still deletable,
+    # preview shows the passing row's path.
+    bad_archive, _ = _archive_photo(db, tmp_path, folder="archive/a")
+    good_archive, _ = _archive_photo(db, tmp_path, folder="archive/b")
+    os.unlink(bad_archive)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    deletable = _entries(result, "deletable")
+    assert len(deletable) == 1
+    assert deletable[0]["archive_path"] == str(good_archive)
+
+
+def test_scan_cancellation_writes_no_manifest(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path, should_cancel=lambda: True)
+    assert result["cancelled"] is True
+    assert not os.path.exists(
+        card_cleanup.manifest_path(str(tmp_path / "manifests"), "scan-1"))
+
+
+def test_scan_hashes_each_card_file_once(db, tmp_path, monkeypatch):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    calls = []
+    real = card_cleanup.compute_file_hash
+
+    def counting(path, *a, **kw):
+        calls.append(str(path))
+        return real(path, *a, **kw)
+
+    monkeypatch.setattr(card_cleanup, "compute_file_hash", counting)
+    _scan(db, tmp_path)
+    card_calls = [p for p in calls if "card" in p]
+    assert len(card_calls) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup.py -k scan -v`
+Expected: FAIL with `AttributeError: ... no attribute 'scan_card'`
+
+- [ ] **Step 3: Implement the qualifying test and `scan_card`** (add to `card_cleanup.py`)
+
+The qualifying test is ONE function used by both scan and delete — the spec's invariant restated in code once, so the two jobs cannot drift. It takes rows (scan passes prefetched rows; delete passes a fresh query) and always stats the archive fresh.
+
+Deliberate substitution vs. the spec: the spec names `DuplicateChecker(CatalogIndex.from_db(db), verify_by_hash=True)` as the matching mechanism, but `CatalogIndex` stores only hash *sets* while the qualifying test needs full rows (`hash_status`, size/mtime baseline, folder path) — which the spec itself acknowledges requires a `photos WHERE file_hash = ?` lookup anyway. Querying rows directly is semantically identical for membership (only rows with a stored `file_hash` can carry `hash_status='ok'`) and skips a redundant layer; the hash-once rule the spec attaches to the checker is satisfied by `scan_card` computing each card hash exactly once (pinned by `test_scan_hashes_each_card_file_once`).
+
+```python
+KEEP_NOT_IN_CATALOG = "not in catalog — not imported yet"
+KEEP_NOT_VERIFIED = (
+    "not verified by a checksummed import — run the integrity audit"
+)
+KEEP_INSIDE_SOURCE = "only catalog copy is inside the selected source"
+KEEP_ARCHIVE_UNREACHABLE = "archive file not reachable"
+KEEP_ARCHIVE_CHANGED = "archive file changed since verification"
+KEEP_UNREADABLE = "could not read card file"
+
+
+def qualify_rows(rows, source_root_real, card_path):
+    """Archive-side test from the spec's safety invariant.
+
+    Returns (archive_path, None) for the first row that passes, else
+    (None, keep_reason). The archive stat happens HERE, fresh, on every
+    call — callers may cache rows, never this function's result.
+    """
+    if not rows:
+        return None, KEEP_NOT_IN_CATALOG
+    reason = KEEP_NOT_VERIFIED
+    try:
+        card_st = os.stat(card_path)
+    except OSError:
+        return None, KEEP_UNREADABLE
+    for row in rows:
+        if row["hash_status"] != "ok":
+            continue
+        if not row["folder_path"]:
+            continue
+        archive_path = os.path.join(row["folder_path"], row["filename"])
+        if path_guard.contains_resolved(
+                source_root_real, os.path.realpath(archive_path)):
+            reason = KEEP_INSIDE_SOURCE
+            continue
+        try:
+            ast = os.stat(archive_path)
+        except OSError:
+            reason = KEEP_ARCHIVE_UNREACHABLE
+            continue
+        # samefile semantics without a second round trip: a mount alias
+        # that survived realpath + case-folding still shares dev+inode.
+        if (ast.st_dev, ast.st_ino) == (card_st.st_dev, card_st.st_ino):
+            reason = KEEP_INSIDE_SOURCE
+            continue
+        if row["file_size"] is None or row["file_mtime"] is None:
+            reason = KEEP_ARCHIVE_CHANGED
+            continue
+        # Exact equality — the audit's 1s window classifies an
+        # already-detected mismatch and certifies nothing here; a false
+        # negative just keeps a file.
+        if (ast.st_size != row["file_size"]
+                or ast.st_mtime != row["file_mtime"]):
+            reason = KEEP_ARCHIVE_CHANGED
+            continue
+        return archive_path, None
+    return None, reason
+
+
+_ROWS_BY_HASH_SQL = """
+    SELECT p.filename, p.file_size, p.file_mtime, p.hash_status,
+           f.path AS folder_path
+    FROM photos p LEFT JOIN folders f ON f.id = p.folder_id
+    WHERE p.file_hash = ?
+"""
+
+
+def fetch_rows_by_hash(db, file_hash):
+    return db.conn.execute(_ROWS_BY_HASH_SQL, (file_hash,)).fetchall()
+
+
+def _load_catalog_by_hash(db):
+    """One pass over the catalog for the scan — a per-file SELECT over an
+    unindexed file_hash column would rescan the photos table for every
+    card file."""
+    rows = db.conn.execute("""
+        SELECT p.filename, p.file_size, p.file_mtime, p.hash_status,
+               p.file_hash, f.path AS folder_path
+        FROM photos p LEFT JOIN folders f ON f.id = p.folder_id
+        WHERE p.file_hash IS NOT NULL
+    """).fetchall()
+    by_hash = {}
+    for row in rows:
+        by_hash.setdefault(row["file_hash"], []).append(row)
+    return by_hash
+
+
+def scan_card(db, source, recursive, manifest_dir, scan_job_id,
+              progress_cb=None, should_cancel=None):
+    source_root_real = os.path.realpath(source)
+    walk_errors = []
+    candidates, ignored = classify_source_files(
+        source, recursive=recursive, onerror=lambda e: walk_errors.append(str(e)))
+    by_hash = _load_catalog_by_hash(db)
+    entries = []
+    totals = {
+        "deletable": {"count": 0, "bytes": 0},
+        "kept": {"count": 0, "bytes": 0},
+        "ignored": {"count": len(ignored)},
+    }
+    for i, f in enumerate(candidates):
+        if should_cancel is not None and should_cancel():
+            return {"cancelled": True}
+        if progress_cb is not None:
+            progress_cb(i + 1, len(candidates), f.name)
+        try:
+            st = os.stat(f)
+            file_hash = compute_file_hash(str(f))
+        except OSError as e:
+            entries.append({
+                "path": str(f), "bucket": "kept",
+                "reason": f"{KEEP_UNREADABLE}: {e}",
+            })
+            totals["kept"]["count"] += 1
+            continue
+        entry = {
+            "path": str(f), "size": st.st_size,
+            "mtime_ns": st.st_mtime_ns, "hash": file_hash,
+        }
+        archive_path, reason = qualify_rows(
+            by_hash.get(file_hash, []), source_root_real, str(f))
+        if archive_path is not None:
+            entry.update(bucket="deletable", archive_path=archive_path)
+            totals["deletable"]["count"] += 1
+            totals["deletable"]["bytes"] += st.st_size
+        else:
+            entry.update(bucket="kept", reason=reason)
+            totals["kept"]["count"] += 1
+            totals["kept"]["bytes"] += st.st_size
+        entries.append(entry)
+    for f in ignored:
+        entries.append({"path": str(f), "bucket": "ignored"})
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "scan_job_id": scan_job_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "source_root": source_root_real,
+        "recursive": bool(recursive),
+        "entries": entries,
+        "walk_errors": walk_errors,
+        "totals": totals,
+    }
+    write_manifest(manifest_dir, manifest)
+    manifest["cancelled"] = False
+    return manifest
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/card_cleanup.py vireo/tests/test_card_cleanup.py
+git commit -m "feat: card-cleanup scan — hash-once matching, archive qualifying test"
+```
+
+---
+
+### Task 5: `delete_verified` — the gates at the destructive moment
+
+**Files:**
+- Modify: `vireo/card_cleanup.py`
+- Modify: `vireo/tests/test_card_cleanup.py`
+
+- [ ] **Step 1: Write the failing tests** (append to `test_card_cleanup.py`)
+
+```python
+def _scan_then_delete(db, tmp_path, mutate=None, should_cancel=None):
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] >= 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    if mutate is not None:
+        mutate()
+    return card_cleanup.delete_verified(
+        db, manifest, should_cancel=should_cancel)
+
+
+def test_delete_happy_path_two_duplicates_both_deleted(db, tmp_path):
+    # Spec: two identical card files matching one archive photo — both
+    # deletable, both deleted.
+    _archive_photo(db, tmp_path)
+    card_a = _card_file(tmp_path, name="IMG_0001.NEF")
+    card_b = _card_file(tmp_path, name="IMG_0001_copy.NEF")
+    summary = _scan_then_delete(db, tmp_path)
+    assert summary["deleted"] == 2
+    assert not card_a.exists() and not card_b.exists()
+    assert summary["skipped"] == [] and summary["failed"] == []
+
+
+def test_delete_skips_file_changed_since_scan(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+
+    def rewrite():
+        card.write_bytes(b"new-shot-reusing-name")
+
+    summary = _scan_then_delete(db, tmp_path, mutate=rewrite)
+    assert summary["deleted"] == 0
+    assert len(summary["skipped"]) == 1
+    assert card.exists()
+
+
+def test_delete_rehash_catches_same_size_same_mtime_swap(db, tmp_path):
+    # Same byte count, mtime forced back to the manifest value: only the
+    # delete-time re-hash can catch this (FAT mtimes are 2s-granular).
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)  # content b"raw-one", 7 bytes
+    st = os.stat(card)
+
+    def swap():
+        card.write_bytes(b"raw-two")  # also 7 bytes
+        os.utime(card, ns=(st.st_atime_ns, st.st_mtime_ns))
+
+    summary = _scan_then_delete(db, tmp_path, mutate=swap)
+    assert summary["deleted"] == 0
+    assert len(summary["skipped"]) == 1
+    assert card.exists()
+
+
+def test_delete_archive_removed_after_scan_skips(db, tmp_path):
+    archive_file, _ = _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    summary = _scan_then_delete(
+        db, tmp_path, mutate=lambda: os.unlink(archive_file))
+    assert summary["deleted"] == 0
+    assert card.exists()
+    assert "archive" in summary["skipped"][0]["reason"]
+
+
+def test_delete_no_stat_reuse_across_duplicates(db, tmp_path):
+    # Two identical card files; archive copy vanishes after the first
+    # deletion. The second file's own fresh stat must fail — a cached
+    # scan-time (or first-delete-time) result would wrongly authorize it.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    card_a = _card_file(tmp_path, name="IMG_0001.NEF")
+    card_b = _card_file(tmp_path, name="IMG_0002.NEF")
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 2
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+
+    deleted_once = []
+    real_remove = os.remove
+
+    def remove_then_kill_archive(path, *a, **kw):
+        real_remove(path, *a, **kw)
+        if not deleted_once:
+            deleted_once.append(path)
+            real_remove(archive_file)
+
+    import unittest.mock
+    with unittest.mock.patch.object(
+            card_cleanup.os, "remove", remove_then_kill_archive):
+        summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 1
+    assert len(summary["skipped"]) == 1
+    assert card_a.exists() != card_b.exists()  # exactly one survived
+
+
+def test_delete_cancellation_honest_summary(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path, name="IMG_0001.NEF")
+    _card_file(tmp_path, name="IMG_0002.NEF")
+    calls = []
+
+    def cancel_after_first():
+        calls.append(1)
+        return len(calls) > 1
+
+    summary = _scan_then_delete(
+        db, tmp_path, should_cancel=cancel_after_first)
+    assert summary["cancelled"] is True
+    assert summary["deleted"] + summary["remaining"] == 2
+
+
+def test_delete_vanished_card_file_counts_skipped(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    summary = _scan_then_delete(db, tmp_path, mutate=lambda: os.unlink(card))
+    assert summary["deleted"] == 0
+    assert "already gone" in summary["skipped"][0]["reason"]
+
+
+def test_delete_per_file_failure_continues(db, tmp_path):
+    # A permission error on one file is recorded as failed; the job
+    # moves on and still deletes the rest.
+    _archive_photo(db, tmp_path)
+    card_a = _card_file(tmp_path, name="IMG_0001.NEF")
+    card_b = _card_file(tmp_path, name="IMG_0002.NEF")
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 2
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    real_remove = os.remove
+    failed_path = str(card_a)
+
+    def failing_remove(path, *a, **kw):
+        if str(path) == failed_path:
+            raise PermissionError(13, "read-only card", failed_path)
+        real_remove(path, *a, **kw)
+
+    import unittest.mock
+    with unittest.mock.patch.object(
+            card_cleanup.os, "remove", failing_remove):
+        summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 1
+    assert len(summary["failed"]) == 1
+    assert summary["failed"][0]["path"] == failed_path
+    assert card_a.exists() and not card_b.exists()
+
+
+def test_delete_only_touches_deletable_bucket(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    stray = _card_file(tmp_path, name="IMG_KEEP.NEF", content=b"unimported")
+    summary = _scan_then_delete(db, tmp_path)
+    assert summary["deleted"] == 1
+    assert stray.exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup.py -k delete -v`
+Expected: FAIL with `AttributeError: ... no attribute 'delete_verified'`
+
+- [ ] **Step 3: Implement `delete_verified`** (add to `card_cleanup.py`)
+
+```python
+def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
+    """Delete the manifest's deletable bucket, re-proving the invariant
+    per file immediately before each unlink. Never reads the kept or
+    ignored buckets."""
+    source_root_real = os.path.realpath(manifest["source_root"])
+    deletable = [e for e in manifest["entries"]
+                 if e.get("bucket") == "deletable"]
+    summary = {
+        "deleted": 0, "deleted_bytes": 0,
+        "skipped": [], "failed": [],
+        "cancelled": False, "remaining": 0,
+    }
+    for i, entry in enumerate(deletable):
+        if should_cancel is not None and should_cancel():
+            summary["cancelled"] = True
+            summary["remaining"] = len(deletable) - i
+            break
+        path = entry["path"]
+        if progress_cb is not None:
+            progress_cb(i + 1, len(deletable), os.path.basename(path))
+        # Card gate: cheap stat pre-check, then full re-hash. Size+mtime
+        # alone cannot detect a swapped card or same-size replacement.
+        try:
+            st = os.stat(path)
+        except FileNotFoundError:
+            summary["skipped"].append(
+                {"path": path, "reason": "already gone from the card"})
+            continue
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if (st.st_size != entry["size"]
+                or st.st_mtime_ns != entry["mtime_ns"]):
+            summary["skipped"].append(
+                {"path": path, "reason": "changed on the card since the scan"})
+            continue
+        try:
+            current_hash = compute_file_hash(path)
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if current_hash != entry["hash"]:
+            summary["skipped"].append(
+                {"path": path,
+                 "reason": "content changed on the card since the scan"})
+            continue
+        # Archive gate: fresh rows, fresh stat — never reused from the
+        # scan or from an earlier deletion in this run.
+        archive_path, reason = qualify_rows(
+            fetch_rows_by_hash(db, entry["hash"]), source_root_real, path)
+        if archive_path is None:
+            summary["skipped"].append({"path": path, "reason": reason})
+            continue
+        try:
+            os.remove(path)
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        summary["deleted"] += 1
+        summary["deleted_bytes"] += entry["size"]
+    return summary
+```
+
+- [ ] **Step 4: Run the full module's tests**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup.py vireo/tests/test_path_guard.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vireo/card_cleanup.py vireo/tests/test_card_cleanup.py
+git commit -m "feat: card-cleanup delete — re-verified card and archive gates per unlink"
+```
+
+---
+
+### Task 6: Endpoints and job wiring in app.py
+
+**Files:**
+- Modify: `vireo/app.py`
+- Create: `vireo/tests/test_card_cleanup_api.py`
+
+Before coding: read the `verify-hashes` endpoint (`vireo/app.py` ~18990–19036) end to end and mirror how it obtains `active_ws`, constructs the thread `Database`, calls `set_active_workspace`, throttles `push_event`, and wires `is_cancelled`. One deliberate deviation: verify-hashes never closes its thread `Database`; the card-cleanup work functions should wrap the body in `try/finally: thread_db.close()` — that is an improvement, not a copy. `json_error` already accepts a status parameter (`json_error(msg, status=400)`, `vireo/app.py:3273`), so use it for 404/409 too.
+
+- [ ] **Step 1: Write the failing endpoint tests**
+
+Create `vireo/tests/test_card_cleanup_api.py`. The `app_and_db` fixture comes from `vireo/tests/conftest.py:168` — the new file gets it for free; do NOT redefine it (a local copy would shadow the shared one). Note it pre-seeds folder rows `/photos/2024` and `/photos/2024/January`; those paths don't exist on disk and pass the overlap guard harmlessly, but they do sit in `folders`, so don't assert on folder counts. Copy only the job-completion-wait helper pattern from `vireo/tests/test_jobs_api.py`. Then:
+
+```python
+def _make_verified_pair(db, tmp_path):
+    # archive file + verified row + matching card file (bytes b"raw-one")
+    ...  # same helpers as test_card_cleanup.py: _archive_photo/_card_file
+
+
+def test_scan_rejects_missing_source(app_and_db):
+    app, _ = app_and_db
+    resp = app.test_client().post(
+        "/api/card-cleanup/scan", json={"source": "/nope/missing"})
+    assert resp.status_code == 400
+
+
+def test_scan_rejects_archive_overlap(app_and_db, tmp_path):
+    # Source equals a cataloged folder root → 400 before any job starts.
+    app, db = app_and_db
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    db.add_folder(str(archive))
+    resp = app.test_client().post(
+        "/api/card-cleanup/scan", json={"source": str(archive)})
+    assert resp.status_code == 400
+    assert "removable media" in resp.get_json()["error"]
+    # ... a source that CONTAINS the archive root:
+    resp = app.test_client().post(
+        "/api/card-cleanup/scan", json={"source": str(tmp_path)})
+    assert resp.status_code == 400
+    # ... and a source INSIDE the archive root:
+    sub = archive / "2026"
+    sub.mkdir()
+    resp = app.test_client().post(
+        "/api/card-cleanup/scan", json={"source": str(sub)})
+    assert resp.status_code == 400
+
+
+def test_scan_rejects_case_swapped_overlap(app_and_db, tmp_path):
+    # Case-swapped source naming the same directory as a cataloged root
+    # must be rejected on case-insensitive platforms (spec: overlap
+    # fail-fast under the containment rules, not string realpath).
+    import sys
+    if sys.platform not in ("darwin", "win32"):
+        pytest.skip("needs an unconditionally case-folding platform")
+    app, db = app_and_db
+    archive = tmp_path / "Archive"
+    archive.mkdir()
+    db.add_folder(str(archive))
+    swapped = str(tmp_path / "archive")
+    resp = app.test_client().post(
+        "/api/card-cleanup/scan", json={"source": swapped})
+    assert resp.status_code == 400
+
+
+def test_scan_then_manifest_then_delete_end_to_end(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    _make_verified_pair(db, tmp_path)
+    resp = client.post("/api/card-cleanup/scan",
+                       json={"source": str(tmp_path / "card")})
+    assert resp.status_code == 200
+    scan_job_id = resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)          # completed
+    resp = client.get(f"/api/card-cleanup/{scan_job_id}/manifest")
+    assert resp.status_code == 200
+    assert resp.get_json()["totals"]["deletable"]["count"] == 1
+    resp = client.post("/api/card-cleanup/delete",
+                       json={"scan_job_id": scan_job_id})
+    assert resp.status_code == 200
+    _wait_for_job(client, resp.get_json()["job_id"])
+    assert not (tmp_path / "card" / "DCIM" / "IMG_0001.NEF").exists()
+
+
+def test_delete_unknown_scan_job_404(app_and_db):
+    app, _ = app_and_db
+    resp = app.test_client().post(
+        "/api/card-cleanup/delete", json={"scan_job_id": "nope"})
+    assert resp.status_code == 404
+
+
+def test_delete_refuses_cancelled_scan(app_and_db, tmp_path):
+    # A scan that was cancelled must not authorize a delete, even with a
+    # manifest present. Seed job_history directly (also proves the
+    # history fallback path is consulted for status, not just existence).
+    app, db = app_and_db
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("scan-c", "card-cleanup-scan", "cancelled", "2026-08-08T00:00:00"))
+    db.conn.commit()
+    resp = app.test_client().post(
+        "/api/card-cleanup/delete", json={"scan_job_id": "scan-c"})
+    assert resp.status_code == 400
+
+
+def test_delete_after_restart_uses_history_and_disk_manifest(
+        app_and_db, tmp_path):
+    # Restart recovery: the runner no longer knows the scan job, but the
+    # job_history row and the on-disk manifest are enough to delete.
+    # Seed both directly instead of monkeypatching runner eviction.
+    app, db = app_and_db
+    client = app.test_client()
+    _make_verified_pair(db, tmp_path)
+    import card_cleanup
+    manifest_dir = app.config["CARD_CLEANUP_DIR"]  # expose in create_app
+    card = tmp_path / "card" / "DCIM" / "IMG_0001.NEF"
+    scan = card_cleanup.scan_card(
+        db, str(tmp_path / "card"), True, manifest_dir, "scan-r")
+    assert scan["totals"]["deletable"]["count"] == 1
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("scan-r", "card-cleanup-scan", "completed", "2026-08-08T00:00:00"))
+    db.conn.commit()
+    resp = client.post(
+        "/api/card-cleanup/delete", json={"scan_job_id": "scan-r"})
+    assert resp.status_code == 200
+    _wait_for_job(client, resp.get_json()["job_id"])
+    assert not card.exists()
+
+
+def test_delete_expired_manifest_404(app_and_db, tmp_path):
+    # Complete a scan, then age the manifest header past 7 days by
+    # rewriting created_at; the delete endpoint must reject it at
+    # request time.
+    ...
+    assert resp.status_code == 404
+    assert "re-scan" in resp.get_json()["error"]
+
+
+def test_delete_concurrent_delete_409(app_and_db, tmp_path):
+    # Start a delete, then POST a second while the first is running
+    # (use a card with enough files, or monkeypatch a slow gate).
+    ...
+    assert second.status_code == 409
+```
+
+Fill in the `...` bodies following the fixture's conventions; each test must assert the exact status code and, where shown, the error copy.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup_api.py -v`
+Expected: FAIL with 404s (routes don't exist)
+
+- [ ] **Step 3: Implement the endpoints**
+
+In `create_app`, next to the other path setup, add:
+
+```python
+    card_cleanup_dir = os.path.join(
+        os.path.dirname(os.path.abspath(db_path)), "card_cleanup")
+    app.config["CARD_CLEANUP_DIR"] = card_cleanup_dir  # tests reach it here
+```
+
+Add `import card_cleanup` beside the other flat sibling imports. Place the three routes near the audit/job endpoints:
+
+```python
+    @app.route("/api/card-cleanup/scan", methods=["POST"])
+    def api_card_cleanup_scan():
+        body = request.get_json(silent=True) or {}
+        source = body.get("source")
+        recursive = bool(body.get("recursive", True))
+        if not source or not isinstance(source, str):
+            return json_error("source required")
+        if not os.path.isabs(source):
+            return json_error("source must be an absolute path")
+        if not os.path.isdir(source):
+            return json_error("source is not an accessible directory")
+        db = _get_db()
+        # Overlap fail-fast, across all workspaces (folders is global):
+        # this tool is for removable media, not the archive. The per-file
+        # guard in card_cleanup.qualify_rows is the real invariant; this
+        # is the clear early error.
+        source_real = os.path.realpath(source)
+        for row in db.conn.execute("SELECT path FROM folders").fetchall():
+            froot = row["path"]
+            if not froot:
+                continue
+            froot_real = os.path.realpath(froot)
+            if (path_guard.contains_resolved(source_real, froot_real)
+                    or path_guard.contains_resolved(froot_real, source_real)):
+                return json_error(
+                    "the selected source overlaps the cataloged archive "
+                    f"folder {froot!r}; this tool is for removable media "
+                    "like memory cards, not archive folders")
+        card_cleanup.prune_manifests(card_cleanup_dir)
+        # ... mirror verify-hashes: resolve active_ws, then:
+
+        def work(job):
+            # mirror verify-hashes' thread Database + set_active_workspace
+            # + finally-close pattern exactly; inside:
+            def progress_cb(current, total, filename):
+                if current % 10 != 0 and current not in (1, total):
+                    return
+                runner.push_event(job["id"], "progress", {
+                    "current": current, "total": total,
+                    "current_file": filename,
+                    "phase": "Verifying card files against the archive",
+                })
+            return card_cleanup.scan_card(
+                thread_db, source, recursive, card_cleanup_dir, job["id"],
+                progress_cb=progress_cb,
+                should_cancel=lambda: runner.is_cancelled(job["id"]),
+            )
+
+        job_id = runner.start(
+            "card-cleanup-scan", work,
+            config={"source": source, "recursive": recursive},
+            workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+
+    @app.route("/api/card-cleanup/<scan_job_id>/manifest")
+    def api_card_cleanup_manifest(scan_job_id):
+        try:
+            manifest = card_cleanup.load_manifest(
+                card_cleanup_dir, scan_job_id)
+        except card_cleanup.ManifestError as e:
+            return jsonify({"error": str(e)}), e.http_status
+        return jsonify(manifest)
+
+    @app.route("/api/card-cleanup/delete", methods=["POST"])
+    def api_card_cleanup_delete():
+        body = request.get_json(silent=True) or {}
+        scan_job_id = body.get("scan_job_id")
+        if not scan_job_id or not isinstance(scan_job_id, str):
+            return json_error("scan_job_id required")
+        db = _get_db()
+        # Scan job must exist and be completed. Works across restart:
+        # fall back to job_history when the runner no longer holds it.
+        job = runner.get(scan_job_id)
+        if job is None:
+            row = db.conn.execute(
+                "SELECT type, status FROM job_history WHERE id = ?",
+                (scan_job_id,)).fetchone()
+            job = dict(row) if row is not None else None
+        if job is None or job.get("type") != "card-cleanup-scan":
+            return jsonify({"error": "unknown scan job"}), 404
+        if job.get("status") != "completed":
+            return json_error(
+                "scan did not complete — re-scan the card")
+        # One delete per manifest. (TOCTOU race between two simultaneous
+        # POSTs is acceptable: the per-file gates make a double-delete
+        # skip, not double-fire.)
+        for j in runner.list_jobs():
+            if (j.get("type") == "card-cleanup-delete"
+                    and j.get("status") in ("queued", "running")
+                    and (j.get("config") or {}).get("scan_job_id")
+                    == scan_job_id):
+                return jsonify({"error":
+                    "a delete for this scan is already running"}), 409
+        try:
+            manifest = card_cleanup.load_manifest(
+                card_cleanup_dir, scan_job_id)
+        except card_cleanup.ManifestError as e:
+            return jsonify({"error": str(e)}), e.http_status
+        if not any(e.get("bucket") == "deletable"
+                   for e in manifest["entries"]):
+            return json_error("nothing to delete — no verified files")
+
+        def work(job):
+            # same thread-Database mirror as the scan; inside:
+            def progress_cb(current, total, filename):
+                runner.push_event(job["id"], "progress", {
+                    "current": current, "total": total,
+                    "current_file": filename,
+                    "phase": "Deleting verified files from the card",
+                })
+            return card_cleanup.delete_verified(
+                thread_db, manifest,
+                progress_cb=progress_cb,
+                should_cancel=lambda: runner.is_cancelled(job["id"]),
+            )
+
+        job_id = runner.start(
+            "card-cleanup-delete", work,
+            config={"scan_job_id": scan_job_id},
+            workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+```
+
+The `# mirror verify-hashes` comments are instructions, not code — replace them with the exact resource-handling pattern from that endpoint (thread `Database(db_path)`, `set_active_workspace(active_ws)` when set, close in `finally`). Delete-job progress is NOT throttled: deletions are the events the user is watching.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest vireo/tests/test_card_cleanup_api.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the regression net**
+
+Run: `python -m pytest vireo/tests/test_jobs_api.py vireo/tests/test_app.py -q`
+Expected: PASS (no regressions from the app.py changes; compare any failures against the known pre-existing failures on this machine before blaming this change)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_card_cleanup_api.py
+git commit -m "feat: card-cleanup scan/delete/manifest endpoints with overlap fail-fast"
+```
+
+---
+
+### Task 7: "Free up card space" UI on the import page
+
+**Files:**
+- Modify: `vireo/templates/import.html`
+
+No automated UI tests — the backend behavior is fully covered; this task is wiring, verified manually.
+
+- [ ] **Step 1: Study the page's existing patterns**
+
+Read how import.html starts jobs and streams progress: the `fetch('/api/jobs/import-photos', ...)` POST (~line 3759), `new EventSource('/api/jobs/' + jobId + '/stream')` (~3785), `pollJobResult` (~2106), and the card-safety pill markup (~4061–4086). Reuse the page's existing CSS classes and collapsible-section markup; do not invent a new visual language.
+
+- [ ] **Step 2: Add the section**
+
+Two entry points, per the spec's UX section:
+
+- The collapsed section below the import form (detailed next).
+- A link/button **next to the existing card-safety pill** (~4061–4086) that appears when an import run finishes or is cancelled — the "Do NOT format the card yet" state is exactly when the user needs this tool. Clicking it expands the section and pre-fills the source input with the import's source path (available in the import job's config/result the pill already renders from).
+
+The collapsed "Free up card space" section below the import form contains:
+
+1. A folder input reusing the page's existing source-picker control, plus a Recursive checkbox (default on).
+2. **Scan card** button → `POST /api/card-cleanup/scan` → progress via EventSource on the job stream (phase text + current/total) → on completion `GET /api/card-cleanup/<id>/manifest`.
+3. Preview render from the manifest:
+   - Three rows: `{deletable.count} files / {formatBytes(deletable.bytes)} verified in the archive — safe to delete`, `{kept.count} files / {bytes} not verified — will be kept`, `{ignored.count} files ignored (not photo files Vireo imports)`.
+   - Each row expands (`<details>`) to the file list; kept rows show `entry.reason`.
+   - If `walk_errors` is non-empty: a warning banner — "Some folders could not be read; this preview is incomplete. Files that were not seen will never be deleted." with the error list.
+4. **Delete verified files** button (disabled when deletable count is 0) → confirmation dialog with exactly the spec's copy:
+   - "Deletion is permanent — memory cards have no trash."
+   - "After deletion, the archive holds the only copy of these photos."
+   - "What 'verified' means: each file's archive copy passed a checksum check (at import or integrity audit) and is confirmed unchanged since by size and timestamp; the card copy itself is re-checksummed at the moment of deletion. Archive bytes are not re-downloaded."
+5. On confirm → `POST /api/card-cleanup/delete` → per-file progress → final summary from the job result: deleted count/bytes, skipped list with reasons, failed list with errors, and "cancelled — N remaining" when applicable. Errors from the POST (404 expired → offer "Re-scan"; 409 → "already running") render inline, not as alerts.
+
+Number formatting: reuse the page's existing byte-formatting helper if present (grep for `formatBytes`/`humanSize`); add a small one only if none exists.
+
+- [ ] **Step 3: Verify in the running app**
+
+Follow the memory note "Verifying browse UI live" (HOME override bypasses the single-instance lock). Create a fake card directory with a few files matching an archived workspace, run:
+
+`python vireo/app.py --db <temp-copy> --port 8081`
+
+Walk the full flow: scan → preview shows correct buckets → delete → files gone from card, kept files intact → re-scan shows 0 deletable. Also confirm the overlap 400 renders its message when pointing the picker at an archive folder.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vireo/templates/import.html
+git commit -m "feat: Free up card space UI on the import page"
+```
+
+---
+
+### Task 8: Full test pass and PR
+
+- [ ] **Step 1: Run the required suite from CLAUDE.md**
+
+Run: `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_card_cleanup.py vireo/tests/test_card_cleanup_api.py vireo/tests/test_path_guard.py -q`
+
+Expected: PASS, modulo the 4 known pre-existing failures on this machine (see memory note "Local test-suite baseline" — verify any failure predates this branch before treating it as yours). Full `vireo/tests` takes ~23 minutes; the list above is the required subset.
+
+- [ ] **Step 2: Create the PR**
+
+```bash
+git push -u origin clear-imported-photos-from-card
+gh pr create --base main --title "Free up card space: verified card cleanup (scan → preview → delete)" --body "$(cat <<'EOF'
+## What
+
+Implements docs/superpowers/specs/2026-08-07-card-cleanup-design.md: a
+standalone tool that deletes files from a memory card only when the
+identical bytes are checksum-verified in the archive — per file, enforced
+at the moment of deletion.
+
+- `vireo/path_guard.py`: behavior-preserving extraction of the import
+  endpoint's case-aware containment guard (PR #1107) — endpoint tests
+  unchanged.
+- `vireo/card_cleanup.py`: scan (walk/classify with discovery parity,
+  hash-once catalog matching, archive qualifying test), atomic validated
+  manifests with 7-day expiry, delete with per-unlink card re-hash and
+  fresh archive re-validation.
+- Endpoints: POST /api/card-cleanup/scan (with cross-workspace
+  source/archive overlap fail-fast), GET .../manifest, POST
+  /api/card-cleanup/delete (expiry at request time, one delete per
+  manifest).
+- Import-page UI section with honest preview buckets and the exact
+  confirmation copy from the spec.
+
+## Tests
+
+[paste the pytest summary line from Step 1]
+
+EOF
+)"
+```
+
+- [ ] **Step 3: Hand off for review**
+
+Reference @superpowers:finishing-a-development-branch for the merge flow; the repo's PR agent re-reviews on push.

--- a/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
@@ -1,14 +1,19 @@
 # Free up card space (card cleanup) — design
 
 **Date:** 2026-08-07
-**Status:** Spec-review approved (2026-08-07); amended same day after
-external review (delete-time revalidation, overlap guard, explicit
-metadata-anchored guarantee, manifest lifecycle, own-walk discovery);
-awaiting maintainer sign-off before implementation planning
-**Scope:** New feature: delete files from a local import source (memory card)
-only after verifying, per file and at deletion time, that the identical bytes
-are already in the archive. Two new job types plus an import-page UI section.
-No changes to the import pipeline itself.
+**Status:** Spec-review approved (2026-08-07); amended twice same day
+after external review (first: delete-time revalidation, overlap guard,
+metadata-anchored guarantee, manifest lifecycle, own-walk discovery;
+second: no stat caching across removals, filesystem-aware containment +
+`samefile`, exact-mtime baseline, delete-time expiry, atomic + validated
+manifests); awaiting maintainer sign-off before implementation planning
+**Scope:** New feature: delete files from a local import source (memory
+card) only after verifying, per file and at deletion time, that the card
+file's bytes match a hash that was checksum-verified into the archive and
+that the archive copy is confirmed unchanged since that verification by
+metadata (see "Safety invariant" for the exact guarantee). Two new job
+types plus an import-page UI section. No changes to the import pipeline
+itself.
 
 ## Problem
 
@@ -29,9 +34,10 @@ option: manually guessing which files landed risks deleting the only copy.
 
 ## Goals
 
-1. After any partial (or complete, or historical) import, the user can point
-   Vireo at the card and delete exactly the files whose content is verifiably
-   in the archive — nothing else.
+1. After any partial (or complete, or historical) import, the user can
+   point Vireo at the card and delete exactly the files whose content was
+   checksum-verified into the archive and whose archive copy is confirmed
+   unchanged (by metadata) at deletion time — nothing else.
 2. The preview shown before deletion is computed from ground truth at scan
    time (card bytes + current catalog), never from a stale record of what a
    past run claimed. This is the CORE_PHILOSOPHY transparency rule: the
@@ -85,10 +91,18 @@ before its `os.remove`:
    replacement and card swaps outright.
 2. **Archive side (metadata-anchored):** a fresh catalog query by that
    hash finds at least one row where (a) `hash_status = 'ok'`, (b) the
-   row's resolved archive path is **outside the resolved source tree**
-   (see overlap guard below), and (c) a fresh `stat` of the archive file
-   matches the cataloged `file_size`/`file_mtime` baseline — the same
-   baseline the stored `file_hash` describes.
+   row's archive path is **outside the source tree** under the
+   filesystem-aware containment rules of the overlap guard below, plus an
+   `os.path.samefile` check against the card file where available (same
+   device+inode means the "archive copy" *is* the card file), and (c) a
+   fresh `stat` of the archive file — performed immediately before this
+   specific `os.remove`, never reused from the scan or from an earlier
+   deletion in the same run — matches the cataloged
+   `file_size`/`file_mtime` baseline exactly. Exact equality, not the
+   audit's 1-second window: that tolerance (`audit.py:398`) only
+   classifies an already-detected hash mismatch as modified-vs-corrupt
+   and certifies nothing here, and a false negative from strict equality
+   merely keeps a file (safe, and remedied by a rescan).
 
 What this promises: the deleted bytes were checksum-verified into the
 archive, and the archive copy is metadata-unchanged since the scan that
@@ -112,15 +126,33 @@ guard a selected source could verify *itself*: pick a cataloged archive
 folder (or a card imported in place) and each file's own catalog row would
 mark it deletable — the tool would erase the archive copy. Two levels:
 
-- **Fail fast at scan start:** resolve the source root (`realpath`) and
-  reject the scan with a clear error if it equals, contains, or lies
-  inside any cataloged folder root — across all workspaces, matching the
+- **Containment is filesystem-aware, not string realpath.** `realpath`
+  alone does not close this hole: macOS/Windows default filesystems are
+  case-insensitive but `realpath` doesn't case-normalize, so
+  `/Volumes/card` and `/Volumes/Card` compare unequal while naming the
+  same directory, and FAT/exFAT removable media on Linux are
+  case-insensitive under a case-sensitive parent. The import
+  destination-inside-source guard already solves exactly this
+  (`_casenorm` + `_fs_is_case_insensitive`, `app.py:25641` area, PR
+  #1107): case-fold unconditionally on darwin/win32, probe the actual
+  filesystem on Linux, treat inconclusive probes as case-insensitive
+  (the strict direction). Extract that logic into a shared helper and
+  use it for every containment comparison in this feature. The
+  extraction is a behavior-preserving refactor of the import endpoint's
+  guard — it must not change that guard's decisions, and the existing
+  PR #1107 tests (or equivalent) must still pass against the shared
+  helper.
+- **Fail fast at scan start:** reject the scan with a clear error if the
+  source root equals, contains, or lies inside any cataloged folder root
+  under those containment rules — across all workspaces, matching the
   per-file guard, which is already global because it queries `photos`.
   This tool is for removable media, not the archive.
 - **Per-file invariant (the real guard, at scan and again at delete):** a
-  catalog row qualifies only if its resolved archive path is outside the
-  resolved source tree. Symlinks and mount aliases can defeat the root
-  check; this per-file check is what rule 2(b) above enforces.
+  catalog row qualifies only if its archive path is outside the source
+  tree under the same containment rules, and additionally not
+  `os.path.samefile` with the card file (device+inode identity catches
+  mount aliases that survive both realpath and case-folding). This
+  per-file check is what rule 2(b) above enforces.
 
 ### UX flow
 
@@ -190,10 +222,11 @@ Phases:
    row, so a matched hash is followed by a `photos WHERE file_hash = ?`
    lookup. The file counts as **deletable** only if at least one matching
    row passes the full qualifying test from the safety invariant:
-   `hash_status = 'ok'`, resolved archive path outside the resolved source
-   tree, and a `stat` of the archive file matching the cataloged
-   `file_size`/`file_mtime` baseline (mtime compared with the scanner's
-   existing tolerance). The preview shows the first row that passes. One
+   `hash_status = 'ok'`, archive path outside the source tree (and not
+   `samefile` with the card file) under the overlap guard's containment
+   rules, and a `stat` of the archive file matching the cataloged
+   `file_size`/`file_mtime` baseline exactly. The preview shows the first
+   row that passes. One
    stat round-trip per file over the SMB mount — never a re-read of
    archive bytes. The same test is repeated per file at delete time; here
    it exists so the preview is honest.
@@ -220,12 +253,23 @@ while this feature is global. So the manifest is written as a JSON file to
 `~/.vireo/card_cleanup/<scan_job_id>.json`, and the job *result* carries
 only the bucket totals, the resolved source root, and the manifest path.
 The delete job reads the manifest from disk, which also makes it work
-across an app restart. Lifecycle: each scan start prunes manifest files
-older than 7 days; a delete request whose manifest file is gone gets a 404
-with "manifest expired — re-scan the card" (a re-scan is minutes, and a
-fresh manifest is strictly safer than an old one). The scan is cancellable
-at file boundaries; a cancelled scan writes no manifest and the UI says
-so.
+across an app restart.
+
+The manifest is written atomically (temp file + rename, the pattern the
+codebase already uses for promotions) so a crash mid-scan can never leave
+a truncated manifest that a later delete trusts. On load, the delete job
+validates before acting: schema version recognized, header source root
+present, and every deletable entry's card path contained within that
+source root (under the overlap guard's containment rules) — a manifest
+that fails any check is rejected as corrupt, and nothing is deleted.
+
+Lifecycle: each scan start prunes manifest files older than 7 days, and
+the 7-day limit is *also* enforced when deletion is requested — a delete
+against a manifest older than 7 days is rejected even if no scan ran in
+between to prune it. Either way the user gets "manifest expired — re-scan
+the card" (a re-scan is minutes, and a fresh manifest is strictly safer
+than an old one). The scan is cancellable at file boundaries; a cancelled
+scan writes no manifest and the UI says so.
 
 Duplicate files on the card (two identical copies matching one archive
 photo) are both deletable — the rule is content-based, not one-to-one.
@@ -253,17 +297,21 @@ For each **deletable** manifest entry, immediately before deletion:
 2. **Archive gate (re-validated now, not trusted from the scan)** —
    re-query `photos WHERE file_hash = ?` and require at least one row to
    pass the qualifying test from the safety invariant: `hash_status =
-   'ok'`, resolved path outside the resolved source tree, fresh archive
-   `stat` matching the cataloged size/mtime baseline. If the mount is
-   down, the file was deleted from the archive, or the baseline no longer
-   matches, the card file is **skipped**, not deleted. The scan-time check
-   only made the preview honest; this one is the guarantee.
+   'ok'`, path outside the source tree and not `samefile` with the card
+   file, fresh archive `stat` exactly matching the cataloged size/mtime
+   baseline. If the mount is down, the file was deleted from the archive,
+   or the baseline no longer matches, the card file is **skipped**, not
+   deleted. The scan-time check only made the preview honest; this one is
+   the guarantee.
 3. **Delete** — `os.remove`. Per-file errors (read-only card, vanished
    file) are recorded as **failed** with the OS error; the job continues.
 
-Archive stats are one SMB round-trip per file (results for duplicate card
-files sharing a hash may be cached within the run); archive bytes are
-never re-read — see the safety invariant for the explicit tradeoff.
+Catalog *row* lookups for duplicate card files sharing a hash may be
+cached within the run; the archive **stat may not** — it must be repeated
+immediately before every individual removal, because a cached stat could
+authorize deleting the second duplicate after the archive vanished
+following the first. One SMB stat round-trip per removal; archive bytes
+are never re-read — see the safety invariant for the explicit tradeoff.
 
 Progress is per-file over SSE. Cancellation stops at a file boundary;
 already-deleted files stay deleted and the summary honestly reports
@@ -276,13 +324,17 @@ they exist only for the preview.
 
 - `POST /api/card-cleanup/scan` — body `{source: str, recursive: bool}`.
   Validates that the source path exists and is a directory, and rejects it
-  (400, with copy explaining this tool is for removable media) if its
-  realpath equals, contains, or lies inside any cataloged folder root —
-  the overlap guard's fail-fast half. Returns the job id.
+  (400, with copy explaining this tool is for removable media) if it
+  equals, contains, or lies inside any cataloged folder root under the
+  overlap guard's containment rules — the guard's fail-fast half. Returns
+  the job id.
 - `POST /api/card-cleanup/delete` — body `{scan_job_id}`. Returns the job
   id. 409 if a delete for that manifest is already running; 400 for an
-  unfinished/cancelled scan; 404 for an unknown scan job or an expired
-  (pruned) manifest file, with "re-scan the card" copy.
+  unfinished/cancelled scan or a manifest that fails load-time validation
+  (corrupt, wrong schema, entries outside the source root); 404 for an
+  unknown scan job, a pruned manifest file, or a manifest older than 7
+  days (age is checked at request time, not only at prune time), with
+  "re-scan the card" copy.
 - Progress and results ride the existing job endpoints (stream, status,
   history).
 
@@ -316,18 +368,27 @@ Unit tests with temp directories (no real card or SMB mount):
 - Hash match but archive file missing, or size/mtime off the cataloged
   baseline → kept.
 - Overlap: scan of a source equal to / containing / inside a cataloged
-  folder root → 400. A catalog row whose path is inside the source tree
-  (self-match via symlinked or in-place catalog) never qualifies a file,
-  at scan or delete.
+  folder root → 400, including a case-swapped variant of the root on a
+  case-insensitive filesystem. A catalog row whose path is inside the
+  source tree (self-match via symlinked or in-place catalog) never
+  qualifies a file, at scan or delete; a row that is `samefile` with the
+  card file (mount alias) never qualifies it either.
 - Card gate: file modified between scan and delete → skipped; same-size
   same-mtime content replacement → caught by the delete-time re-hash and
   skipped.
 - Archive gate at delete time: archive file removed or mutated after the
   scan → skipped; archive mount unreachable → all skipped, none deleted.
+- No stat reuse: two identical card files, archive copy removed after the
+  first deletion → the second is skipped (its own fresh stat fails, even
+  with the catalog row cached).
 - Delete after app restart: manifest loads from disk, scan job validated
   via history, deletion proceeds.
-- Manifest expiry: pruned manifest → delete returns 404; scan-start prune
-  removes only files older than 7 days.
+- Manifest expiry: pruned manifest → delete returns 404; a manifest older
+  than 7 days is rejected at delete-request time even when never pruned;
+  scan-start prune removes only files older than 7 days.
+- Manifest validation: truncated/corrupt JSON, unknown schema version, or
+  a deletable entry whose path falls outside the header source root →
+  delete refuses to start, nothing deleted.
 - Cancellation mid-delete → already-deleted files gone, summary counts
   correct.
 - Two identical card files matching one archive photo → both deletable,

--- a/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
@@ -1,9 +1,10 @@
 # Free up card space (card cleanup) — design
 
 **Date:** 2026-08-07
-**Status:** Spec-review approved (2026-08-07); reviewer's advisory
-recommendations incorporated; awaiting maintainer sign-off before
-implementation planning
+**Status:** Spec-review approved (2026-08-07); amended same day after
+external review (delete-time revalidation, overlap guard, explicit
+metadata-anchored guarantee, manifest lifecycle, own-walk discovery);
+awaiting maintainer sign-off before implementation planning
 **Scope:** New feature: delete files from a local import source (memory card)
 only after verifying, per file and at deletion time, that the identical bytes
 are already in the archive. Two new job types plus an import-page UI section.
@@ -72,6 +73,55 @@ than A, which computes the same answer from ground truth at deletion time.
 
 ## Design
 
+### Safety invariant
+
+Everything below serves one rule, enforced **at the destructive moment**,
+not just at preview time. A card file is deleted only if, immediately
+before its `os.remove`:
+
+1. **Card side (full strength):** its bytes, re-hashed from the card by
+   the delete job, equal the manifest hash. The card is local, so this
+   costs one extra local read per file and defeats same-size/same-mtime
+   replacement and card swaps outright.
+2. **Archive side (metadata-anchored):** a fresh catalog query by that
+   hash finds at least one row where (a) `hash_status = 'ok'`, (b) the
+   row's resolved archive path is **outside the resolved source tree**
+   (see overlap guard below), and (c) a fresh `stat` of the archive file
+   matches the cataloged `file_size`/`file_mtime` baseline — the same
+   baseline the stored `file_hash` describes.
+
+What this promises: the deleted bytes were checksum-verified into the
+archive, and the archive copy is metadata-unchanged since the scan that
+recorded the matching hash. What it deliberately does not promise: a
+byte-for-byte re-read of the archive at deletion time. The archive is SMB
+over Tailscale; re-reading tens of GB over a VPN would take longer than
+the import time this feature exists to reclaim, so the guarantee is
+weakened to metadata-unchanged-since-verification — stated as such in the
+spec and reflected in the UI copy.
+
+The stale-verdict hole this could open is closed from both directions:
+if the archive file was edited *and rescanned*, the refreshed `file_hash`
+no longer matches the card hash (no match → kept); if edited and *not*
+rescanned, its current mtime/size no longer match the cataloged baseline
+(stat gate fails → kept). The residual risk is a same-size,
+identical-mtime content swap on the archive — detectable only by
+re-reading bytes, and accepted.
+
+**Overlap guard.** Matching searches the global catalog, so without a
+guard a selected source could verify *itself*: pick a cataloged archive
+folder (or a card imported in place) and each file's own catalog row would
+mark it deletable — the tool would erase the archive copy. Two levels:
+
+- **Fail fast at scan start:** resolve the source root (`realpath`) and
+  reject the scan with a clear error if it equals, contains, or lies
+  inside any cataloged folder root — across all workspaces, matching the
+  per-file guard, which is already global because it queries `photos`.
+  This tool is for removable media, not the archive.
+- **Per-file invariant (the real guard, at scan and again at delete):** a
+  catalog row qualifies only if its resolved archive path is outside the
+  resolved source tree. Symlinks and mount aliases can defeat the root
+  check; this per-file check is what rule 2(b) above enforces.
+
 ### UX flow
 
 A "Free up card space" section on the import page, plus an entry point next
@@ -90,6 +140,10 @@ verified files** button opens a confirmation dialog that states plainly:
 
 - Deletion is permanent — memory cards have no trash.
 - After deletion, the archive holds the only copy of these photos.
+- What "verified" means: each file's archive copy passed a checksum check
+  (at import or integrity audit) and is confirmed unchanged since by size
+  and timestamp; the card copy itself is re-checksummed at the moment of
+  deletion. Archive bytes are not re-downloaded.
 
 Confirming starts the **delete** job with live per-file progress. The final
 summary reports exact counts: deleted, kept, skipped-because-changed, and
@@ -103,12 +157,21 @@ the existing `/api/jobs/<id>/stream`.
 
 Phases:
 
-1. **Discover** — `vireo.ingest.discover_source_files` (`ingest.py:286`)
-   enumerates candidates exactly as an import would, with
-   `file_types="both"` (all photo types, independent of any import-config
-   filter), so the deletable set can never exceed what import considers a
-   photo. Everything else found under the root is bucketed **ignored** and
-   never touched.
+1. **Discover** — the scan performs one walk using the same machinery
+   discovery uses (`safe_scan_walk`/`safe_iter_dir` with the same
+   data-bundle exclusions) and classifies every regular file with
+   discovery's own predicate — `SUPPORTED_EXTENSIONS` (i.e.
+   `file_types="both"`, independent of any import-config filter) and the
+   leading-dot rule. Matching files are candidates; everything else is
+   bucketed **ignored** and never touched. `discover_source_files`
+   (`ingest.py:286`) itself returns only supported photo files, so it
+   cannot produce the ignored list — but a unit test asserts the scan's
+   candidate set equals `discover_source_files` output on the same tree,
+   so the two filters cannot drift. Walk errors (unreadable subtree,
+   permission denied) are collected via `onerror`, surfaced in the result,
+   and mark the preview **incomplete** in the UI — undiscovered files are
+   never deleted (they are simply absent from the manifest), but totals
+   must not present themselves as a full accounting of the card.
 2. **Hash & match** — each candidate is content-hashed on the card and
    matched against the global photo catalog by hash, using the strict
    `verify_by_hash` identity from `vireo/import_dedup.py`
@@ -117,29 +180,52 @@ Phases:
    not sufficient grounds to delete someone's only other copy. The scan
    calls `match()` only — never `record()`/`check_and_record()` — so
    card-only twin files cannot make each other look "known" the way
-   ingest's seen-state accumulation would.
+   ingest's seen-state accumulation would. Each card file is hashed
+   exactly once: the manifest needs the hash for every file (kept bucket
+   included, for the delete-time card gate and honest preview), so the
+   scan hashes first and checks catalog membership with that hash (or
+   reuses the checker's `content_hash` cache) rather than letting
+   `match()` hash internally a second time.
 3. **Archive check** — `match()` returns an opaque hash token, not a photo
    row, so a matched hash is followed by a `photos WHERE file_hash = ?`
    lookup. The file counts as **deletable** only if at least one matching
-   row has `photos.hash_status = 'ok'` and a `stat` of that row's archive
-   file confirms it exists with the expected size; the preview shows the
-   first row that passes. The archive is SMB over Tailscale, so the check
-   is one stat round-trip per file — never a re-read of archive bytes.
+   row passes the full qualifying test from the safety invariant:
+   `hash_status = 'ok'`, resolved archive path outside the resolved source
+   tree, and a `stat` of the archive file matching the cataloged
+   `file_size`/`file_mtime` baseline (mtime compared with the scanner's
+   existing tolerance). The preview shows the first row that passes. One
+   stat round-trip per file over the SMB mount — never a re-read of
+   archive bytes. The same test is repeated per file at delete time; here
+   it exists so the preview is honest.
 
 Every other candidate is **kept**, with a per-file reason: not in catalog,
 not integrity-verified (`hash_status` not `'ok'`), archive file missing or
-wrong size, unreadable on card. Photos cataloged by an archive *scan*
+changed since verification (size/mtime off baseline), only catalog copy is
+inside the selected source tree, unreadable on card. Photos cataloged by an archive *scan*
 rather than a verified import have `file_hash` but NULL `hash_status`, so
 whole scan-cataloged archives land in this bucket — safely conservative,
 but the keep-reason copy must point at the remedy ("not verified by a
 checksummed import — run the integrity audit") so the tool doesn't read as
 broken.
 
-The job result is a manifest persisted with the job (as job results already
-are): per file — card path, size, `mtime_ns`, content hash, bucket, matched
-archive path or keep-reason — plus bucket totals (count and bytes). The scan
-is cancellable at file boundaries; a cancelled scan produces no manifest and
-the UI says so.
+**Manifest storage and lifecycle.** The manifest — a header with the
+resolved source root (so the delete job's overlap guard travels with the
+manifest it validates, even across a restart), then per file: card path,
+size, `mtime_ns`, content hash, bucket, matched archive path or
+keep-reason — can hold tens of thousands of entries, and job results are
+the wrong home for it: `job_history.result` is a TEXT blob fetched by
+list endpoints, completed jobs are evicted from in-memory lookup by
+`_prune_finished_jobs` (`jobs.py:766`), and history is workspace-filtered
+while this feature is global. So the manifest is written as a JSON file to
+`~/.vireo/card_cleanup/<scan_job_id>.json`, and the job *result* carries
+only the bucket totals, the resolved source root, and the manifest path.
+The delete job reads the manifest from disk, which also makes it work
+across an app restart. Lifecycle: each scan start prunes manifest files
+older than 7 days; a delete request whose manifest file is gone gets a 404
+with "manifest expired — re-scan the card" (a re-scan is minutes, and a
+fresh manifest is strictly safer than an old one). The scan is cancellable
+at file boundaries; a cancelled scan writes no manifest and the UI says
+so.
 
 Duplicate files on the card (two identical copies matching one archive
 photo) are both deletable — the rule is content-based, not one-to-one.
@@ -147,19 +233,37 @@ photo) are both deletable — the rule is content-based, not one-to-one.
 ### Delete job
 
 `POST /api/card-cleanup/delete` with `{scan_job_id}` starts
-`card_cleanup_delete`. It loads the scan job's manifest and refuses to start
-if the scan job is missing, unfinished, cancelled, or its manifest is empty.
-Only one delete job per scan manifest may run at a time.
+`card_cleanup_delete`. It loads the manifest file written by the scan and
+refuses to start if the scan job is missing, unfinished, or cancelled, if
+the manifest file is gone (expired), or if its deletable bucket is empty.
+Only one delete job per scan manifest may run at a time. Because the
+manifest lives on disk, delete-after-restart works: the endpoint validates
+the scan job against `job_history` when it is no longer in memory.
 
-For each **deletable** manifest entry:
+For each **deletable** manifest entry, immediately before deletion:
 
-1. **Drift gate** — re-`stat` the card file. If size or `mtime_ns` differs
-   from the manifest (camera rewrote it, file replaced), the file is
-   **skipped** and reported; it is not deleted. This makes the
-   scan-to-delete gap safe without freezing the card: new files simply are
-   not in the manifest, changed files fail the gate.
-2. **Delete** — `os.remove`. Per-file errors (read-only card, vanished
+1. **Card gate (stat, then re-hash)** — re-`stat` the card file; if size
+   or `mtime_ns` differs from the manifest, **skip** (cheap pre-check).
+   Then re-hash the card file and require the hash to equal the manifest
+   hash — size+mtime alone cannot detect a swapped card or a same-size
+   replacement, especially with FAT/exFAT timestamp granularity. The card
+   is local, so this second read is fast. Any mismatch → **skipped**, with
+   reason. New files are simply absent from the manifest, so the user can
+   keep shooting between scan and delete.
+2. **Archive gate (re-validated now, not trusted from the scan)** —
+   re-query `photos WHERE file_hash = ?` and require at least one row to
+   pass the qualifying test from the safety invariant: `hash_status =
+   'ok'`, resolved path outside the resolved source tree, fresh archive
+   `stat` matching the cataloged size/mtime baseline. If the mount is
+   down, the file was deleted from the archive, or the baseline no longer
+   matches, the card file is **skipped**, not deleted. The scan-time check
+   only made the preview honest; this one is the guarantee.
+3. **Delete** — `os.remove`. Per-file errors (read-only card, vanished
    file) are recorded as **failed** with the OS error; the job continues.
+
+Archive stats are one SMB round-trip per file (results for duplicate card
+files sharing a hash may be cached within the run); archive bytes are
+never re-read — see the safety invariant for the explicit tradeoff.
 
 Progress is per-file over SSE. Cancellation stops at a file boundary;
 already-deleted files stay deleted and the summary honestly reports
@@ -171,10 +275,14 @@ they exist only for the preview.
 ### Endpoints
 
 - `POST /api/card-cleanup/scan` — body `{source: str, recursive: bool}`.
-  Validates the source path exists and is a directory. Returns the job id.
+  Validates that the source path exists and is a directory, and rejects it
+  (400, with copy explaining this tool is for removable media) if its
+  realpath equals, contains, or lies inside any cataloged folder root —
+  the overlap guard's fail-fast half. Returns the job id.
 - `POST /api/card-cleanup/delete` — body `{scan_job_id}`. Returns the job
-  id. 409 if a delete for that manifest is already running; 400/404 for
-  missing or unusable scan jobs.
+  id. 409 if a delete for that manifest is already running; 400 for an
+  unfinished/cancelled scan; 404 for an unknown scan job or an expired
+  (pruned) manifest file, with "re-scan the card" copy.
 - Progress and results ride the existing job endpoints (stream, status,
   history).
 
@@ -189,18 +297,37 @@ workspace-scoped), matching how the catalog works.
   unverifiable so the user knows the mount was the problem.
 - Card unmounted mid-delete → per-file failures accumulate; the job
   finishes with an honest failure count rather than aborting silently.
+- Archive mount down at delete time → every archive gate fails, every file
+  is skipped with "archive not reachable", nothing is deleted; the summary
+  makes the cause obvious rather than reporting a sea of per-file skips.
 - Scan manifest older than the card's current state is handled entirely by
-  the per-file drift gate; there is no root-level signature check, because
-  the whole point is that the user keeps shooting on the card.
+  the per-file card gate (stat + re-hash); there is no root-level
+  signature check, because the whole point is that the user keeps shooting
+  on the card.
 
 ## Testing
 
 Unit tests with temp directories (no real card or SMB mount):
 
 - Bucket assignment: verified / not-in-catalog / ignored non-photo files.
+- Scan candidate set equals `discover_source_files` output on the same
+  tree (filter-parity test, so the two predicates cannot drift).
 - Hash match but `hash_status` ≠ `'ok'` → kept.
-- Hash match but archive file missing or wrong size → kept.
-- Drift gate: file modified between scan and delete → skipped, not deleted.
+- Hash match but archive file missing, or size/mtime off the cataloged
+  baseline → kept.
+- Overlap: scan of a source equal to / containing / inside a cataloged
+  folder root → 400. A catalog row whose path is inside the source tree
+  (self-match via symlinked or in-place catalog) never qualifies a file,
+  at scan or delete.
+- Card gate: file modified between scan and delete → skipped; same-size
+  same-mtime content replacement → caught by the delete-time re-hash and
+  skipped.
+- Archive gate at delete time: archive file removed or mutated after the
+  scan → skipped; archive mount unreachable → all skipped, none deleted.
+- Delete after app restart: manifest loads from disk, scan job validated
+  via history, deletion proceeds.
+- Manifest expiry: pruned manifest → delete returns 404; scan-start prune
+  removes only files older than 7 days.
 - Cancellation mid-delete → already-deleted files gone, summary counts
   correct.
 - Two identical card files matching one archive photo → both deletable,

--- a/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
@@ -1,0 +1,210 @@
+# Free up card space (card cleanup) — design
+
+**Date:** 2026-08-07
+**Status:** Spec-review approved (2026-08-07); reviewer's advisory
+recommendations incorporated; awaiting maintainer sign-off before
+implementation planning
+**Scope:** New feature: delete files from a local import source (memory card)
+only after verifying, per file and at deletion time, that the identical bytes
+are already in the archive. Two new job types plus an import-page UI section.
+No changes to the import pipeline itself.
+
+## Problem
+
+A long import (e.g. 40 hours of travel photos over a slow link) can be
+stopped partway — the import is batch-committed and crash-safe, and a re-run
+skips everything already cataloged — but the user gets no help clearing the
+card afterward:
+
+- The import does not persist per-file source paths; the card-path →
+  archive-file mapping exists only in memory during the run.
+- Files are imported in destination-folder (chronological) order, not card
+  order, so no card region corresponds to "the imported part."
+- The only safety signal is the all-or-nothing `safe_to_format` pill, which
+  correctly says "Do NOT format the card yet" after a partial run.
+
+So a traveler who imported half a card and needs the space back has no safe
+option: manually guessing which files landed risks deleting the only copy.
+
+## Goals
+
+1. After any partial (or complete, or historical) import, the user can point
+   Vireo at the card and delete exactly the files whose content is verifiably
+   in the archive — nothing else.
+2. The preview shown before deletion is computed from ground truth at scan
+   time (card bytes + current catalog), never from a stale record of what a
+   past run claimed. This is the CORE_PHILOSOPHY transparency rule: the
+   numbers must mean what the user reads them as.
+3. The card stays usable throughout: the user can keep shooting between scan
+   and delete; new or changed files are never touched.
+
+## Non-goals (v1 scope cuts)
+
+- **Local sources only.** Memory cards are local mounts; deleting files on a
+  remote/SSH source is out.
+- **No delete-as-you-go during import.** This tool's verify-then-delete core
+  is the building block if that is ever wanted; it is not part of v1.
+- **No persistence of per-file import provenance.** The scan recomputes
+  everything from the card and catalog, so no schema changes are needed.
+- **No empty-directory cleanup** on the card — files only. Cameras recreate
+  their DCIM structure as needed.
+- **No card formatting.** Vireo deletes individual verified files; formatting
+  remains a user action on their own machine.
+
+## Approaches considered
+
+**A. Standalone scan-verify-delete tool (chosen).** Re-scan the card, match
+each file against the catalog by content hash, preview, then delete only the
+verified set. Works regardless of when/how the files were imported (this
+run, last week, another machine), needs no schema changes, and reuses the
+matching machinery `ingest()` already has. Cost: a re-hash pass over the
+card — local reads, minutes not hours.
+
+**B. Delete-as-you-go during import.** Frees space *during* the import, but
+partially erases the card mid-run, is unavailable for the run the user is
+already in, and the remote path is not always hash-verified. Rejected for
+v1; A is its prerequisite anyway.
+
+**C. Run-scoped cleanup** (persist per-file source paths during import,
+offer "delete what this run imported"). Needs schema changes, goes stale if
+the card is touched between runs, and covers only one run. Strictly worse
+than A, which computes the same answer from ground truth at deletion time.
+
+## Design
+
+### UX flow
+
+A "Free up card space" section on the import page, plus an entry point next
+to the existing card-safety pill after an import finishes or is cancelled
+(the "Do NOT format the card yet" state is exactly when the user needs this
+tool). The user picks the card folder with the existing source picker and
+starts a **scan**. When the scan job finishes, the page shows a preview:
+
+> **1,842 files / 61 GB** verified in the archive — safe to delete
+> **2,105 files / 70 GB** not in the archive — will be kept
+> **214 files** ignored (not photo files Vireo imports)
+
+Each bucket expands to its file list (path, size, and for the verified
+bucket the matched archive path; for kept files, the reason). A **Delete
+verified files** button opens a confirmation dialog that states plainly:
+
+- Deletion is permanent — memory cards have no trash.
+- After deletion, the archive holds the only copy of these photos.
+
+Confirming starts the **delete** job with live per-file progress. The final
+summary reports exact counts: deleted, kept, skipped-because-changed, and
+failed, each with reasons.
+
+### Scan job
+
+A new `JobRunner` job type (working name `card_cleanup_scan`), started via
+`POST /api/card-cleanup/scan` with `{source, recursive}`. SSE progress via
+the existing `/api/jobs/<id>/stream`.
+
+Phases:
+
+1. **Discover** — `vireo.ingest.discover_source_files` (`ingest.py:286`)
+   enumerates candidates exactly as an import would, with
+   `file_types="both"` (all photo types, independent of any import-config
+   filter), so the deletable set can never exceed what import considers a
+   photo. Everything else found under the root is bucketed **ignored** and
+   never touched.
+2. **Hash & match** — each candidate is content-hashed on the card and
+   matched against the global photo catalog by hash, using the strict
+   `verify_by_hash` identity from `vireo/import_dedup.py`
+   (`DuplicateChecker(CatalogIndex.from_db(db), verify_by_hash=True)`) —
+   not the metadata (filename/size/EXIF-time) shortcut. A metadata match is
+   not sufficient grounds to delete someone's only other copy. The scan
+   calls `match()` only — never `record()`/`check_and_record()` — so
+   card-only twin files cannot make each other look "known" the way
+   ingest's seen-state accumulation would.
+3. **Archive check** — `match()` returns an opaque hash token, not a photo
+   row, so a matched hash is followed by a `photos WHERE file_hash = ?`
+   lookup. The file counts as **deletable** only if at least one matching
+   row has `photos.hash_status = 'ok'` and a `stat` of that row's archive
+   file confirms it exists with the expected size; the preview shows the
+   first row that passes. The archive is SMB over Tailscale, so the check
+   is one stat round-trip per file — never a re-read of archive bytes.
+
+Every other candidate is **kept**, with a per-file reason: not in catalog,
+not integrity-verified (`hash_status` not `'ok'`), archive file missing or
+wrong size, unreadable on card. Photos cataloged by an archive *scan*
+rather than a verified import have `file_hash` but NULL `hash_status`, so
+whole scan-cataloged archives land in this bucket — safely conservative,
+but the keep-reason copy must point at the remedy ("not verified by a
+checksummed import — run the integrity audit") so the tool doesn't read as
+broken.
+
+The job result is a manifest persisted with the job (as job results already
+are): per file — card path, size, `mtime_ns`, content hash, bucket, matched
+archive path or keep-reason — plus bucket totals (count and bytes). The scan
+is cancellable at file boundaries; a cancelled scan produces no manifest and
+the UI says so.
+
+Duplicate files on the card (two identical copies matching one archive
+photo) are both deletable — the rule is content-based, not one-to-one.
+
+### Delete job
+
+`POST /api/card-cleanup/delete` with `{scan_job_id}` starts
+`card_cleanup_delete`. It loads the scan job's manifest and refuses to start
+if the scan job is missing, unfinished, cancelled, or its manifest is empty.
+Only one delete job per scan manifest may run at a time.
+
+For each **deletable** manifest entry:
+
+1. **Drift gate** — re-`stat` the card file. If size or `mtime_ns` differs
+   from the manifest (camera rewrote it, file replaced), the file is
+   **skipped** and reported; it is not deleted. This makes the
+   scan-to-delete gap safe without freezing the card: new files simply are
+   not in the manifest, changed files fail the gate.
+2. **Delete** — `os.remove`. Per-file errors (read-only card, vanished
+   file) are recorded as **failed** with the OS error; the job continues.
+
+Progress is per-file over SSE. Cancellation stops at a file boundary;
+already-deleted files stay deleted and the summary honestly reports
+deleted vs. remaining. Directories are left in place.
+
+The delete job never re-reads the manifest's *kept* or *ignored* buckets —
+they exist only for the preview.
+
+### Endpoints
+
+- `POST /api/card-cleanup/scan` — body `{source: str, recursive: bool}`.
+  Validates the source path exists and is a directory. Returns the job id.
+- `POST /api/card-cleanup/delete` — body `{scan_job_id}`. Returns the job
+  id. 409 if a delete for that manifest is already running; 400/404 for
+  missing or unusable scan jobs.
+- Progress and results ride the existing job endpoints (stream, status,
+  history).
+
+Both jobs are global (photos and their hashes are global, not
+workspace-scoped), matching how the catalog works.
+
+### Error handling
+
+- Unreadable card file at scan time → kept, reason "could not read".
+- Archive stat failure (mount down, permission) → kept, reason "archive
+  file not reachable"; the scan completes and says how many files were
+  unverifiable so the user knows the mount was the problem.
+- Card unmounted mid-delete → per-file failures accumulate; the job
+  finishes with an honest failure count rather than aborting silently.
+- Scan manifest older than the card's current state is handled entirely by
+  the per-file drift gate; there is no root-level signature check, because
+  the whole point is that the user keeps shooting on the card.
+
+## Testing
+
+Unit tests with temp directories (no real card or SMB mount):
+
+- Bucket assignment: verified / not-in-catalog / ignored non-photo files.
+- Hash match but `hash_status` ≠ `'ok'` → kept.
+- Hash match but archive file missing or wrong size → kept.
+- Drift gate: file modified between scan and delete → skipped, not deleted.
+- Cancellation mid-delete → already-deleted files gone, summary counts
+  correct.
+- Two identical card files matching one archive photo → both deletable,
+  both deleted.
+- Delete refuses to start on a cancelled or missing scan job.
+- Per-file delete failure (permission) → recorded as failed, job continues.
+- Endpoint validation: nonexistent source dir, concurrent delete → 409.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -31,6 +31,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import quote, urlsplit
 
+import path_guard
 import places
 from db import (
     _LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE,
@@ -25644,78 +25645,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # format once ``copied + skipped_duplicate == discovered``; if the
         # destination lives inside the card, formatting the card also erases
         # the supposed archive copy, so allowing this is a data-loss trap.
-        #
-        # macOS's default APFS/HFS+ volumes and Windows NTFS are
-        # case-INSENSITIVE, so ``/Volumes/Card`` and ``/volumes/card`` are
-        # the same directory but ``realpath`` doesn't case-normalize on
-        # POSIX (macOS reports as POSIX). On Linux, a platform-wide
-        # case-sensitivity assumption misses FAT/exFAT/NTFS-mounted
-        # removable media (typical SD-card setup) that sit under a
-        # case-sensitive ext4 parent — the user's real card mount point
-        # can be case-insensitive even when the root filesystem isn't.
-        # Compare case-folded on darwin/win32 unconditionally, and on
-        # Linux probe each source's actual filesystem: if the resolved
-        # path with an alpha character case-swapped still stat's to the
-        # same inode, the mount is case-insensitive and both sides of
-        # the containment comparison need case-folding for that source.
-        _case_insensitive_platform = sys.platform in ("darwin", "win32")
-
-        def _casenorm(p):
-            return p.casefold() if _case_insensitive_platform else p
-
-        def _fs_is_case_insensitive(path):
-            """Probe whether the filesystem at ``path`` treats case as insensitive.
-
-            List an entry inside ``path`` and check whether accessing it
-            under a case-swapped name resolves to the same inode. Probing
-            *inside* the directory (rather than swapping characters in
-            ``path`` itself) is essential when a case-insensitive mount
-            sits under a case-sensitive parent — a FAT/exFAT SD card
-            mounted at ``/mnt/Card`` on Linux under an ext4 root: the
-            ext4 ``/mnt`` cannot resolve ``/Mnt`` or a differently-cased
-            ``Card`` entry (mount-point dentries are stored in the
-            parent FS), so swapping characters in the ``path`` string
-            always reports case-sensitive regardless of the card's own
-            semantics.
-
-            Any inconclusive result (unlistable, empty, no
-            alpha-containing entry, or a stat error while comparing)
-            returns True so the containment check falls back to
-            case-fold — the stricter direction of this safety guard.
-            A false positive on a case-sensitive filesystem can only
-            reject a legitimate destination (recoverable UX error the
-            user immediately sees and fixes by picking a different
-            path), whereas a false negative on a case-insensitive
-            filesystem accepts a case-collision destination inside the
-            card and lets ``safe_to_format`` later green-light
-            formatting while the archive lives on it. The reviewer's
-            example: an SD card whose root contains only numeric
-            top-level directories (Nikon-style ``100``/``101``/``102``)
-            has no alpha-containing entry to probe with. See PR #1107
-            review.
-            """
-            try:
-                entries = os.listdir(path)
-            except OSError:
-                return True
-            for name in entries:
-                for i, c in enumerate(name):
-                    if c.isalpha():
-                        swapped = name[:i] + c.swapcase() + name[i + 1:]
-                        if swapped == name:
-                            continue
-                        original_full = os.path.join(path, name)
-                        probe_full = os.path.join(path, swapped)
-                        if not os.path.exists(probe_full):
-                            # Definitive: case-swap resolves to nothing,
-                            # so the filesystem distinguishes case.
-                            return False
-                        try:
-                            return os.path.samefile(original_full, probe_full)
-                        except OSError:
-                            return True
-            return True
-
+        # Case-fold handling (darwin/win32 unconditional, Linux per-mount
+        # probe) lives in path_guard — see its module docstring and the
+        # fs_is_case_insensitive() docstring for the full rationale
+        # (PR #1107 review).
         try:
             dest_real = os.path.realpath(destination)
         except OSError as e:
@@ -25727,21 +25660,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # Source unresolvable — the os.path.isdir check above
                 # already handled non-existent sources; nothing more to say.
                 continue
-            # Per-source case-fold decision: platform is enough on
-            # darwin/win32; on Linux, probe the actual source mount.
-            per_source_ci = _case_insensitive_platform or (
-                not _case_insensitive_platform
-                and _fs_is_case_insensitive(source_real)
-            )
-            if per_source_ci:
-                source_cmp = source_real.casefold().rstrip(os.sep)
-                dest_cmp = dest_real.casefold()
-            else:
-                source_cmp = source_real.rstrip(os.sep)
-                dest_cmp = dest_real
-            if dest_cmp == source_cmp or dest_cmp.startswith(
-                source_cmp + os.sep
-            ):
+            if path_guard.contains_resolved(source_real, dest_real):
                 return json_error(
                     f"destination cannot be inside a source directory "
                     f"(destination={destination!r}, source={s!r}); "

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -31,6 +31,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import quote, urlsplit
 
+import card_cleanup
 import path_guard
 import places
 from db import (
@@ -3065,6 +3066,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     )
     app.config["REQUIRE_EXIFTOOL_FOR_IMPORT"] = (
         os.environ.get("VIREO_REQUIRE_EXIFTOOL_FOR_IMPORT", "1") != "0"
+    )
+    app.config["CARD_CLEANUP_DIR"] = os.path.join(
+        os.path.dirname(os.path.abspath(db_path)), "card_cleanup"
     )
 
     # Schema creation and migrations are startup work, never request work.
@@ -19034,6 +19038,170 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
 
         job_id = runner.start("verify-hashes", work, workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+
+    @app.route("/api/card-cleanup/scan", methods=["POST"])
+    def api_card_cleanup_scan():
+        """Scan a removable-media source and write a manifest of files
+        that are safely deletable (verified elsewhere in the archive).
+
+        Background job: the manifest is written to disk by
+        card_cleanup.scan_card and read back by the manifest/delete
+        endpoints below, keyed by this job's id.
+        """
+        body = request.get_json(silent=True) or {}
+        source = body.get("source")
+        recursive = bool(body.get("recursive", True))
+        if not source or not isinstance(source, str):
+            return json_error("source required")
+        if not os.path.isabs(source):
+            return json_error("source must be an absolute path")
+        if not os.path.isdir(source):
+            return json_error("source is not an accessible directory")
+        db = _get_db()
+        # Overlap fail-fast, across all workspaces (folders is global):
+        # this tool is for removable media, not the archive. The per-file
+        # guard in card_cleanup.qualify_rows is the real invariant; this
+        # is the clear early error.
+        source_real = os.path.realpath(source)
+        for row in db.conn.execute("SELECT path FROM folders").fetchall():
+            froot = row["path"]
+            if not froot:
+                continue
+            froot_real = os.path.realpath(froot)
+            if (path_guard.contains_resolved(source_real, froot_real)
+                    or path_guard.contains_resolved(froot_real, source_real)):
+                return json_error(
+                    "the selected source overlaps the cataloged archive "
+                    f"folder {froot!r}; this tool is for removable media "
+                    "like memory cards, not archive folders")
+        card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
+        card_cleanup.prune_manifests(card_cleanup_dir)
+
+        runner = app._job_runner
+        active_ws = db._active_workspace_id
+
+        def work(job):
+            thread_db = Database(db_path)
+            try:
+                if active_ws is not None:
+                    thread_db.set_active_workspace(active_ws)
+
+                def progress_cb(current, total, filename):
+                    # Throttle SSE events; hashing is per-file fast on
+                    # small files and the stream doesn't need every one.
+                    if current % 10 != 0 and current not in (1, total):
+                        return
+                    runner.push_event(job["id"], "progress", {
+                        "current": current, "total": total,
+                        "current_file": filename,
+                        "phase": "Verifying card files against the archive",
+                    })
+
+                return card_cleanup.scan_card(
+                    thread_db, source, recursive, card_cleanup_dir,
+                    job["id"],
+                    progress_cb=progress_cb,
+                    should_cancel=lambda: runner.is_cancelled(job["id"]),
+                )
+            finally:
+                thread_db.close()
+
+        job_id = runner.start(
+            "card-cleanup-scan", work,
+            config={"source": source, "recursive": recursive},
+            workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+
+    @app.route("/api/card-cleanup/<scan_job_id>/manifest")
+    def api_card_cleanup_manifest(scan_job_id):
+        """Read back the manifest a completed (or still-running) scan
+        job wrote, so the UI can preview what a delete would remove."""
+        card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
+        try:
+            manifest = card_cleanup.load_manifest(
+                card_cleanup_dir, scan_job_id)
+        except card_cleanup.ManifestError as e:
+            return json_error(str(e), status=e.http_status)
+        return jsonify(manifest)
+
+    @app.route("/api/card-cleanup/delete", methods=["POST"])
+    def api_card_cleanup_delete():
+        """Delete the deletable bucket of a scan's manifest.
+
+        Background job: re-verifies every file against the card and the
+        archive immediately before each unlink (see card_cleanup.delete_
+        verified). Validates the referencing scan job via the live runner
+        first, falling back to job_history so a delete can still be
+        requested for a scan whose job fell out of the runner's in-memory
+        table (e.g. after a process restart) as long as its manifest is
+        still on disk.
+        """
+        body = request.get_json(silent=True) or {}
+        scan_job_id = body.get("scan_job_id")
+        if not scan_job_id or not isinstance(scan_job_id, str):
+            return json_error("scan_job_id required")
+        db = _get_db()
+        runner = app._job_runner
+        active_ws = db._active_workspace_id
+
+        scan_job = runner.get(scan_job_id)
+        if scan_job is None:
+            row = db.conn.execute(
+                "SELECT type, status FROM job_history WHERE id = ?",
+                (scan_job_id,)).fetchone()
+            scan_job = dict(row) if row is not None else None
+        if scan_job is None or scan_job.get("type") != "card-cleanup-scan":
+            return json_error("unknown scan job", status=404)
+        if scan_job.get("status") != "completed":
+            return json_error("scan did not complete — re-scan the card")
+        # One delete per manifest. (A TOCTOU race between two simultaneous
+        # POSTs is acceptable: the per-file gates make a double-delete
+        # skip, not double-fire.)
+        for j in runner.list_jobs():
+            if (j.get("type") == "card-cleanup-delete"
+                    and j.get("status") in ("queued", "running")
+                    and (j.get("config") or {}).get("scan_job_id")
+                    == scan_job_id):
+                return json_error(
+                    "a delete for this scan is already running", status=409)
+        card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
+        try:
+            manifest = card_cleanup.load_manifest(
+                card_cleanup_dir, scan_job_id)
+        except card_cleanup.ManifestError as e:
+            return json_error(str(e), status=e.http_status)
+        if not any(e.get("bucket") == "deletable"
+                   for e in manifest["entries"]):
+            return json_error("nothing to delete — no verified files")
+
+        def work(job):
+            thread_db = Database(db_path)
+            try:
+                if active_ws is not None:
+                    thread_db.set_active_workspace(active_ws)
+
+                def progress_cb(current, total, filename):
+                    # Not throttled — deletions are the events the user
+                    # watches, unlike the scan's per-file hashing.
+                    runner.push_event(job["id"], "progress", {
+                        "current": current, "total": total,
+                        "current_file": filename,
+                        "phase": "Deleting verified files from the card",
+                    })
+
+                return card_cleanup.delete_verified(
+                    thread_db, manifest,
+                    progress_cb=progress_cb,
+                    should_cancel=lambda: runner.is_cancelled(job["id"]),
+                )
+            finally:
+                thread_db.close()
+
+        job_id = runner.start(
+            "card-cleanup-delete", work,
+            config={"scan_job_id": scan_job_id},
+            workspace_id=active_ws)
         return jsonify({"job_id": job_id})
 
     @app.route("/api/audit/resolve", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19051,7 +19051,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """
         body = request.get_json(silent=True) or {}
         source = body.get("source")
-        recursive = bool(body.get("recursive", True))
+        recursive = body.get("recursive", True)
+        if not isinstance(recursive, bool):
+            # bool("false") is True — a stringly-typed client would get
+            # the opposite of what it asked for. JSON booleans only.
+            return json_error("recursive must be a boolean")
         if not source or not isinstance(source, str):
             return json_error("source required")
         if not os.path.isabs(source):
@@ -19183,9 +19187,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("scan still running — wait for it to finish")
         if scan_job.get("status") != "completed":
             return json_error("scan did not complete — re-scan the card")
-        # One delete per manifest. (A TOCTOU race between two simultaneous
-        # POSTs is acceptable: the per-file gates make a double-delete
-        # skip, not double-fire.)
+        # One delete AT A TIME per manifest — this guards concurrency,
+        # not repetition: after a delete finishes, the manifest still
+        # loads and a second delete may start (its per-file gates skip
+        # everything already gone). (A TOCTOU race between two
+        # simultaneous POSTs is likewise acceptable: the gates make a
+        # double-delete skip, not double-fire.)
         for j in runner.list_jobs():
             if (j.get("type") == "card-cleanup-delete"
                     and j.get("status") in ("queued", "running")
@@ -19218,11 +19225,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "phase": "Deleting verified files from the card",
                     })
 
-                return card_cleanup.delete_verified(
+                summary = card_cleanup.delete_verified(
                     thread_db, manifest,
                     progress_cb=progress_cb,
                     should_cancel=lambda: runner.is_cancelled(job["id"]),
                 )
+                # Bound the persisted result: skipped/failed can run to
+                # thousands of per-file entries on a wholesale-drifted
+                # card, and this dict lands in job_history.result and
+                # every /api/jobs/<id> poll. Totals stay exact; the
+                # lists carry a generous sample and the UI says when it
+                # is showing a sample.
+                for key in ("skipped", "failed"):
+                    summary[f"{key}_total"] = len(summary[key])
+                    summary[key] = summary[key][:500]
+                return summary
             finally:
                 thread_db.close()
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19106,12 +19106,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "phase": "Verifying card files against the archive",
                     })
 
-                return card_cleanup.scan_card(
+                manifest = card_cleanup.scan_card(
                     thread_db, source, recursive, card_cleanup_dir,
                     job["id"],
                     progress_cb=progress_cb,
                     should_cancel=lambda: runner.is_cancelled(job["id"]),
                 )
+                if manifest.get("cancelled"):
+                    return {"cancelled": True}
+                # Trimmed on purpose: entries can be a multi-MB blob (one
+                # per card file) and nothing consumes the job result for
+                # them — the UI fetches the manifest endpoint instead.
+                # json-dumping the full manifest into job_history.result,
+                # the SSE complete event, and every /api/jobs/<id> poll
+                # would ship that blob for no reader.
+                return {
+                    "cancelled": False,
+                    "totals": manifest["totals"],
+                    "source_root": manifest["source_root"],
+                    "manifest_path": card_cleanup.manifest_path(
+                        card_cleanup_dir, job["id"]),
+                    "walk_errors": len(manifest["walk_errors"]),
+                }
             finally:
                 thread_db.close()
 
@@ -19123,8 +19139,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/card-cleanup/<scan_job_id>/manifest")
     def api_card_cleanup_manifest(scan_job_id):
-        """Read back the manifest a completed (or still-running) scan
-        job wrote, so the UI can preview what a delete would remove."""
+        """Read back the manifest a completed scan job wrote, so the UI
+        can preview what a delete would remove."""
         card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
         try:
             manifest = card_cleanup.load_manifest(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3186,6 +3186,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     body = {}
                 else:
                     body = request.get_json(silent=True) or {}
+                    if not isinstance(body, dict):
+                        # Valid non-object JSON (5, "x", [..]) — the
+                        # .get() calls below would 500 the response of
+                        # any endpoint after it already ran.
+                        body = {}
                 if "/rating" in path:
                     detail = f" rating={body.get('rating')}"
                 elif "/flag" in path:
@@ -19050,6 +19055,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         endpoints below, keyed by this job's id.
         """
         body = request.get_json(silent=True) or {}
+        if not isinstance(body, dict):
+            # get_json happily returns 5 or "x" for valid non-object
+            # JSON; body.get would then 500.
+            return json_error("request body must be a JSON object")
         source = body.get("source")
         recursive = body.get("recursive", True)
         if not isinstance(recursive, bool):
@@ -19166,6 +19175,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         still on disk.
         """
         body = request.get_json(silent=True) or {}
+        if not isinstance(body, dict):
+            return json_error("request body must be a JSON object")
         scan_job_id = body.get("scan_job_id")
         if not scan_job_id or not isinstance(scan_job_id, str):
             return json_error("scan_job_id required")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19063,6 +19063,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # this tool is for removable media, not the archive. The per-file
         # guard in card_cleanup.qualify_rows is the real invariant; this
         # is the clear early error.
+        #
+        # Cost: O(folders) realpath calls at request time, plus (on Linux,
+        # where contains_resolved probes case sensitivity) a listdir of
+        # each root. Acceptable at the thousands-of-rows scale of a local
+        # folders table with local paths. Revisit — cache the resolved
+        # roots, or narrow the candidate set by prefix first — if folder
+        # counts grow much larger or roots live on network mounts where
+        # each realpath/listdir is a round trip.
         source_real = os.path.realpath(source)
         for row in db.conn.execute("SELECT path FROM folders").fetchall():
             froot = row["path"]
@@ -19153,6 +19161,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             scan_job = dict(row) if row is not None else None
         if scan_job is None or scan_job.get("type") != "card-cleanup-scan":
             return json_error("unknown scan job", status=404)
+        if scan_job.get("status") in ("queued", "running"):
+            # Mid-flight, not a dead end: telling the user to re-scan here
+            # would throw away a scan that is about to succeed.
+            return json_error("scan still running — wait for it to finish")
         if scan_job.get("status") != "completed":
             return json_error("scan did not complete — re-scan the card")
         # One delete per manifest. (A TOCTOU race between two simultaneous

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -1,0 +1,127 @@
+"""Free up card space: verified scan → preview → delete for import sources.
+
+Spec: docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+
+The safety invariant, enforced immediately before every unlink:
+(1) the card file's re-hashed bytes equal the manifest hash, and
+(2) a fresh catalog query finds a row with hash_status='ok' whose
+    archive file is outside the source tree, is not the card file
+    itself (device+inode), and stats exactly at the cataloged
+    file_size/file_mtime baseline. Archive bytes are never re-read —
+    the archive lives on a VPN'd SMB mount, and a re-read of the whole
+    deletable set would cost more than the import this tool reclaims.
+"""
+import contextlib
+import errno
+import json
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import path_guard
+from image_loader import (
+    SUPPORTED_EXTENSIONS,
+    is_excluded_scan_path,
+    safe_iter_dir,
+    safe_scan_walk,
+)
+from scanner import compute_file_hash
+
+MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_MAX_AGE_DAYS = 7
+
+
+class ManifestError(Exception):
+    """Manifest missing, expired, or failing validation.
+
+    http_status lets the endpoint distinguish gone/expired (404,
+    "re-scan the card") from corrupt/invalid (400) without string
+    matching.
+    """
+
+    def __init__(self, message, http_status=400):
+        super().__init__(message)
+        self.http_status = http_status
+
+
+def manifest_path(manifest_dir, scan_job_id):
+    # Job ids are runner-generated, but basename() keeps a hostile id
+    # from escaping the manifest directory.
+    return os.path.join(
+        manifest_dir, f"{os.path.basename(str(scan_job_id))}.json"
+    )
+
+
+def write_manifest(manifest_dir, manifest):
+    """Atomic write (sibling temp + os.replace): a crash mid-scan can
+    never leave a truncated manifest that a later delete trusts."""
+    os.makedirs(manifest_dir, exist_ok=True)
+    path = manifest_path(manifest_dir, manifest["scan_job_id"])
+    fd, tmp = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.", suffix=".tmp",
+        dir=manifest_dir,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+    return path
+
+
+def prune_manifests(manifest_dir, max_age_days=MANIFEST_MAX_AGE_DAYS):
+    if not os.path.isdir(manifest_dir):
+        return
+    cutoff = time.time() - max_age_days * 86400
+    for name in os.listdir(manifest_dir):
+        if not name.endswith(".json"):
+            continue
+        full = os.path.join(manifest_dir, name)
+        with contextlib.suppress(OSError):
+            if os.path.getmtime(full) < cutoff:
+                os.unlink(full)
+
+
+def load_manifest(manifest_dir, scan_job_id,
+                  max_age_days=MANIFEST_MAX_AGE_DAYS):
+    """Load + validate. Everything here must pass before any delete."""
+    path = manifest_path(manifest_dir, scan_job_id)
+    if not os.path.exists(path):
+        raise ManifestError(
+            "manifest expired — re-scan the card", http_status=404)
+    try:
+        with open(path, encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, ValueError) as e:
+        raise ManifestError(f"manifest unreadable or corrupt: {e}") from e
+    if (not isinstance(manifest, dict)
+            or manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION):
+        raise ManifestError("manifest schema not recognized — re-scan the card")
+    source_root = manifest.get("source_root")
+    if not source_root or not os.path.isabs(str(source_root)):
+        raise ManifestError("manifest missing source root — re-scan the card")
+    try:
+        created = datetime.fromisoformat(manifest.get("created_at"))
+        age = datetime.now(timezone.utc) - created
+    except (TypeError, ValueError):
+        raise ManifestError("manifest missing timestamp — re-scan the card")
+    # Age is enforced here — at request time — not only by the
+    # scan-start prune.
+    if age.total_seconds() > max_age_days * 86400:
+        raise ManifestError(
+            "manifest expired — re-scan the card", http_status=404)
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        raise ManifestError("manifest entries malformed — re-scan the card")
+    for entry in entries:
+        if entry.get("bucket") != "deletable":
+            continue
+        if not path_guard.path_contains(source_root, str(entry.get("path", ""))):
+            raise ManifestError(
+                "manifest entry outside its source root — re-scan the card")
+    return manifest

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -15,6 +15,7 @@ import contextlib
 import errno
 import json
 import os
+import stat as stat_mod
 import tempfile
 import time
 from datetime import UTC, datetime
@@ -164,10 +165,17 @@ def load_manifest(manifest_dir, scan_job_id,
         raise ManifestError("manifest missing source root — re-scan the card")
     try:
         created = datetime.fromisoformat(manifest.get("created_at"))
-        age = datetime.now(UTC) - created
     except (TypeError, ValueError) as e:
         raise ManifestError(
             "manifest timestamp invalid — re-scan the card") from e
+    # fromisoformat accepts a naive stamp like "2026-08-08T12:00:00";
+    # subtracting a naive from an aware datetime raises TypeError, so
+    # reject naive timestamps up front. Corrupt manifests must surface
+    # as ManifestError (HTTP 400), never a bare TypeError bubbling up.
+    if created.tzinfo is None or created.utcoffset() is None:
+        raise ManifestError(
+            "manifest timestamp invalid — re-scan the card")
+    age = datetime.now(UTC) - created
     # Age is enforced here — at request time — not only by the
     # scan-start prune.
     if age.total_seconds() > max_age_days * 86400:
@@ -232,6 +240,7 @@ SKIP_ALREADY_GONE = "already gone from the card"
 SKIP_CHANGED = "changed on the card since the scan"
 SKIP_CONTENT_CHANGED = "content changed on the card since the scan"
 SKIP_OUTSIDE_SOURCE = "path no longer resolves inside the scanned source"
+SKIP_SYMLINK = "path is now a symlink — refuses to follow at delete time"
 
 
 def qualify_rows(rows, source_root_real, card_path):
@@ -407,14 +416,26 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
             progress_cb(i + 1, len(deletable), os.path.basename(path))
         # Card gate: cheap stat pre-check, then full re-hash. Size+mtime
         # alone cannot detect a swapped card or same-size replacement.
+        #
+        # lstat, not stat: scan rejects symlinks at classification, but a
+        # post-scan swap of the pathname for a symlink to a byte-identical
+        # file would let os.stat follow the link — every content gate
+        # would then operate on the target, and os.remove would unlink
+        # only the link while the delete summary credited the target's
+        # full bytes as reclaimed. Rejecting symlinks here keeps the
+        # delete anchored to the object the scan hashed.
         try:
-            st = os.stat(path)
+            st = os.lstat(path)
         except FileNotFoundError:
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_ALREADY_GONE})
             continue
         except OSError as e:
             summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if stat_mod.S_ISLNK(st.st_mode):
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_SYMLINK})
             continue
         if (st.st_size != entry["size"]
                 or st.st_mtime_ns != entry["mtime_ns"]):
@@ -463,13 +484,17 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
                 {"path": path, "reason": SKIP_OUTSIDE_SOURCE})
             continue
         try:
-            st2 = os.stat(path)
+            st2 = os.lstat(path)
         except FileNotFoundError:
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_ALREADY_GONE})
             continue
         except OSError as e:
             summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if stat_mod.S_ISLNK(st2.st_mode):
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_SYMLINK})
             continue
         if ((st2.st_dev, st2.st_ino) != (st.st_dev, st.st_ino)
                 or st2.st_size != entry["size"]

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -256,15 +256,24 @@ SKIP_OUTSIDE_SOURCE = "path no longer resolves inside the scanned source"
 SKIP_SYMLINK = "path is now a symlink — refuses to follow at delete time"
 
 
-def qualify_rows(rows, source_root_real, card_path):
+def qualify_rows(rows, source_root_real, card_path, contains_check=None):
     """Archive-side test from the spec's safety invariant.
 
     Returns (archive_path, None) for the first row that passes, else
     (None, keep_reason). The archive stat happens HERE, fresh, on every
     call — callers may cache rows, never this function's result.
+
+    ``contains_check`` is an optional bound containment predicate from
+    ``path_guard.make_case_folded_check(source_root_real)`` — the
+    scan/delete loops pass one so per-file catalog work does not reprobe
+    the source filesystem on every candidate. Single-shot callers can
+    omit it; the fallback matches the plain ``contains_resolved`` call.
     """
     if not rows:
         return None, KEEP_NOT_IN_CATALOG
+    if contains_check is None:
+        def contains_check(child_real):
+            return path_guard.contains_resolved(source_root_real, child_real)
     reason = KEEP_NOT_VERIFIED
     try:
         card_st = os.stat(card_path)
@@ -284,7 +293,7 @@ def qualify_rows(rows, source_root_real, card_path):
             # (which would be silently wrong) or crash the whole job.
             reason = KEEP_ARCHIVE_UNREACHABLE
             continue
-        if path_guard.contains_resolved(source_root_real, archive_real):
+        if contains_check(archive_real):
             reason = KEEP_INSIDE_SOURCE
             continue
         try:
@@ -342,6 +351,7 @@ def _load_catalog_by_hash(db):
 def scan_card(db, source, recursive, manifest_dir, scan_job_id,
               progress_cb=None, should_cancel=None):
     source_root_real = os.path.realpath(source)
+    contains_check = path_guard.make_case_folded_check(source_root_real)
     walk_errors = []
     candidates, ignored = classify_source_files(
         source, recursive=recursive,
@@ -388,7 +398,8 @@ def scan_card(db, source, recursive, manifest_dir, scan_job_id,
             "mtime_ns": st.st_mtime_ns, "hash": file_hash,
         }
         archive_path, reason = qualify_rows(
-            by_hash.get(file_hash, []), source_root_real, str(f))
+            by_hash.get(file_hash, []), source_root_real, str(f),
+            contains_check)
         if archive_path is not None:
             entry.update(bucket="deletable", archive_path=archive_path)
             totals["deletable"]["count"] += 1
@@ -427,6 +438,7 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
     not a supported input.
     """
     source_root_real = os.path.realpath(manifest["source_root"])
+    contains_check = path_guard.make_case_folded_check(source_root_real)
     deletable = [e for e in manifest["entries"]
                  if e.get("bucket") == "deletable"]
     summary = {
@@ -486,7 +498,8 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         # self-evidently correct without needing to trace back to that
         # check.
         archive_path, reason = qualify_rows(
-            fetch_rows_by_hash(db, current_hash), source_root_real, path)
+            fetch_rows_by_hash(db, current_hash), source_root_real, path,
+            contains_check)
         if archive_path is None:
             summary["skipped"].append({"path": path, "reason": reason})
             continue
@@ -506,8 +519,7 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         # re-proven at deletion time. Residual race (swap between these
         # checks and the unlink) is microseconds; full immunity would
         # need dir_fd/O_NOFOLLOW traversal, out of proportion here.
-        if not path_guard.contains_resolved(
-                source_root_real, os.path.realpath(path)):
+        if not contains_check(os.path.realpath(path)):
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_OUTSIDE_SOURCE})
             continue

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -123,7 +123,13 @@ def classify_source_files(source, recursive=True, onerror=None):
         entries = safe_iter_dir(str(source_path), onerror=onerror)
     candidates, ignored = [], []
     for f in entries:
-        if not f.is_file():
+        # Symlinks resolve to bytes stored elsewhere. If we followed one
+        # (Path.is_file does), the size/hash recorded here would be the
+        # target's, but os.remove(path) unlinks only the link — no card
+        # space is reclaimed and delete_verified would credit the
+        # target's full size as "deleted bytes". Reject at classification
+        # so a symlink can never enter the deletable set.
+        if f.is_symlink() or not f.is_file():
             continue
         if (f.suffix.lower() in SUPPORTED_EXTENSIONS
                 and not f.name.startswith(".")):

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -195,6 +195,14 @@ def load_manifest(manifest_dir, scan_job_id,
     # Case-fold acceptance inside contains_resolved is still fine here —
     # a case-swapped path within the root is genuinely still within it,
     # and the delete job's per-file gates are the deeper defense.
+    # Null bytes are rejected explicitly rather than via realpath's
+    # exception: POSIX realpath raises ValueError on them but Windows'
+    # ntpath.realpath swallows the error and returns the string
+    # unchanged, which would let the path sail through validation and
+    # crash later at the stat/unlink. Uniform check, uniform outcome.
+    if "\x00" in str(source_root):
+        raise ManifestError(
+            "manifest source root unresolvable — re-scan the card")
     try:
         root_real = os.path.realpath(source_root)
     except (OSError, ValueError) as e:
@@ -215,6 +223,11 @@ def load_manifest(manifest_dir, scan_job_id,
                 or not entry.get("hash")):
             raise ManifestError(
                 "manifest entries malformed — re-scan the card")
+        # Same explicit null-byte rejection as the source root above —
+        # Windows realpath would pass the string through unchanged.
+        if "\x00" in str(entry.get("path", "")):
+            raise ManifestError(
+                "manifest entry outside its source root — re-scan the card")
         try:
             child_real = os.path.realpath(str(entry.get("path", "")))
         except (OSError, ValueError) as e:

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -191,6 +191,12 @@ def load_manifest(manifest_dir, scan_job_id,
         if not entry.get("path"):
             raise ManifestError(
                 "manifest entries malformed — re-scan the card")
+        if (not isinstance(entry.get("size"), int)
+                or not isinstance(entry.get("mtime_ns"), int)
+                or not isinstance(entry.get("hash"), str)
+                or not entry.get("hash")):
+            raise ManifestError(
+                "manifest entries malformed — re-scan the card")
         try:
             child_real = os.path.realpath(str(entry.get("path", "")))
         except (OSError, ValueError) as e:
@@ -211,6 +217,10 @@ KEEP_INSIDE_SOURCE = "only catalog copy is inside the selected source"
 KEEP_ARCHIVE_UNREACHABLE = "archive file not reachable"
 KEEP_ARCHIVE_CHANGED = "archive file changed since verification"
 KEEP_UNREADABLE = "could not read card file"
+
+SKIP_ALREADY_GONE = "already gone from the card"
+SKIP_CHANGED = "changed on the card since the scan"
+SKIP_CONTENT_CHANGED = "content changed on the card since the scan"
 
 
 def qualify_rows(rows, source_root_real, card_path):
@@ -363,7 +373,11 @@ def scan_card(db, source, recursive, manifest_dir, scan_job_id,
 def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
     """Delete the manifest's deletable bucket, re-proving the invariant
     per file immediately before each unlink. Never reads the kept or
-    ignored buckets."""
+    ignored buckets.
+
+    The manifest must come from load_manifest (validated); raw dicts are
+    not a supported input.
+    """
     source_root_real = os.path.realpath(manifest["source_root"])
     deletable = [e for e in manifest["entries"]
                  if e.get("bucket") == "deletable"]
@@ -386,7 +400,7 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
             st = os.stat(path)
         except FileNotFoundError:
             summary["skipped"].append(
-                {"path": path, "reason": "already gone from the card"})
+                {"path": path, "reason": SKIP_ALREADY_GONE})
             continue
         except OSError as e:
             summary["failed"].append({"path": path, "error": str(e)})
@@ -394,7 +408,7 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         if (st.st_size != entry["size"]
                 or st.st_mtime_ns != entry["mtime_ns"]):
             summary["skipped"].append(
-                {"path": path, "reason": "changed on the card since the scan"})
+                {"path": path, "reason": SKIP_CHANGED})
             continue
         try:
             current_hash = compute_file_hash(path)
@@ -403,13 +417,16 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
             continue
         if current_hash != entry["hash"]:
             summary["skipped"].append(
-                {"path": path,
-                 "reason": "content changed on the card since the scan"})
+                {"path": path, "reason": SKIP_CONTENT_CHANGED})
             continue
         # Archive gate: fresh rows, fresh stat — never reused from the
-        # scan or from an earlier deletion in this run.
+        # scan or from an earlier deletion in this run. Keyed on
+        # current_hash (not entry["hash"]) — the equality check just
+        # above proves them equal, but this makes the lookup
+        # self-evidently correct without needing to trace back to that
+        # check.
         archive_path, reason = qualify_rows(
-            fetch_rows_by_hash(db, entry["hash"]), source_root_real, path)
+            fetch_rows_by_hash(db, current_hash), source_root_real, path)
         if archive_path is None:
             summary["skipped"].append({"path": path, "reason": reason})
             continue

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -437,7 +437,14 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
     The manifest must come from load_manifest (validated); raw dicts are
     not a supported input.
     """
-    source_root_real = os.path.realpath(manifest["source_root"])
+    # Use the manifest's source_root verbatim (Codex P1 review) — it was
+    # realpath'd at scan time (see scan_card) and persisted as the
+    # canonical anchor. Re-resolving here would follow a post-scan symlink
+    # swap of the root itself (e.g. /Volumes/CARD/DCIM renamed and replaced
+    # by a symlink pointing at /elsewhere), re-anchoring every containment
+    # check to the attacker-controlled target and letting a matching file
+    # there pass every gate and be unlinked outside the scanned card.
+    source_root_real = manifest["source_root"]
     contains_check = path_guard.make_case_folded_check(source_root_real)
     deletable = [e for e in manifest["entries"]
                  if e.get("bucket") == "deletable"]

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -12,22 +12,22 @@ The safety invariant, enforced immediately before every unlink:
     deletable set would cost more than the import this tool reclaims.
 """
 import contextlib
-import errno  # noqa: F401 — used by Task 3-5 scan/delete
+import errno
 import json
 import os
 import tempfile
 import time
 from datetime import UTC, datetime
-from pathlib import Path  # noqa: F401 — used by Task 3-5 scan/delete
+from pathlib import Path
 
 import path_guard
-from image_loader import (  # noqa: F401 — used by Task 3-5 scan/delete
+from image_loader import (
     SUPPORTED_EXTENSIONS,
     is_excluded_scan_path,
     safe_iter_dir,
     safe_scan_walk,
 )
-from scanner import compute_file_hash  # noqa: F401 — used by Task 3-5 scan/delete
+from scanner import compute_file_hash  # noqa: F401 — used by Task 4 scan/delete
 
 MANIFEST_SCHEMA_VERSION = 1
 MANIFEST_MAX_AGE_DAYS = 7
@@ -91,6 +91,48 @@ def prune_manifests(manifest_dir, max_age_days=MANIFEST_MAX_AGE_DAYS):
                 os.unlink(full)
 
 
+def classify_source_files(source, recursive=True, onerror=None):
+    """One walk over the card; returns (candidates, ignored), both sorted.
+
+    Mirrors discover_source_files' file_types="both" filter exactly —
+    parity is pinned by a test — but also returns the non-photo files so
+    the preview can show an "ignored, never touched" bucket without a
+    second walk (discover_source_files drops them).
+    """
+    source_path = Path(source)
+    if is_excluded_scan_path(source_path):
+        if onerror is not None:
+            onerror(PermissionError(
+                errno.EACCES, "source is an excluded data bundle",
+                str(source_path)))
+        return [], []
+    if not source_path.is_dir():
+        if onerror is not None:
+            onerror(FileNotFoundError(
+                errno.ENOENT, "source is not an accessible directory",
+                str(source_path)))
+        return [], []
+    if recursive:
+        def _walk():
+            for dirpath, _dirnames, filenames in safe_scan_walk(
+                    str(source_path), onerror=onerror):
+                for name in filenames:
+                    yield Path(dirpath) / name
+        entries = _walk()
+    else:
+        entries = safe_iter_dir(str(source_path), onerror=onerror)
+    candidates, ignored = [], []
+    for f in entries:
+        if not f.is_file():
+            continue
+        if (f.suffix.lower() in SUPPORTED_EXTENSIONS
+                and not f.name.startswith(".")):
+            candidates.append(f)
+        else:
+            ignored.append(f)
+    return sorted(candidates), sorted(ignored)
+
+
 def load_manifest(manifest_dir, scan_job_id,
                   max_age_days=MANIFEST_MAX_AGE_DAYS):
     """Load + validate. Everything here must pass before any delete."""
@@ -130,17 +172,25 @@ def load_manifest(manifest_dir, scan_job_id,
     # accepted, so that polarity is inverted: an unresolvable path must
     # fail closed (rejected), not fail open (accepted). Resolve both
     # sides ourselves and use contains_resolved() directly; a realpath
-    # OSError is treated as "outside" rather than "inside". Case-fold
-    # acceptance inside contains_resolved is still fine here — a
-    # case-swapped path within the root is genuinely still within it,
+    # failure is treated as "outside" rather than "inside" (OSError from
+    # an unreadable path, ValueError from e.g. an embedded null byte).
+    # Case-fold acceptance inside contains_resolved is still fine here —
+    # a case-swapped path within the root is genuinely still within it,
     # and the delete job's per-file gates are the deeper defense.
+    try:
+        root_real = os.path.realpath(source_root)
+    except (OSError, ValueError) as e:
+        raise ManifestError(
+            "manifest source root unresolvable — re-scan the card") from e
     for entry in entries:
+        if not isinstance(entry, dict):
+            raise ManifestError(
+                "manifest entries malformed — re-scan the card")
         if entry.get("bucket") != "deletable":
             continue
         try:
-            root_real = os.path.realpath(source_root)
             child_real = os.path.realpath(str(entry.get("path", "")))
-        except OSError as e:
+        except (OSError, ValueError) as e:
             raise ManifestError(
                 "manifest entry outside its source root — re-scan the card"
             ) from e

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -254,6 +254,8 @@ SKIP_CHANGED = "changed on the card since the scan"
 SKIP_CONTENT_CHANGED = "content changed on the card since the scan"
 SKIP_OUTSIDE_SOURCE = "path no longer resolves inside the scanned source"
 SKIP_SYMLINK = "path is now a symlink — refuses to follow at delete time"
+SKIP_NOT_REGULAR = (
+    "path is not a regular file — refuses to open at delete time")
 
 
 def qualify_rows(rows, source_root_real, card_path, contains_check=None):
@@ -484,6 +486,17 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_SYMLINK})
             continue
+        # Codex P2: not just symlinks — any non-regular replacement must
+        # be rejected BEFORE compute_file_hash. A scanned zero-byte photo
+        # replaced by a FIFO (or socket/device) with size 0 and mtime
+        # forced back to the manifest value would pass the S_ISLNK reject
+        # and the size/mtime check, then compute_file_hash would block
+        # forever opening the pipe — cancellation is checked only at file
+        # boundaries, so the delete job hangs.
+        if not stat_mod.S_ISREG(st.st_mode):
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_NOT_REGULAR})
+            continue
         if (st.st_size != entry["size"]
                 or st.st_mtime_ns != entry["mtime_ns"]):
             summary["skipped"].append(
@@ -566,6 +579,15 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         if stat_mod.S_ISLNK(st2.st_mode):
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_SYMLINK})
+            continue
+        # Codex P2 (mirror of gate 1): a swap for a FIFO/socket/device
+        # after the final hash would pass the S_ISLNK reject and the
+        # dev/inode baseline (a new inode fails that check anyway), but
+        # defence-in-depth: keep both gates identical so an added
+        # code path can't relax one without the other.
+        if not stat_mod.S_ISREG(st2.st_mode):
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_NOT_REGULAR})
             continue
         if ((st2.st_dev, st2.st_ino) != (st.st_dev, st.st_ino)
                 or st2.st_size != entry["size"]

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -430,6 +430,29 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         if archive_path is None:
             summary["skipped"].append({"path": path, "reason": reason})
             continue
+        # Unlink gate (Codex P1 review): the archive gate above can take
+        # SMB-round-trip time, and os.remove resolves the pathname again.
+        # If another writer replaced this name meanwhile (camera reusing
+        # a filename, sync tool), the bytes at `path` are no longer the
+        # ones the card gate hashed. Re-stat and require the same inode
+        # AND the same manifest baseline immediately before the unlink —
+        # shrinking the race window from network-seconds to the
+        # stat-to-remove gap.
+        try:
+            st2 = os.stat(path)
+        except FileNotFoundError:
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_ALREADY_GONE})
+            continue
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if ((st2.st_dev, st2.st_ino) != (st.st_dev, st.st_ino)
+                or st2.st_size != entry["size"]
+                or st2.st_mtime_ns != entry["mtime_ns"]):
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_CHANGED})
+            continue
         try:
             os.remove(path)
         except OSError as e:

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -360,13 +360,28 @@ def scan_card(db, source, recursive, manifest_dir, scan_job_id,
             progress_cb(i + 1, len(candidates), f.name)
         try:
             st = os.stat(f)
-            file_hash = compute_file_hash(str(f))
         except OSError as e:
+            # No stat → no size known; count only.
             entries.append({
                 "path": str(f), "bucket": "kept",
                 "reason": f"{KEEP_UNREADABLE}: {e}",
             })
             totals["kept"]["count"] += 1
+            continue
+        try:
+            file_hash = compute_file_hash(str(f))
+        except OSError as e:
+            # Stat succeeded but read/hash failed (permission, transient
+            # read error). st.st_size is truthful; crediting it to
+            # kept.bytes keeps the preview honest — a wholesale-unreadable
+            # card would otherwise report gigabytes as "0 bytes kept".
+            entries.append({
+                "path": str(f), "bucket": "kept",
+                "size": st.st_size,
+                "reason": f"{KEEP_UNREADABLE}: {e}",
+            })
+            totals["kept"]["count"] += 1
+            totals["kept"]["bytes"] += st.st_size
             continue
         entry = {
             "path": str(f), "size": st.st_size,
@@ -520,6 +535,24 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
                 or st2.st_mtime_ns != entry["mtime_ns"]):
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_CHANGED})
+            continue
+        # Final content re-hash (Codex P1 review): the archive gate above
+        # can take SMB-round-trip time. A same-inode in-place rewrite that
+        # preserves size and forces mtime back to the manifest value (FAT
+        # is 2s-granular; a camera reusing a filename in that window is
+        # the realistic case) passes every metadata check but hashes to
+        # different bytes than the ones we authorized. Repeat the hash
+        # immediately before the unlink and require it to still match
+        # the manifest — the only witness of content mutation with
+        # metadata forged back to the baseline.
+        try:
+            final_hash = compute_file_hash(path)
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if final_hash != entry["hash"]:
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_CONTENT_CHANGED})
             continue
         try:
             os.remove(path)

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -318,6 +318,24 @@ def qualify_rows(rows, source_root_real, card_path, contains_check=None):
                 or ast.st_mtime != row["file_mtime"]):
             reason = KEEP_ARCHIVE_CHANGED
             continue
+        # Bind the containment decision to the statted object (Codex P1):
+        # realpath() and os.stat() above are two separate path walks. A
+        # parent directory swapped between them means containment
+        # approved one target while the metadata gate measured another —
+        # and the dev/inode check only rejects the *candidate* itself,
+        # not some other in-source file the redirect landed on.
+        # Re-resolve after the stat and require the resolution unchanged
+        # and still outside the source. A double swap inside this
+        # microsecond window is the accepted residual, same class as the
+        # stat-to-remove gap at the unlink.
+        try:
+            recheck_real = os.path.realpath(archive_path)
+        except (OSError, ValueError):
+            reason = KEEP_ARCHIVE_UNREACHABLE
+            continue
+        if recheck_real != archive_real or contains_check(recheck_real):
+            reason = KEEP_INSIDE_SOURCE
+            continue
         return archive_path, None
     return None, reason
 

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -233,13 +233,20 @@ def qualify_rows(rows, source_root_real, card_path):
         if not row["folder_path"]:
             continue
         archive_path = os.path.join(row["folder_path"], row["filename"])
-        if path_guard.contains_resolved(
-                source_root_real, os.path.realpath(archive_path)):
+        try:
+            archive_real = os.path.realpath(archive_path)
+        except (OSError, ValueError):
+            # Containment is unknown, not disproven — a row we can't
+            # even resolve must not be treated as "inside the source"
+            # (which would be silently wrong) or crash the whole job.
+            reason = KEEP_ARCHIVE_UNREACHABLE
+            continue
+        if path_guard.contains_resolved(source_root_real, archive_real):
             reason = KEEP_INSIDE_SOURCE
             continue
         try:
             ast = os.stat(archive_path)
-        except OSError:
+        except (OSError, ValueError):
             reason = KEEP_ARCHIVE_UNREACHABLE
             continue
         # samefile semantics without a second round trip: a mount alias
@@ -346,5 +353,71 @@ def scan_card(db, source, recursive, manifest_dir, scan_job_id,
         "totals": totals,
     }
     write_manifest(manifest_dir, manifest)
+    # Job-result flag only — deliberately NOT part of the persisted
+    # manifest (added after write_manifest). A completed scan's manifest
+    # on disk has no "cancelled" key; don't "fix" this into the schema.
     manifest["cancelled"] = False
     return manifest
+
+
+def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
+    """Delete the manifest's deletable bucket, re-proving the invariant
+    per file immediately before each unlink. Never reads the kept or
+    ignored buckets."""
+    source_root_real = os.path.realpath(manifest["source_root"])
+    deletable = [e for e in manifest["entries"]
+                 if e.get("bucket") == "deletable"]
+    summary = {
+        "deleted": 0, "deleted_bytes": 0,
+        "skipped": [], "failed": [],
+        "cancelled": False, "remaining": 0,
+    }
+    for i, entry in enumerate(deletable):
+        if should_cancel is not None and should_cancel():
+            summary["cancelled"] = True
+            summary["remaining"] = len(deletable) - i
+            break
+        path = entry["path"]
+        if progress_cb is not None:
+            progress_cb(i + 1, len(deletable), os.path.basename(path))
+        # Card gate: cheap stat pre-check, then full re-hash. Size+mtime
+        # alone cannot detect a swapped card or same-size replacement.
+        try:
+            st = os.stat(path)
+        except FileNotFoundError:
+            summary["skipped"].append(
+                {"path": path, "reason": "already gone from the card"})
+            continue
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if (st.st_size != entry["size"]
+                or st.st_mtime_ns != entry["mtime_ns"]):
+            summary["skipped"].append(
+                {"path": path, "reason": "changed on the card since the scan"})
+            continue
+        try:
+            current_hash = compute_file_hash(path)
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if current_hash != entry["hash"]:
+            summary["skipped"].append(
+                {"path": path,
+                 "reason": "content changed on the card since the scan"})
+            continue
+        # Archive gate: fresh rows, fresh stat — never reused from the
+        # scan or from an earlier deletion in this run.
+        archive_path, reason = qualify_rows(
+            fetch_rows_by_hash(db, entry["hash"]), source_root_real, path)
+        if archive_path is None:
+            summary["skipped"].append({"path": path, "reason": reason})
+            continue
+        try:
+            os.remove(path)
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        summary["deleted"] += 1
+        summary["deleted_bytes"] += entry["size"]
+    return summary

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -221,6 +221,7 @@ KEEP_UNREADABLE = "could not read card file"
 SKIP_ALREADY_GONE = "already gone from the card"
 SKIP_CHANGED = "changed on the card since the scan"
 SKIP_CONTENT_CHANGED = "content changed on the card since the scan"
+SKIP_OUTSIDE_SOURCE = "path no longer resolves inside the scanned source"
 
 
 def qualify_rows(rows, source_root_real, card_path):
@@ -438,6 +439,19 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         # AND the same manifest baseline immediately before the unlink —
         # shrinking the race window from network-seconds to the
         # stat-to-remove gap.
+        #
+        # Also (second Codex P1): a parent directory swapped for a
+        # symlink can redirect this pathname to a byte-identical file
+        # OUTSIDE the card, which passes every content gate above. The
+        # deletion must stay anchored beneath the scanned source root,
+        # re-proven at deletion time. Residual race (swap between these
+        # checks and the unlink) is microseconds; full immunity would
+        # need dir_fd/O_NOFOLLOW traversal, out of proportion here.
+        if not path_guard.contains_resolved(
+                source_root_real, os.path.realpath(path)):
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_OUTSIDE_SOURCE})
+            continue
         try:
             st2 = os.stat(path)
         except FileNotFoundError:

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -94,10 +94,14 @@ def prune_manifests(manifest_dir, max_age_days=MANIFEST_MAX_AGE_DAYS):
 def classify_source_files(source, recursive=True, onerror=None):
     """One walk over the card; returns (candidates, ignored), both sorted.
 
-    Mirrors discover_source_files' file_types="both" filter exactly —
-    parity is pinned by a test — but also returns the non-photo files so
-    the preview can show an "ignored, never touched" bucket without a
-    second walk (discover_source_files drops them).
+    Mirrors discover_source_files' file_types="both" filter — parity is
+    pinned by a test — with one deliberate divergence: symlinks are
+    rejected here even though discovery follows them (see the loop
+    comment). The candidate set is therefore a subset of discovery's,
+    which is the direction the spec requires ("the deletable set can
+    never exceed what import considers a photo"). Also returns the
+    non-photo files so the preview can show an "ignored, never touched"
+    bucket without a second walk (discover_source_files drops them).
     """
     source_path = Path(source)
     if is_excluded_scan_path(source_path):

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -483,42 +483,60 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
                 {"path": path, "reason": SKIP_CHANGED})
             continue
         try:
-            current_hash = compute_file_hash(path)
+            initial_hash = compute_file_hash(path)
         except OSError as e:
             summary["failed"].append({"path": path, "error": str(e)})
             continue
-        if current_hash != entry["hash"]:
+        if initial_hash != entry["hash"]:
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_CONTENT_CHANGED})
             continue
-        # Archive gate: fresh rows, fresh stat — never reused from the
-        # scan or from an earlier deletion in this run. Keyed on
-        # current_hash (not entry["hash"]) — the equality check just
-        # above proves them equal, but this makes the lookup
-        # self-evidently correct without needing to trace back to that
-        # check.
+        # Archive gate 1: fresh rows, fresh stat. Early fail if the
+        # archive is unreachable or has lost the verified copy — spares
+        # the second full-file read below.
         archive_path, reason = qualify_rows(
-            fetch_rows_by_hash(db, current_hash), source_root_real, path,
+            fetch_rows_by_hash(db, initial_hash), source_root_real, path,
             contains_check)
         if archive_path is None:
             summary["skipped"].append({"path": path, "reason": reason})
             continue
-        # Unlink gate (Codex P1 review): the archive gate above can take
-        # SMB-round-trip time, and os.remove resolves the pathname again.
-        # If another writer replaced this name meanwhile (camera reusing
-        # a filename, sync tool), the bytes at `path` are no longer the
-        # ones the card gate hashed. Re-stat and require the same inode
-        # AND the same manifest baseline immediately before the unlink —
-        # shrinking the race window from network-seconds to the
-        # stat-to-remove gap.
-        #
-        # Also (second Codex P1): a parent directory swapped for a
-        # symlink can redirect this pathname to a byte-identical file
-        # OUTSIDE the card, which passes every content gate above. The
-        # deletion must stay anchored beneath the scanned source root,
-        # re-proven at deletion time. Residual race (swap between these
-        # checks and the unlink) is microseconds; full immunity would
-        # need dir_fd/O_NOFOLLOW traversal, out of proportion here.
+        # Final card re-hash (Codex P1 review): the archive gate above
+        # can take SMB-round-trip time. A same-inode in-place rewrite that
+        # preserves size and forces mtime back to the manifest value (FAT
+        # is 2s-granular; a camera reusing a filename in that window is
+        # the realistic case) passes every metadata check but hashes to
+        # different bytes than the ones we authorized.
+        try:
+            final_hash = compute_file_hash(path)
+        except OSError as e:
+            summary["failed"].append({"path": path, "error": str(e)})
+            continue
+        if final_hash != entry["hash"]:
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_CONTENT_CHANGED})
+            continue
+        # Archive gate 2 (Codex P1): the final hash reads the whole file
+        # and can take seconds. If the archive dies (unmount, SMB drop,
+        # sync process rewriting it) during that window, gate 1's
+        # authorization is stale — deleting the card copy would destroy
+        # the only remaining copy. Re-verify freshness immediately
+        # before the unlink so an authorized archive is the LAST thing
+        # checked, not the first.
+        archive_path, reason = qualify_rows(
+            fetch_rows_by_hash(db, final_hash), source_root_real, path,
+            contains_check)
+        if archive_path is None:
+            summary["skipped"].append({"path": path, "reason": reason})
+            continue
+        # Path gate (Codex P1): a parent directory swapped for a symlink
+        # DURING the final hash can redirect this pathname to a
+        # byte-identical file outside the scanned source — bytes hash
+        # identically, both archive gates pass, but os.remove would
+        # unlink the external file. Both containment and the final
+        # inode/symlink recheck must run AFTER the final hash, not before
+        # it. Residual race (swap between these checks and the unlink)
+        # is microseconds; full immunity would need dir_fd/O_NOFOLLOW
+        # traversal, out of proportion here.
         if not contains_check(os.path.realpath(path)):
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_OUTSIDE_SOURCE})
@@ -547,24 +565,6 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
                 or st2.st_mtime_ns != entry["mtime_ns"]):
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_CHANGED})
-            continue
-        # Final content re-hash (Codex P1 review): the archive gate above
-        # can take SMB-round-trip time. A same-inode in-place rewrite that
-        # preserves size and forces mtime back to the manifest value (FAT
-        # is 2s-granular; a camera reusing a filename in that window is
-        # the realistic case) passes every metadata check but hashes to
-        # different bytes than the ones we authorized. Repeat the hash
-        # immediately before the unlink and require it to still match
-        # the manifest — the only witness of content mutation with
-        # metadata forged back to the baseline.
-        try:
-            final_hash = compute_file_hash(path)
-        except OSError as e:
-            summary["failed"].append({"path": path, "error": str(e)})
-            continue
-        if final_hash != entry["hash"]:
-            summary["skipped"].append(
-                {"path": path, "reason": SKIP_CONTENT_CHANGED})
             continue
         try:
             os.remove(path)

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -27,7 +27,7 @@ from image_loader import (
     safe_iter_dir,
     safe_scan_walk,
 )
-from scanner import compute_file_hash  # noqa: F401 — used by Task 4 scan/delete
+from scanner import compute_file_hash
 
 MANIFEST_SCHEMA_VERSION = 1
 MANIFEST_MAX_AGE_DAYS = 7
@@ -188,6 +188,9 @@ def load_manifest(manifest_dir, scan_job_id,
                 "manifest entries malformed — re-scan the card")
         if entry.get("bucket") != "deletable":
             continue
+        if not entry.get("path"):
+            raise ManifestError(
+                "manifest entries malformed — re-scan the card")
         try:
             child_real = os.path.realpath(str(entry.get("path", "")))
         except (OSError, ValueError) as e:
@@ -197,4 +200,151 @@ def load_manifest(manifest_dir, scan_job_id,
         if not path_guard.contains_resolved(root_real, child_real):
             raise ManifestError(
                 "manifest entry outside its source root — re-scan the card")
+    return manifest
+
+
+KEEP_NOT_IN_CATALOG = "not in catalog — not imported yet"
+KEEP_NOT_VERIFIED = (
+    "not verified by a checksummed import — run the integrity audit"
+)
+KEEP_INSIDE_SOURCE = "only catalog copy is inside the selected source"
+KEEP_ARCHIVE_UNREACHABLE = "archive file not reachable"
+KEEP_ARCHIVE_CHANGED = "archive file changed since verification"
+KEEP_UNREADABLE = "could not read card file"
+
+
+def qualify_rows(rows, source_root_real, card_path):
+    """Archive-side test from the spec's safety invariant.
+
+    Returns (archive_path, None) for the first row that passes, else
+    (None, keep_reason). The archive stat happens HERE, fresh, on every
+    call — callers may cache rows, never this function's result.
+    """
+    if not rows:
+        return None, KEEP_NOT_IN_CATALOG
+    reason = KEEP_NOT_VERIFIED
+    try:
+        card_st = os.stat(card_path)
+    except OSError:
+        return None, KEEP_UNREADABLE
+    for row in rows:
+        if row["hash_status"] != "ok":
+            continue
+        if not row["folder_path"]:
+            continue
+        archive_path = os.path.join(row["folder_path"], row["filename"])
+        if path_guard.contains_resolved(
+                source_root_real, os.path.realpath(archive_path)):
+            reason = KEEP_INSIDE_SOURCE
+            continue
+        try:
+            ast = os.stat(archive_path)
+        except OSError:
+            reason = KEEP_ARCHIVE_UNREACHABLE
+            continue
+        # samefile semantics without a second round trip: a mount alias
+        # that survived realpath + case-folding still shares dev+inode.
+        if (ast.st_dev, ast.st_ino) == (card_st.st_dev, card_st.st_ino):
+            reason = KEEP_INSIDE_SOURCE
+            continue
+        if row["file_size"] is None or row["file_mtime"] is None:
+            reason = KEEP_ARCHIVE_CHANGED
+            continue
+        # Exact equality — the audit's 1s window classifies an
+        # already-detected mismatch and certifies nothing here; a false
+        # negative just keeps a file.
+        if (ast.st_size != row["file_size"]
+                or ast.st_mtime != row["file_mtime"]):
+            reason = KEEP_ARCHIVE_CHANGED
+            continue
+        return archive_path, None
+    return None, reason
+
+
+_ROWS_BY_HASH_SQL = """
+    SELECT p.filename, p.file_size, p.file_mtime, p.hash_status,
+           f.path AS folder_path
+    FROM photos p LEFT JOIN folders f ON f.id = p.folder_id
+    WHERE p.file_hash = ?
+"""
+
+
+def fetch_rows_by_hash(db, file_hash):
+    return db.conn.execute(_ROWS_BY_HASH_SQL, (file_hash,)).fetchall()
+
+
+def _load_catalog_by_hash(db):
+    """One pass over the catalog for the scan — a per-file SELECT over an
+    unindexed file_hash column would rescan the photos table for every
+    card file."""
+    rows = db.conn.execute("""
+        SELECT p.filename, p.file_size, p.file_mtime, p.hash_status,
+               p.file_hash, f.path AS folder_path
+        FROM photos p LEFT JOIN folders f ON f.id = p.folder_id
+        WHERE p.file_hash IS NOT NULL
+    """).fetchall()
+    by_hash = {}
+    for row in rows:
+        by_hash.setdefault(row["file_hash"], []).append(row)
+    return by_hash
+
+
+def scan_card(db, source, recursive, manifest_dir, scan_job_id,
+              progress_cb=None, should_cancel=None):
+    source_root_real = os.path.realpath(source)
+    walk_errors = []
+    candidates, ignored = classify_source_files(
+        source, recursive=recursive,
+        onerror=lambda e: walk_errors.append(str(e)))
+    by_hash = _load_catalog_by_hash(db)
+    entries = []
+    totals = {
+        "deletable": {"count": 0, "bytes": 0},
+        "kept": {"count": 0, "bytes": 0},
+        "ignored": {"count": len(ignored)},
+    }
+    for i, f in enumerate(candidates):
+        if should_cancel is not None and should_cancel():
+            return {"cancelled": True}
+        if progress_cb is not None:
+            progress_cb(i + 1, len(candidates), f.name)
+        try:
+            st = os.stat(f)
+            file_hash = compute_file_hash(str(f))
+        except OSError as e:
+            entries.append({
+                "path": str(f), "bucket": "kept",
+                "reason": f"{KEEP_UNREADABLE}: {e}",
+            })
+            totals["kept"]["count"] += 1
+            continue
+        entry = {
+            "path": str(f), "size": st.st_size,
+            "mtime_ns": st.st_mtime_ns, "hash": file_hash,
+        }
+        archive_path, reason = qualify_rows(
+            by_hash.get(file_hash, []), source_root_real, str(f))
+        if archive_path is not None:
+            entry.update(bucket="deletable", archive_path=archive_path)
+            totals["deletable"]["count"] += 1
+            totals["deletable"]["bytes"] += st.st_size
+        else:
+            entry.update(bucket="kept", reason=reason)
+            totals["kept"]["count"] += 1
+            totals["kept"]["bytes"] += st.st_size
+        entries.append(entry)
+    for f in ignored:
+        entries.append({"path": str(f), "bucket": "ignored"})
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "scan_job_id": scan_job_id,
+        "created_at": datetime.now(UTC).isoformat(),
+        "source_root": source_root_real,
+        "recursive": bool(recursive),
+        "entries": entries,
+        "walk_errors": walk_errors,
+        "totals": totals,
+    }
+    write_manifest(manifest_dir, manifest)
+    manifest["cancelled"] = False
     return manifest

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -12,22 +12,22 @@ The safety invariant, enforced immediately before every unlink:
     deletable set would cost more than the import this tool reclaims.
 """
 import contextlib
-import errno
+import errno  # noqa: F401 — used by Task 3-5 scan/delete
 import json
 import os
 import tempfile
 import time
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: F401 — used by Task 3-5 scan/delete
 
 import path_guard
-from image_loader import (
+from image_loader import (  # noqa: F401 — used by Task 3-5 scan/delete
     SUPPORTED_EXTENSIONS,
     is_excluded_scan_path,
     safe_iter_dir,
     safe_scan_walk,
 )
-from scanner import compute_file_hash
+from scanner import compute_file_hash  # noqa: F401 — used by Task 3-5 scan/delete
 
 MANIFEST_SCHEMA_VERSION = 1
 MANIFEST_MAX_AGE_DAYS = 7
@@ -75,11 +75,15 @@ def write_manifest(manifest_dir, manifest):
 
 
 def prune_manifests(manifest_dir, max_age_days=MANIFEST_MAX_AGE_DAYS):
+    """Remove manifests older than max_age_days, plus any orphaned
+    ``*.tmp`` write-manifest temp files (a hard crash between
+    ``mkstemp`` and ``os.replace`` would otherwise leave them
+    forever)."""
     if not os.path.isdir(manifest_dir):
         return
     cutoff = time.time() - max_age_days * 86400
     for name in os.listdir(manifest_dir):
-        if not name.endswith(".json"):
+        if not (name.endswith(".json") or name.endswith(".tmp")):
             continue
         full = os.path.join(manifest_dir, name)
         with contextlib.suppress(OSError):
@@ -98,7 +102,8 @@ def load_manifest(manifest_dir, scan_job_id,
         with open(path, encoding="utf-8") as f:
             manifest = json.load(f)
     except (OSError, ValueError) as e:
-        raise ManifestError(f"manifest unreadable or corrupt: {e}") from e
+        raise ManifestError(
+            "manifest unreadable or corrupt — re-scan the card") from e
     if (not isinstance(manifest, dict)
             or manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION):
         raise ManifestError("manifest schema not recognized — re-scan the card")
@@ -107,9 +112,10 @@ def load_manifest(manifest_dir, scan_job_id,
         raise ManifestError("manifest missing source root — re-scan the card")
     try:
         created = datetime.fromisoformat(manifest.get("created_at"))
-        age = datetime.now(timezone.utc) - created
-    except (TypeError, ValueError):
-        raise ManifestError("manifest missing timestamp — re-scan the card")
+        age = datetime.now(UTC) - created
+    except (TypeError, ValueError) as e:
+        raise ManifestError(
+            "manifest timestamp invalid — re-scan the card") from e
     # Age is enforced here — at request time — not only by the
     # scan-start prune.
     if age.total_seconds() > max_age_days * 86400:
@@ -118,10 +124,27 @@ def load_manifest(manifest_dir, scan_job_id,
     entries = manifest.get("entries")
     if not isinstance(entries, list):
         raise ManifestError("manifest entries malformed — re-scan the card")
+    # path_guard.path_contains() returns True on "can't tell" — the
+    # strict direction for a guard that *disqualifies* on containment.
+    # Here containment is a *required* condition for the entry to be
+    # accepted, so that polarity is inverted: an unresolvable path must
+    # fail closed (rejected), not fail open (accepted). Resolve both
+    # sides ourselves and use contains_resolved() directly; a realpath
+    # OSError is treated as "outside" rather than "inside". Case-fold
+    # acceptance inside contains_resolved is still fine here — a
+    # case-swapped path within the root is genuinely still within it,
+    # and the delete job's per-file gates are the deeper defense.
     for entry in entries:
         if entry.get("bucket") != "deletable":
             continue
-        if not path_guard.path_contains(source_root, str(entry.get("path", ""))):
+        try:
+            root_real = os.path.realpath(source_root)
+            child_real = os.path.realpath(str(entry.get("path", "")))
+        except OSError as e:
+            raise ManifestError(
+                "manifest entry outside its source root — re-scan the card"
+            ) from e
+        if not path_guard.contains_resolved(root_real, child_real):
             raise ManifestError(
                 "manifest entry outside its source root — re-scan the card")
     return manifest

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -483,6 +483,12 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_OUTSIDE_SOURCE})
             continue
+        # lstat, not stat: a scanned regular file swapped for a symlink
+        # would otherwise be followed to its (byte-identical) target,
+        # pass every identity check on the target's stats, and then
+        # os.remove would unlink only the link while the summary credits
+        # the target's full size. lstat sees the link itself, whose
+        # inode/size/mtime cannot match the scanned file's baseline.
         try:
             st2 = os.lstat(path)
         except FileNotFoundError:

--- a/vireo/path_guard.py
+++ b/vireo/path_guard.py
@@ -1,0 +1,113 @@
+"""Filesystem-aware path containment.
+
+Extracted from the import endpoint's destination-inside-source guard
+(PR #1107) so the card-cleanup overlap guard makes identical decisions.
+``realpath`` alone is not enough: macOS/Windows default filesystems are
+case-insensitive but realpath does not case-normalize, and FAT/exFAT
+removable media on Linux are case-insensitive under a case-sensitive
+parent. Inconclusive probes fall back to case-folding — the strict
+direction for a containment guard.
+
+macOS's default APFS/HFS+ volumes and Windows NTFS are case-INSENSITIVE,
+so ``/Volumes/Card`` and ``/volumes/card`` are the same directory but
+``realpath`` doesn't case-normalize on POSIX (macOS reports as POSIX). On
+Linux, a platform-wide case-sensitivity assumption misses
+FAT/exFAT/NTFS-mounted removable media (typical SD-card setup) that sit
+under a case-sensitive ext4 parent — the user's real card mount point can
+be case-insensitive even when the root filesystem isn't. Compare
+case-folded on darwin/win32 unconditionally, and on Linux probe each
+source's actual filesystem: if the resolved path with an alpha character
+case-swapped still stat's to the same inode, the mount is case-insensitive
+and both sides of the containment comparison need case-folding for that
+source.
+"""
+import os
+import sys
+
+
+def is_case_insensitive_platform():
+    return sys.platform in ("darwin", "win32")
+
+
+def fs_is_case_insensitive(path):
+    """Probe whether the filesystem at ``path`` treats case as insensitive.
+
+    List an entry inside ``path`` and check whether accessing it
+    under a case-swapped name resolves to the same inode. Probing
+    *inside* the directory (rather than swapping characters in
+    ``path`` itself) is essential when a case-insensitive mount
+    sits under a case-sensitive parent — a FAT/exFAT SD card
+    mounted at ``/mnt/Card`` on Linux under an ext4 root: the
+    ext4 ``/mnt`` cannot resolve ``/Mnt`` or a differently-cased
+    ``Card`` entry (mount-point dentries are stored in the
+    parent FS), so swapping characters in the ``path`` string
+    always reports case-sensitive regardless of the card's own
+    semantics.
+
+    Any inconclusive result (unlistable, empty, no
+    alpha-containing entry, or a stat error while comparing)
+    returns True so the containment check falls back to
+    case-fold — the stricter direction of this safety guard.
+    A false positive on a case-sensitive filesystem can only
+    reject a legitimate destination (recoverable UX error the
+    user immediately sees and fixes by picking a different
+    path), whereas a false negative on a case-insensitive
+    filesystem accepts a case-collision destination inside the
+    card and lets ``safe_to_format`` later green-light
+    formatting while the archive lives on it. The reviewer's
+    example: an SD card whose root contains only numeric
+    top-level directories (Nikon-style ``100``/``101``/``102``)
+    has no alpha-containing entry to probe with. See PR #1107
+    review.
+    """
+    try:
+        entries = os.listdir(path)
+    except OSError:
+        return True
+    for name in entries:
+        for i, c in enumerate(name):
+            if c.isalpha():
+                swapped = name[:i] + c.swapcase() + name[i + 1:]
+                if swapped == name:
+                    continue
+                original_full = os.path.join(path, name)
+                probe_full = os.path.join(path, swapped)
+                if not os.path.exists(probe_full):
+                    # Definitive: case-swap resolves to nothing,
+                    # so the filesystem distinguishes case.
+                    return False
+                try:
+                    return os.path.samefile(original_full, probe_full)
+                except OSError:
+                    return True
+    return True
+
+
+def contains_resolved(root_real, child_real):
+    """True if ``child_real`` equals or lies inside ``root_real``.
+
+    Both arguments must already be realpath'd. Case sensitivity is
+    decided per root: unconditional case-fold on darwin/win32; on Linux,
+    probe the root's actual filesystem.
+    """
+    if is_case_insensitive_platform() or fs_is_case_insensitive(root_real):
+        root_cmp = root_real.casefold().rstrip(os.sep)
+        child_cmp = child_real.casefold()
+    else:
+        root_cmp = root_real.rstrip(os.sep)
+        child_cmp = child_real
+    return child_cmp == root_cmp or child_cmp.startswith(root_cmp + os.sep)
+
+
+def path_contains(root, child):
+    """realpath both sides, then ``contains_resolved``.
+
+    Unresolvable paths return True — for a guard that *disqualifies*
+    when contained, "can't tell" must be the strict direction.
+    """
+    try:
+        root_real = os.path.realpath(root)
+        child_real = os.path.realpath(child)
+    except OSError:
+        return True
+    return contains_resolved(root_real, child_real)

--- a/vireo/path_guard.py
+++ b/vireo/path_guard.py
@@ -129,6 +129,13 @@ def contains_resolved(root_real, child_real):
     Both arguments must already be realpath'd. Case sensitivity is
     decided per root: unconditional case-fold on darwin/win32; on Linux,
     probe the root's actual filesystem.
+
+    Single-shot; per-file loops against the same root should use
+    ``make_case_folded_check`` instead — this call reprobes the root's
+    filesystem on Linux when the result would be False (case-sensitive
+    results are deliberately not cached; see the module cache comment
+    above), which turns a scan of N card files into Θ(N) uncached
+    listdirs on top of the O(N) real work.
     """
     if is_case_insensitive_platform() or fs_is_case_insensitive(root_real):
         root_cmp = root_real.casefold().rstrip(os.sep)
@@ -137,6 +144,31 @@ def contains_resolved(root_real, child_real):
         root_cmp = root_real.rstrip(os.sep)
         child_cmp = child_real
     return child_cmp == root_cmp or child_cmp.startswith(root_cmp + os.sep)
+
+
+def make_case_folded_check(root_real):
+    """Bind ``root_real`` and pre-decide case sensitivity once.
+
+    ``contains_resolved`` reprobes the root's filesystem on Linux for
+    every call whose answer would be False (the module cache stores only
+    the strict True result, and only True — see the ``_probe_cache``
+    comment above), so a scan or delete that calls it per catalog row per
+    card file walks each directory once per row. Binding at the top of
+    the run collapses that to one probe and also sidesteps the module
+    cache's remount blind spot: the probe runs fresh every scan/delete.
+    """
+    case_insensitive = (
+        is_case_insensitive_platform() or fs_is_case_insensitive(root_real))
+    if case_insensitive:
+        root_cmp = root_real.casefold().rstrip(os.sep)
+    else:
+        root_cmp = root_real.rstrip(os.sep)
+
+    def check(child_real):
+        child_cmp = child_real.casefold() if case_insensitive else child_real
+        return (child_cmp == root_cmp
+                or child_cmp.startswith(root_cmp + os.sep))
+    return check
 
 
 def path_contains(root, child):

--- a/vireo/path_guard.py
+++ b/vireo/path_guard.py
@@ -29,6 +29,18 @@ def is_case_insensitive_platform():
     return sys.platform in ("darwin", "win32")
 
 
+# Probe results keyed by (realpath, st_dev). The per-file guards call
+# contains_resolved in tight loops (one call per catalog row per card
+# file), and each uncached call would listdir-probe the same root on
+# Linux. st_dev in the key invalidates the entry when a different
+# filesystem is mounted at the same path (card swapped at the same
+# mount point) — a plain path key could serve a stale, non-strict
+# answer. Inconclusive probes are cached too: they are stable for a
+# given mount and the cached value (True) is the strict direction.
+_probe_cache = {}
+_PROBE_CACHE_MAX = 256
+
+
 def fs_is_case_insensitive(path):
     """Probe whether the filesystem at ``path`` treats case as insensitive.
 
@@ -60,6 +72,21 @@ def fs_is_case_insensitive(path):
     has no alpha-containing entry to probe with. See PR #1107
     review.
     """
+    try:
+        cache_key = (os.path.realpath(path), os.stat(path).st_dev)
+    except (OSError, ValueError):
+        cache_key = None
+    if cache_key is not None and cache_key in _probe_cache:
+        return _probe_cache[cache_key]
+    result = _probe_uncached(path)
+    if cache_key is not None:
+        if len(_probe_cache) >= _PROBE_CACHE_MAX:
+            _probe_cache.clear()
+        _probe_cache[cache_key] = result
+    return result
+
+
+def _probe_uncached(path):
     try:
         entries = os.listdir(path)
     except OSError:

--- a/vireo/path_guard.py
+++ b/vireo/path_guard.py
@@ -32,11 +32,15 @@ def is_case_insensitive_platform():
 # Probe results keyed by (realpath, st_dev). The per-file guards call
 # contains_resolved in tight loops (one call per catalog row per card
 # file), and each uncached call would listdir-probe the same root on
-# Linux. st_dev in the key invalidates the entry when a different
-# filesystem is mounted at the same path (card swapped at the same
-# mount point) — a plain path key could serve a stale, non-strict
-# answer. Inconclusive probes are cached too: they are stable for a
-# given mount and the cached value (True) is the strict direction.
+# Linux. Only True (case-insensitive — the STRICT answer) is ever
+# cached: st_dev identifies the backing device, not a mount
+# generation, so a card swapped or reformatted through the same reused
+# device node can keep the key — and a stale True merely over-folds
+# (can only reject more), while a stale False would do case-sensitive
+# comparisons against a FAT card and let the destination-inside-source
+# guard accept a case-collision destination ON the card. Case-sensitive
+# roots therefore re-probe on every call, which is just the pre-cache
+# behavior for them.
 _probe_cache = {}
 _PROBE_CACHE_MAX = 256
 
@@ -79,7 +83,7 @@ def fs_is_case_insensitive(path):
     if cache_key is not None and cache_key in _probe_cache:
         return _probe_cache[cache_key]
     result = _probe_uncached(path)
-    if cache_key is not None:
+    if cache_key is not None and result is True:
         if len(_probe_cache) >= _PROBE_CACHE_MAX:
             _probe_cache.clear()
         _probe_cache[cache_key] = result

--- a/vireo/path_guard.py
+++ b/vireo/path_guard.py
@@ -72,10 +72,19 @@ def fs_is_case_insensitive(path):
                     continue
                 original_full = os.path.join(path, name)
                 probe_full = os.path.join(path, swapped)
-                if not os.path.exists(probe_full):
+                # os.stat, not os.path.exists: exists() collapses
+                # permission errors into False, which would classify an
+                # unreadable probe as case-SENSITIVE — the non-strict
+                # direction, contradicting the fallback rule above.
+                # Only a definitive ENOENT proves case sensitivity.
+                try:
+                    os.stat(probe_full)
+                except FileNotFoundError:
                     # Definitive: case-swap resolves to nothing,
                     # so the filesystem distinguishes case.
                     return False
+                except OSError:
+                    return True
                 try:
                     return os.path.samefile(original_full, probe_full)
                 except OSError:
@@ -108,6 +117,8 @@ def path_contains(root, child):
     try:
         root_real = os.path.realpath(root)
         child_real = os.path.realpath(child)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: e.g. an embedded null byte — as unresolvable as
+        # any OSError, and the same strict fallback applies.
         return True
     return contains_resolved(root_real, child_real)

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -5052,13 +5052,19 @@ function cardCleanupRenderDeleteResult(result) {
   const res = result || {};
   const skipped = res.skipped || [];
   const failed = res.failed || [];
+  // The job result bounds these lists to a sample; *_total carries the
+  // exact count (falls back to list length for pre-trim results).
+  const skippedTotal = (typeof res.skipped_total === 'number')
+    ? res.skipped_total : skipped.length;
+  const failedTotal = (typeof res.failed_total === 'number')
+    ? res.failed_total : failed.length;
   const parts = ['Deleted ' + cardCleanupFileCount(res.deleted) +
     ' (' + formatBytes(res.deleted_bytes) + ')'];
-  if (skipped.length) {
-    parts.push(skipped.length.toLocaleString() + ' skipped');
+  if (skippedTotal) {
+    parts.push(skippedTotal.toLocaleString() + ' skipped');
   }
-  if (failed.length) {
-    parts.push(failed.length.toLocaleString() + ' failed');
+  if (failedTotal) {
+    parts.push(failedTotal.toLocaleString() + ' failed');
   }
   if (res.cancelled) {
     parts.push('Cancelled — ' + Number(res.remaining || 0).toLocaleString() +
@@ -5071,9 +5077,17 @@ function cardCleanupRenderDeleteResult(result) {
   skipped.forEach((s) => {
     lines.push('Skipped: ' + s.path + ' — ' + (s.reason || 'no reason given'));
   });
+  if (skippedTotal > skipped.length) {
+    lines.push('…and ' + (skippedTotal - skipped.length).toLocaleString() +
+      ' more skipped files not listed here (the counts above are exact).');
+  }
   failed.forEach((f) => {
     lines.push('Failed: ' + f.path + ' — ' + (f.error || 'no error given'));
   });
+  if (failedTotal > failed.length) {
+    lines.push('…and ' + (failedTotal - failed.length).toLocaleString() +
+      ' more failed files not listed here (the counts above are exact).');
+  }
   const list = document.getElementById('card-cleanup-result-list');
   if (lines.length) {
     list.style.display = '';

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -4775,16 +4775,29 @@ async function cardCleanupFinishJob(jobId, kind) {
   if (cardCleanupState.finishedJobId === jobId) return;
   cardCleanupState.finishedJobId = jobId;
   let job = null;
+  // The stream is already gone by the time we poll, so say what the page
+  // is actually doing instead of leaving the last SSE line under a bar
+  // that has stopped moving.
+  document.getElementById('card-cleanup-phase').textContent =
+    'Checking job status…';
   for (let i = 0; i < 30; i++) {
-    const resp = await fetch('/api/jobs/' + encodeURIComponent(jobId));
-    if (resp.ok) {
-      const polled = await resp.json();
-      if (polled.status && polled.status !== 'running'
-          && polled.status !== 'queued') {
-        job = polled;
-        break;
+    // A poll that throws (server restarting, network dropped — the very
+    // conditions that killed the stream) must not escape as an unhandled
+    // rejection: that would skip the cleanup below and leave a frozen bar,
+    // a live Cancel button pointing at a stale job, and a disabled Scan
+    // button until reload. Treat it as one failed attempt and keep going
+    // toward the timeout path.
+    try {
+      const resp = await fetch('/api/jobs/' + encodeURIComponent(jobId));
+      if (resp.ok) {
+        const polled = await resp.json();
+        if (polled.status && polled.status !== 'running'
+            && polled.status !== 'queued') {
+          job = polled;
+          break;
+        }
       }
-    }
+    } catch (e) { /* retry below */ }
     await new Promise(r => setTimeout(r, 1000));
   }
   cardCleanupState.jobId = null;

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -224,6 +224,26 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .advanced-import { margin-top: 10px; font-size: 12px; color: var(--text-secondary); }
 .advanced-import summary { cursor: pointer; }
 .metadata-repair { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border-primary); }
+/* Free up card space. The section is a <details class="card">, so its
+   summary has to carry the same weight as the other cards' <h3>. */
+#card-cleanup-section > summary {
+  cursor: pointer; font-size: 14px; font-weight: 600; color: var(--text-primary);
+}
+#card-cleanup-section[open] > summary { margin-bottom: 10px; }
+.card-cleanup-bucket { margin-top: 6px; }
+.card-cleanup-bucket > summary { cursor: pointer; font-size: 12px; color: var(--text-primary); }
+/* Same callout shape as .managed-archive-callout, in warning colours: an
+   incomplete preview must not read as a quiet footnote. */
+.card-cleanup-warning {
+  font-size: 12px; color: var(--text-primary); margin: 8px 0;
+  padding: 8px 10px; border-radius: 6px; overflow-wrap: anywhere;
+  background: color-mix(in srgb, var(--warning, #bf8700) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning, #bf8700) 45%, transparent);
+}
+/* Taller than .staging-details: these lists run to thousands of files. */
+#card-cleanup-section .staging-details { max-height: 220px; }
+.card-cleanup-confirm-list { margin: 0; padding-left: 18px; font-size: 13px; color: var(--text-primary); }
+.card-cleanup-confirm-list li { margin-bottom: 10px; overflow-wrap: anywhere; }
 </style>
 </head>
 <body>
@@ -478,6 +498,11 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <h3>Result</h3>
       <div class="row">
         <span class="pill" id="safeToFormatPill"></span>
+        <!-- Shown by renderResult() only for copy imports that have a card
+             path to hand to the scanner. -->
+        <button class="btn" type="button" id="btnFreeUpCardSpace"
+                style="display:none;"
+                onclick="cardCleanupOpenFromImport()">Free up card space…</button>
       </div>
       <ul class="unsafe-list" id="unsafeList" style="display:none;"></ul>
       <div id="resultSummary" class="hint" style="margin-top:6px;"></div>
@@ -494,6 +519,72 @@ body { display: flex; flex-direction: column; height: 100vh; }
         <a href="/browse">Open Browse</a> &nbsp;·&nbsp; <a href="/jobs">Open Jobs</a>
       </div>
     </div>
+
+    <!-- Free up card space: deletes card files ONLY where the same bytes
+         are already verified in the archive. Collapsed by default; the
+         result card's "Free up card space…" button opens it and pre-fills
+         the source with the import's card path. -->
+    <details class="card" id="card-cleanup-section">
+      <summary>Free up card space</summary>
+      <div class="hint">
+        Checks a memory card against the archive and deletes only the files
+        whose archive copy is verified. Everything else stays on the card.
+      </div>
+      <div class="row" id="card-cleanup-picker-row" style="margin-top:10px;">
+        <button class="btn btn-primary" type="button" id="card-cleanup-browse-btn"
+                data-testid="card-cleanup-browse-btn"
+                onclick="cardCleanupBrowse()">Browse...</button>
+        <input type="text" id="card-cleanup-source" list="volumeDatalist"
+               aria-label="Card folder to check"
+               placeholder="or type a card/folder path">
+      </div>
+      <div class="hint" id="card-cleanup-source-note" style="display:none;"></div>
+      <div class="row">
+        <label><input type="checkbox" id="card-cleanup-recursive" checked> Include subfolders</label>
+      </div>
+      <div class="row">
+        <button class="btn btn-primary" type="button" id="card-cleanup-scan-btn"
+                onclick="cardCleanupStartScan()">Scan card</button>
+        <button class="btn" type="button" id="card-cleanup-cancel-btn"
+                style="display:none;" onclick="cardCleanupCancelJob()">Cancel</button>
+      </div>
+      <div class="field-error" id="card-cleanup-error" role="alert" aria-live="assertive"></div>
+      <div id="card-cleanup-progress" style="display:none;">
+        <div class="row"><span class="hint" id="card-cleanup-phase"></span></div>
+        <div class="progress-bar"><div id="card-cleanup-progress-fill"></div></div>
+      </div>
+      <div id="card-cleanup-preview" style="display:none;">
+        <div class="card-cleanup-warning" id="card-cleanup-incomplete" style="display:none;">
+          <div id="card-cleanup-incomplete-text"></div>
+          <details class="card-cleanup-bucket" id="card-cleanup-walk-errors-details">
+            <summary id="card-cleanup-walk-errors-summary"></summary>
+            <ul class="staging-details" id="card-cleanup-walk-errors"></ul>
+          </details>
+        </div>
+        <div class="hint" id="card-cleanup-scanned-root" style="margin-bottom:6px;"></div>
+        <details class="card-cleanup-bucket" id="card-cleanup-deletable-details">
+          <summary id="card-cleanup-deletable-summary"></summary>
+          <ul class="staging-details" id="card-cleanup-deletable-list"></ul>
+        </details>
+        <details class="card-cleanup-bucket" id="card-cleanup-kept-details">
+          <summary id="card-cleanup-kept-summary"></summary>
+          <ul class="staging-details" id="card-cleanup-kept-list"></ul>
+        </details>
+        <details class="card-cleanup-bucket" id="card-cleanup-ignored-details">
+          <summary id="card-cleanup-ignored-summary"></summary>
+          <ul class="staging-details" id="card-cleanup-ignored-list"></ul>
+        </details>
+        <div class="row" style="margin-top:12px;">
+          <button class="btn btn-primary" type="button" id="card-cleanup-delete-btn"
+                  disabled onclick="cardCleanupOpenConfirm()">Delete verified files</button>
+          <span class="hint" id="card-cleanup-delete-hint"></span>
+        </div>
+      </div>
+      <div id="card-cleanup-result" style="display:none;">
+        <div class="hint" id="card-cleanup-result-summary" style="margin-top:10px;"></div>
+        <ul class="staging-details" id="card-cleanup-result-list" style="display:none;"></ul>
+      </div>
+    </details>
 
   </div>
 </div>
@@ -517,6 +608,33 @@ body { display: flex; flex-direction: column; height: 100vh; }
     <div class="folder-browser-actions">
       <button class="btn" type="button" onclick="closeImportFolderBrowser()">Cancel</button>
       <button class="btn btn-primary" type="button" id="folderBrowserSelectBtn" onclick="selectImportBrowserFolder()">Select This Folder</button>
+    </div>
+  </div>
+</div>
+
+<!-- Delete confirmation. Reuses the folder browser's overlay/panel classes:
+     they are this page's only modal chrome, named after their first user. -->
+<div class="folder-browser-overlay" id="card-cleanup-confirm"
+     data-testid="card-cleanup-confirm">
+  <div class="folder-browser-panel" role="dialog" aria-modal="true"
+       aria-labelledby="card-cleanup-confirm-title">
+    <div class="folder-browser-header">
+      <h3 id="card-cleanup-confirm-title">Delete verified files from the card?</h3>
+      <button class="folder-browser-close" type="button"
+              onclick="cardCleanupCloseConfirm()">&times;</button>
+    </div>
+    <div class="folder-browser-body">
+      <div id="card-cleanup-confirm-count" class="folder-browser-path"></div>
+      <ul class="card-cleanup-confirm-list">
+        <li>Deletion is permanent — memory cards have no trash.</li>
+        <li>After deletion, the archive holds the only copy of these photos.</li>
+        <li>What "verified" means: each file's archive copy passed a checksum check (at import or integrity audit) and is confirmed unchanged since by size and timestamp; the card copy itself is re-checksummed at the moment of deletion. Archive bytes are not re-downloaded.</li>
+      </ul>
+    </div>
+    <div class="folder-browser-actions">
+      <button class="btn" type="button" onclick="cardCleanupCloseConfirm()">Cancel</button>
+      <button class="btn btn-primary" type="button" id="card-cleanup-confirm-btn"
+              onclick="cardCleanupConfirmDelete()">Delete verified files</button>
     </div>
   </div>
 </div>
@@ -1399,11 +1517,20 @@ async function browseForDestination() {
   openImportFolderBrowser('destination');
 }
 
+// Modes: 'source' (multi-select, photo counts), 'destination' and
+// 'card-cleanup' (both single-select — every `=== 'source'` branch below
+// is the multi-select path, so card-cleanup follows destination's).
 function openImportFolderBrowser(mode, opts = {}) {
-  browserMode = mode === 'destination' ? 'destination' : 'source';
+  browserMode = (mode === 'destination' || mode === 'card-cleanup')
+    ? mode : 'source';
   const overlay = document.getElementById('importFolderBrowser');
+  const titles = {
+    source: 'Select Source Folders',
+    destination: 'Select Destination Folder',
+    'card-cleanup': 'Select Card Folder',
+  };
   document.getElementById('folderBrowserTitle').textContent =
-    browserMode === 'source' ? 'Select Source Folders' : 'Select Destination Folder';
+    titles[browserMode];
   browserSelectedPaths = [];
   browserSelectAnchorPath = '';
   updateImportBrowserSelection();
@@ -1419,9 +1546,12 @@ function openImportFolderBrowser(mode, opts = {}) {
   document.body.style.overflow = 'hidden';
   const firstAction = overlay.querySelector('button');
   if (firstAction) firstAction.focus();
-  const startPath = browserMode === 'destination'
-    ? (document.getElementById('destInput').value || '').trim()
-    : '';
+  let startPath = '';
+  if (browserMode === 'destination') {
+    startPath = (document.getElementById('destInput').value || '').trim();
+  } else if (browserMode === 'card-cleanup') {
+    startPath = (document.getElementById('card-cleanup-source').value || '').trim();
+  }
   if (!opts.skipInitialBrowse) browseImportFolderTo(startPath || null);
 }
 
@@ -1535,7 +1665,7 @@ function renderImportFolderBrowser(data, opts) {
   list.onclick = (e) => {
     const item = e.target.closest('.folder-browser-item[data-browse-path]');
     if (!item) return;
-    if (item.getAttribute('data-parent-link') === '1' || browserMode === 'destination') {
+    if (item.getAttribute('data-parent-link') === '1' || browserMode !== 'source') {
       browseImportFolderTo(item.getAttribute('data-browse-path'));
       return;
     }
@@ -1667,6 +1797,12 @@ function updateImportBrowserSelection() {
 }
 
 function selectImportBrowserFolder() {
+  if (browserMode === 'card-cleanup') {
+    if (!browserPath) return;
+    document.getElementById('card-cleanup-source').value = browserPath;
+    closeImportFolderBrowser();
+    return;
+  }
   if (browserMode === 'destination') {
     if (!browserPath) return;
     const destination = document.getElementById('destInput');
@@ -3995,6 +4131,11 @@ function renderResult(res, status) {
   retryRow.style.display = 'none';
   retryHint.textContent = '';
   retryButton.disabled = false;
+  // Card-cleanup entry point. Reset it here so an in-place run after a
+  // copy run doesn't inherit the previous run's button and source path.
+  const freeUpCardBtn = document.getElementById('btnFreeUpCardSpace');
+  freeUpCardBtn.style.display = 'none';
+  cardCleanupImportSources = [];
   const pill = document.getElementById('safeToFormatPill');
   const unsafe = document.getElementById('unsafeList');
   unsafe.innerHTML = '';
@@ -4097,6 +4238,16 @@ function renderResult(res, status) {
       unsafe.style.display = '';
       unsafe.appendChild(li);
     }
+  }
+  // Copy imports leave a second copy on the card, so offer the cleanup
+  // section here — including (especially) when the card is NOT safe to
+  // format, where deleting only the verified subset is the point. The
+  // finished job's config carries the card paths the user picked.
+  const importedSources = (((lastFinishedImportJob || {}).config || {}).sources
+    || []).filter(s => typeof s === 'string' && s);
+  if (importedSources.length) {
+    cardCleanupImportSources = importedSources;
+    freeUpCardBtn.style.display = '';
   }
   document.getElementById('resultSummary').textContent =
     res.discovered + ' discovered · ' + res.copied + ' copied · ' +
@@ -4455,6 +4606,487 @@ async function initImportPage() {
     browseForSource();
   }
 }
+/* ---------- Free up card space ----------
+   Deletes card files only where the archive copy is verified. Every count
+   and byte total shown here is read straight out of the scan manifest —
+   this section never estimates, and it marks the preview incomplete
+   whenever the card walk hit a folder it could not read. */
+const cardCleanupState = {
+  scanJobId: null,      // manifest key of the last scan we started
+  jobId: null,          // job currently streaming (scan or delete)
+  finishedJobId: null,  // guards the double 'complete' + 'error' callback
+  es: null,             // this section's stream; never the page's `es`
+  manifest: null,
+  listsRendered: {},    // bucket -> true once its <li>s are in the DOM
+  confirmEscHandler: null,
+};
+let cardCleanupImportSources = [];
+
+function cardCleanupFileCount(n) {
+  const count = Number(n || 0);
+  return count.toLocaleString() + (count === 1 ? ' file' : ' files');
+}
+
+function cardCleanupSetError(msg, opts) {
+  const el = document.getElementById('card-cleanup-error');
+  el.textContent = '';
+  el.classList.toggle('visible', !!msg);
+  if (!msg) return;
+  el.append(msg);
+  if (opts && opts.rescan) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'retry-link';
+    btn.textContent = 'Re-scan';
+    btn.addEventListener('click', () => cardCleanupStartScan());
+    el.append(' ', btn);
+  }
+}
+
+async function cardCleanupBrowse() {
+  // Same shape as browseForSource()/browseForDestination(): native picker
+  // when the desktop shell offers one, in-page browser otherwise.
+  if (typeof pickDirectory === 'function') {
+    const seqBeforePicker = browserSeq;
+    const result = await pickDirectory('Select the card folder');
+    if (result) {
+      const path = Array.isArray(result) ? result[0] : result;
+      if (path) document.getElementById('card-cleanup-source').value = path;
+      return;
+    }
+    if (typeof isTauri === 'function' && isTauri()) return;
+    if (browserSeq !== seqBeforePicker) {
+      openImportFolderBrowser('card-cleanup', { skipInitialBrowse: true });
+      return;
+    }
+  }
+  openImportFolderBrowser('card-cleanup');
+}
+
+// Entry point from the card-safety pill: open the section pre-filled with
+// the finished import's source folder.
+function cardCleanupOpenFromImport() {
+  const section = document.getElementById('card-cleanup-section');
+  section.open = true;
+  const input = document.getElementById('card-cleanup-source');
+  const note = document.getElementById('card-cleanup-source-note');
+  if (cardCleanupImportSources.length) {
+    input.value = cardCleanupImportSources[0];
+    document.getElementById('card-cleanup-recursive').checked = true;
+    cardCleanupResetPreview();
+    cardCleanupSetError('');
+    document.getElementById('card-cleanup-result').style.display = 'none';
+  }
+  if (cardCleanupImportSources.length > 1) {
+    note.style.display = '';
+    note.textContent =
+      'That import used ' + cardCleanupImportSources.length +
+      ' source folders; this filled in the first one. Check the others one ' +
+      'at a time: ' + cardCleanupImportSources.slice(1).join(', ');
+  } else {
+    note.style.display = 'none';
+    note.textContent = '';
+  }
+  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  input.focus({ preventScroll: true });
+}
+
+async function cardCleanupStartScan() {
+  if (cardCleanupState.jobId) return;  // a run is already streaming
+  const source = (document.getElementById('card-cleanup-source').value || '').trim();
+  const recursive = document.getElementById('card-cleanup-recursive').checked;
+  if (!source) {
+    cardCleanupSetError('Choose the card folder to check.');
+    return;
+  }
+  cardCleanupSetError('');
+  cardCleanupResetPreview();
+  document.getElementById('card-cleanup-result').style.display = 'none';
+  const scanBtn = document.getElementById('card-cleanup-scan-btn');
+  scanBtn.disabled = true;
+  try {
+    const resp = await fetch('/api/card-cleanup/scan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source, recursive }),
+    });
+    const data = await resp.json();
+    // The 400s here are written for the user (archive overlap, unreadable
+    // path) — show the server's own words rather than a generic failure.
+    if (!resp.ok) throw new Error(data.error || 'scan failed to start');
+    cardCleanupState.scanJobId = data.job_id;
+    cardCleanupWatchJob(data.job_id, 'scan', 'Starting scan…');
+  } catch (e) {
+    scanBtn.disabled = false;
+    cardCleanupSetError(String(e.message || e));
+  }
+}
+
+function cardCleanupWatchJob(jobId, kind, startingPhase) {
+  cardCleanupState.jobId = jobId;
+  cardCleanupState.finishedJobId = null;
+  document.getElementById('card-cleanup-progress').style.display = '';
+  document.getElementById('card-cleanup-phase').textContent = startingPhase;
+  document.getElementById('card-cleanup-progress-fill').style.width = '0%';
+  const cancelBtn = document.getElementById('card-cleanup-cancel-btn');
+  cancelBtn.style.display = '';
+  cancelBtn.disabled = false;
+  cancelBtn.textContent = 'Cancel';
+  if (cardCleanupState.es) { cardCleanupState.es.close(); cardCleanupState.es = null; }
+  cardCleanupState.es =
+    new EventSource('/api/jobs/' + encodeURIComponent(jobId) + '/stream');
+  cardCleanupState.es.addEventListener('progress', (evt) => {
+    try { cardCleanupRenderProgress(JSON.parse(evt.data)); } catch (e) { /* ignore */ }
+  });
+  cardCleanupState.es.addEventListener('complete', () => {
+    cardCleanupCloseStream();
+    cardCleanupFinishJob(jobId, kind);
+  });
+  cardCleanupState.es.addEventListener('error', () => {
+    // Stream dropped (server restart, network) — fall back to polling the
+    // job rather than pretending progress continues. Same as watchJob().
+    cardCleanupCloseStream();
+    cardCleanupFinishJob(jobId, kind);
+  });
+}
+
+function cardCleanupCloseStream() {
+  if (cardCleanupState.es) {
+    cardCleanupState.es.close();
+    cardCleanupState.es = null;
+  }
+}
+
+function cardCleanupRenderProgress(data) {
+  const parts = [];
+  if (data.phase) parts.push(data.phase);
+  if (data.total) {
+    parts.push(Number(data.current || 0).toLocaleString() + ' / ' +
+      Number(data.total).toLocaleString());
+  }
+  if (data.current_file) parts.push(data.current_file);
+  document.getElementById('card-cleanup-phase').textContent = parts.join(' · ');
+  const pct = data.total ? Math.round(100 * data.current / data.total) : 0;
+  document.getElementById('card-cleanup-progress-fill').style.width = pct + '%';
+}
+
+async function cardCleanupFinishJob(jobId, kind) {
+  // 'complete' and 'error' can both fire for one job; only finish once.
+  if (cardCleanupState.finishedJobId === jobId) return;
+  cardCleanupState.finishedJobId = jobId;
+  let job = null;
+  for (let i = 0; i < 30; i++) {
+    const resp = await fetch('/api/jobs/' + encodeURIComponent(jobId));
+    if (resp.ok) {
+      const polled = await resp.json();
+      if (polled.status && polled.status !== 'running'
+          && polled.status !== 'queued') {
+        job = polled;
+        break;
+      }
+    }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  cardCleanupState.jobId = null;
+  document.getElementById('card-cleanup-cancel-btn').style.display = 'none';
+  document.getElementById('card-cleanup-progress').style.display = 'none';
+  document.getElementById('card-cleanup-scan-btn').disabled = false;
+  const status = job && job.status;
+  const jobError = job && (job.errors || [])[0];
+  if (kind === 'scan') {
+    if (status === 'completed') {
+      await cardCleanupLoadManifest();
+    } else if (status === 'cancelled') {
+      cardCleanupSetError(
+        'Scan cancelled — no files were checked against the archive, and ' +
+        'nothing was deleted. Scan again when you are ready.');
+    } else if (status) {
+      cardCleanupSetError('Scan ' + status + ' — no preview was produced' +
+        (jobError ? ': ' + jobError : '.'));
+    } else {
+      cardCleanupSetError(
+        'The scan is still running but this page lost track of it — ' +
+        'check the Jobs page.');
+    }
+    return;
+  }
+  // Delete: the per-file outcome lives in the job result, so a job that
+  // ended without one has to say so rather than imply a clean run.
+  if (job && job.result) {
+    cardCleanupRenderDeleteResult(job.result);
+  } else if (status) {
+    cardCleanupSetError('Deletion ' + status +
+      ' and its summary could not be loaded' +
+      (jobError ? ': ' + jobError : '') + ' — check the Jobs page for what ' +
+      'was deleted, then re-scan the card.');
+  } else {
+    cardCleanupSetError(
+      'The deletion is still running but this page lost track of it — ' +
+      'check the Jobs page.');
+  }
+}
+
+async function cardCleanupLoadManifest() {
+  try {
+    const resp = await fetch('/api/card-cleanup/' +
+      encodeURIComponent(cardCleanupState.scanJobId) + '/manifest');
+    const data = await resp.json();
+    if (resp.status === 404) {
+      cardCleanupState.scanJobId = null;
+      cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
+      return;
+    }
+    if (!resp.ok) throw new Error(data.error || 'the preview could not be loaded');
+    cardCleanupRenderManifest(data);
+  } catch (e) {
+    cardCleanupSetError(String(e.message || e));
+  }
+}
+
+function cardCleanupRenderManifest(manifest) {
+  cardCleanupState.manifest = manifest;
+  cardCleanupState.listsRendered = {};
+  const totals = manifest.totals || {};
+  const deletable = totals.deletable || { count: 0, bytes: 0 };
+  const kept = totals.kept || { count: 0, bytes: 0 };
+  const ignored = totals.ignored || { count: 0 };
+  const walkErrors = (manifest.walk_errors || []).map(String);
+
+  // Unmissable and above the numbers: a walk that skipped folders means
+  // the counts below are a floor, not the whole card.
+  const incomplete = document.getElementById('card-cleanup-incomplete');
+  if (walkErrors.length) {
+    incomplete.style.display = '';
+    document.getElementById('card-cleanup-incomplete-text').textContent =
+      'Some folders could not be read; this preview is incomplete. Files ' +
+      'that were not seen will never be deleted.';
+    document.getElementById('card-cleanup-walk-errors-summary').textContent =
+      walkErrors.length.toLocaleString() + ' folder ' +
+      (walkErrors.length === 1 ? 'error' : 'errors');
+    cardCleanupFillList('card-cleanup-walk-errors', walkErrors);
+  } else {
+    incomplete.style.display = 'none';
+  }
+
+  document.getElementById('card-cleanup-scanned-root').textContent =
+    'Checked ' + (manifest.source_root || '') +
+    (manifest.recursive
+      ? ' and its subfolders'
+      : ' only (subfolders were not included)');
+
+  document.getElementById('card-cleanup-deletable-summary').textContent =
+    cardCleanupFileCount(deletable.count) + ' / ' +
+    formatBytes(deletable.bytes) +
+    ' verified in the archive — safe to delete';
+  document.getElementById('card-cleanup-kept-summary').textContent =
+    cardCleanupFileCount(kept.count) + ' / ' + formatBytes(kept.bytes) +
+    ' not verified — will be kept';
+  document.getElementById('card-cleanup-ignored-summary').textContent =
+    cardCleanupFileCount(ignored.count) +
+    ' ignored (not photo files Vireo imports)';
+
+  cardCleanupBindBucket('deletable', 'card-cleanup-deletable-details',
+    'card-cleanup-deletable-list');
+  cardCleanupBindBucket('kept', 'card-cleanup-kept-details',
+    'card-cleanup-kept-list');
+  cardCleanupBindBucket('ignored', 'card-cleanup-ignored-details',
+    'card-cleanup-ignored-list');
+
+  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
+  deleteBtn.disabled = deletable.count === 0;
+  document.getElementById('card-cleanup-delete-hint').textContent =
+    deletable.count === 0
+      ? 'Nothing on this card is verified in the archive, so there is ' +
+        'nothing safe to delete.'
+      : 'Deletes the ' + cardCleanupFileCount(deletable.count) +
+        ' listed as verified above, and nothing else.';
+  document.getElementById('card-cleanup-preview').style.display = '';
+}
+
+// Bucket lists run to thousands of rows, so build them the first time the
+// user opens that group rather than on every scan.
+function cardCleanupBindBucket(bucket, detailsId, listId) {
+  const details = document.getElementById(detailsId);
+  details.open = false;
+  details.ontoggle = () => {
+    if (!details.open || cardCleanupState.listsRendered[bucket]) return;
+    if (!cardCleanupState.manifest) return;
+    cardCleanupState.listsRendered[bucket] = true;
+    const lines = (cardCleanupState.manifest.entries || [])
+      .filter(entry => entry.bucket === bucket)
+      .map(entry => (bucket === 'kept'
+        ? entry.path + ' — ' + (entry.reason || 'not verified')
+        : entry.path));
+    cardCleanupFillList(listId, lines);
+  };
+}
+
+function cardCleanupFillList(listId, lines) {
+  const list = document.getElementById(listId);
+  list.innerHTML = '';
+  const frag = document.createDocumentFragment();
+  if (!lines.length) {
+    const li = document.createElement('li');
+    li.textContent = 'No files in this group.';
+    frag.appendChild(li);
+  }
+  lines.forEach((line) => {
+    const li = document.createElement('li');
+    li.textContent = line;
+    frag.appendChild(li);
+  });
+  list.appendChild(frag);
+}
+
+function cardCleanupResetPreview() {
+  cardCleanupState.manifest = null;
+  cardCleanupState.listsRendered = {};
+  document.getElementById('card-cleanup-preview').style.display = 'none';
+  document.getElementById('card-cleanup-incomplete').style.display = 'none';
+  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
+  deleteBtn.disabled = true;
+  document.getElementById('card-cleanup-delete-hint').textContent = '';
+  [
+    'card-cleanup-deletable-details', 'card-cleanup-kept-details',
+    'card-cleanup-ignored-details', 'card-cleanup-walk-errors-details',
+  ].forEach((id) => { document.getElementById(id).open = false; });
+}
+
+function cardCleanupOpenConfirm() {
+  const manifest = cardCleanupState.manifest;
+  if (!manifest) return;
+  const deletable = (manifest.totals || {}).deletable || { count: 0, bytes: 0 };
+  if (!deletable.count) return;
+  document.getElementById('card-cleanup-confirm-count').textContent =
+    'Deleting ' + cardCleanupFileCount(deletable.count) + ' (' +
+    formatBytes(deletable.bytes) + ') from ' +
+    (manifest.source_root || 'the card') + '.';
+  const overlay = document.getElementById('card-cleanup-confirm');
+  overlay.classList.add('open');
+  overlay.onclick = (e) => { if (e.target === overlay) cardCleanupCloseConfirm(); };
+  if (cardCleanupState.confirmEscHandler) {
+    document.removeEventListener('keydown', cardCleanupState.confirmEscHandler);
+  }
+  cardCleanupState.confirmEscHandler = (e) => {
+    if (e.key === 'Escape') cardCleanupCloseConfirm();
+  };
+  document.addEventListener('keydown', cardCleanupState.confirmEscHandler);
+  document.body.style.overflow = 'hidden';
+  // Focus the dialog's first control (the close button), not the delete
+  // button — a stray Enter must not delete anything.
+  const firstAction = overlay.querySelector('button');
+  if (firstAction) firstAction.focus();
+}
+
+function cardCleanupCloseConfirm() {
+  document.getElementById('card-cleanup-confirm').classList.remove('open');
+  if (cardCleanupState.confirmEscHandler) {
+    document.removeEventListener('keydown', cardCleanupState.confirmEscHandler);
+    cardCleanupState.confirmEscHandler = null;
+  }
+  document.body.style.overflow = '';
+}
+
+async function cardCleanupConfirmDelete() {
+  const confirmBtn = document.getElementById('card-cleanup-confirm-btn');
+  confirmBtn.disabled = true;
+  try {
+    const resp = await fetch('/api/card-cleanup/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scan_job_id: cardCleanupState.scanJobId }),
+    });
+    const data = await resp.json();
+    cardCleanupCloseConfirm();
+    if (!resp.ok) {
+      if (resp.status === 404) {
+        // The manifest is gone, so the preview above no longer describes
+        // anything that can be deleted — take it down with the error.
+        cardCleanupState.scanJobId = null;
+        cardCleanupResetPreview();
+        cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
+      } else {
+        cardCleanupSetError(data.error || 'deletion failed to start');
+      }
+      return;
+    }
+    cardCleanupSetError('');
+    document.getElementById('card-cleanup-result').style.display = 'none';
+    document.getElementById('card-cleanup-delete-btn').disabled = true;
+    document.getElementById('card-cleanup-scan-btn').disabled = true;
+    cardCleanupWatchJob(data.job_id, 'delete', 'Starting deletion…');
+  } catch (e) {
+    cardCleanupCloseConfirm();
+    cardCleanupSetError(String(e.message || e));
+  } finally {
+    confirmBtn.disabled = false;
+  }
+}
+
+function cardCleanupRenderDeleteResult(result) {
+  const res = result || {};
+  const skipped = res.skipped || [];
+  const failed = res.failed || [];
+  const parts = ['Deleted ' + cardCleanupFileCount(res.deleted) +
+    ' (' + formatBytes(res.deleted_bytes) + ')'];
+  if (skipped.length) {
+    parts.push(skipped.length.toLocaleString() + ' skipped');
+  }
+  if (failed.length) {
+    parts.push(failed.length.toLocaleString() + ' failed');
+  }
+  if (res.cancelled) {
+    parts.push('Cancelled — ' + Number(res.remaining || 0).toLocaleString() +
+      ' files not yet processed.');
+  }
+  document.getElementById('card-cleanup-result').style.display = '';
+  document.getElementById('card-cleanup-result-summary').textContent =
+    parts.join(' · ');
+  const lines = [];
+  skipped.forEach((s) => {
+    lines.push('Skipped: ' + s.path + ' — ' + (s.reason || 'no reason given'));
+  });
+  failed.forEach((f) => {
+    lines.push('Failed: ' + f.path + ' — ' + (f.error || 'no error given'));
+  });
+  const list = document.getElementById('card-cleanup-result-list');
+  if (lines.length) {
+    list.style.display = '';
+    cardCleanupFillList('card-cleanup-result-list', lines);
+  } else {
+    list.style.display = 'none';
+    list.innerHTML = '';
+  }
+  // The manifest describes files that are now gone, so the preview above
+  // is history. Say so instead of leaving a live-looking Delete button.
+  document.getElementById('card-cleanup-delete-btn').disabled = true;
+  document.getElementById('card-cleanup-delete-hint').textContent =
+    'These numbers describe the scan that ran before this deletion — ' +
+    'scan again to see what is still on the card.';
+}
+
+async function cardCleanupCancelJob() {
+  const jobId = cardCleanupState.jobId;
+  if (!jobId) return;
+  const btn = document.getElementById('card-cleanup-cancel-btn');
+  btn.disabled = true;
+  btn.textContent = 'Cancelling…';
+  try {
+    const resp = await fetch(
+      '/api/jobs/' + encodeURIComponent(jobId) + '/cancel', { method: 'POST' });
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      btn.disabled = false;
+      btn.textContent = 'Cancel';
+      cardCleanupSetError(data.error || 'Unable to cancel the job.');
+    }
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = 'Cancel';
+    cardCleanupSetError(String(e.message || e));
+  }
+}
+
 initImportPage();
 </script>
 </body>

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -4925,11 +4925,23 @@ function cardCleanupBindBucket(bucket, detailsId, listId) {
     if (!details.open || cardCleanupState.listsRendered[bucket]) return;
     if (!cardCleanupState.manifest) return;
     cardCleanupState.listsRendered[bucket] = true;
+    // Spec ("UX flow"): verified rows show path, size, and the matched
+    // archive copy that justifies the deletion; kept rows show size and
+    // the per-file reason. All fields come straight from the manifest.
     const lines = (cardCleanupState.manifest.entries || [])
       .filter(entry => entry.bucket === bucket)
-      .map(entry => (bucket === 'kept'
-        ? entry.path + ' — ' + (entry.reason || 'not verified')
-        : entry.path));
+      .map(entry => {
+        const size = (typeof entry.size === 'number')
+          ? ' (' + formatBytes(entry.size) + ')' : '';
+        if (bucket === 'kept') {
+          return entry.path + size + ' — ' + (entry.reason || 'not verified');
+        }
+        if (bucket === 'deletable') {
+          return entry.path + size
+            + ' → verified copy: ' + (entry.archive_path || 'unknown');
+        }
+        return entry.path;
+      });
     cardCleanupFillList(listId, lines);
   };
 }

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -27,6 +27,7 @@ GET          /api/audit/untracked
 GET          /api/browse
 GET          /api/browse/init
 GET          /api/browse/summary
+GET          /api/card-cleanup/<scan_job_id>/manifest
 GET          /api/classify/config
 GET          /api/classify/readiness
 GET          /api/collections
@@ -221,6 +222,8 @@ POST         /api/batch/rating
 POST         /api/browse/mkdir
 POST         /api/browse/photo-counts
 POST         /api/capture-time/preview
+POST         /api/card-cleanup/delete
+POST         /api/card-cleanup/scan
 POST         /api/collections
 POST         /api/collections/<int:collection_id>/add-photos
 POST         /api/collections/<int:collection_id>/duplicate

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -724,3 +724,38 @@ def test_delete_skips_file_replaced_during_archive_gate(db, tmp_path):
     assert len(summary["skipped"]) == 1
     assert card.exists()
     assert card.read_bytes() == b"NEW-ONE"
+
+
+def test_delete_skips_path_redirected_outside_source(db, tmp_path):
+    # Second Codex P1: after the manifest is loaded, the card's DCIM
+    # directory is replaced with a symlink to an external directory
+    # holding a byte-identical file with the manifest's size and mtime.
+    # Every content gate passes (the bytes really are verified-archived);
+    # only the deletion-time containment re-check can refuse to unlink a
+    # path that no longer resolves inside the scanned source.
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    entry = next(e for e in manifest["entries"] if e["bucket"] == "deletable")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    decoy = outside / "IMG_0001.NEF"
+    decoy.write_bytes(b"raw-one")
+    os.utime(decoy, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+
+    dcim = tmp_path / "card" / "DCIM"
+    import shutil
+    shutil.rmtree(dcim)
+    try:
+        os.symlink(str(outside), str(dcim))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this filesystem")
+
+    summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 0
+    assert len(summary["skipped"]) == 1
+    assert "no longer resolves inside" in summary["skipped"][0]["reason"]
+    assert decoy.exists() and decoy.read_bytes() == b"raw-one"

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -1,0 +1,111 @@
+"""Unit tests for card cleanup: manifest IO, classification, and the
+scan/delete safety gates. Spec:
+docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+"""
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import card_cleanup
+from card_cleanup import (
+    ManifestError, load_manifest, prune_manifests, write_manifest,
+)
+
+
+def _manifest(tmp_path, **overrides):
+    m = {
+        "schema_version": card_cleanup.MANIFEST_SCHEMA_VERSION,
+        "scan_job_id": "scan-1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "source_root": str(tmp_path / "card"),
+        "recursive": True,
+        "entries": [],
+        "walk_errors": [],
+        "totals": {},
+    }
+    m.update(overrides)
+    return m
+
+
+def test_write_then_load_roundtrip(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    (tmp_path / "card").mkdir()
+    write_manifest(mdir, _manifest(tmp_path))
+    loaded = load_manifest(mdir, "scan-1")
+    assert loaded["scan_job_id"] == "scan-1"
+
+
+def test_write_is_atomic_no_leftover_tmp(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path))
+    names = os.listdir(mdir)
+    assert names == ["scan-1.json"]
+
+
+def test_load_missing_manifest_is_404(tmp_path):
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(str(tmp_path), "nope")
+    assert exc.value.http_status == 404
+
+
+def test_load_rejects_corrupt_json(tmp_path):
+    mdir = tmp_path / "manifests"
+    mdir.mkdir()
+    (mdir / "scan-1.json").write_text("{truncated")
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(str(mdir), "scan-1")
+    assert exc.value.http_status == 400
+
+
+def test_load_rejects_unknown_schema(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, schema_version=99))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def test_load_rejects_missing_source_root(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, source_root=""))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def test_load_rejects_deletable_entry_outside_source_root(tmp_path):
+    (tmp_path / "card").mkdir()
+    entry = {
+        "path": str(tmp_path / "elsewhere" / "x.nef"),
+        "size": 1, "mtime_ns": 1, "hash": "h", "bucket": "deletable",
+    }
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, entries=[entry]))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def test_load_rejects_expired_manifest_at_request_time(tmp_path):
+    (tmp_path / "card").mkdir()
+    old = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, created_at=old))
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(mdir, "scan-1")
+    assert exc.value.http_status == 404
+    assert "re-scan" in str(exc.value)
+
+
+def test_prune_removes_only_old_manifests(tmp_path):
+    mdir = tmp_path / "manifests"
+    mdir.mkdir()
+    old_file = mdir / "old.json"
+    new_file = mdir / "new.json"
+    old_file.write_text("{}")
+    new_file.write_text("{}")
+    eight_days = 8 * 86400
+    stale = os.stat(old_file).st_mtime - eight_days
+    os.utime(old_file, (stale, stale))
+    prune_manifests(str(mdir))
+    assert not old_file.exists()
+    assert new_file.exists()

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -251,6 +251,33 @@ def test_classify_parity_with_discover_source_files(tmp_path):
         str(card), file_types="both", recursive=False)
 
 
+def test_classify_rejects_symlinks(tmp_path):
+    # Codex P2: Path.is_file() follows symlinks, so a symlink to a real
+    # photo would be classified as deletable — hashed for the target's
+    # size, then os.remove would unlink only the link. delete_verified
+    # would then credit the target's full size as "deleted bytes" even
+    # though no card space is reclaimed and the actual photo still
+    # exists. Symlinks must not enter the deletable set.
+    card = tmp_path / "card"
+    card.mkdir()
+    real = tmp_path / "elsewhere" / "IMG_0001.NEF"
+    real.parent.mkdir()
+    real.write_bytes(b"raw-one")
+    link = card / "IMG_LINK.NEF"
+    try:
+        os.symlink(str(real), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this filesystem")
+    # Non-symlink control so we know classification is still running.
+    (card / "IMG_REAL.NEF").write_bytes(b"raw-two")
+    candidates, ignored = classify_source_files(str(card))
+    cand_names = {p.name for p in candidates}
+    ign_names = {p.name for p in ignored}
+    assert "IMG_LINK.NEF" not in cand_names
+    assert "IMG_LINK.NEF" not in ign_names
+    assert cand_names == {"IMG_REAL.NEF"}
+
+
 def test_classify_missing_source_reports_onerror(tmp_path):
     errors = []
     candidates, ignored = classify_source_files(

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -712,9 +712,16 @@ def test_delete_skips_file_replaced_during_archive_gate(db, tmp_path):
 
     def fetch_then_replace(db_arg, file_hash):
         rows = real_fetch(db_arg, file_hash)
-        os.unlink(card)                      # new inode on rewrite
-        card.write_bytes(b"NEW-ONE")         # same 7-byte size
-        os.utime(card, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+        # Swap via a coexisting temp file + os.replace: unlink-then-
+        # recreate would let ext4 hand the replacement the freed inode
+        # number, silently defeating the inode gate this test pins.
+        # With both files alive before the swap, the inodes are distinct
+        # on every POSIX filesystem — and rename is the realistic
+        # replacement primitive anyway.
+        tmp = card.parent / "replacement.tmp"
+        tmp.write_bytes(b"NEW-ONE")          # same 7-byte size
+        os.utime(tmp, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+        os.replace(tmp, card)
         return rows
 
     with unittest.mock.patch.object(

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -793,3 +793,38 @@ def test_delete_skips_path_redirected_outside_source(db, tmp_path):
     assert len(summary["skipped"]) == 1
     assert "no longer resolves inside" in summary["skipped"][0]["reason"]
     assert decoy.exists() and decoy.read_bytes() == b"raw-one"
+
+
+def test_delete_skips_when_card_path_becomes_symlink_post_scan(db, tmp_path):
+    # Codex P2: scan classifies only regular files, but a post-scan swap
+    # of a scanned pathname for a symlink to a byte-identical file with
+    # the same size and mtime would let os.stat follow the link. The
+    # delete would then unlink only the symlink while crediting the
+    # target's full bytes as reclaimed. lstat + explicit S_ISLNK
+    # rejection at the delete gate keeps the destructive step anchored
+    # to the object the scan hashed.
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)  # content b"raw-one", 7 bytes
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    entry = next(e for e in manifest["entries"] if e["bucket"] == "deletable")
+
+    target = card.parent / "IMG_0001_copy.NEF"
+    target.write_bytes(b"raw-one")
+    os.utime(target, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+    os.unlink(card)
+    try:
+        os.symlink(str(target), str(card))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this filesystem")
+
+    summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 0
+    assert summary["deleted_bytes"] == 0
+    assert len(summary["skipped"]) == 1
+    assert summary["skipped"][0]["reason"] == card_cleanup.SKIP_SYMLINK
+    # The symlink itself and the byte-identical target both survive: the
+    # tool refused to operate on a link it never classified.
+    assert card.is_symlink()
+    assert target.exists() and target.read_bytes() == b"raw-one"

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -3,6 +3,7 @@ scan/delete safety gates. Spec:
 docs/superpowers/specs/2026-08-07-card-cleanup-design.md
 """
 import os
+import shutil
 import unittest.mock
 from datetime import UTC, datetime, timedelta
 
@@ -330,6 +331,18 @@ def test_scan_null_hash_status_kept_with_audit_remedy(db, tmp_path):
     assert "integrity audit" in kept[0]["reason"]
 
 
+def test_scan_failed_hash_status_kept_with_audit_remedy(db, tmp_path):
+    # hash_status is a non-ok STRING (a prior verify run flagged the file),
+    # not NULL — must be kept exactly like the null/unverified case, not
+    # mistaken for "ok" by a truthy/None-only check.
+    _archive_photo(db, tmp_path, hash_status="failed")
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    kept = _entries(result, "kept")
+    assert len(kept) == 1
+    assert "integrity audit" in kept[0]["reason"]
+
+
 def test_scan_archive_file_missing_kept(db, tmp_path):
     archive_file, _ = _archive_photo(db, tmp_path)
     _card_file(tmp_path)
@@ -530,6 +543,71 @@ def test_delete_archive_removed_after_scan_skips(db, tmp_path):
     assert summary["deleted"] == 0
     assert card.exists()
     assert "archive" in summary["skipped"][0]["reason"]
+
+
+def test_delete_archive_mutated_after_scan_skips(db, tmp_path):
+    # The archive file survives (unlike the removed case above) but its
+    # bytes change between scan and delete — the delete-time re-stat's
+    # size/mtime mismatch must still catch it and keep the card file.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+
+    def mutate_archive():
+        archive_file.write_bytes(b"mutated!")
+
+    summary = _scan_then_delete(db, tmp_path, mutate=mutate_archive)
+    assert summary["deleted"] == 0
+    assert card.exists()
+    assert len(summary["skipped"]) == 1
+    assert "archive" in summary["skipped"][0]["reason"]
+
+
+def test_delete_archive_mount_unreachable_skips_all(db, tmp_path):
+    # Whole archive tree gone (e.g. an unmounted network volume), not
+    # just one file — every deletable card file must be skipped, none
+    # deleted, and each reason must mention the archive.
+    _archive_photo(db, tmp_path)
+    card_a = _card_file(tmp_path, name="IMG_0001.NEF")
+    card_b = _card_file(tmp_path, name="IMG_0002.NEF")
+    archive_root = tmp_path / "archive"
+
+    def remove_archive_tree():
+        shutil.rmtree(archive_root)
+
+    summary = _scan_then_delete(db, tmp_path, mutate=remove_archive_tree)
+    assert summary["deleted"] == 0
+    assert card_a.exists() and card_b.exists()
+    assert len(summary["skipped"]) == 2
+    assert all("archive" in s["reason"] for s in summary["skipped"])
+
+
+def test_delete_time_inside_source_uses_manifest_source_root(db, tmp_path):
+    # The catalog row qualifies at scan time (archive copy is outside the
+    # source), but before delete runs the archive folder is repointed
+    # (via SQL, as if re-cataloged) to a path inside the selected source
+    # tree. delete_verified must re-derive source_root from the manifest
+    # it was handed and re-run the inside-source check itself — this pins
+    # that wiring, not just qualify_rows' logic (already covered at scan
+    # time by test_scan_self_match_inside_source_never_qualifies).
+    archive_file, pid = _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    row = db.conn.execute(
+        "SELECT folder_id FROM photos WHERE id = ?", (pid,)).fetchone()
+    folder_id = row["folder_id"]
+    card_dir = str(tmp_path / "card" / "DCIM")
+
+    def repoint_inside_source():
+        db.conn.execute(
+            "UPDATE folders SET path = ? WHERE id = ?",
+            (card_dir, folder_id))
+        db.conn.commit()
+
+    summary = _scan_then_delete(db, tmp_path, mutate=repoint_inside_source)
+    assert summary["deleted"] == 0
+    assert card.exists()
+    assert archive_file.exists()  # untouched — never re-read by delete
+    assert len(summary["skipped"]) == 1
+    assert "inside the selected source" in summary["skipped"][0]["reason"]
 
 
 def test_delete_no_stat_reuse_across_duplicates(db, tmp_path):

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -899,3 +899,85 @@ def test_delete_skips_when_card_path_becomes_symlink_post_scan(db, tmp_path):
     # tool refused to operate on a link it never classified.
     assert card.is_symlink()
     assert target.exists() and target.read_bytes() == b"raw-one"
+
+
+def test_delete_skips_when_archive_dies_during_final_hash(db, tmp_path):
+    # Codex P1: gate 1 authorizes, then the final card re-hash reads the
+    # whole file (seconds on real photos). If the archive vanishes during
+    # that hash, gate 1's authorization is stale. A second archive gate
+    # immediately before os.remove must catch the death — otherwise the
+    # card copy would be the ONLY remaining copy at unlink time.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    real_hash = card_cleanup.compute_file_hash
+    hash_calls = []
+
+    def hash_kill_archive_before_final(path, *a, **kw):
+        # Two hash calls per candidate in delete_verified: initial (fast
+        # reject) and final (right before unlink). Simulate the archive
+        # dying during the final call by unlinking it just before this
+        # invocation returns.
+        hash_calls.append(str(path))
+        result = real_hash(path, *a, **kw)
+        if len(hash_calls) == 2:
+            os.unlink(archive_file)
+        return result
+
+    with unittest.mock.patch.object(
+            card_cleanup, "compute_file_hash", hash_kill_archive_before_final):
+        summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 0
+    assert card.exists()
+    assert len(summary["skipped"]) == 1
+    assert "archive" in summary["skipped"][0]["reason"]
+
+
+def test_delete_skips_when_parent_redirected_during_final_hash(db, tmp_path):
+    # Codex P1: after both archive gate 1 and gate 2 authorize, if the
+    # parent directory is swapped for a symlink to a byte-identical
+    # external copy during the final hash, every content gate still
+    # passes — but os.remove would unlink the external file. The final
+    # containment recheck must run AFTER the final hash, not before it.
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)  # content b"raw-one", 7 bytes
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    entry = next(e for e in manifest["entries"] if e["bucket"] == "deletable")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    decoy = outside / "IMG_0001.NEF"
+    decoy.write_bytes(b"raw-one")
+    os.utime(decoy, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+
+    real_hash = card_cleanup.compute_file_hash
+    hash_calls = []
+
+    def hash_then_swap_parent(path, *a, **kw):
+        hash_calls.append(str(path))
+        result = real_hash(path, *a, **kw)
+        if len(hash_calls) == 2:
+            # Second hash call is the FINAL rehash. Swap the parent
+            # directory for a symlink to `outside` after the read has
+            # already committed to card bytes but before containment
+            # is re-verified.
+            dcim = tmp_path / "card" / "DCIM"
+            shutil.rmtree(dcim)
+            try:
+                os.symlink(str(outside), str(dcim))
+            except (OSError, NotImplementedError):
+                pytest.skip("symlinks unsupported on this filesystem")
+        return result
+
+    with unittest.mock.patch.object(
+            card_cleanup, "compute_file_hash", hash_then_swap_parent):
+        summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 0
+    assert len(summary["skipped"]) == 1
+    assert "no longer resolves inside" in summary["skipped"][0]["reason"]
+    # The decoy — the only file behind the redirected path — must survive.
+    assert decoy.exists() and decoy.read_bytes() == b"raw-one"

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -9,6 +9,7 @@ import card_cleanup
 import pytest
 from card_cleanup import (
     ManifestError,
+    classify_source_files,
     load_manifest,
     manifest_path,
     prune_manifests,
@@ -154,3 +155,65 @@ def test_write_manifest_json_dump_failure_leaves_no_tmp_file(tmp_path):
     with pytest.raises(TypeError):
         write_manifest(mdir, bad)
     assert os.listdir(mdir) == []
+
+
+def test_load_rejects_non_dict_entry(tmp_path):
+    (tmp_path / "card").mkdir()
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, entries=[1]))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def test_load_rejects_deletable_entry_with_null_byte(tmp_path):
+    (tmp_path / "card").mkdir()
+    entry = {
+        "path": str(tmp_path / "card" / "x\x00y.nef"),
+        "size": 1, "mtime_ns": 1, "hash": "h", "bucket": "deletable",
+    }
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, entries=[entry]))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def _make_card(tmp_path):
+    card = tmp_path / "card"
+    (card / "DCIM" / "100").mkdir(parents=True)
+    (card / "DCIM" / "100" / "IMG_0001.NEF").write_bytes(b"raw-one")
+    (card / "DCIM" / "100" / "IMG_0002.JPG").write_bytes(b"jpg-two")
+    (card / "DCIM" / "100" / "IMG_0001.XMP").write_bytes(b"sidecar")
+    (card / "DCIM" / "100" / ".hidden.jpg").write_bytes(b"dot")
+    (card / "MISC" / "sub").mkdir(parents=True)
+    (card / "MISC" / "sub" / "firmware.bin").write_bytes(b"fw")
+    return card
+
+
+def test_classify_buckets(tmp_path):
+    card = _make_card(tmp_path)
+    candidates, ignored = classify_source_files(str(card))
+    cand_names = {p.name for p in candidates}
+    ign_names = {p.name for p in ignored}
+    assert cand_names == {"IMG_0001.NEF", "IMG_0002.JPG"}
+    assert ign_names == {"IMG_0001.XMP", ".hidden.jpg", "firmware.bin"}
+
+
+def test_classify_parity_with_discover_source_files(tmp_path):
+    # The deletable set may never exceed what an import would consider a
+    # photo — pin our filter to discovery's, byte for byte.
+    from ingest import discover_source_files
+    card = _make_card(tmp_path)
+    candidates, _ = classify_source_files(str(card), recursive=True)
+    assert candidates == discover_source_files(
+        str(card), file_types="both", recursive=True)
+    candidates_flat, _ = classify_source_files(str(card), recursive=False)
+    assert candidates_flat == discover_source_files(
+        str(card), file_types="both", recursive=False)
+
+
+def test_classify_missing_source_reports_onerror(tmp_path):
+    errors = []
+    candidates, ignored = classify_source_files(
+        str(tmp_path / "nope"), onerror=errors.append)
+    assert candidates == [] and ignored == []
+    assert len(errors) == 1 and isinstance(errors[0], OSError)

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -4,6 +4,7 @@ docs/superpowers/specs/2026-08-07-card-cleanup-design.md
 """
 import os
 import shutil
+import stat
 import unittest.mock
 from datetime import UTC, datetime, timedelta
 
@@ -936,6 +937,56 @@ def test_delete_skips_when_card_path_becomes_symlink_post_scan(db, tmp_path):
     # tool refused to operate on a link it never classified.
     assert card.is_symlink()
     assert target.exists() and target.read_bytes() == b"raw-one"
+
+
+def test_delete_skips_when_card_path_becomes_fifo_post_scan(
+        db, tmp_path, monkeypatch):
+    # Codex P2: rejecting only symlinks at the delete gate leaves other
+    # non-regular replacements open. A scanned zero-byte photo swapped
+    # for a FIFO whose mtime is forced back to the manifest value passes
+    # the S_ISLNK reject and the size/mtime check; compute_file_hash
+    # then blocks forever opening the pipe, and cancellation is checked
+    # only at file boundaries, so the whole delete job hangs. Both lstat
+    # gates must reject any non-regular file BEFORE the hash open.
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("mkfifo unsupported on this platform")
+    _archive_photo(db, tmp_path, content=b"")
+    card = _card_file(tmp_path, content=b"")
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    entry = next(e for e in manifest["entries"] if e["bucket"] == "deletable")
+
+    os.unlink(card)
+    try:
+        os.mkfifo(str(card))
+    except OSError:
+        pytest.skip("mkfifo unsupported on this filesystem")
+    os.utime(card, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+
+    # compute_file_hash on a FIFO would block on open indefinitely. Prove
+    # the gate rejects the replacement BEFORE any hash call happens.
+    hash_calls = []
+    real_hash = card_cleanup.compute_file_hash
+
+    def guarded_hash(path, *a, **kw):
+        hash_calls.append(path)
+        raise AssertionError(
+            "compute_file_hash must not be called on a non-regular replacement")
+
+    monkeypatch.setattr(card_cleanup, "compute_file_hash", guarded_hash)
+    try:
+        summary = card_cleanup.delete_verified(db, manifest)
+    finally:
+        monkeypatch.setattr(card_cleanup, "compute_file_hash", real_hash)
+
+    assert hash_calls == []
+    assert summary["deleted"] == 0
+    assert summary["deleted_bytes"] == 0
+    assert len(summary["skipped"]) == 1
+    assert summary["skipped"][0]["reason"] == card_cleanup.SKIP_NOT_REGULAR
+    # The FIFO is left untouched — the tool refused to operate on it.
+    assert stat.S_ISFIFO(os.lstat(card).st_mode)
 
 
 def test_delete_skips_when_archive_dies_during_final_hash(db, tmp_path):

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -2,15 +2,17 @@
 scan/delete safety gates. Spec:
 docs/superpowers/specs/2026-08-07-card-cleanup-design.md
 """
-import json
 import os
-from datetime import datetime, timedelta, timezone
-
-import pytest
+from datetime import UTC, datetime, timedelta
 
 import card_cleanup
+import pytest
 from card_cleanup import (
-    ManifestError, load_manifest, prune_manifests, write_manifest,
+    ManifestError,
+    load_manifest,
+    manifest_path,
+    prune_manifests,
+    write_manifest,
 )
 
 
@@ -18,7 +20,7 @@ def _manifest(tmp_path, **overrides):
     m = {
         "schema_version": card_cleanup.MANIFEST_SCHEMA_VERSION,
         "scan_job_id": "scan-1",
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": datetime.now(UTC).isoformat(),
         "source_root": str(tmp_path / "card"),
         "recursive": True,
         "entries": [],
@@ -87,7 +89,7 @@ def test_load_rejects_deletable_entry_outside_source_root(tmp_path):
 
 def test_load_rejects_expired_manifest_at_request_time(tmp_path):
     (tmp_path / "card").mkdir()
-    old = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+    old = (datetime.now(UTC) - timedelta(days=8)).isoformat()
     mdir = str(tmp_path / "manifests")
     write_manifest(mdir, _manifest(tmp_path, created_at=old))
     with pytest.raises(ManifestError) as exc:
@@ -109,3 +111,46 @@ def test_prune_removes_only_old_manifests(tmp_path):
     prune_manifests(str(mdir))
     assert not old_file.exists()
     assert new_file.exists()
+
+
+def test_prune_removes_orphaned_tmp_files(tmp_path):
+    mdir = tmp_path / "manifests"
+    mdir.mkdir()
+    orphan = mdir / ".scan-1.json.abc123.tmp"
+    orphan.write_text("{")
+    eight_days = 8 * 86400
+    stale = os.stat(orphan).st_mtime - eight_days
+    os.utime(orphan, (stale, stale))
+    prune_manifests(str(mdir))
+    assert not orphan.exists()
+
+
+def test_hostile_scan_job_id_stays_inside_manifest_dir(tmp_path):
+    (tmp_path / "card").mkdir()
+    mdir = str(tmp_path / "manifests")
+    hostile_id = "../../etc/passwd"
+    path = manifest_path(mdir, hostile_id)
+    assert os.path.dirname(path) == mdir
+
+    write_manifest(mdir, _manifest(tmp_path, scan_job_id=hostile_id))
+    loaded = load_manifest(mdir, hostile_id)
+    assert loaded["scan_job_id"] == hostile_id
+    assert sorted(os.listdir(mdir)) == ["passwd.json"]
+
+
+def test_load_rejects_naive_created_at(tmp_path):
+    (tmp_path / "card").mkdir()
+    mdir = str(tmp_path / "manifests")
+    naive = datetime.now().isoformat()  # deliberately tz-naive
+    write_manifest(mdir, _manifest(tmp_path, created_at=naive))
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(mdir, "scan-1")
+    assert exc.value.http_status == 400
+
+
+def test_write_manifest_json_dump_failure_leaves_no_tmp_file(tmp_path):
+    mdir = str(tmp_path / "manifests")
+    bad = _manifest(tmp_path, entries={"not serializable": {1, 2, 3}})
+    with pytest.raises(TypeError):
+        write_manifest(mdir, bad)
+    assert os.listdir(mdir) == []

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -1069,3 +1069,45 @@ def test_delete_skips_when_parent_redirected_during_final_hash(db, tmp_path):
     assert "no longer resolves inside" in summary["skipped"][0]["reason"]
     # The decoy — the only file behind the redirected path — must survive.
     assert decoy.exists() and decoy.read_bytes() == b"raw-one"
+
+
+def test_qualify_binds_containment_to_statted_object(db, tmp_path, monkeypatch):
+    # Codex P1: realpath() (containment) and os.stat() (metadata gate)
+    # are separate path walks. Swap the archive parent for a symlink
+    # BETWEEN them, pointing at an in-source decoy dir whose file has
+    # the row's exact baseline and a different inode than the candidate:
+    # without the post-stat re-resolution check, the row qualifies on an
+    # "archive copy" that actually lives on the card.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    row = card_cleanup.fetch_rows_by_hash(db, _sha(str(card)))[0]
+
+    decoy_dir = tmp_path / "card" / "DCIM2"
+    decoy_dir.mkdir(parents=True)
+    decoy = decoy_dir / row["filename"]
+    decoy.write_bytes(b"raw-one")
+    st_arch = os.stat(archive_file)
+    os.utime(decoy, (st_arch.st_atime, st_arch.st_mtime))
+
+    archive_parent = archive_file.parent
+    swapped = []
+    real_stat = os.stat
+
+    def swapping_stat(p, *a, **kw):
+        if str(p) == str(archive_file) and not swapped:
+            swapped.append(True)
+            import shutil
+            shutil.rmtree(archive_parent)
+            try:
+                os.symlink(str(decoy_dir), str(archive_parent))
+            except (OSError, NotImplementedError):
+                pytest.skip("symlinks unsupported on this filesystem")
+        return real_stat(p, *a, **kw)
+
+    monkeypatch.setattr(card_cleanup.os, "stat", swapping_stat)
+    source_root_real = os.path.realpath(str(tmp_path / "card"))
+    result, reason = card_cleanup.qualify_rows(
+        [row], source_root_real, str(card))
+    assert result is None
+    assert reason == card_cleanup.KEEP_INSIDE_SOURCE
+    assert decoy.exists()

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -695,3 +695,32 @@ def test_delete_only_touches_deletable_bucket(db, tmp_path):
     summary = _scan_then_delete(db, tmp_path)
     assert summary["deleted"] == 1
     assert stray.exists()
+
+
+def test_delete_skips_file_replaced_during_archive_gate(db, tmp_path):
+    # TOCTOU guard (Codex P1): the pathname is replaced while the archive
+    # gate runs — after the card re-hash, before os.remove. The
+    # replacement has the SAME size and the mtime forced back to the
+    # manifest value, so only the final inode re-stat can catch it.
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)  # content b"raw-one", 7 bytes
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    entry = next(e for e in manifest["entries"] if e["bucket"] == "deletable")
+    real_fetch = card_cleanup.fetch_rows_by_hash
+
+    def fetch_then_replace(db_arg, file_hash):
+        rows = real_fetch(db_arg, file_hash)
+        os.unlink(card)                      # new inode on rewrite
+        card.write_bytes(b"NEW-ONE")         # same 7-byte size
+        os.utime(card, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+        return rows
+
+    with unittest.mock.patch.object(
+            card_cleanup, "fetch_rows_by_hash", fetch_then_replace):
+        summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 0
+    assert len(summary["skipped"]) == 1
+    assert card.exists()
+    assert card.read_bytes() == b"NEW-ONE"

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -866,6 +866,43 @@ def test_delete_skips_path_redirected_outside_source(db, tmp_path):
     assert decoy.exists() and decoy.read_bytes() == b"raw-one"
 
 
+def test_delete_uses_manifest_source_root_not_re_resolved(db, tmp_path):
+    # Codex P1 review of commit 2efff02f: if the scanned root itself is
+    # renamed and replaced by a symlink pointing at a different tree,
+    # re-resolving the manifest's already-canonical source_root at delete
+    # time would re-anchor every containment check to the swap target.
+    # A byte-identical file at the same relative path there would then
+    # pass every gate and be unlinked outside the scanned card. The delete
+    # must use the manifest's stored source_root verbatim.
+    _archive_photo(db, tmp_path)
+    card_file = _card_file(tmp_path)
+    contents = card_file.read_bytes()
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    entry = next(e for e in manifest["entries"] if e["bucket"] == "deletable")
+
+    swapped = tmp_path / "swapped_root"
+    (swapped / "DCIM").mkdir(parents=True)
+    twin = swapped / "DCIM" / card_file.name
+    twin.write_bytes(contents)
+    os.utime(twin, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+
+    original = tmp_path / "card"
+    original.rename(tmp_path / "card_moved")
+    try:
+        os.symlink(str(swapped), str(original))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this filesystem")
+
+    summary = card_cleanup.delete_verified(db, manifest)
+
+    assert summary["deleted"] == 0
+    assert twin.exists() and twin.read_bytes() == contents
+    assert len(summary["skipped"]) == 1
+    assert summary["skipped"][0]["reason"] == card_cleanup.SKIP_OUTSIDE_SOURCE
+
+
 def test_delete_skips_when_card_path_becomes_symlink_post_scan(db, tmp_path):
     # Codex P2: scan classifies only regular files, but a post-scan swap
     # of a scanned pathname for a symlink to a byte-identical file with

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -200,6 +200,18 @@ def test_load_rejects_deletable_entry_without_path(tmp_path):
     assert "malformed" in str(exc.value)
 
 
+def test_load_rejects_deletable_entry_missing_size_hash_mtime(tmp_path):
+    (tmp_path / "card").mkdir()
+    entry = {
+        "path": str(tmp_path / "card" / "x.nef"), "bucket": "deletable",
+    }
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, entries=[entry]))
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(mdir, "scan-1")
+    assert "malformed" in str(exc.value)
+
+
 def _make_card(tmp_path):
     card = tmp_path / "card"
     (card / "DCIM" / "100").mkdir(parents=True)

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -474,6 +474,35 @@ def test_scan_hashes_each_card_file_once(db, tmp_path, monkeypatch):
     assert len(card_calls) == 1
 
 
+def test_scan_unreadable_after_stat_credits_size_to_kept_bytes(
+        db, tmp_path, monkeypatch):
+    # Codex P2: os.stat succeeds but hashing fails (transient read error
+    # or missing read permission). st.st_size is truthful, so it must be
+    # included both in the entry and in totals.kept.bytes — a
+    # wholesale-unreadable card would otherwise report gigabytes as
+    # "0 bytes kept" while the preview shows those files under the kept
+    # bucket.
+    unreadable = _card_file(
+        tmp_path, name="IMG_UNREADABLE.NEF",
+        content=b"twelve-bytes")  # 12 bytes
+    real_hash = card_cleanup.compute_file_hash
+
+    def failing_hash(path, *a, **kw):
+        if str(path) == str(unreadable):
+            raise PermissionError(13, "denied", str(path))
+        return real_hash(path, *a, **kw)
+
+    monkeypatch.setattr(card_cleanup, "compute_file_hash", failing_hash)
+    result = _scan(db, tmp_path)
+    kept = _entries(result, "kept")
+    assert len(kept) == 1
+    assert kept[0]["path"] == str(unreadable)
+    assert kept[0]["size"] == 12
+    assert card_cleanup.KEEP_UNREADABLE in kept[0]["reason"]
+    assert result["totals"]["kept"]["count"] == 1
+    assert result["totals"]["kept"]["bytes"] == 12
+
+
 def test_qualify_rows_null_archive_stat_baseline_keeps(db, tmp_path):
     # Scan-cataloged rows can have NULL file_size/file_mtime even when
     # hash_status is "ok" (e.g. legacy rows) — must not raise, must keep.
@@ -756,6 +785,48 @@ def test_delete_skips_file_replaced_during_archive_gate(db, tmp_path):
         summary = card_cleanup.delete_verified(db, manifest)
     assert summary["deleted"] == 0
     assert len(summary["skipped"]) == 1
+    assert card.exists()
+    assert card.read_bytes() == b"NEW-ONE"
+
+
+def test_delete_skips_inplace_rewrite_during_archive_gate(db, tmp_path):
+    # Final-rehash gate (Codex P1 follow-up): the initial delete-time hash
+    # runs BEFORE the potentially slow archive gate. If the file is
+    # rewritten in place during the archive gate — same inode (open/write
+    # preserves it), same size, mtime forced back to the manifest value
+    # (FAT is 2s-granular; a camera reusing a filename in that window is
+    # the realistic case) — every metadata gate passes but the bytes at
+    # unlink time are not the ones we authorized. Only a rehash right
+    # before os.remove can catch this.
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)  # content b"raw-one", 7 bytes
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    entry = next(e for e in manifest["entries"] if e["bucket"] == "deletable")
+    real_fetch = card_cleanup.fetch_rows_by_hash
+    original_ino = os.stat(card).st_ino
+
+    def fetch_then_inplace_rewrite(db_arg, file_hash):
+        rows = real_fetch(db_arg, file_hash)
+        # Open the same inode and overwrite in place — do NOT unlink and
+        # recreate. This is the scenario the metadata gates cannot see:
+        # inode, size, and mtime all preserved.
+        with open(card, "r+b") as f:
+            f.seek(0)
+            f.write(b"NEW-ONE")  # also 7 bytes
+        os.utime(card, ns=(entry["mtime_ns"], entry["mtime_ns"]))
+        return rows
+
+    with unittest.mock.patch.object(
+            card_cleanup, "fetch_rows_by_hash", fetch_then_inplace_rewrite):
+        summary = card_cleanup.delete_verified(db, manifest)
+    # Inode preserved: metadata gates would have passed. Only the final
+    # rehash can catch the swap — assert both the outcome and the reason.
+    assert os.stat(card).st_ino == original_ino
+    assert summary["deleted"] == 0
+    assert len(summary["skipped"]) == 1
+    assert summary["skipped"][0]["reason"] == card_cleanup.SKIP_CONTENT_CHANGED
     assert card.exists()
     assert card.read_bytes() == b"NEW-ONE"
 

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -15,6 +15,7 @@ from card_cleanup import (
     prune_manifests,
     write_manifest,
 )
+from scanner import compute_file_hash as _sha
 
 
 def _manifest(tmp_path, **overrides):
@@ -177,6 +178,27 @@ def test_load_rejects_deletable_entry_with_null_byte(tmp_path):
         load_manifest(mdir, "scan-1")
 
 
+def test_load_rejects_source_root_with_null_byte(tmp_path):
+    # isabs("/x\x00y") passes; realpath() raises ValueError. Covers the
+    # hoisted source-root-unresolvable branch distinctly from a bad
+    # entry path.
+    mdir = str(tmp_path / "manifests")
+    write_manifest(
+        mdir, _manifest(tmp_path, source_root=str(tmp_path / "x\x00y")))
+    with pytest.raises(ManifestError):
+        load_manifest(mdir, "scan-1")
+
+
+def test_load_rejects_deletable_entry_without_path(tmp_path):
+    (tmp_path / "card").mkdir()
+    entry = {"size": 1, "mtime_ns": 1, "hash": "h", "bucket": "deletable"}
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, entries=[entry]))
+    with pytest.raises(ManifestError) as exc:
+        load_manifest(mdir, "scan-1")
+    assert "malformed" in str(exc.value)
+
+
 def _make_card(tmp_path):
     card = tmp_path / "card"
     (card / "DCIM" / "100").mkdir(parents=True)
@@ -186,6 +208,8 @@ def _make_card(tmp_path):
     (card / "DCIM" / "100" / ".hidden.jpg").write_bytes(b"dot")
     (card / "MISC" / "sub").mkdir(parents=True)
     (card / "MISC" / "sub" / "firmware.bin").write_bytes(b"fw")
+    (card / "ROOT_0001.JPG").write_bytes(b"root-jpg")
+    (card / "readme.txt").write_bytes(b"txt")
     return card
 
 
@@ -194,8 +218,10 @@ def test_classify_buckets(tmp_path):
     candidates, ignored = classify_source_files(str(card))
     cand_names = {p.name for p in candidates}
     ign_names = {p.name for p in ignored}
-    assert cand_names == {"IMG_0001.NEF", "IMG_0002.JPG"}
-    assert ign_names == {"IMG_0001.XMP", ".hidden.jpg", "firmware.bin"}
+    assert cand_names == {"IMG_0001.NEF", "IMG_0002.JPG", "ROOT_0001.JPG"}
+    assert ign_names == {
+        "IMG_0001.XMP", ".hidden.jpg", "firmware.bin", "readme.txt",
+    }
 
 
 def test_classify_parity_with_discover_source_files(tmp_path):
@@ -217,3 +243,179 @@ def test_classify_missing_source_reports_onerror(tmp_path):
         str(tmp_path / "nope"), onerror=errors.append)
     assert candidates == [] and ignored == []
     assert len(errors) == 1 and isinstance(errors[0], OSError)
+
+
+# The `db` fixture comes from vireo/tests/conftest.py (~line 158) — a
+# Database on a temp file. Do not redefine it here.
+
+
+def _archive_photo(db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
+                   hash_status="ok", folder="archive/2026/2026-08-01"):
+    """Create an archive file on disk + its cataloged, verified row."""
+    folder_path = tmp_path / folder
+    folder_path.mkdir(parents=True, exist_ok=True)
+    f = folder_path / name
+    f.write_bytes(content)
+    st = os.stat(f)
+    fid = db.add_folder(str(folder_path))
+    pid = db.add_photo(
+        folder_id=fid, filename=name, extension=os.path.splitext(name)[1],
+        file_size=st.st_size, file_mtime=st.st_mtime,
+        file_hash=_sha(str(f)),
+    )
+    if hash_status is not None:
+        db.update_photo_hash_check(pid, hash_status)
+    return f, pid
+
+
+def _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one"):
+    card = tmp_path / "card" / "DCIM"
+    card.mkdir(parents=True, exist_ok=True)
+    f = card / name
+    f.write_bytes(content)
+    return f
+
+
+def _scan(db, tmp_path, **kwargs):
+    return card_cleanup.scan_card(
+        db, str(tmp_path / "card"), True,
+        str(tmp_path / "manifests"), "scan-1", **kwargs)
+
+
+def _entries(result, bucket):
+    return [e for e in result["entries"] if e["bucket"] == bucket]
+
+
+def test_scan_verified_file_is_deletable(db, tmp_path):
+    archive_file, _ = _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    deletable = _entries(result, "deletable")
+    assert len(deletable) == 1
+    assert deletable[0]["archive_path"] == str(archive_file)
+    assert result["totals"]["deletable"]["count"] == 1
+    # Manifest landed on disk and revalidates.
+    loaded = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    assert loaded["source_root"] == os.path.realpath(str(tmp_path / "card"))
+
+
+def test_scan_uncataloged_file_kept(db, tmp_path):
+    _card_file(tmp_path, content=b"never-imported")
+    result = _scan(db, tmp_path)
+    kept = _entries(result, "kept")
+    assert len(kept) == 1 and "not in catalog" in kept[0]["reason"]
+
+
+def test_scan_null_hash_status_kept_with_audit_remedy(db, tmp_path):
+    # Scan-cataloged archives: file_hash set, hash_status NULL. Kept —
+    # and the reason must point at the remedy, or the tool reads broken.
+    _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    kept = _entries(result, "kept")
+    assert len(kept) == 1
+    assert "integrity audit" in kept[0]["reason"]
+
+
+def test_scan_archive_file_missing_kept(db, tmp_path):
+    archive_file, _ = _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    os.unlink(archive_file)
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "kept")) == 1
+    assert len(_entries(result, "deletable")) == 0
+
+
+def test_scan_archive_mtime_off_baseline_kept(db, tmp_path):
+    # Exact equality, not the audit's 1s window: any drift keeps the file.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    st = os.stat(archive_file)
+    os.utime(archive_file, (st.st_atime, st.st_mtime + 0.5))
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "deletable")) == 0
+    assert "changed since verification" in _entries(result, "kept")[0]["reason"]
+
+
+def test_scan_self_match_inside_source_never_qualifies(db, tmp_path):
+    # The only catalog copy lives inside the selected source tree: the
+    # file must NOT be deletable (it would be deleting the archive copy).
+    _archive_photo(db, tmp_path, folder="card/DCIM")
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "deletable")) == 0
+    kept = _entries(result, "kept")
+    assert len(kept) == 1 and "inside the selected source" in kept[0]["reason"]
+
+
+def test_qualify_rejects_hardlink_alias_of_card_file(db, tmp_path):
+    # Mount-alias/samefile gate: the cataloged "archive copy" lives
+    # outside the source tree by path, but it's a hardlink to the card
+    # file itself — same dev+inode. Deleting the card file would leave
+    # the archive path as the only name for bytes we just proved existed
+    # twice; the spec says such a row never qualifies.
+    card = _card_file(tmp_path)
+    folder_path = tmp_path / "archive" / "2026"
+    folder_path.mkdir(parents=True)
+    alias = folder_path / "IMG_0001.NEF"
+    try:
+        os.link(card, alias)
+    except (OSError, NotImplementedError):
+        pytest.skip("hardlinks unsupported on this filesystem")
+    st = os.stat(alias)
+    fid = db.add_folder(str(folder_path))
+    pid = db.add_photo(
+        folder_id=fid, filename="IMG_0001.NEF", extension=".NEF",
+        file_size=st.st_size, file_mtime=st.st_mtime,
+        file_hash=_sha(str(alias)),
+    )
+    db.update_photo_hash_check(pid, "ok")
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "deletable")) == 0
+    kept = _entries(result, "kept")
+    assert len(kept) == 1 and "inside the selected source" in kept[0]["reason"]
+
+
+def test_scan_duplicate_card_files_both_deletable(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path, name="IMG_0001.NEF")
+    _card_file(tmp_path, name="IMG_0001_copy.NEF")
+    result = _scan(db, tmp_path)
+    assert len(_entries(result, "deletable")) == 2
+
+
+def test_scan_two_rows_one_qualifying_is_deletable(db, tmp_path):
+    # Same hash cataloged twice; only one row passes → still deletable,
+    # preview shows the passing row's path.
+    bad_archive, _ = _archive_photo(db, tmp_path, folder="archive/a")
+    good_archive, _ = _archive_photo(db, tmp_path, folder="archive/b")
+    os.unlink(bad_archive)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    deletable = _entries(result, "deletable")
+    assert len(deletable) == 1
+    assert deletable[0]["archive_path"] == str(good_archive)
+
+
+def test_scan_cancellation_writes_no_manifest(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path, should_cancel=lambda: True)
+    assert result["cancelled"] is True
+    assert not os.path.exists(
+        card_cleanup.manifest_path(str(tmp_path / "manifests"), "scan-1"))
+
+
+def test_scan_hashes_each_card_file_once(db, tmp_path, monkeypatch):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    calls = []
+    real = card_cleanup.compute_file_hash
+
+    def counting(path, *a, **kw):
+        calls.append(str(path))
+        return real(path, *a, **kw)
+
+    monkeypatch.setattr(card_cleanup, "compute_file_hash", counting)
+    _scan(db, tmp_path)
+    card_calls = [p for p in calls if "card" in p]
+    assert len(card_calls) == 1

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -3,6 +3,7 @@ scan/delete safety gates. Spec:
 docs/superpowers/specs/2026-08-07-card-cleanup-design.md
 """
 import os
+import unittest.mock
 from datetime import UTC, datetime, timedelta
 
 import card_cleanup
@@ -419,3 +420,188 @@ def test_scan_hashes_each_card_file_once(db, tmp_path, monkeypatch):
     _scan(db, tmp_path)
     card_calls = [p for p in calls if "card" in p]
     assert len(card_calls) == 1
+
+
+def test_qualify_rows_null_archive_stat_baseline_keeps(db, tmp_path):
+    # Scan-cataloged rows can have NULL file_size/file_mtime even when
+    # hash_status is "ok" (e.g. legacy rows) — must not raise, must keep.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    source_root_real = os.path.realpath(str(tmp_path / "card"))
+    rows = [{
+        "filename": os.path.basename(str(archive_file)),
+        "file_size": None, "file_mtime": None,
+        "hash_status": "ok",
+        "folder_path": os.path.dirname(str(archive_file)),
+    }]
+    archive_path, reason = card_cleanup.qualify_rows(
+        rows, source_root_real, str(card))
+    assert archive_path is None
+    assert reason == card_cleanup.KEEP_ARCHIVE_CHANGED
+
+
+def test_qualify_rows_missing_card_file_unreadable(db, tmp_path):
+    # Unreachable from scan_card (it only calls qualify_rows on files it
+    # just stat'd) — but delete_verified could race a vanished card file
+    # in between its own stat and the archive gate call.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    source_root_real = os.path.realpath(str(tmp_path / "card"))
+    rows = [{
+        "filename": os.path.basename(str(archive_file)),
+        "file_size": None, "file_mtime": None,
+        "hash_status": "ok",
+        "folder_path": os.path.dirname(str(archive_file)),
+    }]
+    archive_path, reason = card_cleanup.qualify_rows(
+        rows, source_root_real, str(tmp_path / "card" / "gone.NEF"))
+    assert archive_path is None
+    assert reason == card_cleanup.KEEP_UNREADABLE
+
+
+def _scan_then_delete(db, tmp_path, mutate=None, should_cancel=None):
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] >= 1
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    if mutate is not None:
+        mutate()
+    return card_cleanup.delete_verified(
+        db, manifest, should_cancel=should_cancel)
+
+
+def test_delete_happy_path_two_duplicates_both_deleted(db, tmp_path):
+    # Spec: two identical card files matching one archive photo — both
+    # deletable, both deleted.
+    _archive_photo(db, tmp_path)
+    card_a = _card_file(tmp_path, name="IMG_0001.NEF")
+    card_b = _card_file(tmp_path, name="IMG_0001_copy.NEF")
+    summary = _scan_then_delete(db, tmp_path)
+    assert summary["deleted"] == 2
+    assert not card_a.exists() and not card_b.exists()
+    assert summary["skipped"] == [] and summary["failed"] == []
+
+
+def test_delete_skips_file_changed_since_scan(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+
+    def rewrite():
+        card.write_bytes(b"new-shot-reusing-name")
+
+    summary = _scan_then_delete(db, tmp_path, mutate=rewrite)
+    assert summary["deleted"] == 0
+    assert len(summary["skipped"]) == 1
+    assert card.exists()
+
+
+def test_delete_rehash_catches_same_size_same_mtime_swap(db, tmp_path):
+    # Same byte count, mtime forced back to the manifest value: only the
+    # delete-time re-hash can catch this (FAT mtimes are 2s-granular).
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)  # content b"raw-one", 7 bytes
+    st = os.stat(card)
+
+    def swap():
+        card.write_bytes(b"raw-two")  # also 7 bytes
+        os.utime(card, ns=(st.st_atime_ns, st.st_mtime_ns))
+
+    summary = _scan_then_delete(db, tmp_path, mutate=swap)
+    assert summary["deleted"] == 0
+    assert len(summary["skipped"]) == 1
+    assert card.exists()
+
+
+def test_delete_archive_removed_after_scan_skips(db, tmp_path):
+    archive_file, _ = _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    summary = _scan_then_delete(
+        db, tmp_path, mutate=lambda: os.unlink(archive_file))
+    assert summary["deleted"] == 0
+    assert card.exists()
+    assert "archive" in summary["skipped"][0]["reason"]
+
+
+def test_delete_no_stat_reuse_across_duplicates(db, tmp_path):
+    # Two identical card files; archive copy vanishes after the first
+    # deletion. The second file's own fresh stat must fail — a cached
+    # scan-time (or first-delete-time) result would wrongly authorize it.
+    archive_file, _ = _archive_photo(db, tmp_path)
+    card_a = _card_file(tmp_path, name="IMG_0001.NEF")
+    card_b = _card_file(tmp_path, name="IMG_0002.NEF")
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 2
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+
+    deleted_once = []
+    real_remove = os.remove
+
+    def remove_then_kill_archive(path, *a, **kw):
+        real_remove(path, *a, **kw)
+        if not deleted_once:
+            deleted_once.append(path)
+            real_remove(archive_file)
+
+    with unittest.mock.patch.object(
+            card_cleanup.os, "remove", remove_then_kill_archive):
+        summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 1
+    assert len(summary["skipped"]) == 1
+    assert card_a.exists() != card_b.exists()  # exactly one survived
+
+
+def test_delete_cancellation_honest_summary(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path, name="IMG_0001.NEF")
+    _card_file(tmp_path, name="IMG_0002.NEF")
+    calls = []
+
+    def cancel_after_first():
+        calls.append(1)
+        return len(calls) > 1
+
+    summary = _scan_then_delete(
+        db, tmp_path, should_cancel=cancel_after_first)
+    assert summary["cancelled"] is True
+    assert summary["deleted"] + summary["remaining"] == 2
+
+
+def test_delete_vanished_card_file_counts_skipped(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    summary = _scan_then_delete(db, tmp_path, mutate=lambda: os.unlink(card))
+    assert summary["deleted"] == 0
+    assert "already gone" in summary["skipped"][0]["reason"]
+
+
+def test_delete_per_file_failure_continues(db, tmp_path):
+    # A permission error on one file is recorded as failed; the job
+    # moves on and still deletes the rest.
+    _archive_photo(db, tmp_path)
+    card_a = _card_file(tmp_path, name="IMG_0001.NEF")
+    card_b = _card_file(tmp_path, name="IMG_0002.NEF")
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 2
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    real_remove = os.remove
+    failed_path = str(card_a)
+
+    def failing_remove(path, *a, **kw):
+        if str(path) == failed_path:
+            raise PermissionError(13, "read-only card", failed_path)
+        real_remove(path, *a, **kw)
+
+    with unittest.mock.patch.object(
+            card_cleanup.os, "remove", failing_remove):
+        summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 1
+    assert len(summary["failed"]) == 1
+    assert summary["failed"][0]["path"] == failed_path
+    assert card_a.exists() and not card_b.exists()
+
+
+def test_delete_only_touches_deletable_bucket(db, tmp_path):
+    _archive_photo(db, tmp_path)
+    _card_file(tmp_path)
+    stray = _card_file(tmp_path, name="IMG_KEEP.NEF", content=b"unimported")
+    summary = _scan_then_delete(db, tmp_path)
+    assert summary["deleted"] == 1
+    assert stray.exists()

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -1,0 +1,287 @@
+"""API tests for the card-cleanup scan/manifest/delete endpoints.
+
+Spec: docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+
+The `app_and_db` fixture comes from vireo/tests/conftest.py — a Flask app
+plus its Database, pre-seeded with a couple of folders/photos unrelated to
+these tests. Do not redefine it here.
+"""
+import json
+import os
+import sys
+import threading
+
+import card_cleanup
+import pytest
+from scanner import compute_file_hash as _sha
+from wait import wait_for_job_via_client
+
+
+def _wait_for_job(client, job_id, timeout=30):
+    """Poll GET /api/jobs/<id> until it reaches a terminal state and
+    assert it completed."""
+    job = wait_for_job_via_client(client, job_id, timeout=timeout)
+    assert job["status"] == "completed", job
+    return job
+
+
+def _archive_photo(db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
+                   folder="archive/2026/2026-08-01"):
+    """Create an archive file on disk + its cataloged, verified row."""
+    folder_path = tmp_path / folder
+    folder_path.mkdir(parents=True, exist_ok=True)
+    f = folder_path / name
+    f.write_bytes(content)
+    st = os.stat(f)
+    fid = db.add_folder(str(folder_path))
+    pid = db.add_photo(
+        folder_id=fid, filename=name, extension=os.path.splitext(name)[1],
+        file_size=st.st_size, file_mtime=st.st_mtime,
+        file_hash=_sha(str(f)),
+    )
+    db.update_photo_hash_check(pid, "ok")
+    return f, pid
+
+
+def _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one"):
+    card = tmp_path / "card" / "DCIM"
+    card.mkdir(parents=True, exist_ok=True)
+    f = card / name
+    f.write_bytes(content)
+    return f
+
+
+def _make_verified_pair(db, tmp_path):
+    """Archive file + verified catalog row, plus a matching card file."""
+    archive_file, _pid = _archive_photo(db, tmp_path)
+    card_file = _card_file(tmp_path)
+    return archive_file, card_file
+
+
+def test_scan_rejects_missing_source(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/card-cleanup/scan", json={"source": "/nope/missing"})
+    assert resp.status_code == 400
+
+
+def test_scan_rejects_archive_overlap(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    db.add_folder(str(archive_root))
+
+    # Exact overlap.
+    resp = client.post(
+        "/api/card-cleanup/scan", json={"source": str(archive_root)})
+    assert resp.status_code == 400
+    assert "removable media" in resp.get_json()["error"]
+
+    # Source CONTAINS the archive root.
+    resp2 = client.post(
+        "/api/card-cleanup/scan", json={"source": str(tmp_path)})
+    assert resp2.status_code == 400
+
+    # Source is INSIDE the archive root.
+    sub = archive_root / "2026"
+    sub.mkdir()
+    resp3 = client.post(
+        "/api/card-cleanup/scan", json={"source": str(sub)})
+    assert resp3.status_code == 400
+
+
+@pytest.mark.skipif(
+    sys.platform not in ("darwin", "win32"),
+    reason="case-insensitive overlap only applies on darwin/win32 by default",
+)
+def test_scan_rejects_case_swapped_overlap(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    archive_root = tmp_path / "Archive"
+    archive_root.mkdir()
+    db.add_folder(str(archive_root))
+
+    resp = client.post(
+        "/api/card-cleanup/scan",
+        json={"source": str(tmp_path / "archive")})
+    assert resp.status_code == 400
+
+
+def test_scan_then_manifest_then_delete_end_to_end(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    archive_file, card_file = _make_verified_pair(db, tmp_path)
+
+    resp = client.post(
+        "/api/card-cleanup/scan",
+        json={"source": str(tmp_path / "card")})
+    assert resp.status_code == 200
+    scan_job_id = resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+
+    manifest_resp = client.get(f"/api/card-cleanup/{scan_job_id}/manifest")
+    assert manifest_resp.status_code == 200
+    manifest = manifest_resp.get_json()
+    assert manifest["totals"]["deletable"]["count"] == 1
+
+    delete_resp = client.post(
+        "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+    assert delete_resp.status_code == 200
+    delete_job_id = delete_resp.get_json()["job_id"]
+    _wait_for_job(client, delete_job_id)
+
+    assert not card_file.exists()
+    assert archive_file.exists()
+
+
+def test_delete_unknown_scan_job_404(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/card-cleanup/delete", json={"scan_job_id": "nope"})
+    assert resp.status_code == 404
+
+
+def test_delete_refuses_cancelled_scan(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("scan-c", "card-cleanup-scan", "cancelled", "2026-08-08T00:00:00"),
+    )
+    db.conn.commit()
+    resp = client.post(
+        "/api/card-cleanup/delete", json={"scan_job_id": "scan-c"})
+    assert resp.status_code == 400
+
+
+def test_delete_after_restart_uses_history_and_disk_manifest(
+        app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    archive_file, card_file = _make_verified_pair(db, tmp_path)
+
+    manifest_dir = app.config["CARD_CLEANUP_DIR"]
+    result = card_cleanup.scan_card(
+        db, str(tmp_path / "card"), True, manifest_dir, "scan-r")
+    assert result["totals"]["deletable"]["count"] == 1
+
+    db.conn.execute(
+        "INSERT INTO job_history "
+        "(id, type, status, started_at, finished_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("scan-r", "card-cleanup-scan", "completed",
+         "2026-08-08T00:00:00", "2026-08-08T00:00:01"),
+    )
+    db.conn.commit()
+
+    delete_resp = client.post(
+        "/api/card-cleanup/delete", json={"scan_job_id": "scan-r"})
+    assert delete_resp.status_code == 200
+    delete_job_id = delete_resp.get_json()["job_id"]
+    _wait_for_job(client, delete_job_id)
+
+    assert not card_file.exists()
+    assert archive_file.exists()
+
+
+def test_delete_expired_manifest_404(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    _make_verified_pair(db, tmp_path)
+
+    resp = client.post(
+        "/api/card-cleanup/scan",
+        json={"source": str(tmp_path / "card")})
+    scan_job_id = resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+
+    manifest_dir = app.config["CARD_CLEANUP_DIR"]
+    mpath = card_cleanup.manifest_path(manifest_dir, scan_job_id)
+    with open(mpath, encoding="utf-8") as f:
+        manifest = json.load(f)
+    from datetime import UTC, datetime, timedelta
+    manifest["created_at"] = (
+        datetime.now(UTC) - timedelta(days=8)).isoformat()
+    with open(mpath, "w", encoding="utf-8") as f:
+        json.dump(manifest, f)
+
+    delete_resp = client.post(
+        "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+    assert delete_resp.status_code == 404
+    assert "re-scan" in delete_resp.get_json()["error"]
+
+
+def test_delete_concurrent_delete_409(app_and_db, tmp_path, monkeypatch):
+    app, db = app_and_db
+    client = app.test_client()
+    _make_verified_pair(db, tmp_path)
+
+    resp = client.post(
+        "/api/card-cleanup/scan",
+        json={"source": str(tmp_path / "card")})
+    scan_job_id = resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+
+    started = threading.Event()
+    release = threading.Event()
+    real_delete_verified = card_cleanup.delete_verified
+
+    def blocking_delete_verified(db_, manifest, progress_cb=None,
+                                 should_cancel=None):
+        started.set()
+        release.wait(timeout=15)
+        return {
+            "deleted": 0, "deleted_bytes": 0, "skipped": [], "failed": [],
+            "cancelled": False, "remaining": 0,
+        }
+
+    monkeypatch.setattr(
+        card_cleanup, "delete_verified", blocking_delete_verified)
+    try:
+        resp1 = client.post(
+            "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+        assert resp1.status_code == 200
+        job1_id = resp1.get_json()["job_id"]
+        assert started.wait(timeout=15)
+
+        runner = app._job_runner
+
+        def _running():
+            job = runner.get(job1_id)
+            return job is not None and job.get("status") == "running"
+        import time
+        deadline = time.monotonic() + 15
+        while not _running() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert _running()
+
+        resp2 = client.post(
+            "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+        assert resp2.status_code == 409
+    finally:
+        release.set()
+        monkeypatch.setattr(
+            card_cleanup, "delete_verified", real_delete_verified)
+        _wait_for_job(client, job1_id)
+
+
+def test_scan_rejects_relative_or_nondir_source(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/card-cleanup/scan", json={"source": "relative/path"})
+    assert resp.status_code == 400
+
+    a_file = tmp_path / "not_a_dir.txt"
+    a_file.write_text("x")
+    resp2 = client.post(
+        "/api/card-cleanup/scan", json={"source": str(a_file)})
+    assert resp2.status_code == 400
+
+    resp3 = client.post("/api/card-cleanup/scan", json={})
+    assert resp3.status_code == 400

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -158,6 +158,33 @@ def test_delete_refuses_cancelled_scan(app_and_db):
     assert resp.status_code == 400
 
 
+def test_delete_refuses_running_scan_without_telling_user_to_rescan(
+        app_and_db):
+    """A delete requested while the scan is still going is early, not
+    doomed — the error must say to wait, not to re-scan."""
+    app, db = app_and_db
+    client = app.test_client()
+    db.conn.execute(
+        "INSERT INTO job_history (id, type, status, started_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("scan-run", "card-cleanup-scan", "running", "2026-08-08T00:00:00"),
+    )
+    db.conn.commit()
+    resp = client.post(
+        "/api/card-cleanup/delete", json={"scan_job_id": "scan-run"})
+    assert resp.status_code == 400
+    error = resp.get_json()["error"]
+    assert "still running" in error
+    assert "re-scan" not in error
+
+
+def test_manifest_unknown_scan_job_404(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/card-cleanup/nope/manifest")
+    assert resp.status_code == 404
+
+
 def test_delete_after_restart_uses_history_and_disk_manifest(
         app_and_db, tmp_path):
     app, db = app_and_db
@@ -241,6 +268,9 @@ def test_delete_concurrent_delete_409(app_and_db, tmp_path, monkeypatch):
 
     monkeypatch.setattr(
         card_cleanup, "delete_verified", blocking_delete_verified)
+    # Bound before the try so a failure on the first POST surfaces as
+    # itself, not as a NameError raised from the finally drain.
+    job1_id = None
     try:
         resp1 = client.post(
             "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
@@ -266,7 +296,8 @@ def test_delete_concurrent_delete_409(app_and_db, tmp_path, monkeypatch):
         release.set()
         monkeypatch.setattr(
             card_cleanup, "delete_verified", real_delete_verified)
-        _wait_for_job(client, job1_id)
+        if job1_id:
+            _wait_for_job(client, job1_id)
 
 
 def test_scan_rejects_relative_or_nondir_source(app_and_db, tmp_path):

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -377,3 +377,14 @@ def test_delete_result_carries_exact_totals(app_and_db, tmp_path):
     assert result["skipped_total"] == len(result["skipped"]) == 0
     assert result["failed_total"] == len(result["failed"]) == 0
     assert result["deleted"] == 1
+
+
+def test_endpoints_reject_non_object_json_body(app_and_db):
+    # get_json returns 5 for a valid non-object JSON document; the
+    # endpoints must 400, not 500 on body.get.
+    app, _ = app_and_db
+    client = app.test_client()
+    for url in ("/api/card-cleanup/scan", "/api/card-cleanup/delete"):
+        resp = client.post(url, json=5)
+        assert resp.status_code == 400, url
+        assert "JSON object" in resp.get_json()["error"]

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -136,6 +136,34 @@ def test_scan_then_manifest_then_delete_end_to_end(app_and_db, tmp_path):
     assert archive_file.exists()
 
 
+def test_scan_job_result_carries_totals_not_entries(app_and_db, tmp_path):
+    """Spec: the scan job's RESULT carries only bucket totals, resolved
+    source root, and the manifest path — never the (potentially
+    multi-MB) per-file entries list. The UI fetches entries from the
+    manifest endpoint instead."""
+    app, db = app_and_db
+    client = app.test_client()
+    _make_verified_pair(db, tmp_path)
+
+    resp = client.post(
+        "/api/card-cleanup/scan",
+        json={"source": str(tmp_path / "card")})
+    scan_job_id = resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+
+    job_resp = client.get(f"/api/jobs/{scan_job_id}")
+    assert job_resp.status_code == 200
+    job = job_resp.get_json()
+    result = job["result"]
+    assert "entries" not in result
+    assert result["cancelled"] is False
+    assert result["totals"]["deletable"]["count"] == 1
+    assert result["source_root"] == os.path.realpath(str(tmp_path / "card"))
+    assert result["manifest_path"] == card_cleanup.manifest_path(
+        app.config["CARD_CLEANUP_DIR"], scan_job_id)
+    assert isinstance(result["walk_errors"], int)
+
+
 def test_delete_unknown_scan_job_404(app_and_db):
     app, db = app_and_db
     client = app.test_client()

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -344,3 +344,36 @@ def test_scan_rejects_relative_or_nondir_source(app_and_db, tmp_path):
 
     resp3 = client.post("/api/card-cleanup/scan", json={})
     assert resp3.status_code == 400
+
+
+def test_scan_rejects_non_boolean_recursive(app_and_db, tmp_path):
+    # bool("false") is True — stringly-typed clients must get a 400, not
+    # the opposite of what they asked for.
+    app, _ = app_and_db
+    card = tmp_path / "card"
+    card.mkdir()
+    resp = app.test_client().post(
+        "/api/card-cleanup/scan",
+        json={"source": str(card), "recursive": "false"})
+    assert resp.status_code == 400
+    assert "boolean" in resp.get_json()["error"]
+
+
+def test_delete_result_carries_exact_totals(app_and_db, tmp_path):
+    # The job result bounds skipped/failed to a sample; *_total fields
+    # carry the exact counts the UI renders.
+    app, db = app_and_db
+    client = app.test_client()
+    _make_verified_pair(db, tmp_path)
+    resp = client.post("/api/card-cleanup/scan",
+                       json={"source": str(tmp_path / "card")})
+    scan_job_id = resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+    resp = client.post("/api/card-cleanup/delete",
+                       json={"scan_job_id": scan_job_id})
+    job_id = resp.get_json()["job_id"]
+    _wait_for_job(client, job_id)
+    result = client.get(f"/api/jobs/{job_id}").get_json()["result"]
+    assert result["skipped_total"] == len(result["skipped"]) == 0
+    assert result["failed_total"] == len(result["failed"]) == 0
+    assert result["deleted"] == 1

--- a/vireo/tests/test_path_guard.py
+++ b/vireo/tests/test_path_guard.py
@@ -72,3 +72,28 @@ def test_darwin_always_casefolds(tmp_path):
     root.mkdir()
     swapped = str(tmp_path / "card" / "IMG.NEF")
     assert contains_resolved(str(root), swapped)
+
+
+def test_path_contains_null_byte_is_strict(tmp_path):
+    root = str(tmp_path / "card")
+    os.makedirs(root)
+    assert path_contains(root, root + "/x\x00y") is True
+
+
+def test_probe_permission_error_is_inconclusive(tmp_path, monkeypatch):
+    # exists() would collapse EACCES into "case-sensitive" (the
+    # non-strict direction); the probe must treat an unreadable
+    # case-swapped name as inconclusive → case-insensitive.
+    root = tmp_path / "CardABC"
+    root.mkdir()
+    (root / "alpha.txt").write_text("x")
+    import path_guard as pg
+    real_stat = os.stat
+
+    def denying_stat(p, *a, **kw):
+        if str(p).endswith("Alpha.txt"):
+            raise PermissionError(13, "denied", str(p))
+        return real_stat(p, *a, **kw)
+
+    monkeypatch.setattr(pg.os, "stat", denying_stat)
+    assert pg.fs_is_case_insensitive(str(root)) is True

--- a/vireo/tests/test_path_guard.py
+++ b/vireo/tests/test_path_guard.py
@@ -8,7 +8,12 @@ import os
 import sys
 
 import pytest
-from path_guard import contains_resolved, fs_is_case_insensitive, path_contains
+from path_guard import (
+    contains_resolved,
+    fs_is_case_insensitive,
+    make_case_folded_check,
+    path_contains,
+)
 
 
 def test_contains_equal_and_nested(tmp_path):
@@ -119,6 +124,43 @@ def test_probe_caches_only_the_strict_result(tmp_path, monkeypatch):
     assert pg.fs_is_case_insensitive(str(root)) is True
     assert pg.fs_is_case_insensitive(str(root)) is True
     assert len(calls) == 1  # strict result served from cache
+
+
+def test_make_case_folded_check_probes_once(tmp_path, monkeypatch):
+    # Tight-loop consumers (scan/delete) call the containment check
+    # thousands of times per run. contains_resolved reprobes the root's
+    # filesystem for every False result (the module cache stores only
+    # True), so the bound helper must lift the probe to once per run.
+    import path_guard as pg
+    root = tmp_path / "BoundCheck"
+    root.mkdir()
+    (root / "photos").mkdir()
+    pg._probe_cache.clear()
+    probe_calls = []
+
+    def counting_probe(path):
+        probe_calls.append(str(path))
+        # Return False so the module cache never intercepts a repeat.
+        return False
+
+    monkeypatch.setattr(pg, "_probe_uncached", counting_probe)
+    check = make_case_folded_check(str(root))
+    for _ in range(10):
+        check(str(root / "photos" / "IMG.NEF"))
+    assert len(probe_calls) == 1
+
+
+def test_make_case_folded_check_agrees_with_contains_resolved(tmp_path):
+    # Behavioral parity with the plain call — the bound helper must
+    # decide the same containment for the same inputs.
+    root = tmp_path / "card"
+    root.mkdir()
+    root_real = os.path.realpath(str(root))
+    check = make_case_folded_check(root_real)
+    child_inside = os.path.realpath(str(root / "DCIM" / "IMG.NEF"))
+    child_outside = os.path.realpath(str(tmp_path / "elsewhere" / "x"))
+    assert check(child_inside) == contains_resolved(root_real, child_inside)
+    assert check(child_outside) == contains_resolved(root_real, child_outside)
 
 
 def test_probe_never_caches_case_sensitive(tmp_path, monkeypatch):

--- a/vireo/tests/test_path_guard.py
+++ b/vireo/tests/test_path_guard.py
@@ -97,3 +97,23 @@ def test_probe_permission_error_is_inconclusive(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pg.os, "stat", denying_stat)
     assert pg.fs_is_case_insensitive(str(root)) is True
+
+
+def test_probe_result_is_cached_per_device(tmp_path, monkeypatch):
+    import path_guard as pg
+    root = tmp_path / "CacheProbe"
+    root.mkdir()
+    (root / "alpha.txt").write_text("x")
+    pg._probe_cache.clear()
+    calls = []
+    real_listdir = os.listdir
+
+    def counting_listdir(p, *a, **kw):
+        calls.append(str(p))
+        return real_listdir(p, *a, **kw)
+
+    monkeypatch.setattr(pg.os, "listdir", counting_listdir)
+    first = pg.fs_is_case_insensitive(str(root))
+    second = pg.fs_is_case_insensitive(str(root))
+    assert first == second
+    assert len(calls) == 1

--- a/vireo/tests/test_path_guard.py
+++ b/vireo/tests/test_path_guard.py
@@ -99,21 +99,40 @@ def test_probe_permission_error_is_inconclusive(tmp_path, monkeypatch):
     assert pg.fs_is_case_insensitive(str(root)) is True
 
 
-def test_probe_result_is_cached_per_device(tmp_path, monkeypatch):
+def test_probe_caches_only_the_strict_result(tmp_path, monkeypatch):
+    # Only True (case-insensitive, the strict answer) is cached: st_dev
+    # identifies the backing device, not a mount generation, so a card
+    # swapped through the same reused device node can keep the cache
+    # key. A stale True merely over-folds; a stale False would run
+    # case-sensitive comparisons against a FAT card.
     import path_guard as pg
     root = tmp_path / "CacheProbe"
     root.mkdir()
-    (root / "alpha.txt").write_text("x")
     pg._probe_cache.clear()
     calls = []
-    real_listdir = os.listdir
 
-    def counting_listdir(p, *a, **kw):
-        calls.append(str(p))
-        return real_listdir(p, *a, **kw)
+    def fake_probe(path):
+        calls.append(str(path))
+        return True
 
-    monkeypatch.setattr(pg.os, "listdir", counting_listdir)
-    first = pg.fs_is_case_insensitive(str(root))
-    second = pg.fs_is_case_insensitive(str(root))
-    assert first == second
-    assert len(calls) == 1
+    monkeypatch.setattr(pg, "_probe_uncached", fake_probe)
+    assert pg.fs_is_case_insensitive(str(root)) is True
+    assert pg.fs_is_case_insensitive(str(root)) is True
+    assert len(calls) == 1  # strict result served from cache
+
+
+def test_probe_never_caches_case_sensitive(tmp_path, monkeypatch):
+    import path_guard as pg
+    root = tmp_path / "NoCacheProbe"
+    root.mkdir()
+    pg._probe_cache.clear()
+    calls = []
+
+    def fake_probe(path):
+        calls.append(str(path))
+        return False
+
+    monkeypatch.setattr(pg, "_probe_uncached", fake_probe)
+    assert pg.fs_is_case_insensitive(str(root)) is False
+    assert pg.fs_is_case_insensitive(str(root)) is False
+    assert len(calls) == 2  # non-strict result re-probed every call

--- a/vireo/tests/test_path_guard.py
+++ b/vireo/tests/test_path_guard.py
@@ -144,6 +144,9 @@ def test_make_case_folded_check_probes_once(tmp_path, monkeypatch):
         return False
 
     monkeypatch.setattr(pg, "_probe_uncached", counting_probe)
+    # Force the probe path: darwin/win32 short-circuit before probing,
+    # so without this the probe count is 0 there, not 1.
+    monkeypatch.setattr(pg, "is_case_insensitive_platform", lambda: False)
     check = make_case_folded_check(str(root))
     for _ in range(10):
         check(str(root / "photos" / "IMG.NEF"))

--- a/vireo/tests/test_path_guard.py
+++ b/vireo/tests/test_path_guard.py
@@ -1,0 +1,75 @@
+"""Unit tests for the case-aware containment helper.
+
+Extracted from the import endpoint's destination-inside-source guard
+(PR #1107). The endpoint-level tests in test_jobs_api.py remain the
+behavior-preservation net; these pin the helper's own contract.
+"""
+import os
+import sys
+
+import pytest
+
+from path_guard import contains_resolved, fs_is_case_insensitive, path_contains
+
+
+def test_contains_equal_and_nested(tmp_path):
+    root = str(tmp_path / "card")
+    os.makedirs(root)
+    assert path_contains(root, root)
+    assert path_contains(root, os.path.join(root, "DCIM", "IMG_0001.NEF"))
+    assert not path_contains(root, str(tmp_path / "archive"))
+
+
+def test_contains_prefix_is_not_containment(tmp_path):
+    # /card-extra is NOT inside /card even though the string is a prefix.
+    root = str(tmp_path / "card")
+    os.makedirs(root)
+    assert not path_contains(root, str(tmp_path / "card-extra" / "x.jpg"))
+
+
+def test_contains_follows_symlinks(tmp_path):
+    root = tmp_path / "card"
+    root.mkdir()
+    link = tmp_path / "alias"
+    try:
+        os.symlink(str(root), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this filesystem")
+    assert path_contains(str(root), str(link / "IMG_0001.NEF"))
+
+
+@pytest.mark.skipif(
+    sys.platform in ("darwin", "win32"),
+    reason="Linux-only probe: darwin/win32 always case-fold",
+)
+def test_inconclusive_probe_casefolds(tmp_path):
+    # Numeric-only entries: the probe cannot case-swap, so it must fall
+    # back to case-insensitive (the strict direction) and the case-swapped
+    # child is treated as contained. Mirrors the PR #1107 endpoint test.
+    root = tmp_path / "Card-BAR"
+    root.mkdir()
+    (root / "100").mkdir()
+    assert fs_is_case_insensitive(str(root)) is True
+    assert contains_resolved(str(root), str(tmp_path / "card-bar" / "x"))
+
+
+@pytest.mark.skipif(
+    sys.platform in ("darwin", "win32"),
+    reason="Linux-only: needs a genuinely case-sensitive filesystem",
+)
+def test_case_sensitive_fs_distinguishes(tmp_path):
+    root = tmp_path / "CardABC"
+    root.mkdir()
+    (root / "alpha.txt").write_text("x")
+    if fs_is_case_insensitive(str(root)):
+        pytest.skip("tmp filesystem is case-insensitive")
+    assert not contains_resolved(str(root), str(tmp_path / "cardabc" / "x"))
+
+
+def test_darwin_always_casefolds(tmp_path):
+    if sys.platform not in ("darwin", "win32"):
+        pytest.skip("case-insensitive-platform path")
+    root = tmp_path / "Card"
+    root.mkdir()
+    swapped = str(tmp_path / "card" / "IMG.NEF")
+    assert contains_resolved(str(root), swapped)

--- a/vireo/tests/test_path_guard.py
+++ b/vireo/tests/test_path_guard.py
@@ -8,7 +8,6 @@ import os
 import sys
 
 import pytest
-
 from path_guard import contains_resolved, fs_is_case_insensitive, path_contains
 
 


### PR DESCRIPTION
## What

Implements docs/superpowers/specs/2026-08-07-card-cleanup-design.md: a
standalone tool that deletes files from a memory card only when the
identical bytes are checksum-verified in the archive — per file, enforced
at the moment of deletion. Use case: a 40-hour import stopped at hour 20
mid-trip; this reclaims the imported half of the card safely.

- `vireo/path_guard.py`: behavior-preserving extraction of the import
  endpoint's case-aware containment guard (PR #1107) — the endpoint tests
  pass unchanged.
- `vireo/card_cleanup.py`: scan (walk/classify with a discovery-parity
  test, hash-once catalog matching, shared `qualify_rows` archive test:
  `hash_status='ok'` + containment + dev/inode self-match + exact
  size/mtime baseline, all with fresh per-call stats), atomic validated
  manifests with 7-day expiry enforced at request time, delete with a
  per-unlink card re-hash and fresh archive re-validation — a byte is
  removed only after both sides re-prove the safety invariant.
- Endpoints: `POST /api/card-cleanup/scan` (cross-workspace
  source/archive overlap fail-fast), `GET /api/card-cleanup/<id>/manifest`,
  `POST /api/card-cleanup/delete` (runner-or-history scan validation for
  restart safety, one delete per manifest, expiry at request time). Scan
  job results carry totals only — the manifest stays on disk.
- Import-page UI: collapsed "Free up card space" section plus an entry
  point next to the card-safety pill; honest three-bucket preview with an
  incomplete-preview banner when the walk hits errors; byte-exact
  confirmation copy from the spec; per-file delete progress and a summary
  that reports deleted/skipped/failed/cancelled truthfully.

## Tests

Required suite at HEAD: **2136 passed, 16 skipped, 1 failed** — the
failure is `test_api_exiftool_status_reports_missing`, verified
pre-existing on the base commit (machine-local exiftool detection).
Feature suites: 64 passed (43 unit + 13 API + path_guard), ruff clean.
Every task passed a spec-compliance review and a code-quality review; a
final whole-branch review walked the safety invariant end-to-end and
confirmed no path to `os.remove` bypasses a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added memory-card cleanup from the import page.
  - Scan cards, preview archive-verified files, and permanently remove matching copies.
  - Supports progress updates, cancellation, folder browsing, warnings, confirmation, and deletion results.
  - Cleanup resumes safely after interruptions and handles expired or invalid scans.
  - Import results can open cleanup with the source folder preselected.

- **Safety Improvements**
  - Files are rechecked immediately before deletion to prevent removing changed, moved, or unverified files.
  - Prevents cleanup when the source overlaps with the archive.

- **Documentation**
  - Added design and implementation plans for the cleanup workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->