### PR TITLE
Import unification 5a follow-up: local zero-byte stamping revalidates the archive file

### DIFF
--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -4497,11 +4497,35 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     if verified_hash == EMPTY_FILE_SHA256:
                         # Zero-byte convention: EMPTY_FILE_SHA256 never
                         # lands in file_hash (it would collide with every
-                        # other empty file). Status only.
-                        db.update_photo_hash_check(
-                            row["id"], "ok", commit=False,
-                        )
-                        imported_photo_ids.add(row["id"])
+                        # other empty file), so a NULL row hash is
+                        # expected here — but do not stamp blind. Re-read
+                        # the archive path so an empty file that vanished
+                        # or became unreadable between scan and stamping
+                        # fails instead of keeping hash_status='ok' with
+                        # safe_to_format green over a missing file.
+                        # Mirrors the remote loop's zero-byte re-read
+                        # (PR #1437 review, Codex P1 r3741224300 — the
+                        # remote fold inherited this hole FROM this
+                        # branch, and the fix landed remote-only).
+                        try:
+                            actual = _rehash_dest_or_none(dest_path)
+                        except DestReadCancelled:
+                            cancelled = True
+                            break
+                        if actual == EMPTY_FILE_SHA256:
+                            db.update_photo_hash_check(
+                                row["id"], "ok", commit=False,
+                            )
+                            imported_photo_ids.add(row["id"])
+                        else:
+                            _reclassify_landed_failed(
+                                rel, entry,
+                                "scan wrote no archive row hash and a "
+                                "re-read of the archive file disagrees "
+                                "with the copy-time hash (archive file "
+                                "vanished, changed, or is unreadable)",
+                            )
+                            reclassified_landed_paths.add(dest_path)
                     else:
                         # Non-empty file with NULL file_hash after scan
                         # means scanner._compute_file_features couldn't

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -9964,6 +9964,147 @@ def test_remote_zero_byte_adopted_companion_revalidates_before_stamping(
         in reasons[dest_key], reasons
 
 
+def test_local_zero_byte_adoption_revalidates_before_stamping(
+        tmp_path, monkeypatch):
+    """Local mirror of
+    ``test_remote_zero_byte_adoption_revalidates_before_stamping``: the
+    local stamping loop's zero-byte convention branch stamped
+    ``hash_status='ok'`` with no archive re-read ("Status only"), so an
+    empty adopted file that vanished between scan and stamping kept its
+    ``skipped_duplicate`` booking and ``safe_to_format`` went True over
+    an archive path that no longer holds the file. The remote loop
+    gained the re-read when Codex flagged it on PR #1437 (P1
+    r3741224300); this pins the same check on the local path — the
+    pre-existing hole the remote fold inherited FROM local.
+    ``skip_duplicates=False`` reaches the checker-less zero-byte adopt
+    branch, mirroring the remote geometry exactly."""
+    import scanner as _scanner
+    from import_job import ImportParams, run_import_job
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "empty.jpg"
+    card_file.write_bytes(b"")
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(card_file), (ts, ts))
+
+    archive = tmp_path / "archive"
+    seed_folder = archive / "2026" / "2026-07-03"
+    seed_folder.mkdir(parents=True)
+    adopted_dest_path = seed_folder / "empty.jpg"
+    adopted_dest_path.write_bytes(b"")
+    os.utime(str(adopted_dest_path), (ts, ts))
+
+    real_scan = _scanner.scan
+    deleted = {}
+
+    def deleting_scan(*args, **kwargs):
+        result = real_scan(*args, **kwargs)
+        if not deleted and adopted_dest_path.exists():
+            adopted_dest_path.unlink()
+            deleted["done"] = True
+        return result
+
+    monkeypatch.setattr(_scanner, "scan", deleting_scan)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    runner = FakeRunner()
+    result = run_import_job(
+        _make_job(), runner, db_path, db._active_workspace_id,
+        ImportParams(
+            sources=[str(card)], destination=str(archive),
+            verify_by_hash=True, skip_duplicates=False,
+        ),
+    )
+    obs = _behavior_observables(result, runner, db, archive)
+
+    assert deleted, "the scan wrapper never saw the adopted file"
+    assert obs["skipped_duplicate"] == 0, obs
+    assert obs["failed"] == 1, obs
+    assert obs["safe_to_format"] is False, obs
+    dest_key = str(adopted_dest_path)
+    reasons = {p: r for p, r in obs["unsafe"]}
+    assert dest_key in reasons, obs["unsafe"]
+    assert "scan wrote no archive row hash" in reasons[dest_key], reasons
+
+
+def test_local_zero_byte_adopted_companion_revalidates_before_stamping(
+        tmp_path, monkeypatch):
+    """Local mirror of
+    ``test_remote_zero_byte_adopted_companion_revalidates_before_stamping``
+    — expected to pass WITHOUT a production change: the local companion
+    branch compares the re-read hash un-normalized (``actual is not None
+    and actual == verified_hash``), so a legitimately empty companion
+    (``EMPTY_FILE_SHA256 == EMPTY_FILE_SHA256``) passes while an
+    OSError re-read (``None``) fails — it never had the remote branch's
+    normalize-then-compare hole. This green pin completes the 2x2 and
+    keeps the paths' zero-byte companion semantics verifiably aligned."""
+    import scanner as _scanner
+    from import_job import ImportParams, run_import_job
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+    raw_seed = dest_dir / "_seed.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(raw_seed))
+    raw_bytes = raw_seed.read_bytes() + b"RAW-SENSOR-DATA"
+    raw_seed.unlink()
+    raw_archive = dest_dir / "DSC_0800.NEF"
+    raw_archive.write_bytes(raw_bytes)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.nef', ?, ?)",
+        (fid, "DSC_0800.NEF", len(raw_bytes), "deadbeef" * 8),
+    )
+    db.conn.commit()
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "DSC_0800.jpg"
+    card_file.write_bytes(b"")
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(card_file), (ts, ts))
+    adopted_dest_path = dest_dir / "DSC_0800.jpg"
+    adopted_dest_path.write_bytes(b"")
+    os.utime(str(adopted_dest_path), (ts, ts))
+
+    real_scan = _scanner.scan
+    deleted = {}
+
+    def deleting_scan(*args, **kwargs):
+        result = real_scan(*args, **kwargs)
+        if not deleted and adopted_dest_path.exists():
+            adopted_dest_path.unlink()
+            deleted["done"] = True
+        return result
+
+    monkeypatch.setattr(_scanner, "scan", deleting_scan)
+
+    runner = FakeRunner()
+    result = run_import_job(
+        _make_job(), runner, db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=str(archive),
+            verify_by_hash=True, skip_duplicates=False,
+        ),
+    )
+    obs = _behavior_observables(result, runner, db, archive)
+
+    assert deleted, "the scan wrapper never saw the adopted companion"
+    assert obs["skipped_duplicate"] == 0, obs
+    assert obs["failed"] == 1, obs
+    assert obs["safe_to_format"] is False, obs
+
+
 def test_local_renamed_twin_of_accepted_duplicate_current_behavior(
         tmp_path, monkeypatch):
     """CHARACTERIZATION for spec decision 5 (local half). The local path


### PR DESCRIPTION
## What this is

Follow-up to #1437. Codex flagged two P1s on the PR 5a fold (zero-byte adopted files could keep `safe_to_format=True` over a vanished mount file); the repo's PR-agent routine fixed both **on the remote path** before the merge, with regression tests. But the direct-row hole was *inherited from the local path*, which has had the same gap since PR #1107: the local stamping loop's zero-byte convention branch stamped `hash_status='ok'` with a "Status only" comment and **no archive re-read** — an empty adopted file that vanished between `scan()` and stamping kept its `skipped_duplicate` booking and let `safe_to_format` go True over a missing file.

## What changed

- **Local direct-row fix** (`vireo/import_job.py` zero-byte convention branch): re-read the archive path via `_rehash_dest_or_none`; accept only `EMPTY_FILE_SHA256`; reclassify to failed (with `reclassified_landed_paths` bookkeeping) on OSError or changed bytes. Mirrors the remote loop's Codex fix, wording adapted, with a comment cross-referencing the review ID.
- **Local companion branch: no change needed, now pinned.** It compares the re-read un-normalized (`actual is not None and actual == verified_hash`), so a legitimately empty companion passes and an OSError fails — it never had the remote branch's normalize-then-compare hole. Verified by inspection and pinned green.
- **Two local mirror tests** complete the 2x2 with the remote pair: `test_local_zero_byte_adoption_revalidates_before_stamping` (TDD red pre-fix: `skipped_duplicate` stayed 1, `failed` 0, `safe_to_format` True) and `test_local_zero_byte_adopted_companion_revalidates_before_stamping` (green pin).

## Tests

- `vireo/tests/test_import_job.py`: **225 passed, 1 skipped** (all 5 zero-byte revalidation tests green).
- Required suite: **2077 passed, 14 skipped**, 1 known environment-only failure (`test_api_exiftool_status_reports_missing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)