### PR TITLE
Import unification PR 5b: run-state object and helper hoist

### DIFF
--- a/docs/superpowers/plans/2026-08-08-import-unify-pr5b-run-state.md
+++ b/docs/superpowers/plans/2026-08-08-import-unify-pr5b-run-state.md
@@ -1,0 +1,124 @@
+# Import Unification PR 5b: Run-State Object + Helper Hoist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move both import paths' run-scoped closure state into a shared `_ImportRunState` dataclass and hoist the four byte-identical(-modulo-log-wording) state-manipulating helpers to module level — a purely mechanical, no-behavior-change refactor that unlocks PR 6's phase extraction.
+
+**Architecture:** Second half of the spec's PR 5 split (recorded in the spec). The risk profile is the OPPOSITE of 5a's: no behavior flips, but ~350 one-token edits where a single missed `state.` prefix silently creates a dead function-local (Python won't complain; `_emit`'s ETA would read stale state). The defenses: per-path conversion commits with identical suite counts, and a mandatory grep audit of every migrated name as the review artifact. Log-only wording changes (documented below) are the sole observable deltas.
+
+**Tech Stack:** `dataclasses` (`field(default_factory=...)`); pytest.
+
+---
+
+## Context for a zero-context engineer
+
+- Repo root: `/Users/julius/conductor/workspaces/vireo/nagoya`; branch `import-unify-pr5b-run-state` (checked out, tracks origin/main at the #1438 merge `0e3e32a8`). Run tests from repo root; commit per task. Baseline: `python -m pytest vireo/tests/test_import_job.py -q` → **225 passed, 1 skipped** — this exact count must hold after EVERY task.
+- `vireo/import_job.py`: remote `_run_remote_import_job` def 1252; local `run_import_job` def 3180. Line numbers below verified at `0e3e32a8`; re-grep before editing.
+- **Nested helpers (current def lines).** Remote: `_probe_dir_case_insensitive` 1325, `_path_under_destination` 1340, `_fold_basename` 1359, `_emit` 1381, `_emit_transfer` 1416, `_discovery_onerror` 1468, `_stop_requested` 1549, `_counts` 1576, `_fail` 1581 (`nonlocal failed` 1582), `_reclassify_landed_failed` 1588 (`nonlocal copied, verified, skipped_duplicate` 1600), `_missing_mount_root` 1662, `_record_checker` 1665, `_do_rsync` 2414, `_rsync_cancelled` 2439. Local: probe 3280, path-under 3295, `_emit` 3322, `_discovery_onerror` 3368, `_stop_requested` 3452, `_counts` 3515, `_fail` 3520 (nonlocal 3521), `_reclassify_landed_failed` 3527 (nonlocal 3539), `_record_checker` 3552, `_src_hash_cached` 4062, `_rehash_dest_or_none` 4392.
+- **This PR hoists exactly FOUR helpers**: `_counts`, `_fail`, `_reclassify_landed_failed`, `_record_checker` — the pure state manipulators, byte-identical between paths except two LOG-ONLY wordings. Everything else (emitters, probes, transport bits) stays nested; PR 6 owns those.
+- **Migrated state names (18)** — run-scoped, present in BOTH functions, moving into `_ImportRunState`: `copied`, `verified`, `skipped_duplicate`, `unverified_duplicate`, `failed`, `emitted`, `cancelled`, `unsafe_files`, `folder_counts`, `discovery_errors`, `imported_photo_ids`, `linked_dup_dirs`, `dup_link_failed`, `run_dest_folders`, `run_verified_hashes`, `mount_ever_lost`, `wc_source_paths`, `wc_dest_folders`. NOT migrated (stay as locals): `eta`, `checker`, `queued`, `batches`, `destination`, `mount_baseline`, per-batch state (`landed`, `dup_dirs`, `dup_skips`, `mount_lost`, `dest_read_cancelled`, `reclassified_landed_paths`, `to_transfer`, `claimed_basenames`, `queued_src_hashes`, remote transfer vars), and `verified_counted_for_copies` (loop-invariant local — see below).
+- **The silent-shadow hazard:** `copied += 1` → must become `state.copied += 1`; a missed one binds a NEW function-local `copied` at first assignment and every later read in that scope sees the wrong value — no exception. This is why the audit commands in Task 4 are mandatory, not advisory.
+- **Log-only wording changes (the only observable deltas; list in the PR body):**
+  1. `_record_checker`'s OSError warning unifies to `"Duplicate-checker record() failed for %s (dest %s): %s"` — the local variant said "after landing at %s", which is wrong for the remote's enqueue-time skip callers (flagged in PR #1433's body for exactly this reconciliation).
+  2. `_fail`'s warning keeps its per-path prefix via `state.log_label` (`"Remote import"` / `"Import"`), so log lines stay byte-identical.
+- **Carry-overs from 5a's reviews (all no-behavior-change, land in Task 3):**
+  1. Booking/rollback pairing: the remote `verified` booking site (`if params.verify_by_hash: verified += 1` — the one in the post-transfer accounting loop near 2542; NOT the two `update_photo_hash_check` stamp sites at 2517/2774) switches to `if verified_counted_for_copies:` so increment and decrement share one predicate (PR 7's `attests_bytes` then switches both at once).
+  2. `verified_counted_for_copies` moves OUT of the per-batch loop to just before it (it's loop-invariant; today the remote helper at 1588 closes over a name first bound at 1897 inside the loop — works via late binding, needlessly fragile).
+  3. Local `reclassified_landed_paths` decl moves up into the per-batch state block (mirroring remote's placement).
+  4. `_LandedFile` gains `frozen=True` (entries are never mutated by design — the reclassified set exists precisely to avoid mutation).
+- No test monkeypatches or spies target any nested helper (they can't — closures aren't patchable); test-side risk is nil beyond behavior itself.
+
+### Task 0: Sanity
+
+- [ ] `git branch --show-current` → `import-unify-pr5b-run-state`; baseline full file → 225 passed, 1 skipped.
+
+### Task 1: `_ImportRunState` + LOCAL conversion
+
+**Files:** Modify `vireo/import_job.py`.
+
+- [ ] **Step 1:** Add at module level, directly below `_LandedFile`:
+
+```python
+@dataclass
+class _ImportRunState:
+    """Run-scoped mutable state shared by the import batch loop and its
+    helpers. One instance per job run; batch-scoped state (``landed``,
+    ``dup_skips``, collision maps, …) deliberately stays in function
+    locals until the PR 6 phase extraction. ``log_label`` keeps the two
+    paths' failure log lines byte-identical after the helper hoist.
+    """
+    log_label: str
+    copied: int = 0
+    verified: int = 0
+    skipped_duplicate: int = 0
+    unverified_duplicate: int = 0
+    failed: int = 0
+    emitted: int = 0
+    cancelled: bool = False
+    mount_ever_lost: bool = False
+    dup_link_failed: bool = False
+    unsafe_files: list = field(default_factory=list)
+    folder_counts: dict = field(default_factory=dict)
+    discovery_errors: list = field(default_factory=list)
+    imported_photo_ids: set = field(default_factory=set)
+    linked_dup_dirs: set = field(default_factory=set)
+    run_dest_folders: dict = field(default_factory=dict)
+    run_verified_hashes: dict = field(default_factory=dict)
+    wc_source_paths: dict = field(default_factory=dict)
+    wc_dest_folders: set = field(default_factory=set)
+```
+
+(`from dataclasses import dataclass, field` — extend the existing import.)
+
+- [ ] **Step 2:** LOCAL function: create `state = _ImportRunState(log_label="Import")` where the first migrated name is currently initialized; delete the 18 bare initializations; convert every read/write in the function body AND in the local nested helpers (`_emit` reads `copied`/`folder_counts`; `_counts` mutates `folder_counts`; `_fail` mutates `failed`/`unsafe_files`; `_reclassify_landed_failed` mutates three counters; `_record_checker` mutates the two run maps; `_discovery_onerror` appends `discovery_errors`) to `state.<name>`; delete the two local `nonlocal` lines (3521, 3539). The result-dict construction and `_selection_summary`/`_emit` call sites read `state.<name>`. Do NOT touch the remote function in this task.
+- [ ] **Step 3:** `python -c "import sys; sys.path.insert(0, 'vireo'); import import_job"` (syntax/scope smoke), then full file → **225 passed, 1 skipped** (identical). Any delta = a missed or extra conversion; stop and find it.
+- [ ] **Step 4:** Commit: `"Local import path: run-scoped state moves into _ImportRunState"`
+
+### Task 2: REMOTE conversion
+
+- [ ] Same procedure for `_run_remote_import_job` with `state = _ImportRunState(log_label="Remote import")`: 18 names, the remote nested helpers (`_emit`, `_emit_transfer` — reads `folder_counts` —, `_counts`, `_fail`, `_reclassify_landed_failed`, `_record_checker`, `_discovery_onerror`), delete `nonlocal` lines 1582/1600. Full file → 225 passed, 1 skipped. Commit: `"Remote import path: run-scoped state moves into _ImportRunState"`
+
+### Task 3: Hoist the four helpers + carry-overs
+
+- [ ] **Step 1:** Add module-level defs (place after `_ImportRunState`); bodies are the current nested ones with `state.` access and explicit params:
+
+```python
+def _counts(state, rel):
+    return state.folder_counts.setdefault(
+        rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0})
+
+
+def _fail(state, rel, source_file, reason):
+    <current body: state.failed += 1; state.unsafe_files.append(...);
+     _counts(state, rel)["failed"] += 1;
+     log.warning("%s failed for %s: %s", state.log_label, source_file, reason)>
+
+
+def _reclassify_landed_failed(state, rel, entry, reason,
+                              verified_counted_for_copies):
+    <current body, switching on entry.origin, decrementing via state,
+     gating verified on the parameter, ending with
+     _fail(state, rel, entry.dest_path, reason)>
+
+
+def _record_checker(state, checker, source_file, dest_folder, file_hash):
+    <current body; unified OSError warning:
+     "Duplicate-checker record() failed for %s (dest %s): %s">
+```
+
+Copy the current docstrings, merging where they differ (keep the PR #1113 rationale; drop the stale "after landing" phrasing). Delete all eight nested defs; update every call site (`_counts(rel)` → `_counts(state, rel)`, etc. — grep counts before/after: the number of call sites must not change). CAREFUL with `_fail`'s log line: currently `"Remote import failed for %s: %s"` / `"Import failed for %s: %s"` — the hoisted form `"%s failed for %s: %s", state.log_label` reproduces both byte-for-byte.
+- [ ] **Step 2 (carry-overs):** booking-site predicate switch (`if verified_counted_for_copies:` at the remote post-transfer `verified` booking); move both `verified_counted_for_copies` decls out of the batch loops to just before them; move local `reclassified_landed_paths` decl into the per-batch state block; add `frozen=True` to `_LandedFile` (run the suite — if anything mutates entries, that's a finding: revert the freeze, report it, and leave a comment).
+- [ ] **Step 3:** Full file → 225 passed, 1 skipped. Commit: `"Hoist the shared state helpers to module level; 5a review carry-overs"`
+
+### Task 4: Audit + verification + PR
+
+- [ ] **Step 1 (the audit — paste results into the PR body):** for each of the 18 migrated names, inside BOTH function ranges, every remaining bare occurrence must be a comment, docstring, keyword argument name, or dict key — never a load/store of a local. Command shape:
+
+```bash
+for n in copied verified skipped_duplicate unverified_duplicate failed emitted cancelled unsafe_files folder_counts discovery_errors imported_photo_ids linked_dup_dirs dup_link_failed run_dest_folders run_verified_hashes mount_ever_lost wc_source_paths wc_dest_folders; do
+  echo "== $n"; grep -nE "(^|[^.\w\"'])${n}\b" vireo/import_job.py | grep -vE "state\.${n}|def |#|\"|'" ; done
+```
+
+Review every hit by eye (e.g. `copied=` keyword args to `_selection_summary` are fine; a bare `copied += 1` is the bug). Also: `grep -n "nonlocal" vireo/import_job.py` → only hits outside the two functions (expect none in them).
+- [ ] **Step 2:** Full file (225/1) + required CLAUDE.md suite (expect 2077 passed, 14 skipped, 1 known env failure).
+- [ ] **Step 3:** Push; `gh pr create --base main --title "Import unification PR 5b: run-state object and helper hoist" --body ...` — body covers: the 5a/5b split pointer; the 18 migrated names; the four hoisted helpers with the two log-wording notes; the four 5a-review carry-overs; the audit output; "no behavior change — suite counts identical at every commit"; notes for PR 6 (the emitters and probes are next; `_reclassify_landed_failed`'s `verified_counted_for_copies` param is the seam PR 7's `attests_bytes` replaces). End with the Claude Code attribution line.

--- a/docs/superpowers/plans/2026-08-08-import-unify-pr5b-run-state.md
+++ b/docs/superpowers/plans/2026-08-08-import-unify-pr5b-run-state.md
@@ -17,12 +17,12 @@
 - **Nested helpers (current def lines).** Remote: `_probe_dir_case_insensitive` 1325, `_path_under_destination` 1340, `_fold_basename` 1359, `_emit` 1381, `_emit_transfer` 1416, `_discovery_onerror` 1468, `_stop_requested` 1549, `_counts` 1576, `_fail` 1581 (`nonlocal failed` 1582), `_reclassify_landed_failed` 1588 (`nonlocal copied, verified, skipped_duplicate` 1600), `_missing_mount_root` 1662, `_record_checker` 1665, `_do_rsync` 2414, `_rsync_cancelled` 2439. Local: probe 3280, path-under 3295, `_emit` 3322, `_discovery_onerror` 3368, `_stop_requested` 3452, `_counts` 3515, `_fail` 3520 (nonlocal 3521), `_reclassify_landed_failed` 3527 (nonlocal 3539), `_record_checker` 3552, `_src_hash_cached` 4062, `_rehash_dest_or_none` 4392.
 - **This PR hoists exactly FOUR helpers**: `_counts`, `_fail`, `_reclassify_landed_failed`, `_record_checker` — the pure state manipulators, byte-identical between paths except two LOG-ONLY wordings. Everything else (emitters, probes, transport bits) stays nested; PR 6 owns those.
 - **Migrated state names (18)** — run-scoped, present in BOTH functions, moving into `_ImportRunState`: `copied`, `verified`, `skipped_duplicate`, `unverified_duplicate`, `failed`, `emitted`, `cancelled`, `unsafe_files`, `folder_counts`, `discovery_errors`, `imported_photo_ids`, `linked_dup_dirs`, `dup_link_failed`, `run_dest_folders`, `run_verified_hashes`, `mount_ever_lost`, `wc_source_paths`, `wc_dest_folders`. NOT migrated (stay as locals): `eta`, `checker`, `queued`, `batches`, `destination`, `mount_baseline`, per-batch state (`landed`, `dup_dirs`, `dup_skips`, `mount_lost`, `dest_read_cancelled`, `reclassified_landed_paths`, `to_transfer`, `claimed_basenames`, `queued_src_hashes`, remote transfer vars), and `verified_counted_for_copies` (loop-invariant local — see below).
-- **The silent-shadow hazard:** `copied += 1` → must become `state.copied += 1`; a missed one binds a NEW function-local `copied` at first assignment and every later read in that scope sees the wrong value — no exception. This is why the audit commands in Task 4 are mandatory, not advisory.
+- **The shadow hazard:** once the bare initializations are deleted, a missed `copied += 1` fails LOUDLY (`UnboundLocalError`); the genuinely SILENT misses are the plain rebinds — `cancelled = True`, `dup_link_failed = True`, `mount_ever_lost = mount_lost` — which quietly create a dead function-local while `state.<name>` keeps its stale value. This is why the audit commands in Task 4 are mandatory, not advisory.
 - **Log-only wording changes (the only observable deltas; list in the PR body):**
   1. `_record_checker`'s OSError warning unifies to `"Duplicate-checker record() failed for %s (dest %s): %s"` — the local variant said "after landing at %s", which is wrong for the remote's enqueue-time skip callers (flagged in PR #1433's body for exactly this reconciliation).
   2. `_fail`'s warning keeps its per-path prefix via `state.log_label` (`"Remote import"` / `"Import"`), so log lines stay byte-identical.
 - **Carry-overs from 5a's reviews (all no-behavior-change, land in Task 3):**
-  1. Booking/rollback pairing: the remote `verified` booking site (`if params.verify_by_hash: verified += 1` — the one in the post-transfer accounting loop near 2542; NOT the two `update_photo_hash_check` stamp sites at 2517/2774) switches to `if verified_counted_for_copies:` so increment and decrement share one predicate (PR 7's `attests_bytes` then switches both at once).
+  1. Booking/rollback pairing: the remote `verified` booking site (`if params.verify_by_hash: verified += 1` — the one in the post-transfer accounting loop at 2542-2543, right after the `copied` booking; NOT 2517, the `remote_verify_files` verification guard, and NOT 2775, the sole remote `update_photo_hash_check` stamp site) switches to `if verified_counted_for_copies:` so increment and decrement share one predicate (PR 7's `attests_bytes` then switches both at once).
   2. `verified_counted_for_copies` moves OUT of the per-batch loop to just before it (it's loop-invariant; today the remote helper at 1588 closes over a name first bound at 1897 inside the loop — works via late binding, needlessly fragile).
   3. Local `reclassified_landed_paths` decl moves up into the per-batch state block (mirroring remote's placement).
   4. `_LandedFile` gains `frozen=True` (entries are never mutated by design — the reclassified set exists precisely to avoid mutation).
@@ -55,7 +55,9 @@ class _ImportRunState:
     failed: int = 0
     emitted: int = 0
     cancelled: bool = False
-    mount_ever_lost: bool = False
+    # None or a mount-root path string; consumers are truthiness-only
+    # plus one f-string interpolation of the path into a failure reason.
+    mount_ever_lost: str | None = None
     dup_link_failed: bool = False
     unsafe_files: list = field(default_factory=list)
     folder_counts: dict = field(default_factory=dict)
@@ -119,6 +121,22 @@ for n in copied verified skipped_duplicate unverified_duplicate failed emitted c
   echo "== $n"; grep -nE "(^|[^.\w\"'])${n}\b" vireo/import_job.py | grep -vE "state\.${n}|def |#|\"|'" ; done
 ```
 
-Review every hit by eye (e.g. `copied=` keyword args to `_selection_summary` are fine; a bare `copied += 1` is the bug). Also: `grep -n "nonlocal" vireo/import_job.py` → only hits outside the two functions (expect none in them).
+Review every hit by eye (e.g. `copied=` keyword args to `_selection_summary` are fine; a bare `cancelled = True` is the bug). Also: `grep -n "nonlocal" vireo/import_job.py` → expect zero hits in the two functions. Belt-and-braces (catches what the grep's comment/quote filters could hide): a `symtable` check asserting none of the 18 names remain locals of either function:
+
+```bash
+python3 - <<'PY'
+import symtable
+src = open('vireo/import_job.py').read()
+names = set('copied verified skipped_duplicate unverified_duplicate failed emitted cancelled unsafe_files folder_counts discovery_errors imported_photo_ids linked_dup_dirs dup_link_failed run_dest_folders run_verified_hashes mount_ever_lost wc_source_paths wc_dest_folders'.split())
+top = symtable.symtable(src, 'import_job.py', 'exec')
+for fn in ('_run_remote_import_job', 'run_import_job'):
+    t = top.lookup(fn).get_namespace()
+    bad = sorted(n for n in names if n in set(t.get_identifiers())
+                 and t.lookup(n).is_local())
+    print(fn, 'OK' if not bad else f'LEAKED LOCALS: {bad}')
+PY
+```
+
+Both lines must print OK.
 - [ ] **Step 2:** Full file (225/1) + required CLAUDE.md suite (expect 2077 passed, 14 skipped, 1 known env failure).
 - [ ] **Step 3:** Push; `gh pr create --base main --title "Import unification PR 5b: run-state object and helper hoist" --body ...` — body covers: the 5a/5b split pointer; the 18 migrated names; the four hoisted helpers with the two log-wording notes; the four 5a-review carry-overs; the audit output; "no behavior change — suite counts identical at every commit"; notes for PR 6 (the emitters and probes are next; `_reclassify_landed_failed`'s `verified_counted_for_copies` param is the seam PR 7's `attests_bytes` replaces). End with the Claude Code attribution line.

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1397,25 +1397,23 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     ])
     runner.update_step(job["id"], "import", status="running")
 
-    copied = 0
+    state = _ImportRunState(log_label="Remote import")
     eta = _ImportEtaEstimator(
         expected_new=(params.checked_count if params.skip_duplicates else None),
     )
 
-    # Live per-folder counters, mutated by the copy loop via _counts() and
-    # snapshotted onto every progress event so the Import page can render
-    # truthful per-folder progress mid-run. Declared before _emit so the
-    # discovery-phase emits see an empty-but-present dict. Mirrors the
-    # local path.
-    folder_counts = {}
+    # ``state.folder_counts``: live per-folder counters, mutated by the
+    # copy loop via _counts() and snapshotted onto every progress event
+    # so the Import page can render truthful per-folder progress
+    # mid-run. Mirrors the local path.
 
     def _emit(phase, current, total, current_file="", *, is_importing=False):
         eta_fields = {}
         if total > 0:
             if is_importing:
-                eta.note_importing(copied)
+                eta.note_importing(state.copied)
             else:
-                eta.note_batch_complete(current, copied)
+                eta.note_batch_complete(current, state.copied)
             eta_fields = eta.fields(total)
         job["progress"]["current"] = current
         job["progress"]["total"] = total
@@ -1438,7 +1436,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 # consumers must see the state at emit time). Mirrors the
                 # local path — spec decision 1.
                 folders={
-                    rel: dict(counts) for rel, counts in folder_counts.items()
+                    rel: dict(counts) for rel, counts in state.folder_counts.items()
                 },
                 **eta_fields,
             ),
@@ -1485,7 +1483,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 # parameter.)
                 folders={
                     rel_: dict(counts)
-                    for rel_, counts in folder_counts.items()
+                    for rel_, counts in state.folder_counts.items()
                 },
                 **extra,
             ),
@@ -1494,10 +1492,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # --- Discover (same enumeration-error handling as the local path) ---
     _emit("Discovering files", 0, 0)
     files = []
-    discovery_errors = []
 
     def _discovery_onerror(exc):
-        discovery_errors.append(exc)
+        state.discovery_errors.append(exc)
         log.warning("Import discovery error: %s", exc)
 
     for src in params.sources:
@@ -1569,13 +1566,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             batches.append((rel, group[i:i + IMPORT_BATCH_SIZE]))
 
     # --- Ledger ---------------------------------------------------------
-    verified = 0            # count of files independently checksum-verified
-    skipped_duplicate = 0
-    unverified_duplicate = 0
-    failed = 0
-    unsafe_files = []
-    emitted = 0
-    cancelled = False
+    # (On ``state``.) ``state.verified``: count of files independently
+    # checksum-verified.
 
     def _stop_requested():
         # Threaded through every destination-side hash read so a Stop can
@@ -1588,32 +1580,29 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # ``cancellation_requested`` for the same reason.
         return runner.cancellation_requested(job["id"])
 
-    wc_source_paths = {}
-    wc_dest_folders = set()
-    # Photo rows this run created or landed bytes into: fresh copies whose
+    # ``state.imported_photo_ids``: photo rows this run created or
+    # landed bytes into: fresh copies whose
     # mount row was cataloged, adopted duplicates whose pre-existing mount
     # row now belongs to this run, verified cataloged-twin skips, and RAW
     # primaries that adopted a landed JPEG companion. The after-import
     # chaining hook scopes its process job to exactly these; without it a
     # successful remote import falls into the "no new photos" branch and
     # the requested process job never runs.
-    imported_photo_ids = set()
-    # Dup-twin dirs already linked across batches.
-    linked_dup_dirs = set()
+    # ``state.linked_dup_dirs``: dup-twin dirs already linked across
+    # batches.
     # A duplicate-only batch's workspace visibility depends on the direct
-    # DB link; if it fails, safe_to_format must remain false.
-    dup_link_failed = False
+    # DB link; if it fails, safe_to_format must remain false
+    # (``state.dup_link_failed``).
 
     def _counts(rel):
-        return folder_counts.setdefault(
+        return state.folder_counts.setdefault(
             rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0},
         )
 
     def _fail(rel, source_file, reason):
-        nonlocal failed
-        failed += 1
+        state.failed += 1
         _counts(rel)["failed"] += 1
-        unsafe_files.append({"path": str(source_file), "reason": reason})
+        state.unsafe_files.append({"path": str(source_file), "reason": reason})
         log.warning("Remote import failed for %s: %s", source_file, reason)
 
     def _reclassify_landed_failed(rel, entry, reason):
@@ -1628,28 +1617,28 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         otherwise the exactly-one-terminal-bucket invariant breaks and
         ``copied + skipped_duplicate + failed`` exceeds ``discovered``.
         """
-        nonlocal copied, verified, skipped_duplicate
         dest_path = entry.dest_path
         origin = entry.origin
         if origin == "copied":
-            copied -= 1
+            state.copied -= 1
             if verified_counted_for_copies:
-                verified -= 1
+                state.verified -= 1
             _counts(rel)["copied"] -= 1
         elif origin == "skipped_duplicate":
-            skipped_duplicate -= 1
+            state.skipped_duplicate -= 1
             _counts(rel)["skipped_duplicate"] -= 1
         _fail(rel, dest_path, reason)
 
-    # Intra-run bookkeeping so a second byte-identical card file (with a
+    # Intra-run bookkeeping (``state.run_dest_folders`` /
+    # ``state.run_verified_hashes``) so a second byte-identical card
+    # file (with a
     # different basename) in this run is recognized as a duplicate before
     # ``scan()`` runs — the DB twin lookup can't help until the batch's
     # ``scan()`` has cataloged the first landing. Mirrors the local path.
-    run_dest_folders = {}
-    run_verified_hashes = {}
 
-    # Sticky across the rest of the run once a mounted → unmounted
-    # transition is observed. The per-batch rollback below undoes
+    # ``state.mount_ever_lost``: sticky across the rest of the run once
+    # a mounted → unmounted transition is observed. The per-batch
+    # rollback below undoes
     # ``to_transfer`` / ``landed`` (adoptions) / ``dup_skips`` / ``dup_dirs``
     # but not the identities the same batch already installed in the
     # job-wide ``checker`` (and in ``run_dest_folders`` /
@@ -1666,7 +1655,6 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # the only real copy. Refusing every remaining batch once a detach
     # has been observed keeps the stale intra-run cache from ever being
     # consulted. See PR #1400 review (Codex P2 r3688614624).
-    mount_ever_lost = None
 
     # Mount-root check (Task 2.7 late follow-up): when a saved remote
     # target's local mount root is not mounted (for example ``/Volumes/NAS``
@@ -1719,12 +1707,12 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             )
             return
         for tok in tokens:
-            run_dest_folders[tok] = dest_folder
-            run_verified_hashes[tok] = file_hash
+            state.run_dest_folders[tok] = dest_folder
+            state.run_verified_hashes[tok] = file_hash
 
     for rel, batch in batches:
         if runner.is_cancelled(job["id"]):
-            cancelled = True
+            state.cancelled = True
             break
 
         # A detach observed in an earlier batch is sticky: the intra-run
@@ -1734,19 +1722,19 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # duplicates of transfers that never happened. Fail every
         # remaining file in the run rather than risk a stale-cache hit.
         # See PR #1400 review (Codex P2 r3688614624).
-        if mount_ever_lost:
+        if state.mount_ever_lost:
             for source_file in batch:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
-                    f"archive mount root {mount_ever_lost} detached "
+                    f"archive mount root {state.mount_ever_lost} detached "
                     "earlier in this import; the intra-run duplicate "
                     "cache still holds identities for files whose "
                     "archive claim was rolled back, so no further batch "
                     "can be trusted to consult it",
                 )
             _emit(
-                f"{rel}: archive unmounted", emitted, queued,
+                f"{rel}: archive unmounted", state.emitted, queued,
             )
             continue
 
@@ -1772,7 +1760,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # archive copy). See PR #1113 review.
         if _path_under_any_source(dest_folder):
             for source_file in batch:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     "destination folder resolves inside a source directory "
@@ -1783,7 +1771,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             _emit(
                 f"{rel}: {_counts(rel)['copied']} copied · "
                 f"{_counts(rel)['skipped_duplicate']} already present",
-                emitted, queued,
+                state.emitted, queued,
             )
             continue
         # Mount-root check (see the ``_missing_mount_root`` helper near the
@@ -1796,7 +1784,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         missing_mount_root = _missing_mount_root()
         if missing_mount_root:
             for source_file in batch:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     f"archive mount root {missing_mount_root} is not "
@@ -1807,7 +1795,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # Specific refusal phase — mirrors the local path; spec
             # decision 3.
             _emit(
-                f"{rel}: archive unavailable", emitted, queued,
+                f"{rel}: archive unavailable", state.emitted, queued,
             )
             continue
         # Persistent-mount-point case (Linux ``/mnt/<name>`` survives the
@@ -1820,7 +1808,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         stale_mount_root = _unmounted_since_baseline(mount_baseline)
         if stale_mount_root:
             for source_file in batch:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     f"archive mount root {stale_mount_root} is no longer "
@@ -1830,7 +1818,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     "archive)",
                 )
             _emit(
-                f"{rel}: archive unmounted", emitted, queued,
+                f"{rel}: archive unmounted", state.emitted, queued,
             )
             continue
         # Mirrors the local path: the checks above only catch a mount
@@ -1842,13 +1830,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             os.makedirs(dest_folder, exist_ok=True)
         except OSError as e:
             for source_file in batch:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     f"could not create destination folder {dest_folder}: {e}",
                 )
             _emit(
-                f"{rel}: destination unavailable", emitted, queued,
+                f"{rel}: destination unavailable", state.emitted, queued,
             )
             continue
 
@@ -1953,12 +1941,12 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         dest_read_cancelled = False
         for source_file in batch:
             if runner.is_cancelled(job["id"]):
-                cancelled = True
+                state.cancelled = True
                 break
             if not mount_lost:
                 mount_lost = _unmounted_since_baseline(mount_baseline)
             if mount_lost:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     f"archive mount root {mount_lost} detached while this "
@@ -1967,9 +1955,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     "duplicate match against it can be trusted)",
                 )
                 continue
-            emitted += 1
+            state.emitted += 1
             _emit(
-                f"{rel}: importing", emitted, queued, source_file.name,
+                f"{rel}: importing", state.emitted, queued, source_file.name,
                 is_importing=True,
             )
             if checker is not None:
@@ -1987,8 +1975,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             db, token, source_file, _path_under_any_source,
                         )
                         if likely_rows:
-                            skipped_duplicate += 1
-                            unverified_duplicate += 1
+                            state.skipped_duplicate += 1
+                            state.unverified_duplicate += 1
                             _counts(rel)["skipped_duplicate"] += 1
                             dup_skips.append((source_file, True))
                             dup_dirs.update(_linkable_twin_dirs(
@@ -2023,11 +2011,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # catalog and a byte-identical second file gets
                     # rsynced/cataloged again. Mirrors the local path.
                     # See PR #1113 review.
-                    if token in run_dest_folders:
+                    if token in state.run_dest_folders:
                         if token[0] == "hash":
                             accept = True
                         else:
-                            run_hash = run_verified_hashes.get(token)
+                            run_hash = state.run_verified_hashes.get(token)
                             if (
                                 src_hash is not None
                                 and run_hash is not None
@@ -2059,7 +2047,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                 twin_hash = _hash_dest_file(
                                     twin_path, _stop_requested)
                             except DestReadCancelled:
-                                cancelled = True
+                                state.cancelled = True
                                 dest_read_cancelled = True
                                 break
                             except OSError:
@@ -2076,14 +2064,14 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                 # Mirrors the local path's collect-then-
                                 # link pattern. See PR #1113 review.
                                 verified_twin_rows.append(twin)
-                    if cancelled:
+                    if state.cancelled:
                         # Stop interrupted a twin hash above. Don't let
                         # this file fall through to the collision checks
                         # and the transfer queue — every further step
                         # touches the same (possibly dead) mount.
                         break
                     if accept:
-                        skipped_duplicate += 1
+                        state.skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
                         dup_skips.append((source_file, False))
                         # Preserve the verified twin folders so the follow-
@@ -2105,7 +2093,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # by this run's own batch scan, so add it to
                         # dup_dirs so a duplicate-only follow-up batch
                         # still finds it visible. Mirrors the local path.
-                        run_dest = run_dest_folders.get(token)
+                        run_dest = state.run_dest_folders.get(token)
                         if run_dest is not None:
                             dup_dirs.add(run_dest)
                         continue
@@ -2162,7 +2150,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 and src_hash is not None
                 and src_hash in queued_src_hashes
             ):
-                skipped_duplicate += 1
+                state.skipped_duplicate += 1
                 _counts(rel)["skipped_duplicate"] += 1
                 dup_skips.append((source_file, False))
                 _record_checker(source_file, dest_folder, src_hash)
@@ -2190,7 +2178,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         checker is not None
                         and claimed_basenames[candidate_key] == src_hash
                     ):
-                        skipped_duplicate += 1
+                        state.skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
                         dup_skips.append((source_file, False))
                         _record_checker(source_file, dest_folder, src_hash)
@@ -2215,13 +2203,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # the source-file loop so nothing else in this
                         # batch touches the mount. The interrupted file
                         # stays on the card for the next run.
-                        cancelled = True
+                        state.cancelled = True
                         dest_read_cancelled = True
                         break
                     except OSError:
                         on_disk = None
                     if on_disk is not None and on_disk == src_hash:
-                        skipped_duplicate += 1
+                        state.skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
                         claimed_basenames[candidate_key] = src_hash
                         # Fold the adoption into ``landed`` (origin
@@ -2259,7 +2247,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     continue
                 dest_basename = candidate
                 break
-            if cancelled:
+            if state.cancelled:
                 # Stop interrupted a collision hash above (mirrors the
                 # twin-hash branch's post-loop check). Don't let this file
                 # (or the rest of the batch) fall through to the queue /
@@ -2324,10 +2312,10 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # holds nor trust the mount-side paths we were about to catalog.
         if mount_lost:
             for skipped_file, counted_unverified in dup_skips:
-                skipped_duplicate -= 1
+                state.skipped_duplicate -= 1
                 _counts(rel)["skipped_duplicate"] -= 1
                 if counted_unverified:
-                    unverified_duplicate -= 1
+                    state.unverified_duplicate -= 1
                 _fail(
                     rel, skipped_file,
                     f"archive mount root {mount_lost} detached mid-batch; "
@@ -2367,7 +2355,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # identities for the files just rolled back above; the
             # checker has no removal API). See PR #1400 review (Codex
             # P2 r3688614624).
-            mount_ever_lost = mount_lost
+            state.mount_ever_lost = mount_lost
 
         # Honor cancellation before any network transfer starts. The break
         # inside the per-file queue-building loop above sets ``cancelled``
@@ -2379,7 +2367,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # entries for files already visible on the mount are still
         # cataloged by the batch-scan block below. See PR #1113
         # review.
-        if to_transfer and not cancelled:
+        if to_transfer and not state.cancelled:
             # ``--ignore-existing`` protects against basename-race overwrites:
             # two remote import jobs (or a job racing another writer) that
             # both passed the earlier mount-side os.path.exists check for
@@ -2499,7 +2487,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         for sf, _bn, _sh, _sz, _mt in flat:
                             _fail(rel, sf, "rsync stalled (no progress)")
                     elif _rsync_cancelled(rc):
-                        cancelled = True
+                        state.cancelled = True
                     elif rc != 0:
                         for sf, _bn, _sh, _sz, _mt in flat:
                             _fail(rel, sf, f"rsync failed: {stderr.strip()}")
@@ -2511,8 +2499,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 # Renamed files: one rsync each to the explicit NAS file
                 # path (rsync <card> user@host:/dir/DSC_0001_1.jpg).
                 for sf, bn, sh, sz, mt in renamed:
-                    if cancelled or runner.is_cancelled(job["id"]):
-                        cancelled = True
+                    if state.cancelled or runner.is_cancelled(job["id"]):
+                        state.cancelled = True
                         break
                     nas_full = posixpath.join(ssh_dest, bn)
                     rc, stderr, timed_out = _do_rsync(
@@ -2522,7 +2510,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     if timed_out:
                         _fail(rel, sf, "rsync stalled (no progress)")
                     elif _rsync_cancelled(rc):
-                        cancelled = True
+                        state.cancelled = True
                         break
                     elif rc != 0:
                         _fail(rel, sf, f"rsync failed: {stderr.strip()}")
@@ -2568,10 +2556,10 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             )
                             _fail(rel, sf, reason)
                             continue
-                    copied += 1
+                    state.copied += 1
                     _counts(rel)["copied"] += 1
                     if params.verify_by_hash:
-                        verified += 1
+                        state.verified += 1
                     landed.append(_LandedFile(
                         dest_path=dest_path,
                         verified_hash=src_hash,
@@ -2766,7 +2754,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             mount_hash = _hash_dest_file(
                                 dest_path, _stop_requested)
                         except DestReadCancelled:
-                            cancelled = True
+                            state.cancelled = True
                             break
                         except OSError:
                             mount_hash = None
@@ -2809,7 +2797,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # Fresh mount row this run stamped as valid — the
                     # after-import chaining hook builds its process job
                     # collection from these ids.
-                    imported_photo_ids.add(row["id"])
+                    state.imported_photo_ids.add(row["id"])
                 else:
                     # RAW+JPEG pairing merges the JPEG's photo row into
                     # the RAW primary (companion_path) and deletes the
@@ -2867,7 +2855,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             mount_hash = _hash_dest_file(
                                 dest_path, _stop_requested)
                         except DestReadCancelled:
-                            cancelled = True
+                            state.cancelled = True
                             break
                         except OSError:
                             mount_hash = None
@@ -2907,7 +2895,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # Collected for the post-validation invalidation
                         # loop — see the raw_companion_invalidations decl.
                         raw_companion_invalidations.add(companion["id"])
-                        imported_photo_ids.add(companion["id"])
+                        state.imported_photo_ids.add(companion["id"])
                         continue
                     _reclassify_landed_failed(
                         rel, entry,
@@ -3016,11 +3004,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # the catalog's view — instead of caching a WC
                         # of bytes the ledger no longer vouches for.
                         continue
-                    wc_source_paths[entry.dest_path] = (
+                    state.wc_source_paths[entry.dest_path] = (
                         entry.source_path, entry.src_size,
                         entry.src_mtime_ns,
                     )
-                wc_dest_folders.add(dest_folder)
+                state.wc_dest_folders.add(dest_folder)
 
         # --- Link verified duplicate-twin folders ----------------------
         # A verified duplicate skip's twin folder may live elsewhere under
@@ -3028,16 +3016,16 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # existing catalog row directly instead of scanning the folder: an
         # incremental scan still enumerates/stats every NAS entry and can
         # turn a zero-copy import into an hours-long metadata walk.
-        new_dup_dirs = dup_dirs - linked_dup_dirs
+        new_dup_dirs = dup_dirs - state.linked_dup_dirs
         if new_dup_dirs:
             linked, failures = _link_duplicate_twin_dirs(
                 db, workspace_id, new_dup_dirs,
             )
-            linked_dup_dirs.update(linked)
+            state.linked_dup_dirs.update(linked)
             if failures:
-                dup_link_failed = True
+                state.dup_link_failed = True
                 for d, detail in failures.items():
-                    unsafe_files.append({
+                    state.unsafe_files.append({
                         "path": d,
                         "reason": (
                             "duplicate-folder workspace link failed: "
@@ -3047,36 +3035,36 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "
             f"{_counts(rel)['skipped_duplicate']} already present",
-            emitted, queued,
+            state.emitted, queued,
         )
-        if cancelled:
+        if state.cancelled:
             break
 
     # --- Deferred working-copy extraction ------------------------------
-    if params.vireo_dir and wc_dest_folders and not cancelled:
+    if params.vireo_dir and state.wc_dest_folders and not state.cancelled:
         from scanner import _extract_working_copies
 
         try:
             _extract_working_copies(
                 db, params.vireo_dir,
-                scope=[(d, "exact") for d in sorted(wc_dest_folders)],
-                source_paths=wc_source_paths,
+                scope=[(d, "exact") for d in sorted(state.wc_dest_folders)],
+                source_paths=state.wc_source_paths,
                 cancel_check=lambda: runner.is_cancelled(job["id"]),
             )
         except Exception:
             log.exception(
                 "Working-copy extraction failed for %s",
-                sorted(wc_dest_folders),
+                sorted(state.wc_dest_folders),
             )
         if runner.is_cancelled(job["id"]):
-            cancelled = True
+            state.cancelled = True
 
-    status = "cancelled" if cancelled else (
-        "failed" if failed else "completed"
+    status = "cancelled" if state.cancelled else (
+        "failed" if state.failed else "completed"
     )
     summary = _selection_summary(
-        params, include_paths, discovered=discovered, copied=copied,
-        skipped_duplicate=skipped_duplicate, failed=failed,
+        params, include_paths, discovered=discovered, copied=state.copied,
+        skipped_duplicate=state.skipped_duplicate, failed=state.failed,
     )
     runner.update_step(
         job["id"], "import",
@@ -3084,8 +3072,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         summary=summary,
     )
 
-    for exc in discovery_errors:
-        unsafe_files.append({
+    for exc in state.discovery_errors:
+        state.unsafe_files.append({
             "path": str(getattr(exc, "filename", None) or "<discovery>"),
             "reason": f"source enumeration failed: {exc}",
         })
@@ -3113,32 +3101,32 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # that with the plan's reason string.
     remote_unverified = not params.verify_by_hash
     if remote_unverified and discovered > 0:
-        unsafe_files.append({
+        state.unsafe_files.append({
             "path": "<remote>",
             "reason": "enable verify_by_hash for remote verification",
         })
-    if unverified_duplicate:
-        unsafe_files.append({
+    if state.unverified_duplicate:
+        state.unsafe_files.append({
             "path": "Likely duplicates",
             "reason": (
-                f"{unverified_duplicate} matched by filename, byte size, "
+                f"{state.unverified_duplicate} matched by filename, byte size, "
                 "and capture time but were not compared byte-for-byte"
             ),
         })
     # Selection drift entries. Shared with the local path.
     _append_selection_unsafe(
-        unsafe_files, deselected=deselected, vanished_paths=vanished_paths,
+        state.unsafe_files, deselected=deselected, vanished_paths=vanished_paths,
         appeared=appeared,
     )
     safe_to_format = (
-        not cancelled
-        and failed == 0
-        and not discovery_errors
-        and not dup_link_failed
+        not state.cancelled
+        and state.failed == 0
+        and not state.discovery_errors
+        and not state.dup_link_failed
         and not partial_scope
         and not remote_unverified
-        and unverified_duplicate == 0
-        and (copied + skipped_duplicate) == discovered
+        and state.unverified_duplicate == 0
+        and (state.copied + state.skipped_duplicate) == discovered
         and not _selection_blocks_format(
             deselected=deselected, vanished_paths=vanished_paths)
     )
@@ -3148,28 +3136,28 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # exclusion is incidental, and a change to either flag would silently
     # reopen the hole.
     unverified_duplicates_only = (
-        unverified_duplicate > 0
-        and not cancelled
-        and failed == 0
-        and not discovery_errors
-        and not dup_link_failed
+        state.unverified_duplicate > 0
+        and not state.cancelled
+        and state.failed == 0
+        and not state.discovery_errors
+        and not state.dup_link_failed
         and not partial_scope
         and not remote_unverified
-        and (copied + skipped_duplicate) == discovered
+        and (state.copied + state.skipped_duplicate) == discovered
         and not _selection_blocks_format(
             deselected=deselected, vanished_paths=vanished_paths)
     )
     result = {
         "discovered": discovered,
-        "copied": copied,
-        "verified": verified,
+        "copied": state.copied,
+        "verified": state.verified,
         # Photo rows the after-import chaining hook should process.
         # Duplicate-only imports intentionally return an empty list so
         # ``_chain_after_import`` skips into its "no new photos" branch
         # instead of enqueueing an empty process run — same convention as
         # the local path. Without this the remote import always missed
         # after-import processing. See PR #1113 review.
-        "photo_ids": sorted(imported_photo_ids),
+        "photo_ids": sorted(state.imported_photo_ids),
         # Stable-identity map so a recovery retry can verify each carried
         # ID still points at the same file. Without this the retry
         # authorizes any current photo row that happens to share an ID
@@ -3177,7 +3165,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # after users delete recent imports (SQLite reuses the freed
         # IDs on the next insert).
         "photo_fingerprints": _capture_photo_fingerprints(
-            db, imported_photo_ids,
+            db, state.imported_photo_ids,
         ),
         # Per-source signature over the discovered file set so a
         # recovery retry can detect a source whose contents changed
@@ -3188,22 +3176,22 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # would let a mid-copy card ejection stamp ``-1`` sizes and
         # refuse a legitimate reinsert-and-retry recovery.
         "source_snapshots": source_snapshots,
-        "skipped_duplicate": skipped_duplicate,
-        "unverified_duplicate": unverified_duplicate,
+        "skipped_duplicate": state.skipped_duplicate,
+        "unverified_duplicate": state.unverified_duplicate,
         "unverified_duplicates_only": unverified_duplicates_only,
-        "failed": failed,
+        "failed": state.failed,
         "safe_to_format": safe_to_format,
-        "unsafe_files": unsafe_files,
-        "folders": folder_counts,
-        "cancelled": cancelled,
-        "discovery_errors": len(discovery_errors),
+        "unsafe_files": state.unsafe_files,
+        "folders": state.folder_counts,
+        "cancelled": state.cancelled,
+        "discovery_errors": len(state.discovery_errors),
         # Selection drift, for the caller's readout. ``files_appeared`` is a
         # clamped net delta (card size minus previewed count), so it reads 0
         # — never negative — when more files vanished than arrived.
         "files_appeared": appeared,
         "files_vanished": len(vanished_paths),
-        "ok": (failed == 0 and not discovery_errors and not dup_link_failed),
-        "errors": [f"{u['path']}: {u['reason']}" for u in unsafe_files],
+        "ok": (state.failed == 0 and not state.discovery_errors and not state.dup_link_failed),
+        "errors": [f"{u['path']}: {u['reason']}" for u in state.unsafe_files],
     }
     return result
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -2357,7 +2357,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         f"archive mount root {mount_lost} detached "
                         "mid-batch; this file landed in a local shadow "
                         "of the archive, not on the share",
-                                            verified_counted_for_copies,
+                        verified_counted_for_copies,
                     )
                 landed = []
             # Trip the run-wide sticky flag so every remaining batch is
@@ -2651,7 +2651,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 for entry in landed:
                     _reclassify_landed_failed(
                         state, rel, entry, f"catalog scan failed: {e}",
-                                            verified_counted_for_copies,
+                        verified_counted_for_copies,
                     )
                 landed = []
             else:
@@ -2786,7 +2786,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                    "on the NAS")
                                 + " (mount base is likely stale, "
                                 "unreadable, or misconfigured)",
-                                                            verified_counted_for_copies,
+                                verified_counted_for_copies,
                             )
                             reclassified_landed_paths.add(entry.dest_path)
                             continue
@@ -2800,7 +2800,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             "scanned mount row hash does not match "
                             "the hash verified on the NAS (mount "
                             "base is likely stale or misconfigured)",
-                                                    verified_counted_for_copies,
+                            verified_counted_for_copies,
                         )
                         reclassified_landed_paths.add(entry.dest_path)
                         continue
@@ -2897,7 +2897,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                 "not match the hash verified on "
                                 "the NAS (mount base is likely "
                                 "stale or misconfigured)",
-                                                            verified_counted_for_copies,
+                                verified_counted_for_copies,
                             )
                             reclassified_landed_paths.add(entry.dest_path)
                             continue
@@ -2915,7 +2915,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     _reclassify_landed_failed(
                         state, rel, entry,
                         "not cataloged after scan (no photo row)",
-                                            verified_counted_for_copies,
+                        verified_counted_for_copies,
                     )
                     reclassified_landed_paths.add(entry.dest_path)
             # Invalidate derived caches for any landed/adopted row whose
@@ -4234,7 +4234,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     f"archive mount root {mount_lost} detached mid-batch; "
                     "this file landed in a local shadow of the archive, "
                     "not on the share",
-                                    verified_counted_for_copies,
+                    verified_counted_for_copies,
                 )
             landed = []
 
@@ -4318,7 +4318,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 for entry in landed:
                     _reclassify_landed_failed(
                         state, rel, entry, f"catalog scan failed: {e}",
-                                            verified_counted_for_copies,
+                        verified_counted_for_copies,
                     )
                 landed = []
             else:
@@ -4442,13 +4442,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             state, rel, entry,
                             "paired companion archive bytes no longer "
                             "match the copy-time hash",
-                                                    verified_counted_for_copies,
+                            verified_counted_for_copies,
                         )
                         reclassified_landed_paths.add(dest_path)
                         continue
                     _reclassify_landed_failed(
                         state, rel, entry, "not cataloged after scan",
-                                            verified_counted_for_copies,
+                        verified_counted_for_copies,
                     )
                     reclassified_landed_paths.add(dest_path)
                     continue
@@ -4488,7 +4488,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 "re-read of the archive file disagrees "
                                 "with the copy-time hash (archive file "
                                 "vanished, changed, or is unreadable)",
-                                                            verified_counted_for_copies,
+                                verified_counted_for_copies,
                             )
                             reclassified_landed_paths.add(dest_path)
                     else:
@@ -4519,7 +4519,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 "archive file unhashable after copy "
                                 "verification (scan wrote no hash and "
                                 "re-hash disagrees)",
-                                                            verified_counted_for_copies,
+                                verified_counted_for_copies,
                             )
                             reclassified_landed_paths.add(dest_path)
                 else:
@@ -4527,7 +4527,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         state, rel, entry,
                         "destination changed between copy verification and "
                         "catalog scan (hash mismatch)",
-                                            verified_counted_for_copies,
+                        verified_counted_for_copies,
                     )
                     reclassified_landed_paths.add(dest_path)
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -571,7 +571,7 @@ class ImportParams:
     thumb_cache_dir: str | None = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class _LandedFile:
     """One file this batch landed (fresh copy/transfer) or adopted.
 
@@ -608,7 +608,7 @@ class _ImportRunState:
     # plus one f-string interpolation of the path into a failure reason.
     mount_ever_lost: str | None = None
     dup_link_failed: bool = False
-    unsafe_files: list = field(default_factory=list)
+    unsafe_files: list = field(default_factory=list)  # [{path, reason}]
     folder_counts: dict = field(default_factory=dict)
     discovery_errors: list = field(default_factory=list)
     imported_photo_ids: set = field(default_factory=set)
@@ -617,6 +617,79 @@ class _ImportRunState:
     run_verified_hashes: dict = field(default_factory=dict)
     wc_source_paths: dict = field(default_factory=dict)
     wc_dest_folders: set = field(default_factory=set)
+
+
+def _counts(state, rel):
+    return state.folder_counts.setdefault(
+        rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0},
+    )
+
+
+def _fail(state, rel, source_file, reason):
+    state.failed += 1
+    _counts(state, rel)["failed"] += 1
+    state.unsafe_files.append({"path": str(source_file), "reason": reason})
+    log.warning("%s failed for %s: %s", state.log_label, source_file, reason)
+
+
+def _reclassify_landed_failed(state, rel, entry, reason,
+                              verified_counted_for_copies):
+    """Move a landed file's count from copied/skipped_duplicate to failed.
+
+    A landed entry has already been booked into ``copied`` (fresh copy)
+    or ``skipped_duplicate`` (crash-recovery adopt) at the moment its
+    bytes were verified on disk. When a later step in the batch pass
+    (scan itself failing, a missing catalog row after scan, or a
+    hash mismatch against what scan re-hashed) forces this file into
+    the ``failed`` bucket, the origin count must be rolled back —
+    otherwise the exactly-one-terminal-bucket invariant breaks and
+    ``copied + skipped_duplicate + failed`` exceeds ``discovered``.
+
+    ``verified_counted_for_copies``: whether each ``copied`` booking
+    also incremented ``verified``, so the rollback must undo both. (PR
+    7's transport ``attests_bytes`` absorbs this flag.)
+    """
+    dest_path = entry.dest_path
+    origin = entry.origin
+    if origin == "copied":
+        state.copied -= 1
+        if verified_counted_for_copies:
+            state.verified -= 1
+        _counts(state, rel)["copied"] -= 1
+    elif origin == "skipped_duplicate":
+        state.skipped_duplicate -= 1
+        _counts(state, rel)["skipped_duplicate"] -= 1
+    _fail(state, rel, dest_path, reason)
+
+
+def _record_checker(state, checker, source_file, dest_folder, file_hash):
+    """Register a landed/adopted file's identity with the intra-run checker.
+
+    Without this the checker only sees the pre-run catalog, so a later
+    byte-identical card file with a different basename in the same run
+    is copied/cataloged again instead of being recognized as an
+    intra-run duplicate (spec decision 5): every caller passes the
+    landed/adopted ``dest_folder`` and verified ``file_hash``, recorded
+    unconditionally per token. ``DuplicateChecker.record``
+    re-``os.stat``s the source path — on removable media yanked after
+    this file's bytes were verified, that raises ``OSError`` and would
+    kill the whole background job. Swallow it: the run keeps its
+    already-verified landings and only loses the intra-run dedupe
+    optimization. See PR #1113 review.
+    """
+    if checker is None:
+        return
+    try:
+        tokens = checker.record(source_file)
+    except OSError as e:
+        log.warning(
+            "Duplicate-checker record() failed for %s (dest %s): %s",
+            source_file, dest_folder, e,
+        )
+        return
+    for tok in tokens:
+        state.run_dest_folders[tok] = dest_folder
+        state.run_verified_hashes[tok] = file_hash
 
 
 def copy_and_hash_verify(src, dst, *, src_hash=None):
@@ -1594,41 +1667,6 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # DB link; if it fails, safe_to_format must remain false
     # (``state.dup_link_failed``).
 
-    def _counts(rel):
-        return state.folder_counts.setdefault(
-            rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0},
-        )
-
-    def _fail(rel, source_file, reason):
-        state.failed += 1
-        _counts(rel)["failed"] += 1
-        state.unsafe_files.append({"path": str(source_file), "reason": reason})
-        log.warning("Remote import failed for %s: %s", source_file, reason)
-
-    def _reclassify_landed_failed(rel, entry, reason):
-        """Move a landed file's count from copied/skipped_duplicate to failed.
-
-        A landed entry has already been booked into ``copied`` (fresh copy)
-        or ``skipped_duplicate`` (crash-recovery adopt) at the moment its
-        bytes were verified on disk. When a later step in the batch pass
-        (scan itself failing, a missing catalog row after scan, or a
-        hash mismatch against what scan re-hashed) forces this file into
-        the ``failed`` bucket, the origin count must be rolled back —
-        otherwise the exactly-one-terminal-bucket invariant breaks and
-        ``copied + skipped_duplicate + failed`` exceeds ``discovered``.
-        """
-        dest_path = entry.dest_path
-        origin = entry.origin
-        if origin == "copied":
-            state.copied -= 1
-            if verified_counted_for_copies:
-                state.verified -= 1
-            _counts(rel)["copied"] -= 1
-        elif origin == "skipped_duplicate":
-            state.skipped_duplicate -= 1
-            _counts(rel)["skipped_duplicate"] -= 1
-        _fail(rel, dest_path, reason)
-
     # Intra-run bookkeeping (``state.run_dest_folders`` /
     # ``state.run_verified_hashes``) so a second byte-identical card
     # file (with a
@@ -1681,34 +1719,14 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     def _missing_mount_root():
         return _missing_archive_mount_root(destination)
 
-    def _record_checker(source_file, dest_folder, file_hash):
-        """Register a landed/adopted file's identity with the intra-run checker.
-
-        Without this the checker only sees the pre-run catalog, so a later
-        byte-identical card file with a different basename in the same run
-        is rsynced/cataloged again instead of being recognized as an
-        intra-run duplicate. Same shape as the local path's
-        ``_record_checker`` (spec decision 5, toward a single shared
-        helper): every caller passes the landed/adopted ``dest_folder``
-        and verified ``file_hash``, recorded unconditionally per token.
-        ``DuplicateChecker.record`` re-``os.stat``s the source path — swallow
-        OSError (removable media yanked mid-run) so the run keeps its
-        already-verified landings and only loses the intra-run dedupe
-        optimization. See PR #1113 review.
-        """
-        if checker is None:
-            return
-        try:
-            tokens = checker.record(source_file)
-        except OSError as e:
-            log.warning(
-                "Duplicate-checker record() failed for %s: %s",
-                source_file, e,
-            )
-            return
-        for tok in tokens:
-            state.run_dest_folders[tok] = dest_folder
-            state.run_verified_hashes[tok] = file_hash
+    # Whether each ``copied`` booking also incremented ``verified``:
+    # the remote path books ``verified`` only when
+    # ``params.verify_by_hash`` made the independent card->NAS check,
+    # so ``_reclassify_landed_failed`` must undo ``verified`` only in
+    # that case. (The local path hash-verifies every copy and sets
+    # this to True. PR 7's transport ``attests_bytes`` absorbs this
+    # flag.)
+    verified_counted_for_copies = params.verify_by_hash
 
     for rel, batch in batches:
         if runner.is_cancelled(job["id"]):
@@ -1726,7 +1744,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             for source_file in batch:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"archive mount root {state.mount_ever_lost} detached "
                     "earlier in this import; the intra-run duplicate "
                     "cache still holds identities for files whose "
@@ -1762,15 +1780,15 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             for source_file in batch:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     "destination folder resolves inside a source directory "
                     "(dest_folder would be created under the card being "
                     "imported); formatting the card would erase the archive "
                     "copy",
                 )
             _emit(
-                f"{rel}: {_counts(rel)['copied']} copied · "
-                f"{_counts(rel)['skipped_duplicate']} already present",
+                f"{rel}: {_counts(state, rel)['copied']} copied · "
+                f"{_counts(state, rel)['skipped_duplicate']} already present",
                 state.emitted, queued,
             )
             continue
@@ -1786,7 +1804,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             for source_file in batch:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"archive mount root {missing_mount_root} is not "
                     "available (destination drive is not mounted; refusing "
                     "to create a shadow directory tree under it, which "
@@ -1810,7 +1828,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             for source_file in batch:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"archive mount root {stale_mount_root} is no longer "
                     "mounted (it was at the start of this import; the "
                     "directory persists but the share has detached, so "
@@ -1832,7 +1850,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             for source_file in batch:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"could not create destination folder {dest_folder}: {e}",
                 )
             _emit(
@@ -1906,14 +1924,6 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # card looks safe to erase. Mirrors the local path's ``dup_skips``.
         # See PR #1396 review (Codex P1 r3688498501 / r3688501706).
         dup_skips = []
-        # Whether each ``copied`` booking also incremented ``verified``:
-        # the remote path books ``verified`` only when
-        # ``params.verify_by_hash`` made the independent card->NAS check,
-        # so ``_reclassify_landed_failed`` must undo ``verified`` only in
-        # that case. (The local path hash-verifies every copy and sets
-        # this to True. PR 7's transport ``attests_bytes`` absorbs this
-        # flag.)
-        verified_counted_for_copies = params.verify_by_hash
         # dest_paths the post-scan cross-checks reclassified from
         # ``copied`` to ``failed``. The entries stay in ``landed``
         # (mutating a list during its own iteration is error-prone), so
@@ -1948,7 +1958,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             if mount_lost:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"archive mount root {mount_lost} detached while this "
                     "batch was being prepared (the directory persists but "
                     "the share is gone, so neither a transfer nor a "
@@ -1964,7 +1974,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 try:
                     token = checker.match(source_file)
                 except OSError as e:
-                    _fail(rel, source_file, f"duplicate check failed: {e}")
+                    _fail(state, rel, source_file, f"duplicate check failed: {e}")
                     continue
                 if token is not None:
                     if (
@@ -1977,7 +1987,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         if likely_rows:
                             state.skipped_duplicate += 1
                             state.unverified_duplicate += 1
-                            _counts(rel)["skipped_duplicate"] += 1
+                            _counts(state, rel)["skipped_duplicate"] += 1
                             dup_skips.append((source_file, True))
                             dup_dirs.update(_linkable_twin_dirs(
                                 likely_rows, _path_under_destination,
@@ -1994,7 +2004,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         try:
                             src_hash = checker.content_hash(source_file)
                         except OSError as e:
-                            _fail(rel, source_file,
+                            _fail(state, rel, source_file,
                                   f"duplicate check failed: {e}")
                             continue
                     accept = False
@@ -2072,7 +2082,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         break
                     if accept:
                         state.skipped_duplicate += 1
-                        _counts(rel)["skipped_duplicate"] += 1
+                        _counts(state, rel)["skipped_duplicate"] += 1
                         dup_skips.append((source_file, False))
                         # Preserve the verified twin folders so the follow-
                         # up direct link can pull them into the active
@@ -2119,7 +2129,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 st = source_file.stat()
                 src_size, src_mtime_ns = st.st_size, st.st_mtime_ns
             except OSError as e:
-                _fail(rel, source_file, str(e))
+                _fail(state, rel, source_file, str(e))
                 continue
             try:
                 src_hash = (
@@ -2128,7 +2138,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     else compute_file_hash(str(source_file))
                 )
             except OSError as e:
-                _fail(rel, source_file, str(e))
+                _fail(state, rel, source_file, str(e))
                 continue
             # Intra-batch same-content dedup: an earlier file THIS BATCH
             # queued a byte-identical source under a different basename
@@ -2151,9 +2161,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 and src_hash in queued_src_hashes
             ):
                 state.skipped_duplicate += 1
-                _counts(rel)["skipped_duplicate"] += 1
+                _counts(state, rel)["skipped_duplicate"] += 1
                 dup_skips.append((source_file, False))
-                _record_checker(source_file, dest_folder, src_hash)
+                _record_checker(state, checker, source_file, dest_folder, src_hash)
                 continue
             stem, suffix = os.path.splitext(source_file.name)
             counter = 0
@@ -2179,9 +2189,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         and claimed_basenames[candidate_key] == src_hash
                     ):
                         state.skipped_duplicate += 1
-                        _counts(rel)["skipped_duplicate"] += 1
+                        _counts(state, rel)["skipped_duplicate"] += 1
                         dup_skips.append((source_file, False))
-                        _record_checker(source_file, dest_folder, src_hash)
+                        _record_checker(state, checker, source_file, dest_folder, src_hash)
                         adopted = True
                         break
                     counter += 1
@@ -2210,7 +2220,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         on_disk = None
                     if on_disk is not None and on_disk == src_hash:
                         state.skipped_duplicate += 1
-                        _counts(rel)["skipped_duplicate"] += 1
+                        _counts(state, rel)["skipped_duplicate"] += 1
                         claimed_basenames[candidate_key] = src_hash
                         # Fold the adoption into ``landed`` (origin
                         # "skipped_duplicate") so the restricted scan
@@ -2240,7 +2250,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             src_size=src_size,
                             src_mtime_ns=src_mtime_ns,
                         ))
-                        _record_checker(source_file, dest_folder, src_hash)
+                        _record_checker(state, checker, source_file, dest_folder, src_hash)
                         adopted = True
                         break
                     counter += 1
@@ -2313,11 +2323,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         if mount_lost:
             for skipped_file, counted_unverified in dup_skips:
                 state.skipped_duplicate -= 1
-                _counts(rel)["skipped_duplicate"] -= 1
+                _counts(state, rel)["skipped_duplicate"] -= 1
                 if counted_unverified:
                     state.unverified_duplicate -= 1
                 _fail(
-                    rel, skipped_file,
+                    state, rel, skipped_file,
                     f"archive mount root {mount_lost} detached mid-batch; "
                     "the duplicate this file matched cannot be confirmed "
                     "to be on the archive rather than in a local shadow",
@@ -2327,7 +2337,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             for queued_file, _dest_basename, _queued_hash, _sz, _mt \
                     in to_transfer:
                 _fail(
-                    rel, queued_file,
+                    state, rel, queued_file,
                     f"archive mount root {mount_lost} detached before this "
                     "file was transferred",
                 )
@@ -2343,10 +2353,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             if landed:
                 for entry in landed:
                     _reclassify_landed_failed(
-                        rel, entry,
+                        state, rel, entry,
                         f"archive mount root {mount_lost} detached "
                         "mid-batch; this file landed in a local shadow "
                         "of the archive, not on the share",
+                                            verified_counted_for_copies,
                     )
                 landed = []
             # Trip the run-wide sticky flag so every remaining batch is
@@ -2412,7 +2423,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             ok_mkdir, mkdir_detail = move_mod._remote_mkdir_p(remote, ssh_dest)
             if not ok_mkdir:
                 for sf, _bn, _sh, _sz, _mt in to_transfer:
-                    _fail(rel, sf,
+                    _fail(state, rel, sf,
                           f"remote mkdir failed for {ssh_dest}: {mkdir_detail}")
             else:
                 # Split into the flat fast path (dest basename == card
@@ -2485,12 +2496,12 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             _emit_transfer(_rel, done, _bs, name))
                     if timed_out:
                         for sf, _bn, _sh, _sz, _mt in flat:
-                            _fail(rel, sf, "rsync stalled (no progress)")
+                            _fail(state, rel, sf, "rsync stalled (no progress)")
                     elif _rsync_cancelled(rc):
                         state.cancelled = True
                     elif rc != 0:
                         for sf, _bn, _sh, _sz, _mt in flat:
-                            _fail(rel, sf, f"rsync failed: {stderr.strip()}")
+                            _fail(state, rel, sf, f"rsync failed: {stderr.strip()}")
                     else:
                         for sf, bn, sh, sz, mt in flat:
                             transferred.append((
@@ -2508,12 +2519,12 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         move_mod.rsync_dest_spec(remote, nas_full), False,
                         extra_args)
                     if timed_out:
-                        _fail(rel, sf, "rsync stalled (no progress)")
+                        _fail(state, rel, sf, "rsync stalled (no progress)")
                     elif _rsync_cancelled(rc):
                         state.cancelled = True
                         break
                     elif rc != 0:
-                        _fail(rel, sf, f"rsync failed: {stderr.strip()}")
+                        _fail(state, rel, sf, f"rsync failed: {stderr.strip()}")
                     else:
                         transferred.append((sf, bn, sh, sz, mt, nas_full))
                         # ``len(transferred)`` counts only files that truly
@@ -2554,11 +2565,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                 else f"remote verification: '{name}' missing "
                                      f"or differs at destination"
                             )
-                            _fail(rel, sf, reason)
+                            _fail(state, rel, sf, reason)
                             continue
                     state.copied += 1
-                    _counts(rel)["copied"] += 1
-                    if params.verify_by_hash:
+                    _counts(state, rel)["copied"] += 1
+                    if verified_counted_for_copies:
                         state.verified += 1
                     landed.append(_LandedFile(
                         dest_path=dest_path,
@@ -2568,7 +2579,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         src_size=sz,
                         src_mtime_ns=mt,
                     ))
-                    _record_checker(sf, dest_folder, src_hash)
+                    _record_checker(state, checker, sf, dest_folder, src_hash)
 
         # --- Catalog this batch ----------------------------------------
         # Scan only files that were freshly transferred or adopted from an
@@ -2639,7 +2650,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 # to failed) so the ledger never double-counts.
                 for entry in landed:
                     _reclassify_landed_failed(
-                        rel, entry, f"catalog scan failed: {e}",
+                        state, rel, entry, f"catalog scan failed: {e}",
+                                            verified_counted_for_copies,
                     )
                 landed = []
             else:
@@ -2765,7 +2777,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         )
                         if read_failed or mount_norm != src_h_norm:
                             _reclassify_landed_failed(
-                                rel, entry,
+                                state, rel, entry,
                                 "scan wrote no mount row hash and a re-"
                                 "read of the mount file "
                                 + ("disagrees with the source hash"
@@ -2774,12 +2786,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                    "on the NAS")
                                 + " (mount base is likely stale, "
                                 "unreadable, or misconfigured)",
+                                                            verified_counted_for_copies,
                             )
                             reclassified_landed_paths.add(entry.dest_path)
                             continue
                     elif scan_h is not None and scan_h != src_h_norm:
                         _reclassify_landed_failed(
-                            rel, entry,
+                            state, rel, entry,
                             "scanned mount row hash does not match "
                             "the source hash (mount base is likely "
                             "stale or misconfigured)"
@@ -2787,6 +2800,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             "scanned mount row hash does not match "
                             "the hash verified on the NAS (mount "
                             "base is likely stale or misconfigured)",
+                                                    verified_counted_for_copies,
                         )
                         reclassified_landed_paths.add(entry.dest_path)
                         continue
@@ -2870,7 +2884,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         )
                         if read_failed or mount_norm != src_h_norm:
                             _reclassify_landed_failed(
-                                rel, entry,
+                                state, rel, entry,
                                 "paired companion mount bytes could "
                                 "not be read"
                                 if read_failed else
@@ -2883,6 +2897,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                 "not match the hash verified on "
                                 "the NAS (mount base is likely "
                                 "stale or misconfigured)",
+                                                            verified_counted_for_copies,
                             )
                             reclassified_landed_paths.add(entry.dest_path)
                             continue
@@ -2898,8 +2913,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         state.imported_photo_ids.add(companion["id"])
                         continue
                     _reclassify_landed_failed(
-                        rel, entry,
+                        state, rel, entry,
                         "not cataloged after scan (no photo row)",
+                                            verified_counted_for_copies,
                     )
                     reclassified_landed_paths.add(entry.dest_path)
             # Invalidate derived caches for any landed/adopted row whose
@@ -3033,8 +3049,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         ),
                     })
         _emit(
-            f"{rel}: {_counts(rel)['copied']} copied · "
-            f"{_counts(rel)['skipped_duplicate']} already present",
+            f"{rel}: {_counts(state, rel)['copied']} copied · "
+            f"{_counts(state, rel)['skipped_duplicate']} already present",
             state.emitted, queued,
         )
         if state.cancelled:
@@ -3520,68 +3536,6 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # Same rationale as the remote path (see PR #1400 review, Codex P2
     # r3688614624).
 
-    def _counts(rel):
-        return state.folder_counts.setdefault(
-            rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0},
-        )
-
-    def _fail(rel, source_file, reason):
-        state.failed += 1
-        _counts(rel)["failed"] += 1
-        state.unsafe_files.append({"path": str(source_file), "reason": reason})
-        log.warning("Import failed for %s: %s", source_file, reason)
-
-    def _reclassify_landed_failed(rel, entry, reason):
-        """Move a landed file's count from copied/skipped_duplicate to failed.
-
-        A landed entry has already been booked into ``copied`` (fresh copy)
-        or ``skipped_duplicate`` (crash-recovery adopt) at the moment its
-        bytes were verified on disk. When a later step in the batch pass
-        (scan itself failing, a missing catalog row after scan, or a
-        hash mismatch against what scan re-hashed) forces this file into
-        the ``failed`` bucket, the origin count must be rolled back —
-        otherwise the exactly-one-terminal-bucket invariant breaks and
-        ``copied + skipped_duplicate + failed`` exceeds ``discovered``.
-        """
-        dest_path = entry.dest_path
-        origin = entry.origin
-        if origin == "copied":
-            state.copied -= 1
-            if verified_counted_for_copies:
-                state.verified -= 1
-            _counts(rel)["copied"] -= 1
-        elif origin == "skipped_duplicate":
-            state.skipped_duplicate -= 1
-            _counts(rel)["skipped_duplicate"] -= 1
-        _fail(rel, dest_path, reason)
-
-    def _record_checker(source_file, dest_folder, file_hash):
-        """Register a landed file's identity with the intra-run checker.
-
-        ``DuplicateChecker.record`` re-``os.stat``s the source path — on
-        removable media that was yanked just after ``copy_and_hash_verify``
-        succeeded, that raises ``OSError`` and would kill the whole
-        background job even though this file's bytes are already
-        verified at ``dest_folder``. Swallow the error, keep the copy in
-        the ledger, and accept that later intra-run tokens for this
-        file's identity won't dedupe: the archive is intact, the run
-        just loses a small cache-hit optimization.
-        """
-        if checker is None:
-            return
-        try:
-            tokens = checker.record(source_file)
-        except OSError as e:
-            log.warning(
-                "Duplicate-checker record() failed for %s after landing "
-                "at %s: %s",
-                source_file, dest_folder, e,
-            )
-            return
-        for tok in tokens:
-            state.run_dest_folders[tok] = dest_folder
-            state.run_verified_hashes[tok] = file_hash
-
     # Dup-folder linking runs in a SEPARATE ``scan(restrict_dirs=…)`` call
     # after the duplicate skip; its exception was previously logged and
     # swallowed, leaving safe_to_format true while the imported
@@ -3589,6 +3543,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # explicitly (``state.dup_link_failed``) so safe_to_format reflects
     # "workspace can actually see these bytes" and not just "the bytes
     # are somewhere on disk".
+
+    # Whether each ``copied`` booking also incremented ``verified``:
+    # the local path hash-verifies every copy (``copy_and_hash_verify``
+    # reads the landed bytes back), so ``_reclassify_landed_failed``
+    # must always undo both. (The remote path books ``verified`` only
+    # under ``params.verify_by_hash`` and sets this accordingly. PR
+    # 7's transport ``attests_bytes`` absorbs this flag.)
+    verified_counted_for_copies = True
 
     for rel, batch in batches:
         if runner.is_cancelled(job["id"]):
@@ -3606,7 +3568,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             for source_file in batch:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"archive mount root {state.mount_ever_lost} detached "
                     "earlier in this import; the intra-run duplicate "
                     "cache still holds identities for files whose "
@@ -3644,15 +3606,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # file. Mirrors the remote guard — spec decision 2.
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     "destination folder resolves inside a source directory "
                     "(dest_folder would be created under the card being "
                     "imported); formatting the card would erase the archive "
                     "copy",
                 )
             _emit(
-                f"{rel}: {_counts(rel)['copied']} copied · "
-                f"{_counts(rel)['skipped_duplicate']} already present",
+                f"{rel}: {_counts(state, rel)['copied']} copied · "
+                f"{_counts(state, rel)['skipped_duplicate']} already present",
                 state.emitted, queued,
             )
             continue
@@ -3678,7 +3640,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # the card is quietly failing.
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"archive mount root {missing_mount_root} is not "
                     "available (destination drive is not mounted; refusing "
                     "to create a shadow directory tree under it, which "
@@ -3703,7 +3665,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             for source_file in batch:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"archive mount root {stale_mount_root} is no longer "
                     "mounted (it was at the start of this import; the "
                     "directory persists but the share has detached, so "
@@ -3727,7 +3689,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             for source_file in batch:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"could not create destination folder {dest_folder}: {e}",
                 )
             _emit(
@@ -3764,13 +3726,6 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # working-copy extraction so it reads local card bytes, never the
         # just-written archive copy.
         landed = []
-        # Whether each ``copied`` booking also incremented ``verified``:
-        # the local path hash-verifies every copy (``copy_and_hash_verify``
-        # reads the landed bytes back), so ``_reclassify_landed_failed``
-        # must always undo both. (The remote path books ``verified`` only
-        # under ``params.verify_by_hash`` and sets this accordingly. PR
-        # 7's transport ``attests_bytes`` absorbs this flag.)
-        verified_counted_for_copies = True
         dup_dirs = set()
         # Duplicate skips accepted in this batch that never enter
         # ``landed`` — (source_file, counted_unverified). An accepted skip
@@ -3781,6 +3736,17 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # report safe_to_format True over an archive holding nothing.
         # See PR #1396 review (Codex P1 r3687506040).
         dup_skips = []
+        # dest_paths that hash-stamping reclassified from
+        # copied/skipped_duplicate to failed. The entries stay in
+        # ``landed`` (mutating a list during its own iteration is
+        # error-prone), so we filter them out of the working-copy
+        # override map below — otherwise the deferred
+        # ``_extract_working_copies`` would read card-side bytes for
+        # a photo whose catalog row is missing (JPEG-pair miss aside)
+        # or whose archive bytes no longer match what we copied, and
+        # cache a working copy that doesn't correspond to what the
+        # rest of the app sees at the archive path. See PR #1107 review.
+        reclassified_landed_paths = set()
         # Sticky once tripped: a batch can hold hundreds of files (the
         # 2026-07-26 folder held 200), and when it is the only batch there
         # is no later batch boundary to catch a detach. Probing per file
@@ -3810,7 +3776,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             if mount_lost:
                 state.emitted += 1
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     f"archive mount root {mount_lost} detached while this "
                     "batch was copying (the directory persists but the "
                     "share is gone, so further writes would land on the "
@@ -3828,7 +3794,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 try:
                     token = checker.match(source_file)
                 except OSError as e:
-                    _fail(rel, source_file, f"duplicate check failed: {e}")
+                    _fail(state, rel, source_file, f"duplicate check failed: {e}")
                     continue
                 if token is not None:
                     if (
@@ -3841,7 +3807,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         if likely_rows:
                             state.skipped_duplicate += 1
                             state.unverified_duplicate += 1
-                            _counts(rel)["skipped_duplicate"] += 1
+                            _counts(state, rel)["skipped_duplicate"] += 1
                             dup_skips.append((source_file, True))
                             dup_dirs.update(_linkable_twin_dirs(
                                 likely_rows, _path_under_destination,
@@ -3878,7 +3844,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             src_hash = checker.content_hash(source_file)
                         except OSError as e:
                             _fail(
-                                rel, source_file,
+                                state, rel, source_file,
                                 f"duplicate check failed: {e}",
                             )
                             continue
@@ -3964,7 +3930,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         break
                     if accept:
                         state.skipped_duplicate += 1
-                        _counts(rel)["skipped_duplicate"] += 1
+                        _counts(state, rel)["skipped_duplicate"] += 1
                         dup_skips.append((source_file, False))
                         # verified_twin_rows carries only twins whose
                         # bytes we re-hashed and matched this run — the
@@ -4033,7 +3999,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             dest_under_source = _path_under_any_source(dest_file)
             if same_file or dest_under_source:
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     "destination file resolves inside a source directory "
                     "(dest_file would live under the card being imported); "
                     "formatting the card would erase the archive copy",
@@ -4053,7 +4019,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             try:
                 src_stat = source_file.stat()
             except OSError as e:
-                _fail(rel, source_file, str(e))
+                _fail(state, rel, source_file, str(e))
                 continue
             src_size = src_stat.st_size
             src_mtime_ns = src_stat.st_mtime_ns
@@ -4144,7 +4110,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 if adopted_dest is not None:
                     dest_file, adopt_hash = adopted_dest
                     state.skipped_duplicate += 1
-                    _counts(rel)["skipped_duplicate"] += 1
+                    _counts(state, rel)["skipped_duplicate"] += 1
                     landed.append(
                         _LandedFile(
                             dest_path=dest_file,
@@ -4155,7 +4121,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             src_mtime_ns=src_mtime_ns,
                         ),
                     )
-                    _record_checker(source_file, dest_folder, adopt_hash)
+                    _record_checker(state, checker, source_file, dest_folder, adopt_hash)
                     continue
 
                 src_hash = (
@@ -4174,18 +4140,18 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 dest_read_cancelled = True
                 break
             except OSError as e:
-                _fail(rel, source_file, str(e))
+                _fail(state, rel, source_file, str(e))
                 continue
             if not ok:
                 _fail(
-                    rel, source_file,
+                    state, rel, source_file,
                     "copy verification failed (destination bytes do not "
                     "match the source)",
                 )
                 continue
             state.copied += 1
             state.verified += 1
-            _counts(rel)["copied"] += 1
+            _counts(state, rel)["copied"] += 1
             landed.append(
                 _LandedFile(
                     dest_path=dest_file,
@@ -4196,7 +4162,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     src_mtime_ns=src_mtime_ns,
                 ),
             )
-            _record_checker(source_file, dest_folder, file_hash)
+            _record_checker(state, checker, source_file, dest_folder, file_hash)
 
         # The per-file probe runs BEFORE each copy, so it cannot see a
         # detach that happens during the last (or only) file — there is no
@@ -4242,11 +4208,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         if mount_lost and dup_skips:
             for skipped_file, counted_unverified in dup_skips:
                 state.skipped_duplicate -= 1
-                _counts(rel)["skipped_duplicate"] -= 1
+                _counts(state, rel)["skipped_duplicate"] -= 1
                 if counted_unverified:
                     state.unverified_duplicate -= 1
                 _fail(
-                    rel, skipped_file,
+                    state, rel, skipped_file,
                     f"archive mount root {mount_lost} detached mid-batch; "
                     "the duplicate this file matched cannot be confirmed "
                     "to be on the archive rather than in a local shadow",
@@ -4264,10 +4230,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         if mount_lost and landed:
             for entry in landed:
                 _reclassify_landed_failed(
-                    rel, entry,
+                    state, rel, entry,
                     f"archive mount root {mount_lost} detached mid-batch; "
                     "this file landed in a local shadow of the archive, "
                     "not on the share",
+                                    verified_counted_for_copies,
                 )
             landed = []
 
@@ -4350,7 +4317,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # to failed) so the ledger never double-counts.
                 for entry in landed:
                     _reclassify_landed_failed(
-                        rel, entry, f"catalog scan failed: {e}",
+                        state, rel, entry, f"catalog scan failed: {e}",
+                                            verified_counted_for_copies,
                     )
                 landed = []
             else:
@@ -4362,18 +4330,6 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # the cache expires or another full scan runs. Mirrors
                 # api_job_scan / api_job_import_full / pipeline_job.
                 _invalidate_new_images(db, dest_folder)
-
-            # dest_paths that hash-stamping reclassified from
-            # copied/skipped_duplicate to failed. The entries stay in
-            # ``landed`` (mutating a list during its own iteration is
-            # error-prone), so we filter them out of the working-copy
-            # override map below — otherwise the deferred
-            # ``_extract_working_copies`` would read card-side bytes for
-            # a photo whose catalog row is missing (JPEG-pair miss aside)
-            # or whose archive bytes no longer match what we copied, and
-            # cache a working copy that doesn't correspond to what the
-            # rest of the app sees at the archive path. See PR #1107 review.
-            reclassified_landed_paths = set()
 
             # RAW rows whose derived caches need invalidation because a
             # newly-landed JPEG became (or already was) their companion.
@@ -4483,14 +4439,16 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             state.imported_photo_ids.add(companion["id"])
                             continue
                         _reclassify_landed_failed(
-                            rel, entry,
+                            state, rel, entry,
                             "paired companion archive bytes no longer "
                             "match the copy-time hash",
+                                                    verified_counted_for_copies,
                         )
                         reclassified_landed_paths.add(dest_path)
                         continue
                     _reclassify_landed_failed(
-                        rel, entry, "not cataloged after scan",
+                        state, rel, entry, "not cataloged after scan",
+                                            verified_counted_for_copies,
                     )
                     reclassified_landed_paths.add(dest_path)
                     continue
@@ -4525,11 +4483,12 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             state.imported_photo_ids.add(row["id"])
                         else:
                             _reclassify_landed_failed(
-                                rel, entry,
+                                state, rel, entry,
                                 "scan wrote no archive row hash and a "
                                 "re-read of the archive file disagrees "
                                 "with the copy-time hash (archive file "
                                 "vanished, changed, or is unreadable)",
+                                                            verified_counted_for_copies,
                             )
                             reclassified_landed_paths.add(dest_path)
                     else:
@@ -4556,17 +4515,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             state.imported_photo_ids.add(row["id"])
                         else:
                             _reclassify_landed_failed(
-                                rel, entry,
+                                state, rel, entry,
                                 "archive file unhashable after copy "
                                 "verification (scan wrote no hash and "
                                 "re-hash disagrees)",
+                                                            verified_counted_for_copies,
                             )
                             reclassified_landed_paths.add(dest_path)
                 else:
                     _reclassify_landed_failed(
-                        rel, entry,
+                        state, rel, entry,
                         "destination changed between copy verification and "
                         "catalog scan (hash mismatch)",
+                                            verified_counted_for_copies,
                     )
                     reclassified_landed_paths.add(dest_path)
 
@@ -4702,8 +4663,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         ),
                     })
         _emit(
-            f"{rel}: {_counts(rel)['copied']} copied · "
-            f"{_counts(rel)['skipped_duplicate']} already present",
+            f"{rel}: {_counts(state, rel)['copied']} copied · "
+            f"{_counts(state, rel)['skipped_duplicate']} already present",
             state.emitted, queued,
         )
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -66,7 +66,7 @@ import sys
 import threading
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
 
@@ -586,6 +586,37 @@ class _LandedFile:
     origin: str
     src_size: int | None
     src_mtime_ns: int | None
+
+
+@dataclass
+class _ImportRunState:
+    """Run-scoped mutable state shared by the import batch loop and its
+    helpers. One instance per job run; batch-scoped state (``landed``,
+    ``dup_skips``, collision maps, …) deliberately stays in function
+    locals until the PR 6 phase extraction. ``log_label`` keeps the two
+    paths' failure log lines byte-identical after the helper hoist.
+    """
+    log_label: str
+    copied: int = 0
+    verified: int = 0
+    skipped_duplicate: int = 0
+    unverified_duplicate: int = 0
+    failed: int = 0
+    emitted: int = 0
+    cancelled: bool = False
+    # None or a mount-root path string; consumers are truthiness-only
+    # plus one f-string interpolation of the path into a failure reason.
+    mount_ever_lost: str | None = None
+    dup_link_failed: bool = False
+    unsafe_files: list = field(default_factory=list)
+    folder_counts: dict = field(default_factory=dict)
+    discovery_errors: list = field(default_factory=list)
+    imported_photo_ids: set = field(default_factory=set)
+    linked_dup_dirs: set = field(default_factory=set)
+    run_dest_folders: dict = field(default_factory=dict)
+    run_verified_hashes: dict = field(default_factory=dict)
+    wc_source_paths: dict = field(default_factory=dict)
+    wc_dest_folders: set = field(default_factory=set)
 
 
 def copy_and_hash_verify(src, dst, *, src_hash=None):
@@ -3307,25 +3338,23 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     ])
     runner.update_step(job["id"], "import", status="running")
 
-    copied = 0
+    state = _ImportRunState(log_label="Import")
     eta = _ImportEtaEstimator(
         expected_new=(params.checked_count if params.skip_duplicates else None),
     )
 
-    # Live per-folder counters, mutated by the copy loop via _counts() and
-    # snapshotted onto every progress event so the Import page can render
-    # truthful per-folder progress mid-run (not just from the terminal
-    # result). Initialized before _emit so the discovery-phase emits see
-    # an empty-but-present dict.
-    folder_counts = {}
+    # ``state.folder_counts``: live per-folder counters, mutated by the
+    # copy loop via _counts() and snapshotted onto every progress event
+    # so the Import page can render truthful per-folder progress mid-run
+    # (not just from the terminal result).
 
     def _emit(phase, current, total, current_file="", *, is_importing=False):
         eta_fields = {}
         if total > 0:
             if is_importing:
-                eta.note_importing(copied)
+                eta.note_importing(state.copied)
             else:
-                eta.note_batch_complete(current, copied)
+                eta.note_batch_complete(current, state.copied)
             eta_fields = eta.fields(total)
         job["progress"]["current"] = current
         job["progress"]["total"] = total
@@ -3347,7 +3376,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # Snapshot (counts dicts mutate as the loop advances; SSE
                 # consumers must see the state at emit time).
                 folders={
-                    rel: dict(counts) for rel, counts in folder_counts.items()
+                    rel: dict(counts) for rel, counts in state.folder_counts.items()
                 },
                 **eta_fields,
             ),
@@ -3363,10 +3392,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # tied to the source path where it occurred.
     _emit("Discovering files", 0, 0)
     files = []
-    discovery_errors = []
 
     def _discovery_onerror(exc):
-        discovery_errors.append(exc)
+        state.discovery_errors.append(exc)
         log.warning("Import discovery error: %s", exc)
 
     for src in params.sources:
@@ -3433,21 +3461,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             batches.append((rel, group[i:i + IMPORT_BATCH_SIZE]))
 
     # --- Ledger -----------------------------------------------------
-    # Every discovered file ends in exactly one terminal bucket.
-    verified = 0
-    skipped_duplicate = 0
-    unverified_duplicate = 0
-    failed = 0
-    unsafe_files = []          # [{path, reason}] — failed copies etc.
-    # (folder_counts is initialized above _emit — see there.)
-    # Photo rows this run created or landed bytes into: hash-stamped fresh
-    # copies plus RAW primaries that adopted a landed companion JPEG.
-    # The after-import chaining hook scopes its process job to exactly
-    # these (duplicates are excluded — a duplicates-only import chains to
-    # "no new photos", not an empty run).
-    imported_photo_ids = set()
-    emitted = 0
-    cancelled = False
+    # Every discovered file ends in exactly one terminal bucket on
+    # ``state``. ``state.imported_photo_ids``: photo rows this run
+    # created or landed bytes into: hash-stamped fresh copies plus RAW
+    # primaries that adopted a landed companion JPEG. The after-import
+    # chaining hook scopes its process job to exactly these (duplicates
+    # are excluded — a duplicates-only import chains to "no new
+    # photos", not an empty run).
 
     def _stop_requested():
         # Threaded through every destination-side hash read so a Stop can
@@ -3475,31 +3495,32 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # JPEG is still available. Deferring to end-of-run means every
     # companion in the run has landed and been paired before
     # ``_extract_working_copies`` decides which source to read.
-    # dest_path -> (card_src_path, expected_size, expected_mtime_ns).
+    # ``state.wc_source_paths``: dest_path -> (card_src_path,
+    # expected_size, expected_mtime_ns).
     # The identity tuple is captured at land time (before any WC
     # extraction pass), so the deferred ``_extract_working_copies`` call
     # can verify the override still holds the exact bytes we copied —
     # not just any same-sized file that happens to be at the same path.
     # A rewrite or a reused-mount collision differ in mtime and get
     # rejected; extraction falls back to the verified archive copy.
-    wc_source_paths = {}
-    wc_dest_folders = set()  # exact-match scope for extraction
-    # Intra-run duplicate destinations: token -> dest folder where the
-    # identity landed this run (mirrors ingest's batch_dest_folders).
-    run_dest_folders = {}
-    # Byte-proven verified hash for each intra-run token. A ('hash', h)
+    # ``state.wc_dest_folders`` is the extraction's exact-match scope.
+    # ``state.run_dest_folders``: intra-run duplicate destinations —
+    # token -> dest folder where the identity landed this run (mirrors
+    # ingest's batch_dest_folders).
+    # ``state.run_verified_hashes``: byte-proven verified hash for each
+    # intra-run token. A ('hash', h)
     # token's own value IS the proof; a ('key', …) token carries no bytes,
     # so accepting a later key match against a run twin requires hashing
     # the current source and comparing against this recorded value (two
     # different files with the same filename+size+capture-second across
     # cards would otherwise be counted as skipped_duplicate without ever
     # verifying bytes — safe_to_format green, second card is only copy).
-    run_verified_hashes = {}
-    linked_dup_dirs = set()    # dup-twin dirs already scanned+linked
+    # ``state.linked_dup_dirs``: dup-twin dirs already scanned+linked.
 
-    # Sticky across the rest of the run once a mounted → unmounted
-    # transition is observed. The per-batch rollback below undoes
-    # ``dup_skips`` and ``landed`` but not the identities the same batch
+    # ``state.mount_ever_lost``: sticky across the rest of the run once
+    # a mounted → unmounted transition is observed. The per-batch
+    # rollback below undoes ``dup_skips`` and ``landed`` but not the
+    # identities the same batch
     # already installed in the job-wide ``checker`` (and in
     # ``run_dest_folders`` / ``run_verified_hashes``) via
     # ``_record_checker`` — and ``DuplicateChecker`` exposes no removal
@@ -3510,18 +3531,16 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # batch keeps the stale intra-run cache from ever being consulted.
     # Same rationale as the remote path (see PR #1400 review, Codex P2
     # r3688614624).
-    mount_ever_lost = None
 
     def _counts(rel):
-        return folder_counts.setdefault(
+        return state.folder_counts.setdefault(
             rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0},
         )
 
     def _fail(rel, source_file, reason):
-        nonlocal failed
-        failed += 1
+        state.failed += 1
         _counts(rel)["failed"] += 1
-        unsafe_files.append({"path": str(source_file), "reason": reason})
+        state.unsafe_files.append({"path": str(source_file), "reason": reason})
         log.warning("Import failed for %s: %s", source_file, reason)
 
     def _reclassify_landed_failed(rel, entry, reason):
@@ -3536,16 +3555,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         otherwise the exactly-one-terminal-bucket invariant breaks and
         ``copied + skipped_duplicate + failed`` exceeds ``discovered``.
         """
-        nonlocal copied, verified, skipped_duplicate
         dest_path = entry.dest_path
         origin = entry.origin
         if origin == "copied":
-            copied -= 1
+            state.copied -= 1
             if verified_counted_for_copies:
-                verified -= 1
+                state.verified -= 1
             _counts(rel)["copied"] -= 1
         elif origin == "skipped_duplicate":
-            skipped_duplicate -= 1
+            state.skipped_duplicate -= 1
             _counts(rel)["skipped_duplicate"] -= 1
         _fail(rel, dest_path, reason)
 
@@ -3573,20 +3591,20 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             )
             return
         for tok in tokens:
-            run_dest_folders[tok] = dest_folder
-            run_verified_hashes[tok] = file_hash
+            state.run_dest_folders[tok] = dest_folder
+            state.run_verified_hashes[tok] = file_hash
 
     # Dup-folder linking runs in a SEPARATE ``scan(restrict_dirs=…)`` call
     # after the duplicate skip; its exception was previously logged and
     # swallowed, leaving safe_to_format true while the imported
     # duplicates never became visible in the active workspace. Track it
-    # explicitly so safe_to_format reflects "workspace can actually see
-    # these bytes" and not just "the bytes are somewhere on disk".
-    dup_link_failed = False
+    # explicitly (``state.dup_link_failed``) so safe_to_format reflects
+    # "workspace can actually see these bytes" and not just "the bytes
+    # are somewhere on disk".
 
     for rel, batch in batches:
         if runner.is_cancelled(job["id"]):
-            cancelled = True
+            state.cancelled = True
             break
 
         # A detach observed in an earlier batch is sticky for the rest
@@ -3596,19 +3614,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # count fresh card files as duplicates of copies that never
         # completed. Refuse every remaining file rather than risk a
         # stale-cache hit. See PR #1400 review (Codex P2 r3688614624).
-        if mount_ever_lost:
+        if state.mount_ever_lost:
             for source_file in batch:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
-                    f"archive mount root {mount_ever_lost} detached "
+                    f"archive mount root {state.mount_ever_lost} detached "
                     "earlier in this import; the intra-run duplicate "
                     "cache still holds identities for files whose "
                     "landing was rolled back, so no further batch can "
                     "be trusted to consult it",
                 )
             _emit(
-                f"{rel}: archive unmounted", emitted, queued,
+                f"{rel}: archive unmounted", state.emitted, queued,
             )
             continue
 
@@ -3636,7 +3654,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # Count these as emitted so the progress bar reflects the
                 # rejected batch instead of freezing at the last copied
                 # file. Mirrors the remote guard — spec decision 2.
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     "destination folder resolves inside a source directory "
@@ -3647,7 +3665,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             _emit(
                 f"{rel}: {_counts(rel)['copied']} copied · "
                 f"{_counts(rel)['skipped_duplicate']} already present",
-                emitted, queued,
+                state.emitted, queued,
             )
             continue
         # Same guard the remote path applies (see ``_missing_mount_root``
@@ -3670,7 +3688,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # branch skips, and a progress bar frozen at the last
                 # copied file reads as "still working" while the rest of
                 # the card is quietly failing.
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     f"archive mount root {missing_mount_root} is not "
@@ -3679,7 +3697,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     "would prevent the real share from remounting)",
                 )
             _emit(
-                f"{rel}: archive unavailable", emitted, queued,
+                f"{rel}: archive unavailable", state.emitted, queued,
             )
             continue
         # The check above only sees a mount point that VANISHED. Linux
@@ -3695,7 +3713,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         stale_mount_root = _unmounted_since_baseline(mount_baseline)
         if stale_mount_root:
             for source_file in batch:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     f"archive mount root {stale_mount_root} is no longer "
@@ -3705,7 +3723,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     "stale mount point)",
                 )
             _emit(
-                f"{rel}: archive unmounted", emitted, queued,
+                f"{rel}: archive unmounted", state.emitted, queued,
             )
             continue
         # A stale-but-registered mount (ismount still true while reads
@@ -3719,13 +3737,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             os.makedirs(dest_folder, exist_ok=True)
         except OSError as e:
             for source_file in batch:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     f"could not create destination folder {dest_folder}: {e}",
                 )
             _emit(
-                f"{rel}: destination unavailable", emitted, queued,
+                f"{rel}: destination unavailable", state.emitted, queued,
             )
             continue
 
@@ -3797,12 +3815,12 @@ def run_import_job(job, runner, db_path, workspace_id, params):
 
         for source_file in batch:
             if runner.is_cancelled(job["id"]):
-                cancelled = True
+                state.cancelled = True
                 break
             if not mount_lost:
                 mount_lost = _unmounted_since_baseline(mount_baseline)
             if mount_lost:
-                emitted += 1
+                state.emitted += 1
                 _fail(
                     rel, source_file,
                     f"archive mount root {mount_lost} detached while this "
@@ -3811,9 +3829,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     "local disk under a stale mount point)",
                 )
                 continue
-            emitted += 1
+            state.emitted += 1
             _emit(
-                f"{rel}: importing", emitted, queued, source_file.name,
+                f"{rel}: importing", state.emitted, queued, source_file.name,
                 is_importing=True,
             )
 
@@ -3833,8 +3851,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             db, token, source_file, _path_under_any_source,
                         )
                         if likely_rows:
-                            skipped_duplicate += 1
-                            unverified_duplicate += 1
+                            state.skipped_duplicate += 1
+                            state.unverified_duplicate += 1
                             _counts(rel)["skipped_duplicate"] += 1
                             dup_skips.append((source_file, True))
                             dup_dirs.update(_linkable_twin_dirs(
@@ -3895,11 +3913,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     # would let the card be counted as skipped_duplicate
                     # and safe_to_format go green while the card is the
                     # only remaining copy of the bytes.
-                    if token in run_dest_folders:
+                    if token in state.run_dest_folders:
                         if token[0] == "hash":
                             accept = True
                         else:
-                            run_hash = run_verified_hashes.get(token)
+                            run_hash = state.run_verified_hashes.get(token)
                             if (
                                 src_hash is not None
                                 and run_hash is not None
@@ -3928,7 +3946,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 twin_hash = _hash_dest_file(
                                     twin_path, _stop_requested)
                             except DestReadCancelled:
-                                cancelled = True
+                                state.cancelled = True
                                 dest_read_cancelled = True
                                 break
                             except OSError:
@@ -3950,14 +3968,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 # the on-disk bytes). See PR #1107
                                 # review.
                                 verified_twin_rows.append(twin)
-                    if cancelled:
+                    if state.cancelled:
                         # Stop interrupted a twin hash above. Don't let
                         # this file fall through to the adopt/copy path —
                         # every further step touches the same (possibly
                         # dead) mount.
                         break
                     if accept:
-                        skipped_duplicate += 1
+                        state.skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
                         dup_skips.append((source_file, False))
                         # verified_twin_rows carries only twins whose
@@ -3980,7 +3998,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 verified_twin_rows, _path_under_destination,
                             ),
                         )
-                        run_dest = run_dest_folders.get(token)
+                        run_dest = state.run_dest_folders.get(token)
                         if run_dest is not None:
                             dup_dirs.add(run_dest)
                         continue
@@ -4137,7 +4155,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
 
                 if adopted_dest is not None:
                     dest_file, adopt_hash = adopted_dest
-                    skipped_duplicate += 1
+                    state.skipped_duplicate += 1
                     _counts(rel)["skipped_duplicate"] += 1
                     landed.append(
                         _LandedFile(
@@ -4164,7 +4182,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # collision hashing above). The file is neither copied nor
                 # failed — it stays on the card for the next run, like any
                 # file the cancel got to before its batch.
-                cancelled = True
+                state.cancelled = True
                 dest_read_cancelled = True
                 break
             except OSError as e:
@@ -4177,8 +4195,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     "match the source)",
                 )
                 continue
-            copied += 1
-            verified += 1
+            state.copied += 1
+            state.verified += 1
             _counts(rel)["copied"] += 1
             landed.append(
                 _LandedFile(
@@ -4235,10 +4253,10 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # workspace. See PR #1396 review (Codex P1 r3687506040).
         if mount_lost and dup_skips:
             for skipped_file, counted_unverified in dup_skips:
-                skipped_duplicate -= 1
+                state.skipped_duplicate -= 1
                 _counts(rel)["skipped_duplicate"] -= 1
                 if counted_unverified:
-                    unverified_duplicate -= 1
+                    state.unverified_duplicate -= 1
                 _fail(
                     rel, skipped_file,
                     f"archive mount root {mount_lost} detached mid-batch; "
@@ -4271,7 +4289,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # for the files just rolled back above; the checker has no
         # removal API). See PR #1400 review (Codex P2 r3688614624).
         if mount_lost:
-            mount_ever_lost = mount_lost
+            state.mount_ever_lost = mount_lost
 
         # --- Catalog this batch (even when cancelled mid-batch: what
         # landed on disk must be cataloged before we stop, so every
@@ -4443,7 +4461,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         try:
                             actual = _rehash_dest_or_none(dest_path)
                         except DestReadCancelled:
-                            cancelled = True
+                            state.cancelled = True
                             break
                         if actual is not None and actual == verified_hash:
                             # Landed JPEG paired with an existing RAW
@@ -4474,7 +4492,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             # The landed JPEG's bytes are now represented
                             # on the RAW primary — that row is what the
                             # chaining hook should process.
-                            imported_photo_ids.add(companion["id"])
+                            state.imported_photo_ids.add(companion["id"])
                             continue
                         _reclassify_landed_failed(
                             rel, entry,
@@ -4492,7 +4510,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     db.update_photo_hash_check(
                         row["id"], "ok", commit=False,
                     )
-                    imported_photo_ids.add(row["id"])
+                    state.imported_photo_ids.add(row["id"])
                 elif row["file_hash"] is None:
                     if verified_hash == EMPTY_FILE_SHA256:
                         # Zero-byte convention: EMPTY_FILE_SHA256 never
@@ -4510,13 +4528,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         try:
                             actual = _rehash_dest_or_none(dest_path)
                         except DestReadCancelled:
-                            cancelled = True
+                            state.cancelled = True
                             break
                         if actual == EMPTY_FILE_SHA256:
                             db.update_photo_hash_check(
                                 row["id"], "ok", commit=False,
                             )
-                            imported_photo_ids.add(row["id"])
+                            state.imported_photo_ids.add(row["id"])
                         else:
                             _reclassify_landed_failed(
                                 rel, entry,
@@ -4540,14 +4558,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         try:
                             actual = _rehash_dest_or_none(dest_path)
                         except DestReadCancelled:
-                            cancelled = True
+                            state.cancelled = True
                             break
                         if actual is not None and actual == verified_hash:
                             db.update_photo_hash_check(
                                 row["id"], "ok", file_hash=verified_hash,
                                 commit=False,
                             )
-                            imported_photo_ids.add(row["id"])
+                            state.imported_photo_ids.add(row["id"])
                         else:
                             _reclassify_landed_failed(
                                 rel, entry,
@@ -4667,10 +4685,10 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     src_path = entry.source_path
                     exp_size = entry.src_size
                     exp_mtime_ns = entry.src_mtime_ns
-                    wc_source_paths[dest_path] = (
+                    state.wc_source_paths[dest_path] = (
                         src_path, exp_size, exp_mtime_ns,
                     )
-                wc_dest_folders.add(dest_folder)
+                state.wc_dest_folders.add(dest_folder)
 
         # --- Link duplicate-twin folders -------------------------------
         # The twins already have catalog rows and _linkable_twin_dirs has
@@ -4679,16 +4697,16 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # enumerate/stat every file in the matched NAS folders before the
         # import could finish; uncataloged-stray repair belongs to the
         # explicit folder-rescan workflow instead.
-        new_dup_dirs = dup_dirs - linked_dup_dirs
+        new_dup_dirs = dup_dirs - state.linked_dup_dirs
         if new_dup_dirs:
             linked, failures = _link_duplicate_twin_dirs(
                 db, workspace_id, new_dup_dirs,
             )
-            linked_dup_dirs.update(linked)
+            state.linked_dup_dirs.update(linked)
             if failures:
-                dup_link_failed = True
+                state.dup_link_failed = True
                 for d, detail in failures.items():
-                    unsafe_files.append({
+                    state.unsafe_files.append({
                         "path": d,
                         "reason": (
                             "duplicate-folder workspace link failed: "
@@ -4698,10 +4716,10 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "
             f"{_counts(rel)['skipped_duplicate']} already present",
-            emitted, queued,
+            state.emitted, queued,
         )
 
-        if cancelled:
+        if state.cancelled:
             break
 
     # --- Deferred working-copy extraction ---------------------------
@@ -4717,30 +4735,30 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # imports while the extractor decodes what the user asked us to
     # abort. During the pass, poll ``runner.is_cancelled`` so cancellation
     # aborts extraction row-by-row too.
-    if params.vireo_dir and wc_dest_folders and not cancelled:
+    if params.vireo_dir and state.wc_dest_folders and not state.cancelled:
         from scanner import _extract_working_copies
 
         try:
             _extract_working_copies(
                 db, params.vireo_dir,
-                scope=[(d, "exact") for d in sorted(wc_dest_folders)],
-                source_paths=wc_source_paths,
+                scope=[(d, "exact") for d in sorted(state.wc_dest_folders)],
+                source_paths=state.wc_source_paths,
                 cancel_check=lambda: runner.is_cancelled(job["id"]),
             )
         except Exception:
             log.exception(
                 "Working-copy extraction failed for %s",
-                sorted(wc_dest_folders),
+                sorted(state.wc_dest_folders),
             )
         if runner.is_cancelled(job["id"]):
-            cancelled = True
+            state.cancelled = True
 
-    status = "cancelled" if cancelled else (
-        "failed" if failed else "completed"
+    status = "cancelled" if state.cancelled else (
+        "failed" if state.failed else "completed"
     )
     summary = _selection_summary(
-        params, include_paths, discovered=discovered, copied=copied,
-        skipped_duplicate=skipped_duplicate, failed=failed,
+        params, include_paths, discovered=discovered, copied=state.copied,
+        skipped_duplicate=state.skipped_duplicate, failed=state.failed,
     )
     runner.update_step(
         job["id"], "import",
@@ -4756,8 +4774,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # ``unsafe_files`` (path = the enumeration failure's own filename when
     # available, otherwise ``<discovery>``) so the caller can show what
     # went unseen.
-    for exc in discovery_errors:
-        unsafe_files.append({
+    for exc in state.discovery_errors:
+        state.unsafe_files.append({
             "path": str(getattr(exc, "filename", None) or "<discovery>"),
             "reason": f"source enumeration failed: {exc}",
         })
@@ -4803,46 +4821,46 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             )
         else:
             partial_scope = True
-    if unverified_duplicate:
-        unsafe_files.append({
+    if state.unverified_duplicate:
+        state.unsafe_files.append({
             "path": "Likely duplicates",
             "reason": (
-                f"{unverified_duplicate} matched by filename, byte size, "
+                f"{state.unverified_duplicate} matched by filename, byte size, "
                 "and capture time but were not compared byte-for-byte"
             ),
         })
     # Selection drift entries. Shared with the remote path.
     _append_selection_unsafe(
-        unsafe_files, deselected=deselected, vanished_paths=vanished_paths,
+        state.unsafe_files, deselected=deselected, vanished_paths=vanished_paths,
         appeared=appeared,
     )
     safe_to_format = (
-        not cancelled
-        and failed == 0
-        and not discovery_errors
-        and not dup_link_failed
+        not state.cancelled
+        and state.failed == 0
+        and not state.discovery_errors
+        and not state.dup_link_failed
         and not partial_scope
-        and unverified_duplicate == 0
-        and (copied + skipped_duplicate) == discovered
+        and state.unverified_duplicate == 0
+        and (state.copied + state.skipped_duplicate) == discovered
         and not _selection_blocks_format(
             deselected=deselected, vanished_paths=vanished_paths)
     )
     unverified_duplicates_only = (
-        unverified_duplicate > 0
-        and not cancelled
-        and failed == 0
-        and not discovery_errors
-        and not dup_link_failed
+        state.unverified_duplicate > 0
+        and not state.cancelled
+        and state.failed == 0
+        and not state.discovery_errors
+        and not state.dup_link_failed
         and not partial_scope
-        and (copied + skipped_duplicate) == discovered
+        and (state.copied + state.skipped_duplicate) == discovered
         and not _selection_blocks_format(
             deselected=deselected, vanished_paths=vanished_paths)
     )
     result = {
         "discovered": discovered,
-        "copied": copied,
-        "verified": verified,
-        "photo_ids": sorted(imported_photo_ids),
+        "copied": state.copied,
+        "verified": state.verified,
+        "photo_ids": sorted(state.imported_photo_ids),
         # Stable-identity map so a recovery retry can verify each carried
         # ID still points at the same file. Without this the retry
         # authorizes any current photo row that happens to share an ID
@@ -4850,7 +4868,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # after users delete recent imports (SQLite reuses the freed
         # IDs on the next insert).
         "photo_fingerprints": _capture_photo_fingerprints(
-            db, imported_photo_ids,
+            db, state.imported_photo_ids,
         ),
         # Per-source signature over the discovered file set so a
         # recovery retry can detect a source whose contents changed
@@ -4861,15 +4879,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # would let a mid-copy card ejection stamp ``-1`` sizes and
         # refuse a legitimate reinsert-and-retry recovery.
         "source_snapshots": source_snapshots,
-        "skipped_duplicate": skipped_duplicate,
-        "unverified_duplicate": unverified_duplicate,
+        "skipped_duplicate": state.skipped_duplicate,
+        "unverified_duplicate": state.unverified_duplicate,
         "unverified_duplicates_only": unverified_duplicates_only,
-        "failed": failed,
+        "failed": state.failed,
         "safe_to_format": safe_to_format,
-        "unsafe_files": unsafe_files,
-        "folders": folder_counts,
-        "cancelled": cancelled,
-        "discovery_errors": len(discovery_errors),
+        "unsafe_files": state.unsafe_files,
+        "folders": state.folder_counts,
+        "cancelled": state.cancelled,
+        "discovery_errors": len(state.discovery_errors),
         # Selection drift, for the caller's readout. ``files_appeared`` is a
         # clamped net delta (card size minus previewed count), so it reads 0
         # — never negative — when more files vanished than arrived.
@@ -4880,10 +4898,10 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # recorded "failed" (with per-file / per-operation reasons),
         # never "completed".
         "ok": (
-            failed == 0
-            and not discovery_errors
-            and not dup_link_failed
+            state.failed == 0
+            and not state.discovery_errors
+            and not state.dup_link_failed
         ),
-        "errors": [f"{u['path']}: {u['reason']}" for u in unsafe_files],
+        "errors": [f"{u['path']}: {u['reason']}" for u in state.unsafe_files],
     }
     return result


### PR DESCRIPTION
Second half of the spec's PR 5 split — a purely mechanical, no-behavior-change refactor that moves both import paths' run-scoped closure state into a shared `_ImportRunState` dataclass and hoists the four byte-identical state-manipulating helpers to module level, unlocking PR 6's phase extraction.

- Spec: `docs/superpowers/specs/2026-08-06-import-path-unification-design.md`
- Plan: `docs/superpowers/plans/2026-08-08-import-unify-pr5b-run-state.md`
- First half (behavior flips) landed as PR 5a (#1438).

**Suite counts are identical at every commit** (`vireo/tests/test_import_job.py` → 225 passed, 1 skipped after each of the six commits), so the series is bisectable — reviewers verified the intermediate conversion commits independently.

## The run-state object

`_ImportRunState` (module level, below `_LandedFile`) carries the 18 run-scoped names present in BOTH functions:

`copied`, `verified`, `skipped_duplicate`, `unverified_duplicate`, `failed`, `emitted`, `cancelled`, `unsafe_files`, `folder_counts`, `discovery_errors`, `imported_photo_ids`, `linked_dup_dirs`, `dup_link_failed`, `run_dest_folders`, `run_verified_hashes`, `mount_ever_lost`, `wc_source_paths`, `wc_dest_folders`

plus `log_label` ("Import" / "Remote import") so the two paths' failure log lines stay byte-identical after the helper hoist. Batch-scoped state (`landed`, `dup_skips`, collision maps, …) deliberately stays in function locals until PR 6.

## The four hoisted helpers

`_counts(state, rel)`, `_fail(state, rel, source_file, reason)`, `_reclassify_landed_failed(state, rel, entry, reason, verified_counted_for_copies)`, `_record_checker(state, checker, source_file, dest_folder, file_hash)` — the pure state manipulators, previously nested byte-identically in both functions. Emitters, probes, and transport bits stay nested; PR 6 owns those. In-function call-site counts are unchanged (`_counts` 20, `_fail` 31, `_reclassify_landed_failed` 13, `_record_checker` 6).

## The ONLY observable deltas (both log-wording)

1. `_fail`'s warning becomes the template `"%s failed for %s: %s"` fed by `state.log_label` — the rendered lines (`Import failed for …` / `Remote import failed for …`) are byte-identical to before.
2. `_record_checker`'s OSError warning unifies to `"Duplicate-checker record() failed for %s (dest %s): %s"`. The local variant said "after landing at %s" (wrong for the remote's enqueue-time skip callers — flagged in PR #1433's body); the remote variant omitted the dest entirely.

## 5a review carry-overs (all no-behavior-change)

1. **Booking/rollback predicate pairing:** the remote post-transfer `verified` booking switches from `if params.verify_by_hash:` to `if verified_counted_for_copies:` so increment and decrement share one predicate (PR 7's `attests_bytes` then switches both at once). The `remote_verify_files` guard and the `update_photo_hash_check` stamp site are untouched.
2. **`verified_counted_for_copies` is loop-invariant** — both decls move out of the per-batch loops to just before them. This also removes a fragile late-binding closure: the remote helper previously closed over a name first bound inside the loop.
3. **Local `reclassified_landed_paths` decl** moves into the per-batch state block (mirroring remote's placement) — also fixing a latent cross-batch name leak the review found.
4. **`_LandedFile` gains `frozen=True`** — entries are never mutated by design (the reclassified set exists precisely to avoid mutation); held by the full suite.

## Audit artifact

Per-name bare-occurrence grep inside both function ranges (everything must be a comment/docstring/keyword-arg/dict key — never a load/store of a local):

```
--- remote function range ---
(no hits)
--- local function range ---
== verified
6:    verified file cataloged and nothing else.
== failed
1148:                failed between promote and scan). Without it, mutation of
(all remaining hits are docstring lines; zero code loads/stores)

$ grep -n nonlocal vireo/import_job.py
(no matches)
```

Recursive symtable check (none of the 18 names may remain a local of either function or any child namespace):

```
_run_remote_import_job OK
_run_remote_import_job._probe_dir_case_insensitive OK
_run_remote_import_job._path_under_destination OK
_run_remote_import_job._fold_basename OK
_run_remote_import_job._emit OK
_run_remote_import_job._emit_transfer OK
_run_remote_import_job._discovery_onerror OK
_run_remote_import_job._stop_requested OK
_run_remote_import_job._missing_mount_root OK
_run_remote_import_job._do_rsync OK
_run_remote_import_job._do_rsync.lambda OK
_run_remote_import_job._rsync_cancelled OK
_run_remote_import_job.lambda OK
_run_remote_import_job.lambda OK
run_import_job OK
run_import_job._probe_dir_case_insensitive OK
run_import_job._path_under_destination OK
run_import_job._emit OK
run_import_job._discovery_onerror OK
run_import_job._stop_requested OK
run_import_job._src_hash_cached OK
run_import_job._rehash_dest_or_none OK
run_import_job.lambda OK
```

## Notes for PR 6

- The emitters (`_emit`, `_emit_transfer`) and probes are the next extraction targets; every phase helper can now take `state`.
- `_reclassify_landed_failed`'s `verified_counted_for_copies` parameter is the seam PR 7's transport `attests_bytes` replaces — the remote booking site now shares the same predicate, so both flip together.

## Tests

- `python -m pytest vireo/tests/test_import_job.py -q` → **225 passed, 1 skipped** (identical at every commit in this series)
- Required CLAUDE.md suite (`tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py`) → **2077 passed, 14 skipped, 1 failure** = the known env failure `test_api_exiftool_status_reports_missing` (pre-existing on this machine, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import reliability across local and remote sources.
  * More accurately reports failures, cancellations, duplicate files, mount interruptions, and catalog or archive validation issues.
  * Prevents unsafe formatting when imported files cannot be fully verified.
* **Improvements**
  * Import progress, results, photo counts, fingerprints, and error reporting are now more consistent.
  * Remote transfers respond more reliably to cancellation requests and avoid indefinite stalls.
  * Duplicate-only imports can link existing catalog folders directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
