### PR TITLE
Scope import folder dialog test selectors

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -2145,9 +2145,10 @@ def test_import_browse_button_opens_folder_browser_fallback(live_server, page):
     browser = page.locator("[data-testid='import-folder-browser']")
     expect(browser).to_have_class(re.compile(r"\bopen\b"))
     expect(page.locator("#folderBrowserTitle")).to_have_text("Select Source Folders")
-    expect(page.locator(".folder-browser-panel")).to_have_attribute("role", "dialog")
-    expect(page.locator(".folder-browser-panel")).to_have_attribute("aria-modal", "true")
-    expect(page.locator(".folder-browser-panel")).to_have_attribute(
+    panel = browser.locator(".folder-browser-panel")
+    expect(panel).to_have_attribute("role", "dialog")
+    expect(panel).to_have_attribute("aria-modal", "true")
+    expect(panel).to_have_attribute(
         "aria-labelledby", "folderBrowserTitle")
 
 
@@ -2444,14 +2445,13 @@ def test_import_folder_browser_escape_closes_modal(live_server, page):
     page.evaluate("window.pickDirectory = async () => null")
 
     page.locator("[data-testid='import-source-browse-btn']").click()
-    expect(page.locator("[data-testid='import-folder-browser']")).to_have_class(
-        re.compile(r"\bopen\b"))
-    expect(page.locator(".folder-browser-close")).to_be_focused()
+    browser = page.locator("[data-testid='import-folder-browser']")
+    expect(browser).to_have_class(re.compile(r"\bopen\b"))
+    expect(browser.locator(".folder-browser-close")).to_be_focused()
 
     page.keyboard.press("Escape")
 
-    expect(page.locator("[data-testid='import-folder-browser']")).not_to_have_class(
-        re.compile(r"\bopen\b"))
+    expect(browser).not_to_have_class(re.compile(r"\bopen\b"))
 
 
 def test_import_destination_structure_hides_when_folder_browser_picks_destination(


### PR DESCRIPTION
Scopes the import folder browser's dialog and close-button assertions to its own overlay.
The card-cleanup confirmation now reuses the same modal CSS classes, which made the page-wide Playwright locators ambiguous and broke two Chromium E2E tests.
This keeps the accessibility and focus assertions targeted at the modal under test without changing production behavior.
Validated with the two affected Chromium tests, Ruff, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated folder-browser end-to-end tests for clearer dialog attribute and Escape-key closure checks.
  * No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->