### PR TITLE
Add portable computation cache

### DIFF
--- a/docs/superpowers/specs/2026-08-08-portable-computation-cache-design.md
+++ b/docs/superpowers/specs/2026-08-08-portable-computation-cache-design.md
@@ -142,11 +142,12 @@ These are recommendations for review, not yet approved decisions.
 
 Settings gains a **Computation Cache** section with **Export Results…**.
 
-The export sheet offers:
+The phase-one controls offer:
 
-- scope: selected folders or all processed photos;
+- scope: all processed photos (selected-folder scope is follow-up work);
 - artifact types: Detection and Species classification (both selected by
-  default);
+  default); selecting Species classification automatically includes its
+  Detection dependency;
 - destination: a file ending in `.vireo-cache`.
 
 Before writing, Vireo reports how many photos have reusable results for the
@@ -156,8 +157,9 @@ counts would be misleading here. Export can hash missing non-empty photos after
 explicit confirmation; it does not silently read terabytes of originals and it
 does not repeatedly chase deliberately NULL hashes for empty files.
 
-The completion summary reports photos, detector runs, classifier runs, bundle
-size, skipped legacy results, and failures.
+The completion summary labels each unit explicitly: unique artifacts, affected
+catalog photo rows, detector runs, classifier runs, bundle bytes, artifacts
+stored for later, skipped legacy rows, and failures.
 
 ### Import on computer B
 
@@ -180,7 +182,8 @@ later, the next Process/Classify run discovers and applies the cached result.
 
 During processing, progress and the final job card show a line such as:
 
-> Reused 1,248 detector results and 1,103 classifications from imported cache.
+> Reused 1,248 detector-run artifacts across 1,310 catalog photo rows and
+> 1,103 classifier-run artifacts; stored 87 artifacts for later.
 
 The review UI does not need a permanent badge on every card. Prediction detail
 may show optional provenance: origin device label, Vireo version, execution

--- a/docs/superpowers/specs/2026-08-08-portable-computation-cache-design.md
+++ b/docs/superpowers/specs/2026-08-08-portable-computation-cache-design.md
@@ -1,0 +1,804 @@
+# Portable computation cache
+
+**Date:** 2026-08-08
+**Status:** Experimental phase-one implementation — format remains draft
+pending the cross-provider experiment
+
+## Implementation status
+
+The experimental phase-one bundle workflow is implemented behind an explicit
+**Experimental** label in Settings. It includes:
+
+- schema migration and full runtime/input/label identities for new detector
+  and classifier runs;
+- review-aware runtime replacement, including a pin from any workspace and an
+  explicit Reclassify override;
+- an immutable local object store and atomic `.vireo-cache` ZIP export;
+- full-bundle validation before import publication, including size, digest,
+  traversal, symlink, numeric-bound, and compression-ratio checks;
+- immediate exact-hash fan-out to matching catalog photos, plus local-store
+  reuse when a photo is cataloged after the bundle was imported;
+- Settings export/import controls and status summaries; and
+- automatic publication of newly computed portable detector and classifier
+  output when Vireo can prove the source, model, label, and input identities.
+
+Existing database results remain tagged `legacy`: they are valid local cache
+hits but are not exported. An explicit Reclassify recomputes them with the new
+identity contract. RAW+JPEG companion-backed runs also remain local-only until
+the canonical multi-source rendition contract is frozen.
+
+The cross-provider experiment, semantic-divergence diagnostics/tolerances,
+folder-scoped export sheet, retention controls, and shared NAS pack/index are
+still follow-up work. The artifact schema is therefore intentionally marked
+experimental rather than a compatibility promise.
+
+## Summary
+
+Let one Vireo installation reuse expensive detector and classifier work done by
+another installation, without sharing a live SQLite catalog and without
+turning Vireo into a cloud service.
+
+The first release is a portable cache bundle: computer A exports raw processing
+results for selected photos, computer B imports the bundle, and Vireo matches
+the results to its own catalog by the photo's SHA-256 content hash. A later
+release can point both computers at an append-only cache folder on a NAS and
+use the same artifact format automatically.
+
+This complements XMP rather than replacing it:
+
+- XMP remains the portable source of truth for accepted species, keywords,
+  ratings, flags, and other user decisions.
+- The computation cache carries reproducible machine output: detections,
+  classifier candidates, confidences, model identities, and completed-run
+  markers.
+- Workspace review state, edits, collections, and pending XMP changes remain
+  local unless another feature explicitly synchronizes them.
+
+This first release skips detector and classifier inference only. A full
+pipeline on computer B still computes working copies, masks, DINO embeddings,
+quality metrics, and any other enabled stages that are not yet portable.
+
+## Problem
+
+Wildlife photographers commonly keep originals on a NAS, process on a powerful
+desktop, and browse or review on a laptop. Vireo's current cache avoids repeated
+work across workspaces in one catalog, but it is local to `vireo.db`. A second
+computer that catalogs the same photo bytes cannot reuse the first computer's
+MegaDetector or classifier results.
+
+The current workarounds each lose something important:
+
+- Syncing accepted species to XMP shares the final decision, but not pending
+  predictions, alternatives, confidences, or detection boxes.
+- Copying `vireo.db` is a whole-catalog replacement, depends on compatible
+  absolute paths, and cannot safely merge two computers' work.
+- Putting the active SQLite database on a network share creates locking,
+  availability, and corruption risks and still does not define merge semantics.
+
+The useful first feature is therefore **shared computation**, not shared
+catalog state and not distributed job scheduling.
+
+## Goals
+
+1. Reuse detector and species-classifier results for byte-identical photos on
+   another Vireo installation.
+2. Keep the feature local-first: bundles and user-chosen filesystem locations,
+   with no Vireo-hosted service required.
+3. Never overwrite or implicitly transfer human review decisions.
+4. Reject stale results when the model, weights, canonical input rendition,
+   preprocessing, label set, or artifact schema is incompatible.
+5. Make reuse visible in job progress and summaries.
+6. Make export/import idempotent and safe to repeat.
+7. Use one artifact format for one-off bundles now and a shared NAS cache later.
+
+## Non-goals
+
+- Running one Vireo instance as a remote worker or job server.
+- Sharing a live `vireo.db` between machines.
+- Synchronizing workspaces, collections, history, culling choices, accepted or
+  rejected prediction status, pending XMP changes, or application settings.
+- Resolving conflicting human edits. XMP and the existing audit flow own that
+  problem.
+- Sharing masks, DINO embeddings, quality metrics, or rendered working copies
+  in the first release. These can use the same envelope later, but have larger
+  payloads, more complex cache keys, and additional privacy implications.
+- Matching visually similar or metadata-similar photos. Version 1 requires an
+  exact byte hash.
+
+## Proposed product decisions
+
+These are recommendations for review, not yet approved decisions.
+
+1. **Ship export/import before automatic NAS sharing.** It proves identity,
+   compatibility, merge, and UX semantics without introducing concurrent
+   writers or an always-online dependency.
+2. **Version 1 shares raw detector and classifier output only.** This directly
+   solves the species-identification use case while keeping bundles small.
+3. **Match only by full-file SHA-256.** Vireo already computes and stores this
+   as `photos.file_hash`. Paths, filenames, timestamps, perceptual hashes, and
+   file sizes are not sufficient identity.
+4. **Review state never travels in a computation artifact.** Imported
+   predictions enter the destination workspace exactly as locally computed
+   results would. Existing accepted/rejected state on the destination wins.
+5. **Cache writes are immutable and atomic.** A shared folder contains
+   content-addressed files, never a SQLite database that several machines open.
+6. **Separate semantic equivalence from exact payload identity.** Execution
+   providers are provenance, not compatibility identity. Artifacts preserve
+   useful confidence values and have an exact integrity digest, while a
+   provider-tolerance policy decides whether two payloads represent the same
+   boxes and ordered species. Equivalent payloads reuse the already-
+   materialized result; meaningful divergence is retained and reported rather
+   than forcing inference forever.
+7. **No filenames or folder paths in portable artifacts.** The photo hash is
+   sufficient for matching and avoids leaking a user's library organization.
+8. **Standardize inference input before shipping sharing.** The current
+   classifier can consume either a working-copy JPEG or a direct original/RAW
+   decode. Portable publication requires a named canonical input-rendition
+   contract; current fallback-dependent runs are legacy and not exportable.
+
+## User experience
+
+### Export on computer A
+
+Settings gains a **Computation Cache** section with **Export Results…**.
+
+The export sheet offers:
+
+- scope: selected folders or all processed photos;
+- artifact types: Detection and Species classification (both selected by
+  default);
+- destination: a file ending in `.vireo-cache`.
+
+Before writing, Vireo reports how many photos have reusable results for the
+selected detector/model/label-set scope, how many are missing a full content
+hash, and how many legacy results lack a safe runtime identity. Global catalog
+counts would be misleading here. Export can hash missing non-empty photos after
+explicit confirmation; it does not silently read terabytes of originals and it
+does not repeatedly chase deliberately NULL hashes for empty files.
+
+The completion summary reports photos, detector runs, classifier runs, bundle
+size, skipped legacy results, and failures.
+
+### Import on computer B
+
+The same section provides **Import Results…**. Import validates the entire
+bundle, stores valid artifacts in the local computation cache, and applies them
+to matching catalog photos through the normal cache-hit paths.
+
+The summary distinguishes:
+
+- matched and applied now;
+- stored for photos not yet present in the catalog;
+- already present;
+- unknown to the destination Vireo version;
+- produced with a regional label set that is not installed locally (including
+  its display name, species count, and full fingerprint);
+- semantically divergent or invalid.
+
+Artifacts for uncataloged photos remain useful. If those bytes are cataloged
+later, the next Process/Classify run discovers and applies the cached result.
+
+During processing, progress and the final job card show a line such as:
+
+> Reused 1,248 detector results and 1,103 classifications from imported cache.
+
+The review UI does not need a permanent badge on every card. Prediction detail
+may show optional provenance: origin device label, Vireo version, execution
+provider, input rendition, and compute date. On first export, Vireo proposes
+the hostname as an editable device label and explains that hostnames can
+contain a person's name before including it.
+
+## Architecture
+
+```text
+Computer A database
+        |
+        | export raw, compatible runs by photo SHA-256
+        v
+  .vireo-cache bundle  ----copy / NAS / AirDrop---->
+        |
+        v
+Computer B local artifact store
+        |
+        | exact photo + runtime cache lookup
+        v
+normal detector/classifier cache-hit paths
+        |
+        +--> global raw results in B's catalog
+        +--> B's workspace-local review reconciliation
+```
+
+### 1. Photo identity
+
+The outer identity is:
+
+```text
+photo_sha256 = SHA-256(original file bytes)
+```
+
+Vireo already stores this value in `photos.file_hash`, and scanner hashes are
+full-file SHA-256. The same photo may have a different filename, folder, mount
+point, or photo id on the destination computer and still match.
+
+An edited derivative is a different photo because its bytes differ. XMP-only
+changes do not change the original's hash and do not invalidate raw inference;
+workspace categorization is recomputed when the artifact is applied.
+
+### 2. Canonical input rendition
+
+The original-file hash identifies the library asset, but it does not fully
+identify the pixels Vireo feeds a model today. Classification prefers a
+4096-pixel quality-92 working-copy JPEG and falls back to a direct original
+decode. RAW decoding mode/version and RAW+JPEG companion substitution can also
+change pixels while `photos.file_hash` remains unchanged.
+
+Portable publication therefore has a prerequisite: define versioned canonical
+rendition recipes for detector and classifier inputs. A recipe covers:
+
+- source-selection rules, including companion substitution;
+- the SHA-256 of every source file whose bytes contributed pixels;
+- RAW decode mode and decoder implementation/version;
+- orientation, color space, resize/crop algorithm, maximum edge, and JPEG
+  settings where an intermediate JPEG is used;
+- model tensor size and normalization; and
+- a digest of the actual canonical pixel/tensor input produced for the run.
+
+These are concrete algorithm constants, not a vague application-version tag.
+For today's detector they include the 640-pixel tensor, padding/box decoding,
+NMS IoU `0.45`, category mapping, and raw confidence floor. For today's
+classifier the current sequence is: decode the working copy/original without a
+load-time size cap, crop with 20% subject-box padding, thumbnail that crop to
+1024×1024 with Lanczos, then apply the model-specific tensor preprocessing.
+The latter's input size, mean, and standard deviation come from the model
+directory's preprocessing config; portable identity hashes that config file
+rather than duplicating its values in hand-maintained version constants.
+
+The recipe should reuse the existing working-copy path where possible, but a
+missing working copy must not silently switch an exportable run to a different
+input. Vireo either creates the canonical rendition or treats the fallback run
+as local-only legacy output. This refactor is required before portable
+artifacts are enabled.
+
+### 3. Runtime identity
+
+Current local gates use `detector_model` and
+`(classifier_model, labels_fingerprint)`. Portable reuse needs a stronger
+identity because a model name can survive a weights or preprocessing change.
+
+Introduce a central `runtime_fingerprint` helper that hashes canonical JSON
+containing:
+
+- artifact type and artifact schema version;
+- public model id;
+- exact model-weights SHA-256 or immutable upstream revision;
+- preprocessing/postprocessing pipeline version;
+- inference implementation version;
+- canonical input-rendition recipe version;
+- raw detector output floor for detection artifacts;
+- classifier label fingerprint for classification artifacts;
+- detector runtime fingerprint for a box-based classifier artifact.
+
+The portable label fingerprint is the full SHA-256 of the canonical label set,
+not the current 12-character display/storage prefix. `compute_fingerprint()`
+and the existing PK/UNIQUE key columns do **not** change: changing their return
+value would miss every existing classifier run and reclassify the catalog.
+Instead, add a `compute_full_fingerprint()` helper and nullable
+`labels_fingerprint_full` compatibility columns alongside the existing short
+keys. New runs write both. Existing rows are backfilled in place only when
+their canonical label source is available; otherwise they remain usable local
+legacy hits but are not portable. If an imported full hash collides on the same
+12-character prefix, retain it externally and refuse automatic materialization
+rather than aliasing two label sets.
+
+The ONNX execution provider and hardware are recorded as provenance but are
+not part of compatibility identity. CPU, CUDA, and CoreML are expected to
+produce small numeric differences for the same logical result; including the
+provider would defeat desktop-to-laptop reuse.
+
+The detector threshold visible in workspace settings is deliberately absent:
+MegaDetector stores raw boxes above its fixed floor and applies the workspace
+threshold at read time. Changing that preference must remain a cache hit.
+
+Run tables need to record the runtime fingerprint used at compute time. This is
+more than a cosmetic provenance column: every local cache gate must evaluate it
+under the staleness rules below, or a weights/preprocessing change would still
+silently reuse stale unreviewed rows while the portable store correctly missed.
+
+The recommended migration avoids rebuilding the largest primary keys in the
+first release:
+
+- add the runtime fingerprint to `detector_runs` and `classifier_runs` as a
+  required validity field for new runs;
+- add the detector runtime fingerprint to each `detections` row so stale-row
+  retirement can prove which run owns a box;
+- add nullable full-label-fingerprint columns without changing the existing
+  short keys or `compute_fingerprint()` return value;
+- keep at most one materialized runtime for an existing local logical run key;
+  the external artifact store may retain several runtimes;
+- on a runtime mismatch with unreviewed output, treat the local row as stale and
+  eligible for a portable hit or fresh inference;
+- on a runtime mismatch with a manually reviewed/pinned result, satisfy the
+  gate without inference, preserve the result, and surface **Reviewed with an
+  older runtime**. Only an explicit Reclassify may replace it.
+
+Detections and raw predictions are global while review rows are workspace-
+scoped, so “reviewed/pinned” means a manual review in **any** workspace that
+references the materialized result. Otherwise replacing a global row for
+workspace B could silently cascade-delete workspace A's decision. Reclassify
+must enumerate affected workspaces in its existing destructive warning.
+
+Pinning is enforced at **photo × detector model**, not only at classifier-run
+granularity. If any prediction on any detection for that photo/model is
+manually reviewed in any workspace, a detector runtime mismatch is a pinned
+stale hit: Vireo does not re-detect the photo automatically. Detector boxes are
+the parent rows of predictions, so moving or retiring one would cascade-delete
+the prediction and every workspace's review before a classifier gate could
+protect it.
+
+Stale-row retirement is runtime-scoped. The ordinary detection UPSERT may
+retire only boxes whose `runtime_fingerprint` equals the incoming run. Replacing
+an older detector runtime is a separate atomic operation that first proves the
+photo/model is unpinned, then deletes the old runtime and writes the new run.
+It never lets `_upsert_detection_rows` cross a runtime boundary implicitly.
+This also fixes the existing hazard where a same-named MegaDetector weights
+change nudges a quantized box id and silently cascades reviewed predictions.
+
+An implementation plan must enumerate and update every detector/classifier
+gate and write path. A migration marks existing rows `legacy` until Vireo can
+prove their identity from an immutable bundled model revision. Unverifiable
+legacy results continue to work locally but are not exported.
+
+### 4. Artifact model
+
+One photo/run artifact contains only raw machine output. Local database ids,
+workspace ids, comparison categories, and review status are excluded.
+
+Artifact integrity and semantic equivalence are separate:
+
+- The **lookup key** is the photo hash, artifact type, runtime fingerprint, and
+  canonical input identity. It finds candidate payloads without assuming their
+  floating-point bytes are identical.
+- The **artifact digest** hashes canonical JSON of the exact portable payload.
+  Canonical JSON normalizes negative zero, rejects NaN/infinity, and uses a
+  stable field/list order, but it does not coarsely round away useful detector
+  confidence. Classification confidences retain the precision Vireo already
+  persists.
+- A versioned **semantic comparison policy** decides whether two exact
+  payloads are equivalent enough to reuse as the same logical output.
+
+For detections, semantic comparison uses the raw stored set above the fixed
+raw floor—never the workspace's read-time threshold. It pairs same-category
+boxes within an empirically chosen geometric tolerance, compares confidence
+within a separate tolerance, and permits an unmatched box only inside an
+empirically chosen epsilon band around `RAW_CONF_FLOOR`. For classifications,
+it requires the same subject mapping and ordered top-k species, then compares
+confidences with a provider tolerance. A top-1 change is semantic divergence.
+The comparison-policy version is part of portable compatibility.
+
+`detection_id.py`'s four-decimal box quantization remains the local database-id
+rule; it is useful evidence but is not assumed to be a sufficient portable
+confidence or equivalence policy.
+
+`input_fingerprint` is SHA-256 of the canonical input block: recipe id, ordered
+source roles/hashes, and pixel/tensor digest. A classification artifact's input
+fingerprint covers its ordered subject input digests and the detector artifact
+identity. Different input fingerprints are cache misses, not semantically
+divergent candidates—a RAW decode and a companion-JPEG rendition must never be
+compared as two executions of the same input.
+
+Illustrative detector record:
+
+```json
+{
+  "artifact_schema": 1,
+  "type": "detection",
+  "photo_sha256": "…",
+  "runtime_fingerprint": "…",
+  "input_fingerprint": "…",
+  "input": {
+    "recipe": "detector-input-v1",
+    "pixel_sha256": "…",
+    "sources": [{"role": "original", "sha256": "…"}]
+  },
+  "completed": true,
+  "subjects": [
+    {
+      "key": "d0",
+      "kind": "box",
+      "box": {"x": 0.12, "y": 0.08, "w": 0.43, "h": 0.61},
+      "confidence": 0.94,
+      "category": "animal"
+    }
+  ]
+}
+```
+
+An empty `subjects` list with `completed: true` is a valid cached empty scene.
+A failed or cancelled run is never exported as completed.
+
+A classification artifact references subjects by the bundle-local `key` and
+contains the ordered species candidates and confidences for each subject. A
+synthetic full-image subject uses `kind: "full_image"`; each subject result
+also records its canonical model-input digest. Scientific taxonomy
+may travel as source metadata, but destination-dependent categories `match`,
+`new`, `conflict`, and `refinement` are always reconciled locally rather than
+trusted from the source catalog.
+
+Classification metadata includes the label-set display name, count, and full
+SHA-256 fingerprint. Version 1 does not include the complete regional species
+list by default; that list is not needed to reuse the candidates and may reveal
+location. If the exact list is absent on the destination, the import summary
+says so rather than calling the artifact corrupt or silently claiming it
+matches the destination's current list.
+
+Each candidate may carry its source taxonomy id and lineage plus the taxonomy
+snapshot identity. The destination prefers its local taxonomy when available
+and falls back to the carried lineage for display/enrichment. Relationship
+categorization that needs a taxonomy graph remains pending with a clear
+"taxonomy required" reason when neither source is sufficient; it must not
+silently degrade an otherwise matching result to `new`.
+
+The artifact digest is SHA-256 of the complete canonical artifact. Provenance
+is stored in bundle manifests and import history, outside the artifact, and
+does not change whether the computation is reusable.
+
+If a result for the same lookup/runtime key is already materialized locally, it
+remains selected whether it is reviewed or not; a later lower-digest import
+never churns detections or repeats review reconciliation. A reviewed result is
+additionally pinned across runtime changes by the stale-runtime rule above. An
+unreviewed result from a different/stale runtime remains replaceable. When
+several candidates are discovered before anything is materialized, the
+lexicographically lowest artifact digest wins. All payloads remain available
+for diagnostics, and semantic divergence is reported. This converges among
+installations choosing from the same candidate set while making later imports
+order-stable; it does not claim that machines which have seen different
+artifact sets magically converge.
+
+### 5. Local artifact store
+
+Import places validated objects under the Vireo profile, separate from the
+catalog and thumbnail cache:
+
+```text
+~/.vireo/computation-cache/
+  objects/<photo-hash-prefix>/<photo-sha256>/
+    detection/<runtime-fingerprint>/<input-fingerprint>/<artifact-digest>.json
+    classification/<runtime-fingerprint>/<input-fingerprint>/<artifact-digest>.json
+  divergence/
+```
+
+Writers use a temporary file in the destination directory, `fsync`, and atomic
+rename. Existing identical objects are a no-op. The store is rebuildable and
+may be deleted without losing accepted metadata or catalog state.
+
+New local inference publishes to this store after its database transaction
+commits. Export also lazily synthesizes artifacts from compatible database rows
+created before the store existed.
+
+### 6. Bundle format
+
+`.vireo-cache` is a ZIP container using only standard ZIP compression so the
+first release adds no compression dependency:
+
+```text
+manifest.json
+objects/<artifact-digest>.json
+```
+
+The manifest includes format version, creation time, optional device label,
+object count, byte totals, and each object's digest, uncompressed size, and
+optional provenance. It does not contain secrets, filesystem paths, XMP,
+thumbnails, or original image bytes.
+
+Import enforces limits before extraction, rejects absolute or parent-traversal
+paths and symlinks, checks declared and actual sizes, hashes every object, and
+validates numeric bounds and required fields. Validation happens before any
+artifact is made visible.
+
+### 7. Applying imported results
+
+The importer must not insert review rows directly. For each matched photo it:
+
+1. matches against the stored `photos.file_hash` (it does not re-read the
+   original during ordinary import);
+2. materializes the detector run and normalized detections using local ids;
+3. maps bundle-local subject keys to those detection ids;
+4. materializes raw prediction candidates and classifier-run markers;
+5. invokes the same cache-reuse reconciliation used by a normal Process or
+   Classify job.
+
+That last step preserves current behavior: taxonomy categories are evaluated
+against the destination's XMP/keywords, existing manual review is preserved,
+and a cached result is surfaced into grouping and downstream pipeline stages.
+
+The apply operation is transactional per photo. A malformed classifier record
+cannot leave a completed `classifier_runs` marker without its predictions.
+
+`photos.file_hash` is intentionally not unique because exact duplicates are a
+first-class catalog feature. Apply fans one artifact out to every non-rejected
+photo row carrying that hash, generating each row's local detection ids. Import
+and job summaries report both unique artifacts and affected catalog photo rows
+so their counts remain explainable. A later Audit/Verify Hashes run still owns
+detecting files changed behind a stale stored hash.
+
+### 8. Job integration and reclassify
+
+The current standalone Classify job resolves/downloads and constructs its model
+before the per-photo classifier cache gate. The pipeline also starts model
+loading before it knows whether all classifier work can be served portably.
+The promise that destination weights are unnecessary therefore requires a job
+refactor, not just an import path:
+
+1. resolve the requested public runtime and label-set identity without loading
+   weights;
+2. resolve database, local-store, and shared-store hits;
+3. lazily download/load detector or classifier weights only when the first
+   genuine miss is reached; and
+4. let progress mark model loading as **Skipped — all results reused**.
+
+For a regional list, the job compares the full canonical label hash. An
+imported result remains reviewable when that list is absent, but a newly
+requested run cannot claim the same cache key without the list. UI explains
+the missing display name/count rather than degrading to a generic model miss.
+
+Tree-of-Life identity must also be resolvable without installed ToL files.
+Today `_load_labels` discovers ToL readiness from `tol_embeddings.npy` and
+`tol_classes.json` under the downloaded model, creating a cache-key paradox on
+a fresh laptop. The model registry therefore gains an immutable label-space id,
+ToL taxonomy/embedding revision, and portable fingerprint independent of local
+readiness. On-disk checks answer only whether inference can run after a miss.
+If an older/custom model has no registry identity, Vireo says the portable key
+is unresolvable and falls back to today's explicit model/label setup; it does
+not download speculatively just to ask the cache.
+
+**Reclassify means fresh inference.** It bypasses the database cache, portable
+local store, and shared store for the selected scope, then publishes the fresh
+normalized artifact. It retains today's destructive/review warnings. Ordinary
+Process/Classify is the action that reuses imported artifacts; importing a
+bundle itself may immediately apply hits via the same cancellable reuse path.
+
+## Phase 2: shared cache folder
+
+After bundle import/export is proven, Settings may allow one or more **Shared
+Cache Folders**, typically on a mounted NAS. They use the same artifact and
+identity format, but not necessarily the local store's one-file-per-object
+physical layout.
+
+A pipeline over 100,000 photos cannot issue several `stat` calls per photo over
+SMB/VPN. The shared format therefore needs batch discovery: immutable pack
+files plus immutable, per-writer index generations that readers copy locally
+and query in one pass. Each writer owns its own namespace and atomically
+publishes a small current-generation pointer, so no two machines write the same
+index database. Phase 2 planning must benchmark lookup and hit-fetch round trips
+on LAN SMB and high-latency VPN mounts before choosing the exact pack size.
+
+Lookup order during processing becomes:
+
+1. normal result already materialized in the local catalog;
+2. local artifact store;
+3. configured shared stores in user-defined order;
+4. local inference.
+
+A shared hit is copied into the local store before it is materialized, so an
+intermittent NAS does not break later use. Shared folders are reuse-only by
+default; publishing is a separate opt-in. Locally computed objects that are
+published use immutable writer packs. Identical outputs converge by artifact
+digest at lookup, while semantically divergent outputs use the deterministic
+selection rule above.
+
+Offline or read-only shared folders degrade to local processing and a visible
+warning. They never block a pipeline indefinitely. Cache cleanup is explicit;
+version 1 of shared folders does not automatically delete another machine's
+objects.
+
+## Privacy and trust
+
+The feature is local-only by default and never uploads artifacts.
+
+Although a detector box or species prediction is less sensitive than an
+original photograph, photo hashes and inferred species can still reveal
+information about a collection. Import treats bundles as untrusted input, and
+the UI explains what an export contains.
+
+Embeddings are excluded from version 1 because they may encode substantially
+more information about image content. Adding them requires a separate product
+and privacy review as well as a binary payload format.
+
+Imported artifacts are data, never executable plugins. Unknown model/runtime
+identities may be retained for a future compatible Vireo release but are not
+loaded into active results. A known compatible model does not need to have its
+weights downloaded on the destination: reuse should avoid that download as
+well as inference.
+
+## Failure and conflict semantics
+
+| Situation | Behavior |
+| --- | --- |
+| Same photo at a different path | Reuse by SHA-256 |
+| Original bytes changed | Cache miss; leave artifact stored |
+| Same detector, different workspace threshold | Reuse raw detections |
+| Same classifier, different label fingerprint | Reuse detection; classifier miss |
+| Runtime unknown to this Vireo version | Store but do not apply |
+| Known runtime whose weights are not downloaded | Apply; weights are unnecessary |
+| Any reviewed prediction under a photo's older detector runtime | Pin photo × detector model; no inference/box retirement; show stale-runtime state |
+| Identical artifact imported twice | No-op |
+| Same key, differences within semantic tolerances | Reuse materialized result, or lowest digest if none is materialized |
+| Same key, semantic divergence | Report/retain all; keep materialized result, otherwise lowest digest wins |
+| Lower-digest artifact imported after materialization | Keep current result; do not churn reconciliation |
+| Bundle partially corrupt | Reject bundle before publishing objects |
+| App exits during import | Atomic objects survive; incomplete temp files ignored |
+| NAS unavailable in phase 2 | Warn and continue with local cache/inference |
+
+## Observability
+
+Job events and history should separately count:
+
+- database cache hits;
+- local portable-cache hits;
+- shared-cache hits;
+- detector and classifier inference runs;
+- incompatible, semantically divergent, and invalid artifacts.
+
+An import-history record stores the bundle digest, source label, counts, and
+time. It does not own the imported objects and deleting the history row does
+not invalidate cache entries.
+
+## Testing
+
+### Identity and compatibility
+
+- Same bytes under different names and paths reuse successfully.
+- One-byte modification is a miss.
+- A detector threshold change remains a hit.
+- Measured CPU/CUDA/CoreML drift within the frozen tolerances is semantically
+  equivalent even when exact artifact digests differ.
+- Detector comparison uses raw stored boxes, and floor-band noise does not
+  depend on a workspace's visible threshold.
+- Different box counts or top species are reported as semantic divergence and
+  fresh installations with the same candidate set choose the same winner.
+- A model-weight, preprocessing-version, or label-fingerprint change misses
+  only the affected artifact type.
+- Working-copy versus direct-original fallback runs are not accidentally
+  treated as the same portable rendition.
+- A RAW+JPEG companion artifact matches only when every contributing source
+  hash matches.
+- Different input fingerprints occupy different store keys and are cache
+  misses, never semantic-divergence candidates.
+- Completed zero-detection runs round-trip and skip detector inference.
+- Failed/cancelled runs are not exported as completed.
+- All-cache-hit jobs skip model download/session construction; the first miss
+  triggers lazy loading.
+- A ToL cache key resolves from registry metadata on a machine with no ToL
+  files or model weights installed.
+- Adding full label fingerprints neither changes existing short keys nor
+  triggers catalog-wide classification.
+- Reclassify bypasses every cache layer and publishes its fresh result.
+
+### Merge and review safety
+
+- Import is idempotent.
+- Imported predictions surface through the same path as locally cached
+  predictions.
+- Existing accepted, rejected, and manually corrected prediction state is not
+  overwritten.
+- A reviewed older-runtime row satisfies later cache gates without repeated
+  inference and exposes its stale-runtime state.
+- One reviewed prediction in any workspace pins the complete photo × detector-
+  model run; an automatic runtime change neither invokes detection nor retires
+  any of that photo's boxes.
+- Same-runtime stale-box retirement cannot delete a different runtime's rows;
+  explicit runtime replacement first proves the photo/model is unpinned.
+- A late lower-digest artifact does not replace an already-materialized
+  unreviewed result or rerun reconciliation.
+- One artifact fans out idempotently to several non-rejected duplicate photo
+  rows, and summaries separate artifact count from affected-row count.
+- Destination XMP and local taxonomy are used to recategorize imported raw
+  output; carried lineage is the fallback when local taxonomy is unavailable.
+- Applying one bad photo rolls back that photo without corrupting successful
+  photos.
+- A classifier-run marker is never committed without its required prediction
+  rows.
+
+### Bundle security
+
+- Reject path traversal, absolute paths, symlinks, undeclared objects, digest
+  mismatches, oversized fields, excessive object counts, and ZIP bombs.
+- Unknown artifact versions are retained only when safe and never applied.
+- No config secrets, paths, filenames, or original bytes appear in an export.
+
+### Shared folder (phase 2)
+
+- Concurrent identical writers converge without partial objects.
+- Concurrent semantically divergent writers retain both payloads; readers with
+  the same candidate set and no materialized result choose the same winner.
+- Read-only, disconnected, and reconnecting shares degrade safely.
+- A shared hit is usable after the share disconnects because it was copied
+  locally first.
+- Scope lookup uses copied indexes/batched queries rather than per-photo SMB
+  metadata round trips.
+
+## Pre-format cross-provider experiment
+
+Semantic tolerances are a measured compatibility contract, not values to pick
+from intuition. Before the artifact format is frozen, run a representative set
+of roughly 200 JPEG and RAW photos through each supported execution provider
+using the exact same canonical renditions and model bytes. Include empty
+scenes, multiple subjects, detections close to the raw floor, and visually
+similar species.
+
+Record and retain as test fixtures:
+
+- maximum and percentile detector/classifier confidence deltas;
+- normalized box deltas and IoU after local four-decimal id quantization;
+- detection-count changes, especially inside bands around `RAW_CONF_FLOOR`;
+- ordered top-k and top-1 species flip rates; and
+- resulting semantic-equivalence and divergence rates under proposed policies;
+- exact objects per lookup key/provider and projected store size as the number
+  of contributing machines grows.
+
+Run detector and classifier experiments separately, with separate policies.
+MegaDetector's current external-data ONNX excludes CoreML, so its realistic Mac
+laptop comparison is CPU↔CUDA desktop; do not manufacture a CoreML detector
+axis the product cannot run. Exercise CPU↔CUDA and CPU/CUDA↔CoreML for each
+classifier model only where that model is actually supported; do not infer
+CoreML behavior merely from nominal provider availability.
+
+The experiments set per-artifact box, confidence, and raw-floor tolerances and
+make artifact multiplicity/store growth a first-class acceptance result. If no
+useful tolerance separates benign provider drift from meaningful confidence
+changes, keep confidences out of semantic identity and expose their variance as
+provenance instead of destroying their precision. The format remains draft
+until this experiment has a checked-in result and fixtures.
+
+## Rollout
+
+1. Standardize and version detector/classifier input renditions, run the
+   cross-provider experiment, and freeze semantic comparison tolerances.
+2. Add runtime fingerprints to run tables and update every local cache gate,
+   replacement path, full-label-fingerprint sidecar column, and
+   migration/legacy rule.
+3. Refactor jobs to resolve cache hits before lazily loading model weights.
+4. Add the local artifact store and publish new inference results to it behind
+   a feature flag.
+5. Add bundle export/import and cache-hit observability.
+6. Enable by default after cross-provider, round-trip, large-catalog upgrade,
+   and macOS/Windows testing.
+7. Design and benchmark shared pack indexes, then add reuse-only shared-folder
+   lookup and opt-in publishing as a separate phase.
+
+Steps 1–3 are invasive core-path changes, so they do not land as one hidden
+prerequisite stack. Each ships and is validated independently on an existing
+Vireo benefit:
+
+- canonical renditions make repeated local inference reproducible;
+- runtime-aware gates prevent silent stale reuse after same-named weights or
+  preprocessing changes; and
+- lazy loading makes today's all-database-cache-hit jobs start faster and work
+  offline without touching already-cached model assets.
+
+Each step has its own rollback/exit point. Portable bundle work proceeds only
+if those changes are stable and the provider experiment shows acceptable
+semantic agreement and store multiplicity.
+
+## Open questions
+
+1. Should import immediately apply matching artifacts, or only make them
+   available for the next explicit Process/Classify run? This draft recommends
+   immediate application with a reviewable summary.
+2. Should exported bundles optionally include accepted/rejected status? This
+   draft recommends no; accepted metadata already has the safer XMP path.
+3. Should a device label be included by default, requested on first export, or
+   omitted unless configured? This draft recommends a first-export prompt with
+   the hostname prefilled and editable.
+4. Should missing hashes be computed inside Export, or should Export direct
+   the user to an Audit/Verify Hashes job first? This draft offers an explicit
+   compute-now choice for non-empty files.
+5. What retention controls should the local store expose: maximum size, age,
+   per-model cleanup, or manual-only cleanup for the first release? The initial
+   recommendation is manual cleanup plus a user-visible maximum-size cap.
+6. Should bundles optionally include the complete canonical regional label
+   list, or only its display name, count, and hash? This draft recommends
+   metadata only by default because the full list can disclose location.
+7. Should confidence participate in semantic equivalence once provider deltas
+   are measured, or should it remain payload/provenance only? The experiment
+   above decides this before the format is frozen.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -27006,7 +27006,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
 
         def work(job):
-            return run_classify_job(job, runner, db_path, active_ws, params, vireo_dir=vireo_dir)
+            return run_classify_job(
+                job, runner, db_path, active_ws, params,
+                vireo_dir=vireo_dir,
+                computation_cache_dir=app.config["COMPUTATION_CACHE_DIR"],
+            )
 
         job_id = runner.start(
             "classify",
@@ -29094,6 +29098,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     job, runner, db_path, workspace_id, params,
                     thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
                     missing_originals_invalidator=_invalidate_missing_originals_cache,
+                    computation_cache_dir=app.config["COMPUTATION_CACHE_DIR"],
                 )
                 return result
             finally:
@@ -29844,6 +29849,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 job, runner, db_path, active_ws, params,
                 thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
                 missing_originals_invalidator=_invalidate_missing_originals_cache,
+                computation_cache_dir=app.config["COMPUTATION_CACHE_DIR"],
             )
 
         # Enqueue rather than start directly: when SLOT_CAP is 1 and

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3052,6 +3052,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         __name__, template_folder=os.path.join(os.path.dirname(__file__), "templates")
     )
     app.config["DB_PATH"] = db_path
+    app.config["COMPUTATION_CACHE_DIR"] = os.path.expanduser(
+        "~/.vireo/computation-cache"
+    )
     app.config["THUMB_CACHE_DIR"] = thumb_cache_dir or os.path.expanduser(
         "~/.vireo/thumbnails"
     )
@@ -16583,6 +16586,97 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             cfg.save(payload)
             _settings_post_save_side_effects(cfg.load())
         return jsonify({"ok": True})
+
+    def _computation_store():
+        from computation_cache import ArtifactStore
+
+        return ArtifactStore(app.config["COMPUTATION_CACHE_DIR"])
+
+    @app.route("/api/computation-cache")
+    def api_computation_cache_status():
+        """Return local portable-object and currently exportable-run counts."""
+        from computation_cache import exportable_run_counts
+
+        export_summary = exportable_run_counts(_get_db())
+        return jsonify({
+            **_computation_store().stats(),
+            "exportable": export_summary,
+            "experimental": True,
+            "artifact_schema": 1,
+        })
+
+    @app.route("/api/computation-cache/export")
+    def api_computation_cache_export():
+        """Download portable detector/classifier results as a cache bundle."""
+        import datetime as _datetime
+
+        from computation_cache import exportable_artifacts, write_bundle
+
+        requested = request.args.get("types", "detection,classification")
+        artifact_types = {part.strip() for part in requested.split(",") if part.strip()}
+        try:
+            database_artifacts, summary = exportable_artifacts(
+                _get_db(), artifact_types=artifact_types,
+            )
+            stored_artifacts = [
+                artifact for _digest, artifact
+                in (_computation_store().iter_artifacts() or ())
+                if artifact["type"] in artifact_types
+            ]
+            fd, temp_path = tempfile.mkstemp(suffix=".vireo-cache")
+            os.close(fd)
+            try:
+                manifest = write_bundle(
+                    temp_path,
+                    [*database_artifacts, *stored_artifacts],
+                    device_label=request.args.get("device_label") or None,
+                )
+                with open(temp_path, "rb") as handle:
+                    body = handle.read()
+            finally:
+                with contextlib.suppress(OSError):
+                    os.unlink(temp_path)
+        except ValueError as exc:
+            return json_error(str(exc), status=400)
+
+        today = _datetime.date.today().isoformat()
+        response = make_response(body)
+        response.headers["Content-Type"] = "application/vnd.vireo.cache+zip"
+        response.headers["Content-Disposition"] = (
+            f'attachment; filename="vireo-results-{today}.vireo-cache"'
+        )
+        response.headers["X-Vireo-Cache-Objects"] = str(manifest["object_count"])
+        response.headers["X-Vireo-Cache-Skipped-Legacy"] = str(
+            summary["skipped_legacy"]
+        )
+        return response
+
+    @app.route("/api/computation-cache/import", methods=["POST"])
+    def api_computation_cache_import():
+        """Validate, store, and immediately apply an uploaded cache bundle."""
+        import zipfile
+
+        from computation_cache import (
+            CacheFormatError,
+            import_bundle,
+            materialize_artifacts,
+        )
+
+        upload = request.files.get("file")
+        if upload is None or not upload.filename:
+            return json_error("a .vireo-cache file is required", status=400)
+        try:
+            imported = import_bundle(upload.stream, _computation_store())
+            applied = materialize_artifacts(_get_db(), imported["artifacts"])
+        except (CacheFormatError, zipfile.BadZipFile) as exc:
+            return json_error(str(exc), status=400)
+        return jsonify({
+            "ok": True,
+            "objects": imported["manifest"]["object_count"],
+            "added": imported["added"],
+            "already_present": imported["already_present"],
+            **applied,
+        })
 
     @app.route("/api/darktable/status")
     def api_darktable_status():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16614,6 +16614,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         requested = request.args.get("types", "detection,classification")
         artifact_types = {part.strip() for part in requested.split(",") if part.strip()}
+        # exportable_artifacts dependency-closes the copy set — a classifier
+        # export always drags its detector dependencies along.  Mirror that
+        # expansion here so detector artifacts forwarded from the local
+        # object store (e.g. imports whose photos were not yet cataloged
+        # when they landed) travel with the classifications that reference
+        # them; otherwise the destination has to reproduce detection from
+        # model weights it may not have.
+        if "classification" in artifact_types:
+            artifact_types = artifact_types | {"detection"}
         try:
             database_artifacts, summary = exportable_artifacts(
                 _get_db(), artifact_types=artifact_types,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16668,7 +16668,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from computation_cache import (
             CacheFormatError,
             import_bundle,
-            materialize_artifacts,
+            materialize_local_store,
         )
 
         upload = request.files.get("file")
@@ -16676,6 +16676,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("a .vireo-cache file is required", status=400)
         try:
             store = _computation_store()
+            # Stream the upload through the store so a large bundle never
+            # accumulates every parsed artifact in Python at once — the
+            # returned "artifacts" field is intentionally empty and
+            # materialization reads back from the store's on-disk objects.
             imported = import_bundle(upload.stream, store)
             # An explicit user-initiated import is a trust action for the
             # runtimes this bundle carries: quarantine gates for unknown
@@ -16684,16 +16688,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # here the user chose the source. Whitelist the artifact-
             # supplied fingerprints so the objects they just uploaded
             # actually plant instead of getting stranded in the store.
-            detector_rts = {
-                artifact["runtime_fingerprint"]
-                for artifact in imported["artifacts"]
-                if artifact.get("type") == "detection"
-            }
-            classifier_rts = {
-                artifact["runtime_fingerprint"]
-                for artifact in imported["artifacts"]
-                if artifact.get("type") == "classification"
-            }
+            detector_rts = imported["detector_runtimes"]
+            classifier_rts = imported["classifier_runtimes"]
             # Persist the trust so later materialize_local_store calls
             # from run_classify_job / the pipeline accept these runtimes
             # too. Without persistence, a bundle imported before its
@@ -16704,8 +16700,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 detector_runtimes=detector_rts,
                 classifier_runtimes=classifier_rts,
             )
-            applied = materialize_artifacts(
-                _get_db(), imported["artifacts"],
+            applied = materialize_local_store(
+                _get_db(), store=store,
                 known_runtimes=detector_rts,
                 known_classifier_runtimes=classifier_rts,
             )

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16666,7 +16666,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if upload is None or not upload.filename:
             return json_error("a .vireo-cache file is required", status=400)
         try:
-            imported = import_bundle(upload.stream, _computation_store())
+            store = _computation_store()
+            imported = import_bundle(upload.stream, store)
             # An explicit user-initiated import is a trust action for the
             # runtimes this bundle carries: quarantine gates for unknown
             # detector/classifier runtimes exist to keep drive-by
@@ -16684,6 +16685,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 for artifact in imported["artifacts"]
                 if artifact.get("type") == "classification"
             }
+            # Persist the trust so later materialize_local_store calls
+            # from run_classify_job / the pipeline accept these runtimes
+            # too. Without persistence, a bundle imported before its
+            # matching photos are cataloged would leave those artifacts
+            # quarantined forever — the one-shot whitelist below only
+            # covers this HTTP call.
+            store.record_trusted_runtimes(
+                detector_runtimes=detector_rts,
+                classifier_runtimes=classifier_rts,
+            )
             applied = materialize_artifacts(
                 _get_db(), imported["artifacts"],
                 known_runtimes=detector_rts,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16667,7 +16667,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("a .vireo-cache file is required", status=400)
         try:
             imported = import_bundle(upload.stream, _computation_store())
-            applied = materialize_artifacts(_get_db(), imported["artifacts"])
+            # An explicit user-initiated import is a trust action for the
+            # runtimes this bundle carries: quarantine gates for unknown
+            # detector/classifier runtimes exist to keep drive-by
+            # materialize calls from surfacing foreign inference, but
+            # here the user chose the source. Whitelist the artifact-
+            # supplied fingerprints so the objects they just uploaded
+            # actually plant instead of getting stranded in the store.
+            detector_rts = {
+                artifact["runtime_fingerprint"]
+                for artifact in imported["artifacts"]
+                if artifact.get("type") == "detection"
+            }
+            classifier_rts = {
+                artifact["runtime_fingerprint"]
+                for artifact in imported["artifacts"]
+                if artifact.get("type") == "classification"
+            }
+            applied = materialize_artifacts(
+                _get_db(), imported["artifacts"],
+                known_runtimes=detector_rts,
+                known_classifier_runtimes=classifier_rts,
+            )
         except (CacheFormatError, zipfile.BadZipFile) as exc:
             return json_error(str(exc), status=400)
         return jsonify({

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -332,6 +332,33 @@ def _classify_detection_gated(db, detection_id, classifier_model,
     return predictions
 
 
+def _all_photos_cache_satisfied(db, photo_ids):
+    """True when every photo already has a completed classifier run.
+
+    Used to short-circuit model resolution when a bundle import (or an
+    earlier run) has already produced results for the whole collection.
+    A fresh install with no downloaded classifier weights can then reuse
+    imported predictions instead of failing with "No model available".
+
+    "Satisfied" here means: for every photo in the collection, at least
+    one detection has a matching classifier_runs row.  A photo with no
+    detections at all is treated as unsatisfied so we still fall through
+    to detection + classification.
+    """
+    if not photo_ids:
+        return False
+    placeholders = ",".join("?" for _ in photo_ids)
+    row = db.conn.execute(
+        f"""SELECT COUNT(DISTINCT d.photo_id) AS covered
+             FROM detections d
+             JOIN classifier_runs cr ON cr.detection_id = d.id
+            WHERE d.photo_id IN ({placeholders})""",
+        list(photo_ids),
+    ).fetchone()
+    covered = (row["covered"] if row else 0) or 0
+    return covered == len(photo_ids)
+
+
 def _resolve_label_sources(params, db):
     """Return list of source file paths used to build the active label set.
 
@@ -2204,6 +2231,35 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 "failed": 0,
             }
 
+        # Model resolution is otherwise unavoidable — get_active_model()
+        # raises "No model available" on a fresh install with no downloads.
+        # But when materialization has already covered every photo, the
+        # classifier is not going to add any work: skip resolution and
+        # finish so an all-cache-hit run on a fresh machine still succeeds.
+        if not params.reclassify and _all_photos_cache_satisfied(
+            thread_db, [p["id"] for p in photos],
+        ):
+            log.info(
+                "Classify job: every photo has cached classifier runs — "
+                "skipping model resolution and detection",
+            )
+            _finalize_remaining_steps(
+                runner, job["id"],
+                ["load_taxonomy", "load_model", "detect", "classify",
+                 "finalize"],
+                status="completed",
+                summary="Reused cached classification results",
+            )
+            return {
+                "total": total,
+                "predictions_stored": 0,
+                "burst_groups": 0,
+                "already_classified": total,
+                "already_labeled": 0,
+                "detected": 0,
+                "failed": 0,
+            }
+
         # Resolve model (deferred until we know there is work to do)
         if params.model_id:
             all_models = get_models()
@@ -2501,6 +2557,37 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 job["id"], "detect", status="completed",
                 summary=f"{detected} animals detected in {total} photos",
             )
+
+        # Reapply the local computation cache now that detection has run.
+        # Classification artifacts whose detector dependency was absent at
+        # the pre-detection materialize call get a second chance to land
+        # here, so a bundle containing only classifications still populates
+        # predictions instead of being silently dropped.
+        if not params.reclassify:
+            try:
+                from computation_cache import (
+                    materialize_local_store,
+                    megadetector_runtime_fingerprint,
+                )
+
+                try:
+                    local_runtime = megadetector_runtime_fingerprint()
+                except (OSError, ValueError):
+                    local_runtime = None
+                reapplied = materialize_local_store(
+                    thread_db,
+                    known_runtimes={local_runtime} if local_runtime else None,
+                )
+                if reapplied.get("classifier_runs_applied"):
+                    log.info(
+                        "Portable cache added %d classifier runs after detect",
+                        reapplied["classifier_runs_applied"],
+                    )
+            except Exception:
+                log.warning(
+                    "Could not reapply local computation cache after detect",
+                    exc_info=True,
+                )
 
         # Phase 6: Classify each photo. The per-detection classifier_runs
         # gate inside _classify_photos skips already-done detections and

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -351,10 +351,18 @@ def _all_photos_cache_satisfied(
     unsatisfied so the caller falls through to real classification with
     the user's requested identity.  A photo with no detections at all is
     also unsatisfied so we still fall through to detection.
+
+    When neither filter is supplied (fresh-install fallback path), we
+    additionally require every covered detection to share the SAME
+    ``(classifier_model, labels_fingerprint)`` pair.  Otherwise the
+    downstream cached-only finalize adopts the first row's identity and
+    reconciles every other row against it — silently swapping the
+    classifier identity on detections covered by a different pair.
     """
     if not photo_ids:
         return False
-    placeholders = ",".join("?" for _ in photo_ids)
+    from db import _chunks  # module-level helper, avoids exceeding SQLITE_MAX_VARIABLE_NUMBER
+
     filter_sql = ""
     filter_args = []
     if classifier_model is not None:
@@ -364,35 +372,62 @@ def _all_photos_cache_satisfied(
         filter_sql += " AND cr.labels_fingerprint = ?"
         filter_args.append(labels_fingerprint)
 
-    # Every detection must have a matching run.  A single covered
-    # detection on a photo with multiple detections used to fool the old
-    # per-photo check — that let a second detection surface unclassified.
-    # ``classifier_runs`` has no surrogate id column; use
-    # ``cr.detection_id`` (NOT NULL PK member) as the presence sentinel.
-    row = db.conn.execute(
-        f"""SELECT COUNT(*) AS total,
-                   SUM(CASE WHEN cr.detection_id IS NOT NULL THEN 1 ELSE 0 END)
-                     AS covered
-             FROM detections d
-             LEFT JOIN classifier_runs cr
-               ON cr.detection_id = d.id{filter_sql}
-            WHERE d.photo_id IN ({placeholders})""",
-        filter_args + list(photo_ids),
-    ).fetchone()
-    total = (row["total"] if row else 0) or 0
-    covered = (row["covered"] if row else 0) or 0
+    total = 0
+    covered = 0
+    covered_photos = 0
+    distinct_identities = set()
+    identity_gate = classifier_model is None and labels_fingerprint is None
+
+    # Chunk ``photo_ids`` so a large collection (per_page=999999) does
+    # not blow past SQLite's default SQLITE_MAX_VARIABLE_NUMBER (999)
+    # and fail the whole classify job.
+    for chunk in _chunks(photo_ids):
+        placeholders = ",".join("?" for _ in chunk)
+        row = db.conn.execute(
+            f"""SELECT COUNT(*) AS total,
+                       SUM(CASE WHEN cr.detection_id IS NOT NULL THEN 1 ELSE 0 END)
+                         AS covered
+                 FROM detections d
+                 LEFT JOIN classifier_runs cr
+                   ON cr.detection_id = d.id{filter_sql}
+                WHERE d.photo_id IN ({placeholders})""",
+            filter_args + list(chunk),
+        ).fetchone()
+        total += (row["total"] if row else 0) or 0
+        covered += (row["covered"] if row else 0) or 0
+
+        photo_row = db.conn.execute(
+            f"""SELECT COUNT(DISTINCT photo_id) AS covered_photos
+                 FROM detections
+                WHERE photo_id IN ({placeholders})""",
+            list(chunk),
+        ).fetchone()
+        covered_photos += (
+            (photo_row["covered_photos"] if photo_row else 0) or 0
+        )
+
+        if identity_gate:
+            # Track how many distinct (model, fp) pairs cover this
+            # chunk's classifier_runs so the caller can't finalize
+            # under a single identity when several are actually
+            # present.  We short-circuit as soon as two are seen.
+            for identity_row in db.conn.execute(
+                f"""SELECT DISTINCT cr.classifier_model AS m,
+                                    cr.labels_fingerprint AS fp
+                     FROM detections d
+                     JOIN classifier_runs cr
+                       ON cr.detection_id = d.id
+                    WHERE d.photo_id IN ({placeholders})""",
+                list(chunk),
+            ):
+                distinct_identities.add(
+                    (identity_row["m"], identity_row["fp"])
+                )
+                if len(distinct_identities) > 1:
+                    return False
+
     if total == 0 or covered != total:
         return False
-
-    # Every photo must have at least one detection — an empty-scene photo
-    # with no full-image anchor yet is unsatisfied so we still create it.
-    photo_row = db.conn.execute(
-        f"""SELECT COUNT(DISTINCT photo_id) AS covered_photos
-             FROM detections
-            WHERE photo_id IN ({placeholders})""",
-        list(photo_ids),
-    ).fetchone()
-    covered_photos = (photo_row["covered_photos"] if photo_row else 0) or 0
     return covered_photos == len(photo_ids)
 
 
@@ -578,27 +613,50 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
 
             # Publication follows the database commit.  A store failure must
             # never turn successful inference into a failed detector run.
+            #
+            # ``write_detection_batch`` returns early (leaving the stored
+            # detector_runs.runtime_fingerprint at its OLD value) when a
+            # runtime change is proposed against a review-pinned run and
+            # ``force_runtime_replace`` is False.  Publishing with the new
+            # ``detector_runtime`` in that case would attach a foreign
+            # runtime identity to boxes that were actually produced by an
+            # older runtime — the artifact is content-addressed and
+            # exportable, so downstream catalogs would trust that lie.
+            # Read back the persisted runtime and only publish when it
+            # equals the runtime we intended to write.
             if portable_input is not None:
                 try:
                     from computation_cache import publish_detection_artifact
 
-                    normalized_detections = [{
-                        "box": {
-                            "x": row["box_x"], "y": row["box_y"],
-                            "w": row["box_w"], "h": row["box_h"],
-                        },
-                        "confidence": row["detector_confidence"],
-                        "category": row["category"],
-                    } for row in db.get_detections(
-                        photo["id"], min_conf=0,
-                        detector_model="megadetector-v6",
-                    )]
-                    publish_detection_artifact(
-                        portable_photo_hash,
-                        "megadetector-v6",
-                        detector_runtime,
-                        normalized_detections,
+                    persisted_runtime_row = db.conn.execute(
+                        """SELECT runtime_fingerprint
+                           FROM detector_runs
+                           WHERE photo_id = ?
+                             AND detector_model = 'megadetector-v6'""",
+                        (photo["id"],),
+                    ).fetchone()
+                    persisted_runtime = (
+                        persisted_runtime_row["runtime_fingerprint"]
+                        if persisted_runtime_row else None
                     )
+                    if persisted_runtime == detector_runtime:
+                        normalized_detections = [{
+                            "box": {
+                                "x": row["box_x"], "y": row["box_y"],
+                                "w": row["box_w"], "h": row["box_h"],
+                            },
+                            "confidence": row["detector_confidence"],
+                            "category": row["category"],
+                        } for row in db.get_detections(
+                            photo["id"], min_conf=0,
+                            detector_model="megadetector-v6",
+                        )]
+                        publish_detection_artifact(
+                            portable_photo_hash,
+                            "megadetector-v6",
+                            detector_runtime,
+                            normalized_detections,
+                        )
                 except Exception:
                     log.warning(
                         "Could not publish portable detector result for photo %s",
@@ -1429,17 +1487,18 @@ def _classify_photos(
                         )
                     except ValueError:
                         full_input = None
-                full_det_ids = db.save_detections(
-                    photo["id"], full_image_det,
-                    detector_model="full-image",
-                    runtime_fingerprint=full_runtime,
-                )
-                full_det_id = full_det_ids[0]
-                db.record_detector_run(
-                    photo["id"], "full-image", box_count=1,
+                # Wrap both writes in the single ``write_detection_batch``
+                # transaction so a crash between save_detections and
+                # record_detector_run can't leave a full-image detection
+                # row without its matching detector_runs row — that torn
+                # state would fool the runtime-aware reuse gates into
+                # treating the photo as never detected.
+                full_det_ids = db.write_detection_batch(
+                    photo["id"], "full-image", full_image_det,
                     runtime_fingerprint=full_runtime,
                     input_fingerprint=full_input,
                 )
+                full_det_id = full_det_ids[0]
             # Gate check for the synthetic full-image detection too.
             # Mirror the regular detection branch: when gated, surface the
             # cached top-1 prediction into raw_results so downstream
@@ -2863,6 +2922,10 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                     photo["id"] for photo in photos
                     if not detection_map.get(photo["id"])
                 ]
+                # Import CacheFormatError locally so a NULL / non-canonical
+                # file_hash escapes into full_input=None instead of the
+                # outer except Exception (which would abandon reapply).
+                from computation_cache import CacheFormatError
                 for photo_id in empty_scene_ids:
                     identity = thread_db.conn.execute(
                         """SELECT file_hash, companion_path
@@ -2876,7 +2939,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                                 identity["file_hash"],
                                 "vireo-detector-source-v1",
                             )
-                        except ValueError:
+                        except (ValueError, CacheFormatError):
                             full_input = None
                     existing_full = thread_db.get_detections(
                         photo_id, detector_model="full-image", min_conf=0,
@@ -2892,6 +2955,24 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                             detector_model="full-image",
                             runtime_fingerprint=full_runtime,
                         )
+                    else:
+                        # Promote a legacy full-image detection row so its
+                        # ``runtime_fingerprint`` matches the run we're
+                        # about to record.  ``exportable_artifacts`` reads
+                        # the detector runtime from ``detections`` — if we
+                        # leave the row at ``'legacy'`` an export skips
+                        # the attached classifier run and emits an empty
+                        # full-image detection artifact for this photo.
+                        thread_db.conn.execute(
+                            """UPDATE detections
+                                  SET runtime_fingerprint = ?
+                                WHERE photo_id = ?
+                                  AND detector_model = 'full-image'
+                                  AND (runtime_fingerprint IS NULL
+                                       OR runtime_fingerprint != ?)""",
+                            (full_runtime, photo_id, full_runtime),
+                        )
+                        thread_db.conn.commit()
                     existing_run = thread_db.conn.execute(
                         """SELECT runtime_fingerprint FROM detector_runs
                            WHERE photo_id = ?

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -2290,7 +2290,13 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                     (m for m in get_models() if m["id"] == params.model_id),
                     None,
                 )
-                if peek_model and peek_model.get("downloaded"):
+                if peek_model:
+                    # Preserve the explicitly requested model identity
+                    # even when the weights aren't downloaded yet.
+                    # Otherwise ``_all_photos_cache_satisfied`` would
+                    # treat any classifier's cached runs as valid for
+                    # this explicit request and silently return
+                    # wrong-model results on a fresh install.
                     desired_classifier_model = (
                         params.model_name or peek_model.get("name")
                     )
@@ -2690,17 +2696,22 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                     known_runtimes.add(local_runtime)
 
                 # Pre-create full-image anchors for empty-scene photos.
+                # For photos that already carry a legacy full-image
+                # detection (upgraded catalogs where the detection
+                # predates the portable-runtime columns), also promote
+                # the ``detector_runs`` row to the current portable
+                # runtime.  Without the promotion, materialize's
+                # classifier gate would defer any imported full-image
+                # classification because the stored runtime fingerprint
+                # doesn't match ``full_runtime`` — and the classify
+                # loop would fall back to real inference (or fail with
+                # "No model available" on a fresh machine).
                 full_runtime = full_image_runtime_fingerprint()
                 empty_scene_ids = [
                     photo["id"] for photo in photos
                     if not detection_map.get(photo["id"])
                 ]
                 for photo_id in empty_scene_ids:
-                    existing_full = thread_db.get_detections(
-                        photo_id, detector_model="full-image", min_conf=0,
-                    )
-                    if existing_full:
-                        continue
                     identity = thread_db.conn.execute(
                         """SELECT file_hash, companion_path
                            FROM photos WHERE id = ?""",
@@ -2715,21 +2726,35 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                             )
                         except ValueError:
                             full_input = None
-                    thread_db.save_detections(
-                        photo_id,
-                        [{
-                            "box": {"x": 0, "y": 0, "w": 1, "h": 1},
-                            "confidence": 0,
-                            "category": "animal",
-                        }],
-                        detector_model="full-image",
-                        runtime_fingerprint=full_runtime,
+                    existing_full = thread_db.get_detections(
+                        photo_id, detector_model="full-image", min_conf=0,
                     )
-                    thread_db.record_detector_run(
-                        photo_id, "full-image", box_count=1,
-                        runtime_fingerprint=full_runtime,
-                        input_fingerprint=full_input,
-                    )
+                    if not existing_full:
+                        thread_db.save_detections(
+                            photo_id,
+                            [{
+                                "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                                "confidence": 0,
+                                "category": "animal",
+                            }],
+                            detector_model="full-image",
+                            runtime_fingerprint=full_runtime,
+                        )
+                    existing_run = thread_db.conn.execute(
+                        """SELECT runtime_fingerprint FROM detector_runs
+                           WHERE photo_id = ?
+                             AND detector_model = 'full-image'""",
+                        (photo_id,),
+                    ).fetchone()
+                    if (
+                        existing_run is None
+                        or existing_run["runtime_fingerprint"] != full_runtime
+                    ):
+                        thread_db.record_detector_run(
+                            photo_id, "full-image", box_count=1,
+                            runtime_fingerprint=full_runtime,
+                            input_fingerprint=full_input,
+                        )
 
                 # Compute the classifier runtimes this job would produce
                 # so cached classifications from other machines that

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -332,31 +332,68 @@ def _classify_detection_gated(db, detection_id, classifier_model,
     return predictions
 
 
-def _all_photos_cache_satisfied(db, photo_ids):
-    """True when every photo already has a completed classifier run.
+def _all_photos_cache_satisfied(
+    db, photo_ids, classifier_model=None, labels_fingerprint=None,
+):
+    """True when every detection on every photo already has a matching run.
 
     Used to short-circuit model resolution when a bundle import (or an
     earlier run) has already produced results for the whole collection.
     A fresh install with no downloaded classifier weights can then reuse
     imported predictions instead of failing with "No model available".
 
-    "Satisfied" here means: for every photo in the collection, at least
-    one detection has a matching classifier_runs row.  A photo with no
-    detections at all is treated as unsatisfied so we still fall through
-    to detection + classification.
+    "Satisfied" here means: every photo in the collection has at least
+    one detection, and every one of its detections has a matching
+    ``classifier_runs`` row.  When ``classifier_model`` and/or
+    ``labels_fingerprint`` are given, matching also requires the run to
+    carry that exact model name / label set — a photo whose detections
+    only carry runs for a different model or label set is treated as
+    unsatisfied so the caller falls through to real classification with
+    the user's requested identity.  A photo with no detections at all is
+    also unsatisfied so we still fall through to detection.
     """
     if not photo_ids:
         return False
     placeholders = ",".join("?" for _ in photo_ids)
+    filter_sql = ""
+    filter_args = []
+    if classifier_model is not None:
+        filter_sql += " AND cr.classifier_model = ?"
+        filter_args.append(classifier_model)
+    if labels_fingerprint is not None:
+        filter_sql += " AND cr.labels_fingerprint = ?"
+        filter_args.append(labels_fingerprint)
+
+    # Every detection must have a matching run.  A single covered
+    # detection on a photo with multiple detections used to fool the old
+    # per-photo check — that let a second detection surface unclassified.
+    # ``classifier_runs`` has no surrogate id column; use
+    # ``cr.detection_id`` (NOT NULL PK member) as the presence sentinel.
     row = db.conn.execute(
-        f"""SELECT COUNT(DISTINCT d.photo_id) AS covered
+        f"""SELECT COUNT(*) AS total,
+                   SUM(CASE WHEN cr.detection_id IS NOT NULL THEN 1 ELSE 0 END)
+                     AS covered
              FROM detections d
-             JOIN classifier_runs cr ON cr.detection_id = d.id
+             LEFT JOIN classifier_runs cr
+               ON cr.detection_id = d.id{filter_sql}
             WHERE d.photo_id IN ({placeholders})""",
+        filter_args + list(photo_ids),
+    ).fetchone()
+    total = (row["total"] if row else 0) or 0
+    covered = (row["covered"] if row else 0) or 0
+    if total == 0 or covered != total:
+        return False
+
+    # Every photo must have at least one detection — an empty-scene photo
+    # with no full-image anchor yet is unsatisfied so we still create it.
+    photo_row = db.conn.execute(
+        f"""SELECT COUNT(DISTINCT photo_id) AS covered_photos
+             FROM detections
+            WHERE photo_id IN ({placeholders})""",
         list(photo_ids),
     ).fetchone()
-    covered = (row["covered"] if row else 0) or 0
-    return covered == len(photo_ids)
+    covered_photos = (photo_row["covered_photos"] if photo_row else 0) or 0
+    return covered_photos == len(photo_ids)
 
 
 def _resolve_label_sources(params, db):
@@ -2236,8 +2273,71 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # But when materialization has already covered every photo, the
         # classifier is not going to add any work: skip resolution and
         # finish so an all-cache-hit run on a fresh machine still succeeds.
+        #
+        # Opportunistically resolve the requested classifier name and its
+        # labels_fingerprint before checking so a cache built with a
+        # DIFFERENT model or label set does not silently pass as
+        # "satisfied".  When we can't resolve either (no downloaded model
+        # AND no labels file), we still fall through to the permissive
+        # any-run check — the whole point of the short-circuit is the
+        # fresh-install case where nothing else is available.
+        desired_classifier_model = None
+        desired_labels_fingerprint = None
+        peek_model = None
+        try:
+            if params.model_id:
+                peek_model = next(
+                    (m for m in get_models() if m["id"] == params.model_id),
+                    None,
+                )
+                if peek_model and peek_model.get("downloaded"):
+                    desired_classifier_model = (
+                        params.model_name or peek_model.get("name")
+                    )
+            elif params.model_name:
+                desired_classifier_model = params.model_name
+                peek_model = next(
+                    (
+                        m for m in get_models()
+                        if m.get("name") == params.model_name
+                    ),
+                    None,
+                )
+            else:
+                peek_model = get_active_model()
+                if peek_model:
+                    desired_classifier_model = (
+                        params.model_name or peek_model.get("name")
+                    )
+        except Exception:
+            desired_classifier_model = None
+            peek_model = None
+        # Compute labels_fingerprint from the user-selected label sources
+        # so a cache built from a DIFFERENT label set does not silently
+        # pass as satisfied.  Uses the same _load_labels path that later
+        # produces the authoritative fingerprint, but tolerates failure
+        # (missing weights on a fresh install, TOL path unavailable) —
+        # in that case desired_labels_fingerprint stays None and the
+        # check falls back to model-only filtering.
+        try:
+            from labels_fingerprint import compute_fingerprint
+
+            peek_labels, peek_use_tol = _load_labels(
+                model_type=(peek_model or {}).get("model_type", "bioclip"),
+                model_str=(peek_model or {}).get("model_str", ""),
+                labels_file=params.labels_file,
+                labels_files=params.labels_files,
+                db=thread_db,
+                model_dir=(peek_model or {}).get("weights_path"),
+            )
+            desired_labels_fingerprint = compute_fingerprint(peek_labels)
+        except Exception:
+            desired_labels_fingerprint = None
+
         if not params.reclassify and _all_photos_cache_satisfied(
             thread_db, [p["id"] for p in photos],
+            classifier_model=desired_classifier_model,
+            labels_fingerprint=desired_labels_fingerprint,
         ):
             log.info(
                 "Classify job: every photo has cached classifier runs — "
@@ -2563,20 +2663,104 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # the pre-detection materialize call get a second chance to land
         # here, so a bundle containing only classifications still populates
         # predictions instead of being silently dropped.
+        #
+        # We ALSO pre-create synthetic full-image detector rows for every
+        # empty-scene photo before this reapply.  The classify loop below
+        # creates those rows lazily per-photo, so without pre-creating
+        # them here a cached full_image classification artifact has no
+        # anchor to attach to at reapply time — the classify loop then
+        # runs the classifier itself (or, on a fresh machine, fails with
+        # "No model available") even though the answer is already sitting
+        # in the local store.
         if not params.reclassify:
             try:
                 from computation_cache import (
+                    full_image_runtime_fingerprint,
                     materialize_local_store,
                     megadetector_runtime_fingerprint,
+                    source_input,
                 )
 
                 try:
                     local_runtime = megadetector_runtime_fingerprint()
                 except (OSError, ValueError):
                     local_runtime = None
+                known_runtimes = {full_image_runtime_fingerprint()}
+                if local_runtime:
+                    known_runtimes.add(local_runtime)
+
+                # Pre-create full-image anchors for empty-scene photos.
+                full_runtime = full_image_runtime_fingerprint()
+                empty_scene_ids = [
+                    photo["id"] for photo in photos
+                    if not detection_map.get(photo["id"])
+                ]
+                for photo_id in empty_scene_ids:
+                    existing_full = thread_db.get_detections(
+                        photo_id, detector_model="full-image", min_conf=0,
+                    )
+                    if existing_full:
+                        continue
+                    identity = thread_db.conn.execute(
+                        """SELECT file_hash, companion_path
+                           FROM photos WHERE id = ?""",
+                        (photo_id,),
+                    ).fetchone()
+                    full_input = None
+                    if identity is not None and not identity["companion_path"]:
+                        try:
+                            _block, full_input = source_input(
+                                identity["file_hash"],
+                                "vireo-detector-source-v1",
+                            )
+                        except ValueError:
+                            full_input = None
+                    thread_db.save_detections(
+                        photo_id,
+                        [{
+                            "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                            "confidence": 0,
+                            "category": "animal",
+                        }],
+                        detector_model="full-image",
+                        runtime_fingerprint=full_runtime,
+                    )
+                    thread_db.record_detector_run(
+                        photo_id, "full-image", box_count=1,
+                        runtime_fingerprint=full_runtime,
+                        input_fingerprint=full_input,
+                    )
+
+                # Compute the classifier runtimes this job would produce
+                # so cached classifications from other machines that
+                # match are accepted at reapply time. Without this the
+                # classifier-runtime quarantine would drop them even
+                # though this install just proved it can reproduce the
+                # exact same runtime.
+                known_classifier_runtimes = set()
+                if fp_full and classifier_identity:
+                    try:
+                        from computation_cache import (
+                            classifier_runtime_fingerprint,
+                        )
+
+                        for det_runtime in (local_runtime, full_runtime):
+                            if not det_runtime:
+                                continue
+                            crt = classifier_runtime_fingerprint(
+                                classifier_identity, fp_full, det_runtime,
+                            )
+                            if crt:
+                                known_classifier_runtimes.add(crt)
+                    except Exception:
+                        known_classifier_runtimes = set()
+
                 reapplied = materialize_local_store(
                     thread_db,
-                    known_runtimes={local_runtime} if local_runtime else None,
+                    known_runtimes=known_runtimes,
+                    known_classifier_runtimes=(
+                        known_classifier_runtimes or None
+                    ),
                 )
                 if reapplied.get("classifier_runs_applied"):
                     log.info(

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -213,7 +213,9 @@ def _load_labels(
     return labels, use_tol
 
 
-def _record_labels_fingerprint(db, fingerprint, labels, sources):
+def _record_labels_fingerprint(
+    db, fingerprint, labels, sources, full_fingerprint=None,
+):
     """Populate the labels_fingerprints sidecar. Cosmetic — powers UX lookups."""
     display = ", ".join(os.path.basename(s) for s in (sources or [])) or None
     db.upsert_labels_fingerprint(
@@ -221,6 +223,7 @@ def _record_labels_fingerprint(db, fingerprint, labels, sources):
         display_name=display,
         sources=sources,
         label_count=len(labels or []),
+        full_fingerprint=full_fingerprint,
     )
 
 
@@ -480,9 +483,63 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
             # matching detector_runs row, or the reverse for empty scenes).
             # Failures from `detect_animals` were handled by the ``is None``
             # early-continue above and must not poison the skip set.
+            detector_runtime = job.get("_detector_runtime_fingerprint") or "legacy"
+            portable_input = None
+            portable_photo_hash = None
+            if detector_runtime != "legacy":
+                identity_row = db.conn.execute(
+                    "SELECT file_hash, companion_path FROM photos WHERE id = ?",
+                    (photo["id"],),
+                ).fetchone()
+                if (
+                    identity_row is not None
+                    and not identity_row["companion_path"]
+                ):
+                    try:
+                        from computation_cache import source_input
+
+                        portable_photo_hash = identity_row["file_hash"]
+                        _input_block, portable_input = source_input(
+                            portable_photo_hash, "vireo-detector-source-v1",
+                        )
+                    except (TypeError, ValueError):
+                        portable_input = None
+                        portable_photo_hash = None
             det_ids = db.write_detection_batch(
                 photo["id"], "megadetector-v6", detections,
+                runtime_fingerprint=detector_runtime,
+                input_fingerprint=portable_input,
+                force_runtime_replace=reclassify,
             )
+
+            # Publication follows the database commit.  A store failure must
+            # never turn successful inference into a failed detector run.
+            if portable_input is not None:
+                try:
+                    from computation_cache import publish_detection_artifact
+
+                    normalized_detections = [{
+                        "box": {
+                            "x": row["box_x"], "y": row["box_y"],
+                            "w": row["box_w"], "h": row["box_h"],
+                        },
+                        "confidence": row["detector_confidence"],
+                        "category": row["category"],
+                    } for row in db.get_detections(
+                        photo["id"], min_conf=0,
+                        detector_model="megadetector-v6",
+                    )]
+                    publish_detection_artifact(
+                        portable_photo_hash,
+                        "megadetector-v6",
+                        detector_runtime,
+                        normalized_detections,
+                    )
+                except Exception:
+                    log.warning(
+                        "Could not publish portable detector result for photo %s",
+                        photo["id"], exc_info=True,
+                    )
 
             if detections:
                 detected += 1
@@ -621,9 +678,24 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
     # Resolve cached-detection state before running MegaDetector so we can skip
     # the weight download entirely when every photo already has a detector_runs
     # row (including empty-scene rows with box_count=0).
+    detector_runtime = None
+    if not reclassify:
+        try:
+            from computation_cache import megadetector_runtime_fingerprint
+
+            detector_runtime = megadetector_runtime_fingerprint()
+        except (OSError, ValueError):
+            detector_runtime = None
     already_detected_ids = (
-        db.get_detector_run_photo_ids("megadetector-v6") if not reclassify else set()
+        db.get_detector_run_photo_ids(
+            "megadetector-v6", runtime_fingerprint=detector_runtime,
+        )
+        if not reclassify and detector_runtime is not None
+        else db.get_detector_run_photo_ids("megadetector-v6")
+        if not reclassify
+        else set()
     )
+    job["_detector_runtime_fingerprint"] = detector_runtime
 
     # Track photos whose state we mutated (clear_detections + write_detection_batch
     # in reclassify mode). Declared up here so the except handlers and early
@@ -677,7 +749,15 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
                 job["_detect_processed_ids"] = processed_for_rebuild
                 return {}, 0
 
-            ensure_megadetector_weights(progress_callback=_dl_progress)
+            weights_path = ensure_megadetector_weights(progress_callback=_dl_progress)
+            from computation_cache import megadetector_runtime_fingerprint
+
+            detector_runtime = megadetector_runtime_fingerprint(weights_path)
+            job["_detector_runtime_fingerprint"] = detector_runtime
+            if not reclassify:
+                already_detected_ids = db.get_detector_run_photo_ids(
+                    "megadetector-v6", runtime_fingerprint=detector_runtime,
+                )
 
         runner.push_event(
             job["id"],
@@ -1048,6 +1128,28 @@ def _classify_photos(
     total = len(photos)
     batch = []
     cancelled = False
+    portable_labels_full = job.get("_labels_fingerprint_full")
+    portable_model_identity = job.get("_classifier_model_identity")
+
+    def _runtime_aware_run_keys(detection_id):
+        expected_runtime = None
+        if portable_labels_full and portable_model_identity:
+            try:
+                from computation_cache import classifier_runtime_for_detection
+
+                expected_runtime = classifier_runtime_for_detection(
+                    db,
+                    detection_id,
+                    portable_model_identity,
+                    portable_labels_full,
+                )
+            except (OSError, ValueError):
+                expected_runtime = None
+        if expected_runtime is None:
+            return db.get_classifier_run_keys(detection_id)
+        return db.get_classifier_run_keys(
+            detection_id, runtime_fingerprint=expected_runtime,
+        )
 
     start_time = time.time()
 
@@ -1152,7 +1254,7 @@ def _classify_photos(
                 # otherwise the photo is stranded until the user forces
                 # --reclassify. Fall through to re-classify instead.
                 if not reclassify:
-                    run_keys = db.get_classifier_run_keys(detection["id"])
+                    run_keys = _runtime_aware_run_keys(detection["id"])
                     if (model_name, fp) in run_keys:
                         cached = db.get_predictions_for_detection(
                             detection["id"],
@@ -1224,7 +1326,11 @@ def _classify_photos(
                 if len(batch) >= _BATCH_SIZE:
                     pre_len = len(raw_results)
                     failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
-                    _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
+                    _record_batch_classifier_runs(
+                        db, batch, model_name, fp, raw_results, pre_len,
+                        labels_fingerprint_full=job.get("_labels_fingerprint_full"),
+                        model_identity=job.get("_classifier_model_identity"),
+                    )
                     batch = []
         else:
             # No detections — use (or create) a full-image synthetic detection
@@ -1242,11 +1348,34 @@ def _classify_photos(
             else:
                 full_image_det = [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
                                    "confidence": 0, "category": "animal"}]
+                from computation_cache import (
+                    full_image_runtime_fingerprint,
+                    source_input,
+                )
+                full_runtime = full_image_runtime_fingerprint()
+                identity = db.conn.execute(
+                    "SELECT file_hash, companion_path FROM photos WHERE id = ?",
+                    (photo["id"],),
+                ).fetchone()
+                full_input = None
+                if identity is not None and not identity["companion_path"]:
+                    try:
+                        _block, full_input = source_input(
+                            identity["file_hash"], "vireo-detector-source-v1",
+                        )
+                    except ValueError:
+                        full_input = None
                 full_det_ids = db.save_detections(
                     photo["id"], full_image_det,
                     detector_model="full-image",
+                    runtime_fingerprint=full_runtime,
                 )
                 full_det_id = full_det_ids[0]
+                db.record_detector_run(
+                    photo["id"], "full-image", box_count=1,
+                    runtime_fingerprint=full_runtime,
+                    input_fingerprint=full_input,
+                )
             # Gate check for the synthetic full-image detection too.
             # Mirror the regular detection branch: when gated, surface the
             # cached top-1 prediction into raw_results so downstream
@@ -1254,7 +1383,7 @@ def _classify_photos(
             # reruns silently drop cached full-image photos even though
             # those photos were intentionally kept in the cache.
             if not reclassify:
-                run_keys = db.get_classifier_run_keys(full_det_id)
+                run_keys = _runtime_aware_run_keys(full_det_id)
                 if (model_name, fp) in run_keys:
                     cached = db.get_predictions_for_detection(
                         full_det_id,
@@ -1324,7 +1453,11 @@ def _classify_photos(
             if len(batch) >= _BATCH_SIZE:
                 pre_len = len(raw_results)
                 failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
-                _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
+                _record_batch_classifier_runs(
+                    db, batch, model_name, fp, raw_results, pre_len,
+                    labels_fingerprint_full=job.get("_labels_fingerprint_full"),
+                    model_identity=job.get("_classifier_model_identity"),
+                )
                 batch = []
 
     # Flush remaining images. The pending batch holds photos that haven't
@@ -1339,13 +1472,18 @@ def _classify_photos(
     if batch and (not cancelled or reclassify):
         pre_len = len(raw_results)
         failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
-        _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
+        _record_batch_classifier_runs(
+            db, batch, model_name, fp, raw_results, pre_len,
+            labels_fingerprint_full=job.get("_labels_fingerprint_full"),
+            model_identity=job.get("_classifier_model_identity"),
+        )
 
     return raw_results, failed, skipped_existing
 
 
 def _record_batch_classifier_runs(
     db, batch, model_name, labels_fingerprint, raw_results, raw_results_start=0,
+    labels_fingerprint_full=None, model_identity=None,
 ):
     """Record classifier_runs rows for every detection in ``batch``.
 
@@ -1385,7 +1523,25 @@ def _record_batch_classifier_runs(
         db.record_classifier_run(
             did, model_name, labels_fingerprint,
             prediction_count=n,
+            labels_fingerprint_full=labels_fingerprint_full,
         )
+        if labels_fingerprint_full and model_identity:
+            try:
+                from computation_cache import promote_and_publish_classifier_run
+
+                promote_and_publish_classifier_run(
+                    db,
+                    did,
+                    model_name,
+                    labels_fingerprint,
+                    labels_fingerprint_full,
+                    model_identity,
+                )
+            except Exception:
+                log.warning(
+                    "Could not publish portable classifier result for detection %s",
+                    did, exc_info=True,
+                )
 
 
 def _store_match_prediction(
@@ -2006,6 +2162,27 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 "failed": 0,
             }
 
+        # Photos may have been cataloged after a bundle import. Apply any
+        # matching stored objects before model resolution so their raw results
+        # participate in the ordinary database cache gates.
+        try:
+            from computation_cache import materialize_local_store
+
+            reused = (
+                materialize_local_store(thread_db)
+                if not params.reclassify else {}
+            )
+            if reused.get("detector_runs_applied") or reused.get(
+                "classifier_runs_applied"
+            ):
+                log.info(
+                    "Portable cache applied %d detector and %d classifier runs",
+                    reused.get("detector_runs_applied", 0),
+                    reused.get("classifier_runs_applied", 0),
+                )
+        except Exception:
+            log.warning("Could not apply local computation cache", exc_info=True)
+
         # Cancellation gate before the expensive phases (model resolution,
         # weight download, inference). The job loops below also check
         # per-photo; _run_job flips the terminal status to 'cancelled'.
@@ -2079,10 +2256,29 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # Compute a content-addressable fingerprint for the active label set.
         # Kept in scope so downstream classifier_runs writes can record the
         # exact (classifier_model, labels_fingerprint) that produced a result.
-        from labels_fingerprint import compute_fingerprint
+        from labels_fingerprint import compute_fingerprint, compute_full_fingerprint
         fp = compute_fingerprint(labels)
+        fp_full = compute_full_fingerprint(labels)
+        if len(fp_full) != 64:
+            fp_full = None
+        try:
+            from computation_cache import classifier_model_identity, fingerprint
+
+            classifier_identity = classifier_model_identity(active_model)
+            if fp_full is None and use_tol and classifier_identity:
+                fp_full = fingerprint({
+                    "label_space": "tree-of-life",
+                    "model": classifier_identity,
+                })
+        except (OSError, ValueError):
+            classifier_identity = None
         label_sources = _resolve_label_sources(params, thread_db)
-        _record_labels_fingerprint(thread_db, fp, labels, sources=label_sources)
+        _record_labels_fingerprint(
+            thread_db, fp, labels, sources=label_sources,
+            full_fingerprint=fp_full,
+        )
+        job["_labels_fingerprint_full"] = fp_full
+        job["_classifier_model_identity"] = classifier_identity
 
         tax_summary = "Taxonomy loaded" if tax else "No taxonomy"
         labels_summary = f"{len(labels)} labels" if labels else ("Tree of Life" if use_tol else "no labels")

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -2750,10 +2750,8 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # weights, missing revision file) working as before.
         desired_model_identity = None
         try:
-            from computation_cache import (
-                classifier_model_identity,
-                fingerprint as identity_fingerprint,
-            )
+            from computation_cache import classifier_model_identity
+            from computation_cache import fingerprint as identity_fingerprint
 
             if peek_model and peek_model.get("weights_path"):
                 desired_model_identity = classifier_model_identity(peek_model)

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -2457,7 +2457,10 @@ def _finalize_cached_only(
     }
 
 
-def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None):
+def run_classify_job(
+    job, runner, db_path, workspace_id, params, vireo_dir=None,
+    computation_cache_dir=None,
+):
     """Execute classification job. Called by JobRunner in a background thread.
 
     Args:
@@ -2468,6 +2471,11 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         params: ClassifyParams with request parameters
         vireo_dir: optional path to ~/.vireo/; when set, classification uses
             pre-extracted working copy JPEGs instead of decoding RAW files.
+        computation_cache_dir: portable-cache root the HTTP import route
+            writes to (``app.config["COMPUTATION_CACHE_DIR"]``). When
+            provided, background materialization reads from the same store
+            so bundles imported before their photos were cataloged still
+            plant on the next classify run outside the default location.
     """
     thread_db = Database(db_path)
     try:
@@ -2608,10 +2616,14 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # matching stored objects before model resolution so their raw results
         # participate in the ordinary database cache gates.
         try:
-            from computation_cache import materialize_local_store
+            from computation_cache import ArtifactStore, materialize_local_store
 
+            cache_store = (
+                ArtifactStore(computation_cache_dir)
+                if computation_cache_dir else None
+            )
             reused = (
-                materialize_local_store(thread_db)
+                materialize_local_store(thread_db, store=cache_store)
                 if not params.reclassify else {}
             )
             if reused.get("detector_runs_applied") or reused.get(
@@ -3257,8 +3269,15 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                     except Exception:
                         known_classifier_runtimes = set()
 
+                from computation_cache import ArtifactStore
+
+                reapply_store = (
+                    ArtifactStore(computation_cache_dir)
+                    if computation_cache_dir else None
+                )
                 reapplied = materialize_local_store(
                     thread_db,
+                    store=reapply_store,
                     known_runtimes=known_runtimes,
                     known_classifier_runtimes=(
                         known_classifier_runtimes or None

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -2079,6 +2079,146 @@ def _finalize_remaining_steps(runner, job_id, step_ids, status, summary):
         runner.update_step(job_id, step_id, status=status, summary=summary)
 
 
+def _finalize_cached_only(
+    thread_db, runner, job, params, photos,
+    classifier_model, labels_fingerprint,
+):
+    """Reconcile imported classifier results without loading a model.
+
+    ``_all_photos_cache_satisfied`` proves every detection already has a
+    matching classifier_run row, so no inference is needed. But those
+    rows still carry ``category='new'`` from the materialize path and
+    lack burst grouping metadata — the ordinary finalize path
+    (``_store_grouped_predictions``) performs auto-match reconciliation
+    against destination XMP/taxonomy and stamps group_id / vote counts.
+    Skipping it silently leaves imported predictions unreconciled, which
+    is why the earlier early-return "success" was actually a bug.
+
+    Returns the count dict ``run_classify_job`` returns to the runner.
+    """
+    from datetime import datetime as dt
+
+    from taxonomy import load_local_taxonomy
+
+    total = len(photos)
+
+    runner.update_step(job["id"], "load_taxonomy", status="running")
+    tax = load_local_taxonomy()
+    runner.update_step(
+        job["id"], "load_taxonomy",
+        status="completed",
+        summary="Taxonomy loaded" if tax else "No taxonomy",
+    )
+    _finalize_remaining_steps(
+        runner, job["id"], ["load_model", "detect"],
+        status="completed", summary="Reused cached results",
+    )
+
+    folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+    photo_ids = [p["id"] for p in photos]
+    detection_map = thread_db.get_detections_for_photos(photo_ids, min_conf=0)
+
+    runner.update_step(job["id"], "classify", status="running")
+
+    raw_results = []
+    resolved_model = classifier_model
+    resolved_fingerprint = labels_fingerprint
+    reused_predictions = 0
+    for photo in photos:
+        folder_path = folders.get(photo["folder_id"], "")
+        image_path = os.path.join(folder_path, photo["filename"])
+        timestamp = None
+        if photo["timestamp"]:
+            try:
+                timestamp = dt.fromisoformat(photo["timestamp"])
+            except Exception:
+                timestamp = None
+        for detection in detection_map.get(photo["id"], []):
+            cached = thread_db.get_predictions_for_detection(
+                detection["id"],
+                classifier_model=classifier_model,
+                labels_fingerprint=labels_fingerprint,
+                min_classifier_conf=0,
+            )
+            if not cached:
+                continue
+            top = cached[0]
+            # When the caller didn't request a specific (model, fp), the
+            # satisfaction check accepts any classifier's cached row.
+            # Adopt the first cached row's identity so the reconcile
+            # UPDATE below hits the same rows we consumed from — passing
+            # None here would leave the reconcile matching zero rows.
+            if resolved_model is None:
+                resolved_model = top["classifier_model"]
+            if resolved_fingerprint is None:
+                resolved_fingerprint = top["labels_fingerprint"]
+            raw_results.append({
+                "photo": photo,
+                "detection_id": detection["id"],
+                "folder_path": folder_path,
+                "image_path": image_path,
+                "prediction": top["species"],
+                "confidence": top["confidence"],
+                "timestamp": timestamp,
+                "filename": photo["filename"],
+                "embedding": None,
+                "taxonomy": None,
+                "alternatives": [],
+                "_existing": True,
+            })
+            reused_predictions += 1
+    runner.update_step(
+        job["id"], "classify",
+        status="completed",
+        summary=(
+            f"{reused_predictions} cached"
+            if reused_predictions else "No cached predictions"
+        ),
+    )
+
+    runner.update_step(job["id"], "finalize", status="running")
+    runner.push_event(
+        job["id"], "progress",
+        {
+            "current": total,
+            "total": total,
+            "current_file": "Grouping bursts and computing consensus...",
+            "rate": 0,
+            "phase": "Finalizing results",
+        },
+    )
+    group_result = _store_grouped_predictions(
+        raw_results=raw_results,
+        job_id=job["id"],
+        model_name=resolved_model,
+        grouping_window=params.grouping_window,
+        similarity_threshold=params.similarity_threshold,
+        tax=tax,
+        db=thread_db,
+        labels_fingerprint=resolved_fingerprint or "legacy",
+    )
+    finalize_parts = [f"{group_result['predictions_stored']} predictions"]
+    if group_result["burst_groups"]:
+        finalize_parts.append(f"{group_result['burst_groups']} burst groups")
+    if group_result["already_labeled"]:
+        finalize_parts.append(
+            f"{group_result['already_labeled']} already labeled"
+        )
+    runner.update_step(
+        job["id"], "finalize",
+        status="completed", summary=", ".join(finalize_parts),
+    )
+    return {
+        "total": total,
+        "predictions_stored": group_result["predictions_stored"],
+        "burst_groups": group_result["burst_groups"],
+        "already_classified": reused_predictions,
+        "already_labeled": group_result["already_labeled"],
+        "detected": 0,
+        "failed": 0,
+    }
+
+
 def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None):
     """Execute classification job. Called by JobRunner in a background thread.
 
@@ -2284,6 +2424,12 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         desired_classifier_model = None
         desired_labels_fingerprint = None
         peek_model = None
+        # ``model_id_missing`` distinguishes "the requested model really is
+        # gone from the catalog" (a stale job referencing a deleted model)
+        # from a transient ``get_models()`` failure. The catch-all below
+        # nulls out the transient case; a bare miss stays flagged so we
+        # can raise the definitive error before the cache shortcut.
+        model_id_missing = False
         try:
             if params.model_id:
                 peek_model = next(
@@ -2300,6 +2446,8 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                     desired_classifier_model = (
                         params.model_name or peek_model.get("name")
                     )
+                else:
+                    model_id_missing = True
             elif params.model_name:
                 desired_classifier_model = params.model_name
                 peek_model = next(
@@ -2318,6 +2466,17 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         except Exception:
             desired_classifier_model = None
             peek_model = None
+            model_id_missing = False
+
+        # An unknown model_id must never fall through to the cache
+        # shortcut. Without this, ``desired_classifier_model`` stays
+        # ``None`` and ``_all_photos_cache_satisfied`` accepts runs from
+        # any classifier, silently reporting success for a request that
+        # would otherwise raise "not found or not downloaded" below.
+        if model_id_missing:
+            raise RuntimeError(
+                f"Model '{params.model_id}' not found or not downloaded."
+            )
         # Compute labels_fingerprint from the user-selected label sources
         # so a cache built from a DIFFERENT label set does not silently
         # pass as satisfied.  Uses the same _load_labels path that later
@@ -2349,22 +2508,15 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 "Classify job: every photo has cached classifier runs — "
                 "skipping model resolution and detection",
             )
-            _finalize_remaining_steps(
-                runner, job["id"],
-                ["load_taxonomy", "load_model", "detect", "classify",
-                 "finalize"],
-                status="completed",
-                summary="Reused cached classification results",
+            # Route reused rows through the ordinary finalize path so
+            # imported predictions get auto-match reconciliation against
+            # destination XMP/taxonomy and burst grouping metadata, which
+            # the earlier early-return silently skipped.
+            return _finalize_cached_only(
+                thread_db, runner, job, params, photos,
+                classifier_model=desired_classifier_model,
+                labels_fingerprint=desired_labels_fingerprint,
             )
-            return {
-                "total": total,
-                "predictions_stored": 0,
-                "burst_groups": 0,
-                "already_classified": total,
-                "already_labeled": 0,
-                "detected": 0,
-                "failed": 0,
-            }
 
         # Resolve model (deferred until we know there is work to do)
         if params.model_id:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -757,11 +757,22 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
                             photo["id"], min_conf=0,
                             detector_model="megadetector-v6",
                         )]
+                        # Reconstruct the configured ArtifactStore from
+                        # the path stashed by ``run_classify_job`` /
+                        # ``run_pipeline_job`` so newly published detector
+                        # artifacts honor ``COMPUTATION_CACHE_DIR``
+                        # instead of landing in the default location.
+                        from computation_cache import ArtifactStore
+                        _cache_dir = job.get("_computation_cache_dir")
+                        _publish_store = (
+                            ArtifactStore(_cache_dir) if _cache_dir else None
+                        )
                         publish_detection_artifact(
                             portable_photo_hash,
                             "megadetector-v6",
                             detector_runtime,
                             normalized_detections,
+                            store=_publish_store,
                         )
                 except Exception:
                     log.warning(
@@ -1770,7 +1781,7 @@ def _record_batch_classifier_runs(
 def _publish_classifier_runs_for_raw_results(
     db, raw_results, classifier_model, labels_fingerprint,
     labels_fingerprint_full=None, model_identity=None,
-    taxonomy_identity="no-tax",
+    taxonomy_identity="no-tax", store=None,
 ):
     """Publish portable classifier artifacts for freshly-classified detections.
 
@@ -1787,6 +1798,12 @@ def _publish_classifier_runs_for_raw_results(
     Entries from the reuse path carry ``_existing = True``; their
     runtime_fingerprint is already populated from the earlier successful
     publish, so they are skipped here.
+
+    ``store`` is the caller's configured ``ArtifactStore``. Callers that
+    honor ``COMPUTATION_CACHE_DIR`` must forward the job's store here so
+    freshly promoted artifacts land in the same cache the status / export /
+    catalog-reapplication paths use; passing ``None`` falls back to the
+    default ``~/.vireo/computation-cache`` location.
     """
     if not labels_fingerprint_full or not model_identity or not raw_results:
         return
@@ -1806,6 +1823,7 @@ def _publish_classifier_runs_for_raw_results(
                 labels_fingerprint,
                 labels_fingerprint_full,
                 model_identity,
+                store=store,
                 taxonomy_identity=taxonomy_identity,
             )
         except Exception:
@@ -2482,6 +2500,19 @@ def run_classify_job(
         thread_db.set_active_workspace(workspace_id)
         job["_start_time"] = time.time()
 
+        # Stash the job's configured cache root so downstream helpers
+        # publish freshly computed artifacts into the SAME cache the
+        # status / export / catalog-reapplication paths use when
+        # ``COMPUTATION_CACHE_DIR`` is overridden. Without this,
+        # ``publish_detection_artifact`` and ``promote_and_publish_classifier_run``
+        # fall back to the default ``~/.vireo/computation-cache`` and the
+        # newly written artifacts disappear from the configured cache as
+        # soon as the backing database rows are removed. The path (not the
+        # ``ArtifactStore`` instance) is stashed so ``jsonify(job)`` on the
+        # /api/jobs/<id> route keeps working — the helpers reconstruct the
+        # lightweight wrapper on demand.
+        job["_computation_cache_dir"] = computation_cache_dir
+
         runner.set_steps(job["id"], [
             {"id": "load_photos", "label": "Load photos"},
             {"id": "load_taxonomy", "label": "Load taxonomy"},
@@ -2714,9 +2745,24 @@ def run_classify_job(
                         params.model_name or peek_model.get("name")
                     )
         except Exception:
-            desired_classifier_model = None
+            # A raising get_models() here left both peek and constraints
+            # unresolved. Clearing ``model_id_missing`` or
+            # ``desired_classifier_model`` unconditionally would let
+            # ``_all_photos_cache_satisfied`` silently accept cached
+            # runs from a classifier the caller did not select. Preserve
+            # the explicit request so either the guard below propagates
+            # the lookup failure or the cache filter still rejects
+            # wrong-model runs.
             peek_model = None
-            model_id_missing = False
+            if params.model_id:
+                desired_classifier_model = None
+                model_id_missing = True
+            elif params.model_name:
+                desired_classifier_model = params.model_name
+                model_id_missing = False
+            else:
+                desired_classifier_model = None
+                model_id_missing = False
 
         # An unknown model_id must never fall through to the cache
         # shortcut. Without this, ``desired_classifier_model`` stays
@@ -3385,11 +3431,21 @@ def run_classify_job(
         # _record_batch_classifier_runs would no-op because those rows
         # don't exist yet, leaving fresh classifier_runs stranded on
         # runtime_fingerprint = 'legacy' and out of bundle exports.
+        # Reconstruct the configured ArtifactStore from the path stashed
+        # by ``run_classify_job`` so the classifier artifacts land in the
+        # same cache the status / export paths use, matching
+        # ``publish_detection_artifact``'s behavior above.
+        from computation_cache import ArtifactStore
+        _publish_cache_dir = job.get("_computation_cache_dir")
+        _publish_store = (
+            ArtifactStore(_publish_cache_dir) if _publish_cache_dir else None
+        )
         _publish_classifier_runs_for_raw_results(
             thread_db, raw_results, model_name, fp,
             labels_fingerprint_full=job.get("_labels_fingerprint_full"),
             model_identity=job.get("_classifier_model_identity"),
             taxonomy_identity=job.get("_taxonomy_identity", "no-tax"),
+            store=_publish_store,
         )
         finalize_parts = [f"{group_result['predictions_stored']} predictions"]
         if group_result["burst_groups"]:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -360,6 +360,15 @@ def _all_photos_cache_satisfied(
     reconciles every other row against it — silently swapping the
     unbound component of the classifier identity on detections covered
     by a different pair.
+
+    A classifier_run row is only counted as covered when at least one
+    matching ``predictions`` row exists.  Local jobs write classifier_runs
+    in ``_record_batch_classifier_runs`` *before* ``_store_grouped_predictions``
+    persists the corresponding prediction rows; if the job crashes or
+    finalization raises in that window, a naive coverage count would still
+    call every detection "covered" and the retry would enter
+    ``_finalize_cached_only`` and report success without repairing the
+    missing prediction rows.
     """
     if not photo_ids:
         return False
@@ -374,6 +383,17 @@ def _all_photos_cache_satisfied(
         filter_sql += " AND cr.labels_fingerprint = ?"
         filter_args.append(labels_fingerprint)
 
+    # Only classifier_runs backed by at least one predictions row count as
+    # cache-satisfying.  See docstring — a classifier_run without matching
+    # predictions is a torn write from a crashed local job, not a
+    # reusable cache row.
+    predictions_exists = (
+        "EXISTS (SELECT 1 FROM predictions pr "
+        "WHERE pr.detection_id = cr.detection_id "
+        "AND pr.classifier_model = cr.classifier_model "
+        "AND pr.labels_fingerprint = cr.labels_fingerprint)"
+    )
+
     total = 0
     covered = 0
     covered_photos = 0
@@ -387,7 +407,9 @@ def _all_photos_cache_satisfied(
         placeholders = ",".join("?" for _ in chunk)
         row = db.conn.execute(
             f"""SELECT COUNT(*) AS total,
-                       SUM(CASE WHEN cr.detection_id IS NOT NULL THEN 1 ELSE 0 END)
+                       SUM(CASE WHEN cr.detection_id IS NOT NULL
+                                 AND {predictions_exists}
+                                THEN 1 ELSE 0 END)
                          AS covered
                  FROM detections d
                  LEFT JOIN classifier_runs cr
@@ -413,13 +435,17 @@ def _all_photos_cache_satisfied(
             # chunk's classifier_runs so the caller can't finalize
             # under a single identity when several are actually
             # present.  We short-circuit as soon as two are seen.
+            # Same predictions-must-exist filter as the coverage
+            # query: a torn classifier_runs row without predictions
+            # is not a real identity that can satisfy the cache.
             for identity_row in db.conn.execute(
                 f"""SELECT DISTINCT cr.classifier_model AS m,
                                     cr.labels_fingerprint AS fp
                      FROM detections d
                      JOIN classifier_runs cr
                        ON cr.detection_id = d.id
-                    WHERE d.photo_id IN ({placeholders})""",
+                    WHERE d.photo_id IN ({placeholders})
+                      AND {predictions_exists}""",
                 list(chunk),
             ):
                 distinct_identities.add(
@@ -1618,8 +1644,17 @@ def _record_batch_classifier_runs(
     (``raw_results[raw_results_start:]``) are tallied. Earlier rows belong to
     prior batches; re-scanning the whole growing list on every flush would
     make the bookkeeping O(n^2) across a large collection. Called after
-    _flush_batch has committed predictions so the run row is only written for
-    detections that actually produced output.
+    _flush_batch has appended to ``raw_results`` so the run row is only
+    written for detections that actually produced classifier output.
+
+    Portable-artifact promotion (``promote_and_publish_classifier_run``) is
+    NOT done here even when ``labels_fingerprint_full`` /
+    ``model_identity`` are provided — that function reads the persisted
+    ``predictions`` rows to synthesize the exportable artifact, and those
+    rows are not written until ``_store_grouped_predictions`` runs later.
+    Callers must invoke ``_publish_classifier_runs_for_raw_results`` after
+    ``_store_grouped_predictions`` completes so fresh runs do not stay
+    stranded on ``runtime_fingerprint = 'legacy'``.
     """
     if not batch:
         return
@@ -1650,23 +1685,52 @@ def _record_batch_classifier_runs(
             prediction_count=n,
             labels_fingerprint_full=labels_fingerprint_full,
         )
-        if labels_fingerprint_full and model_identity:
-            try:
-                from computation_cache import promote_and_publish_classifier_run
 
-                promote_and_publish_classifier_run(
-                    db,
-                    did,
-                    model_name,
-                    labels_fingerprint,
-                    labels_fingerprint_full,
-                    model_identity,
-                )
-            except Exception:
-                log.warning(
-                    "Could not publish portable classifier result for detection %s",
-                    did, exc_info=True,
-                )
+
+def _publish_classifier_runs_for_raw_results(
+    db, raw_results, classifier_model, labels_fingerprint,
+    labels_fingerprint_full=None, model_identity=None,
+):
+    """Publish portable classifier artifacts for freshly-classified detections.
+
+    ``promote_and_publish_classifier_run`` reads the persisted ``predictions``
+    rows for a detection to build the exportable artifact and only then
+    stamps the classifier_runs row with the real ``runtime_fingerprint``.
+    Predictions are written by ``_store_grouped_predictions``, so the
+    promotion pass belongs AFTER it — running it earlier (inside
+    ``_record_batch_classifier_runs``, before those rows exist) silently
+    no-ops and leaves classifier_runs stranded on
+    ``runtime_fingerprint = 'legacy'``, excluding those runs from cache
+    bundle exports.
+
+    Entries from the reuse path carry ``_existing = True``; their
+    runtime_fingerprint is already populated from the earlier successful
+    publish, so they are skipped here.
+    """
+    if not labels_fingerprint_full or not model_identity or not raw_results:
+        return
+    from computation_cache import promote_and_publish_classifier_run
+
+    seen: set = set()
+    for result in raw_results:
+        det_id = result.get("detection_id")
+        if det_id is None or det_id in seen or result.get("_existing"):
+            continue
+        seen.add(det_id)
+        try:
+            promote_and_publish_classifier_run(
+                db,
+                det_id,
+                classifier_model,
+                labels_fingerprint,
+                labels_fingerprint_full,
+                model_identity,
+            )
+        except Exception:
+            log.warning(
+                "Could not publish portable classifier result for detection %s",
+                det_id, exc_info=True,
+            )
 
 
 def _store_match_prediction(
@@ -3127,6 +3191,16 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             tax=tax,
             db=thread_db,
             labels_fingerprint=fp,
+        )
+        # promote_and_publish reads persisted predictions written by
+        # _store_grouped_predictions above; running it inside
+        # _record_batch_classifier_runs would no-op because those rows
+        # don't exist yet, leaving fresh classifier_runs stranded on
+        # runtime_fingerprint = 'legacy' and out of bundle exports.
+        _publish_classifier_runs_for_raw_results(
+            thread_db, raw_results, model_name, fp,
+            labels_fingerprint_full=job.get("_labels_fingerprint_full"),
+            model_identity=job.get("_classifier_model_identity"),
         )
         finalize_parts = [f"{group_result['predictions_stored']} predictions"]
         if group_result["burst_groups"]:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -334,8 +334,9 @@ def _classify_detection_gated(db, detection_id, classifier_model,
 
 def _all_photos_cache_satisfied(
     db, photo_ids, classifier_model=None, labels_fingerprint=None,
+    detector_confidence=0.0,
 ):
-    """True when every detection on every photo already has a matching run.
+    """True when every classifiable detection already has a matching run.
 
     Used to short-circuit model resolution when a bundle import (or an
     earlier run) has already produced results for the whole collection.
@@ -343,8 +344,9 @@ def _all_photos_cache_satisfied(
     imported predictions instead of failing with "No model available".
 
     "Satisfied" here means: every photo in the collection has at least
-    one detection, and every one of its detections has a matching
-    ``classifier_runs`` row.  When ``classifier_model`` and/or
+    one detection eligible at the workspace threshold (with synthetic
+    full-image anchors always eligible), and every eligible detection has a
+    matching ``classifier_runs`` row.  When ``classifier_model`` and/or
     ``labels_fingerprint`` are given, matching also requires the run to
     carry that exact model name / label set — a photo whose detections
     only carry runs for a different model or label set is treated as
@@ -393,6 +395,12 @@ def _all_photos_cache_satisfied(
         "AND pr.classifier_model = cr.classifier_model "
         "AND pr.labels_fingerprint = cr.labels_fingerprint)"
     )
+    classifiable_detection = (
+        "(d.detector_model = 'full-image' OR "
+        "(d.detector_model != 'full-image' "
+        "AND COALESCE(d.category, 'animal') = 'animal' "
+        "AND d.detector_confidence >= ?))"
+    )
 
     total = 0
     covered = 0
@@ -414,8 +422,9 @@ def _all_photos_cache_satisfied(
                  FROM detections d
                  LEFT JOIN classifier_runs cr
                    ON cr.detection_id = d.id{filter_sql}
-                WHERE d.photo_id IN ({placeholders})""",
-            filter_args + list(chunk),
+                WHERE {classifiable_detection}
+                  AND d.photo_id IN ({placeholders})""",
+            filter_args + [detector_confidence] + list(chunk),
         ).fetchone()
         total += (row["total"] if row else 0) or 0
         covered += (row["covered"] if row else 0) or 0
@@ -423,8 +432,12 @@ def _all_photos_cache_satisfied(
         photo_row = db.conn.execute(
             f"""SELECT COUNT(DISTINCT photo_id) AS covered_photos
                  FROM detections
-                WHERE photo_id IN ({placeholders})""",
-            list(chunk),
+                WHERE (detector_model = 'full-image' OR
+                       (detector_model != 'full-image'
+                        AND COALESCE(category, 'animal') = 'animal'
+                        AND detector_confidence >= ?))
+                  AND photo_id IN ({placeholders})""",
+            [detector_confidence] + list(chunk),
         ).fetchone()
         covered_photos += (
             (photo_row["covered_photos"] if photo_row else 0) or 0
@@ -445,8 +458,9 @@ def _all_photos_cache_satisfied(
                      JOIN classifier_runs cr
                        ON cr.detection_id = d.id
                     WHERE d.photo_id IN ({placeholders})
-                      AND {predictions_exists}""",
-                list(chunk),
+                      AND {classifiable_detection}
+                      AND {predictions_exists}{filter_sql}""",
+                list(chunk) + [detector_confidence] + filter_args,
             ):
                 distinct_identities.add(
                     (identity_row["m"], identity_row["fp"])
@@ -2251,6 +2265,28 @@ def _finalize_cached_only(
     detection_map = thread_db.get_detections_for_photos(
         photo_ids, min_conf=det_conf_threshold,
     )
+    detection_map = {
+        photo_id: [
+            detection for detection in detections
+            if detection.get("detector_model") != "full-image"
+            and detection.get("category", "animal") == "animal"
+        ]
+        for photo_id, detections in detection_map.items()
+    }
+    # Synthetic full-image anchors intentionally have confidence 0, so the
+    # positive MegaDetector threshold above hides them. They are nevertheless
+    # classifier inputs and must participate in cached-only reconciliation.
+    # Fetch them independently at min_conf=0 and merge them back.
+    full_image_map = thread_db.get_detections_for_photos(
+        photo_ids, min_conf=0, detector_model="full-image",
+    )
+    for photo_id, detections in full_image_map.items():
+        existing = detection_map.setdefault(photo_id, [])
+        existing_ids = {detection["id"] for detection in existing}
+        existing.extend(
+            detection for detection in detections
+            if detection["id"] not in existing_ids
+        )
 
     runner.update_step(job["id"], "classify", status="running")
 
@@ -2633,10 +2669,17 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         except Exception:
             desired_labels_fingerprint = None
 
+        import config as cfg
+
+        cache_effective_cfg = thread_db.get_effective_config(cfg.load())
+        cache_detector_confidence = cache_effective_cfg.get(
+            "detector_confidence", 0.2,
+        )
         if not params.reclassify and _all_photos_cache_satisfied(
             thread_db, [p["id"] for p in photos],
             classifier_model=desired_classifier_model,
             labels_fingerprint=desired_labels_fingerprint,
+            detector_confidence=cache_detector_confidence,
         ):
             log.info(
                 "Classify job: every photo has cached classifier runs — "

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -352,12 +352,14 @@ def _all_photos_cache_satisfied(
     the user's requested identity.  A photo with no detections at all is
     also unsatisfied so we still fall through to detection.
 
-    When neither filter is supplied (fresh-install fallback path), we
-    additionally require every covered detection to share the SAME
-    ``(classifier_model, labels_fingerprint)`` pair.  Otherwise the
+    When either filter is unsupplied (fresh-install fallback path or a
+    partially resolved request where only one of model/fingerprint is
+    known), we additionally require every covered detection to share the
+    SAME ``(classifier_model, labels_fingerprint)`` pair.  Otherwise the
     downstream cached-only finalize adopts the first row's identity and
     reconciles every other row against it — silently swapping the
-    classifier identity on detections covered by a different pair.
+    unbound component of the classifier identity on detections covered
+    by a different pair.
     """
     if not photo_ids:
         return False
@@ -376,7 +378,7 @@ def _all_photos_cache_satisfied(
     covered = 0
     covered_photos = 0
     distinct_identities = set()
-    identity_gate = classifier_model is None and labels_fingerprint is None
+    identity_gate = classifier_model is None or labels_fingerprint is None
 
     # Chunk ``photo_ids`` so a large collection (per_page=999999) does
     # not blow past SQLite's default SQLITE_MAX_VARIABLE_NUMBER (999)
@@ -2175,7 +2177,16 @@ def _finalize_cached_only(
 
     folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
     photo_ids = [p["id"] for p in photos]
-    detection_map = thread_db.get_detections_for_photos(photo_ids, min_conf=0)
+    # Apply the workspace-effective detector_confidence so imported bundles
+    # from a machine with a lower threshold don't surface subjects the
+    # destination workspace would hide.  The normal (non-cache) classify path
+    # filters detections with the same threshold before grouping/review.
+    import config as cfg
+    effective_cfg = thread_db.get_effective_config(cfg.load())
+    det_conf_threshold = effective_cfg.get("detector_confidence", 0.2)
+    detection_map = thread_db.get_detections_for_photos(
+        photo_ids, min_conf=det_conf_threshold,
+    )
 
     runner.update_step(job["id"], "classify", status="running")
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -335,6 +335,7 @@ def _classify_detection_gated(db, detection_id, classifier_model,
 def _all_photos_cache_satisfied(
     db, photo_ids, classifier_model=None, labels_fingerprint=None,
     detector_confidence=0.0,
+    model_identity=None, labels_fingerprint_full=None,
 ):
     """True when every classifiable detection already has a matching run.
 
@@ -363,6 +364,18 @@ def _all_photos_cache_satisfied(
     unbound component of the classifier identity on detections covered
     by a different pair.
 
+    When both ``model_identity`` and ``labels_fingerprint_full`` are
+    given, coverage additionally filters by the derived classifier
+    runtime.  Without it, an old classifier_runs row (weights or
+    preprocessing changed under the same ``classifier_model``) still
+    satisfies this join and the caller shortcuts to
+    ``_finalize_cached_only`` on stale results — the ordinary
+    ``_classify_photos`` gate would reject that mismatch via
+    ``_runtime_aware_run_keys``.  ``runtime_fingerprint = 'legacy'``
+    stays accepted for pre-portable rows, and manually reviewed rows
+    (real accept/reject decisions, not auto-match) remain authoritative
+    across runtime changes until an explicit reclassify.
+
     A classifier_run row is only counted as covered when at least one
     matching ``predictions`` row exists.  Local jobs write classifier_runs
     in ``_record_batch_classifier_runs`` *before* ``_store_grouped_predictions``
@@ -384,6 +397,55 @@ def _all_photos_cache_satisfied(
     if labels_fingerprint is not None:
         filter_sql += " AND cr.labels_fingerprint = ?"
         filter_args.append(labels_fingerprint)
+
+    # Derive the set of expected classifier runtime_fingerprints.  A
+    # classifier runtime encodes (model_identity, labels_full,
+    # detector_runtime), so each distinct detector runtime in the
+    # collection produces its own expected classifier runtime.  Empty
+    # when the caller couldn't resolve either input (fresh install with
+    # no downloaded weights) — the runtime filter is then omitted and
+    # we keep the historic model/labels-only behavior.
+    expected_runtimes = set()
+    if model_identity is not None and labels_fingerprint_full:
+        try:
+            from computation_cache import classifier_runtime_fingerprint
+
+            detector_runtimes = set()
+            for chunk in _chunks(photo_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                for r in db.conn.execute(
+                    f"""SELECT DISTINCT runtime_fingerprint
+                         FROM detector_runs
+                         WHERE photo_id IN ({placeholders})""",
+                    list(chunk),
+                ):
+                    if r["runtime_fingerprint"]:
+                        detector_runtimes.add(r["runtime_fingerprint"])
+            for dr in detector_runtimes:
+                expected = classifier_runtime_fingerprint(
+                    model_identity, labels_fingerprint_full, dr,
+                )
+                if expected:
+                    expected_runtimes.add(expected)
+        except (OSError, ValueError):
+            expected_runtimes = set()
+
+    runtime_clause = ""
+    runtime_args = []
+    if expected_runtimes:
+        placeholders = ",".join("?" for _ in expected_runtimes)
+        runtime_clause = (
+            f" AND (cr.runtime_fingerprint IN ({placeholders})"
+            " OR cr.runtime_fingerprint = 'legacy'"
+            " OR EXISTS (SELECT 1 FROM predictions p"
+            " JOIN prediction_review pr ON pr.prediction_id = p.id"
+            " WHERE p.detection_id = cr.detection_id"
+            " AND p.classifier_model = cr.classifier_model"
+            " AND p.labels_fingerprint = cr.labels_fingerprint"
+            " AND pr.status IN ('accepted', 'rejected')"
+            " AND COALESCE(pr.individual, '') != ?))"
+        )
+        runtime_args = list(expected_runtimes) + [AUTO_MATCH_REVIEW_MARKER]
 
     # Only classifier_runs backed by at least one predictions row count as
     # cache-satisfying.  See docstring — a classifier_run without matching
@@ -421,10 +483,10 @@ def _all_photos_cache_satisfied(
                          AS covered
                  FROM detections d
                  LEFT JOIN classifier_runs cr
-                   ON cr.detection_id = d.id{filter_sql}
+                   ON cr.detection_id = d.id{filter_sql}{runtime_clause}
                 WHERE {classifiable_detection}
                   AND d.photo_id IN ({placeholders})""",
-            filter_args + [detector_confidence] + list(chunk),
+            filter_args + runtime_args + [detector_confidence] + list(chunk),
         ).fetchone()
         total += (row["total"] if row else 0) or 0
         covered += (row["covered"] if row else 0) or 0
@@ -459,8 +521,8 @@ def _all_photos_cache_satisfied(
                        ON cr.detection_id = d.id
                     WHERE d.photo_id IN ({placeholders})
                       AND {classifiable_detection}
-                      AND {predictions_exists}{filter_sql}""",
-                list(chunk) + [detector_confidence] + filter_args,
+                      AND {predictions_exists}{filter_sql}{runtime_clause}""",
+                list(chunk) + [detector_confidence] + filter_args + runtime_args,
             ):
                 distinct_identities.add(
                     (identity_row["m"], identity_row["fp"])
@@ -2654,8 +2716,14 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # (missing weights on a fresh install, TOL path unavailable) —
         # in that case desired_labels_fingerprint stays None and the
         # check falls back to model-only filtering.
+        desired_labels_fingerprint_full = None
+        peek_labels = None
+        peek_use_tol = False
         try:
-            from labels_fingerprint import compute_fingerprint
+            from labels_fingerprint import (
+                compute_fingerprint,
+                compute_full_fingerprint,
+            )
 
             peek_labels, peek_use_tol = _load_labels(
                 model_type=(peek_model or {}).get("model_type", "bioclip"),
@@ -2666,8 +2734,43 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 model_dir=(peek_model or {}).get("weights_path"),
             )
             desired_labels_fingerprint = compute_fingerprint(peek_labels)
+            fp_full_peek = compute_full_fingerprint(peek_labels)
+            if isinstance(fp_full_peek, str) and len(fp_full_peek) == 64:
+                desired_labels_fingerprint_full = fp_full_peek
         except Exception:
             desired_labels_fingerprint = None
+
+        # Resolve the installed classifier's portable identity so the
+        # cache check can filter classifier_runs by runtime_fingerprint.
+        # Without this, a stale run (weights or preprocessing changed
+        # under the same classifier_model, unchanged label fingerprint)
+        # still satisfies the coverage join and the caller shortcuts to
+        # ``_finalize_cached_only`` on wrong-runtime results.  Falling
+        # back to ``None`` keeps the fresh-install case (undownloaded
+        # weights, missing revision file) working as before.
+        desired_model_identity = None
+        try:
+            from computation_cache import (
+                classifier_model_identity,
+                fingerprint as identity_fingerprint,
+            )
+
+            if peek_model and peek_model.get("weights_path"):
+                desired_model_identity = classifier_model_identity(peek_model)
+            if (
+                desired_labels_fingerprint_full is None
+                and peek_use_tol
+                and desired_model_identity
+            ):
+                # Tree-of-Life mode uses a synthetic labels_full that
+                # does not require ``peek_labels`` to be non-empty.
+                # Mirrors the fp_full fallback later in the job.
+                desired_labels_fingerprint_full = identity_fingerprint({
+                    "label_space": "tree-of-life",
+                    "model": desired_model_identity,
+                })
+        except (OSError, ValueError):
+            desired_model_identity = None
 
         import config as cfg
 
@@ -2680,6 +2783,8 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             classifier_model=desired_classifier_model,
             labels_fingerprint=desired_labels_fingerprint,
             detector_confidence=cache_detector_confidence,
+            model_identity=desired_model_identity,
+            labels_fingerprint_full=desired_labels_fingerprint_full,
         ):
             log.info(
                 "Classify job: every photo has cached classifier runs — "

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -336,6 +336,7 @@ def _all_photos_cache_satisfied(
     db, photo_ids, classifier_model=None, labels_fingerprint=None,
     detector_confidence=0.0,
     model_identity=None, labels_fingerprint_full=None,
+    taxonomy_identity="no-tax",
 ):
     """True when every classifiable detection already has a matching run.
 
@@ -424,6 +425,7 @@ def _all_photos_cache_satisfied(
             for dr in detector_runtimes:
                 expected = classifier_runtime_fingerprint(
                     model_identity, labels_fingerprint_full, dr,
+                    taxonomy_identity=taxonomy_identity,
                 )
                 if expected:
                     expected_runtimes.add(expected)
@@ -1356,6 +1358,7 @@ def _classify_photos(
     cancelled = False
     portable_labels_full = job.get("_labels_fingerprint_full")
     portable_model_identity = job.get("_classifier_model_identity")
+    portable_taxonomy_identity = job.get("_taxonomy_identity", "no-tax")
 
     def _runtime_aware_run_keys(detection_id):
         expected_runtime = None
@@ -1368,6 +1371,7 @@ def _classify_photos(
                     detection_id,
                     portable_model_identity,
                     portable_labels_full,
+                    taxonomy_identity=portable_taxonomy_identity,
                 )
             except (OSError, ValueError):
                 expected_runtime = None
@@ -1766,6 +1770,7 @@ def _record_batch_classifier_runs(
 def _publish_classifier_runs_for_raw_results(
     db, raw_results, classifier_model, labels_fingerprint,
     labels_fingerprint_full=None, model_identity=None,
+    taxonomy_identity="no-tax",
 ):
     """Publish portable classifier artifacts for freshly-classified detections.
 
@@ -1801,6 +1806,7 @@ def _publish_classifier_runs_for_raw_results(
                 labels_fingerprint,
                 labels_fingerprint_full,
                 model_identity,
+                taxonomy_identity=taxonomy_identity,
             )
         except Exception:
             log.warning(
@@ -2776,6 +2782,18 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         cache_detector_confidence = cache_effective_cfg.get(
             "detector_confidence", 0.2,
         )
+        # Peek the local taxonomy identity so the expected classifier
+        # runtimes computed inside ``_all_photos_cache_satisfied`` include
+        # the taxonomy axis. Otherwise the check would compute expected
+        # runtimes with "no-tax" while installed classifier_runs carry
+        # the real taxonomy digest — the cached-only shortcut would then
+        # never fire on installs that use taxonomy. ``load_local_taxonomy``
+        # is cached, so the actual load in Phase 2 below is free.
+        from computation_cache import (
+            local_taxonomy_identity as _peek_tax_identity,
+        )
+
+        cache_taxonomy_identity = _peek_tax_identity()
         if not params.reclassify and _all_photos_cache_satisfied(
             thread_db, [p["id"] for p in photos],
             classifier_model=desired_classifier_model,
@@ -2783,6 +2801,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             detector_confidence=cache_detector_confidence,
             model_identity=desired_model_identity,
             labels_fingerprint_full=desired_labels_fingerprint_full,
+            taxonomy_identity=cache_taxonomy_identity,
         ):
             log.info(
                 "Classify job: every photo has cached classifier runs — "
@@ -2873,6 +2892,8 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         )
         job["_labels_fingerprint_full"] = fp_full
         job["_classifier_model_identity"] = classifier_identity
+        from computation_cache import taxonomy_identity as _taxonomy_identity
+        job["_taxonomy_identity"] = _taxonomy_identity(tax)
 
         tax_summary = "Taxonomy loaded" if tax else "No taxonomy"
         labels_summary = f"{len(labels)} labels" if labels else ("Tree of Life" if use_tol else "no labels")
@@ -3217,6 +3238,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 # though this install just proved it can reproduce the
                 # exact same runtime.
                 known_classifier_runtimes = set()
+                job_tax_identity = job.get("_taxonomy_identity", "no-tax")
                 if fp_full and classifier_identity:
                     try:
                         from computation_cache import (
@@ -3228,6 +3250,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                                 continue
                             crt = classifier_runtime_fingerprint(
                                 classifier_identity, fp_full, det_runtime,
+                                taxonomy_identity=job_tax_identity,
                             )
                             if crt:
                                 known_classifier_runtimes.add(crt)
@@ -3347,6 +3370,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             thread_db, raw_results, model_name, fp,
             labels_fingerprint_full=job.get("_labels_fingerprint_full"),
             model_identity=job.get("_classifier_model_identity"),
+            taxonomy_identity=job.get("_taxonomy_identity", "no-tax"),
         )
         finalize_parts = [f"{group_result['predictions_stored']} predictions"]
         if group_result["burst_groups"]:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -2269,7 +2269,7 @@ def _finalize_cached_only(
         photo_id: [
             detection for detection in detections
             if detection.get("detector_model") != "full-image"
-            and detection.get("category", "animal") == "animal"
+            and (detection.get("category") or "animal") == "animal"
         ]
         for photo_id, detections in detection_map.items()
     }

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -92,7 +92,8 @@ def runtime_fingerprint(descriptor):
 def sha256_file(path):
     """Hash a model file once per unchanged (path, size, mtime) process state."""
     stat_result = os.stat(path)
-    key = (os.path.abspath(path), stat_result.st_size, stat_result.st_mtime_ns)
+    abspath = os.path.abspath(path)
+    key = (abspath, stat_result.st_size, stat_result.st_mtime_ns)
     cached = _FILE_DIGEST_CACHE.get(key)
     if cached is not None:
         return cached
@@ -101,7 +102,12 @@ def sha256_file(path):
         for chunk in iter(lambda: handle.read(4 * 1024 * 1024), b""):
             digest.update(chunk)
     value = digest.hexdigest()
-    _FILE_DIGEST_CACHE.clear()
+    # Evict stale entries for THIS path only. Clearing the whole cache
+    # here would force every custom-model sidecar to be re-read on each
+    # cache check, defeating the point of the cache for multi-file
+    # models whose identity hashes each ONNX file in turn.
+    for stale in [k for k in _FILE_DIGEST_CACHE if k[0] == abspath and k != key]:
+        _FILE_DIGEST_CACHE.pop(stale, None)
     _FILE_DIGEST_CACHE[key] = value
     return value
 

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -1437,6 +1437,55 @@ def materialize_artifacts(
     the built-in local check does not have to grow special cases.
     """
     normalized = [validate_artifact(artifact) for artifact in artifacts]
+    # Trusted detection artifacts for the same (photo, detector_model)
+    # can carry multiple runtime_fingerprints -- e.g. the local store
+    # was populated by successive imports from different weights.  Every
+    # ``materialize_local_store`` call would otherwise write each of
+    # them in turn, and each runtime change deletes the currently
+    # selected detections and cascades their unreviewed predictions.
+    # The result is churn on every reapply plus a settled winner of
+    # whichever runtime happens to sort last.  Collapse to one artifact
+    # per logical (photo, detector_model) run before the loop, preferring
+    # whichever runtime the catalog already has installed so routine
+    # cache reapplication is a no-op; ties fall back to a deterministic
+    # runtime_fingerprint sort so repeated calls stay stable.
+    detection_by_key = {}
+    other_artifacts = []
+    for artifact in normalized:
+        if artifact["type"] != "detection":
+            other_artifacts.append(artifact)
+            continue
+        key = (artifact["photo_sha256"], artifact["detector_model"])
+        detection_by_key.setdefault(key, []).append(artifact)
+    chosen_detections = []
+    for (photo_sha256, detector_model), candidates in detection_by_key.items():
+        if len(candidates) == 1:
+            chosen_detections.append(candidates[0])
+            continue
+        existing = db.conn.execute(
+            """SELECT dr.runtime_fingerprint
+               FROM detector_runs dr
+               JOIN photos p ON p.id = dr.photo_id
+               WHERE p.file_hash = ? AND dr.detector_model = ?
+                 AND p.companion_path IS NULL
+                 AND p.working_copy_path IS NULL
+                 AND (p.flag IS NULL OR p.flag != 'rejected')
+               LIMIT 1""",
+            (photo_sha256, detector_model),
+        ).fetchone()
+        existing_runtime = (
+            existing["runtime_fingerprint"] if existing else None
+        )
+        match = next(
+            (c for c in candidates
+             if c["runtime_fingerprint"] == existing_runtime),
+            None,
+        )
+        chosen_detections.append(
+            match if match is not None
+            else min(candidates, key=lambda a: a["runtime_fingerprint"])
+        )
+    normalized = chosen_detections + other_artifacts
     normalized.sort(key=lambda item: item["type"] != "detection")
     identity_cache = {}
     result = {

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -289,15 +289,23 @@ def promote_and_publish_classifier_run(
     row = db.conn.execute(
         """SELECT d.photo_id, d.detector_model, d.runtime_fingerprint,
                   d.box_x, d.box_y, d.box_w, d.box_h, d.category,
-                  p.file_hash, p.companion_path
+                  p.file_hash, p.companion_path, p.working_copy_path
            FROM detections d
            JOIN photos p ON p.id = d.photo_id
            WHERE d.id = ?""",
         (detection_id,),
     ).fetchone()
+    # Working-copy-backed photos also stay local-only: ``_prepare_image``
+    # feeds the extracted working-copy JPEG (a specific rendition/recipe
+    # of the original) to the classifier when ``vireo_dir`` is set, but
+    # the v1 input identity carries only ``p.file_hash``. Publishing the
+    # result would advertise it as computed from the original bytes, so
+    # a destination that decodes the original — or that has a different
+    # working copy — would materialize predictions made on foreign pixels.
     if (
         row is None
         or row["companion_path"]
+        or row["working_copy_path"]
         or not _is_sha256(row["file_hash"])
         or not _is_sha256(row["runtime_fingerprint"])
     ):
@@ -1446,9 +1454,19 @@ def materialize_artifacts(
     matched_photo_ids = set()
 
     for artifact in normalized:
+        # v1 artifacts carry only the original ``photo_sha256`` in their
+        # input identity. When a destination photo has a
+        # ``companion_path`` (RAW+JPEG), Vireo processes the companion
+        # rendition, whose pixels can differ from the original even though
+        # both photos share the RAW's ``file_hash``. Materializing the
+        # original-only artifact onto that row would install detections
+        # and classifications for the wrong rendition, silently replacing
+        # locally correct results. Until an artifact variant declares
+        # companion identity, skip companion-backed catalog rows.
         photos = db.conn.execute(
             """SELECT id FROM photos
-               WHERE file_hash = ? AND (flag IS NULL OR flag != 'rejected')
+               WHERE file_hash = ? AND companion_path IS NULL
+                 AND (flag IS NULL OR flag != 'rejected')
                ORDER BY id""",
             (artifact["photo_sha256"],),
         ).fetchall()

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -602,13 +602,21 @@ def validate_artifact(artifact):
                 "labels.display_name must be a string of at most 500 chars"
             )
         label_count = labels.get("count")
+        # SQLite integer columns are signed 64-bit; a bundle carrying an
+        # arbitrarily large JSON int (e.g. 10**100) would pass a naive
+        # non-negativity check and only fail with OverflowError when
+        # materialize_artifacts binds the value.  By that point the bundle
+        # object has already been published, leaving an unmaterialized
+        # entry behind.  Reject out-of-range values up-front instead.
+        _SQLITE_INT64_MAX = (1 << 63) - 1
         if label_count is not None and (
             isinstance(label_count, bool)
             or not isinstance(label_count, int)
             or label_count < 0
+            or label_count > _SQLITE_INT64_MAX
         ):
             raise CacheFormatError(
-                "labels.count must be a non-negative integer"
+                "labels.count must be a non-negative integer within SQLite's 64-bit range"
             )
         detector_runtime = artifact.get("detector_runtime_fingerprint")
         if not _is_sha256(detector_runtime):

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -7,6 +7,7 @@ objects are published to the local store.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import math
@@ -16,7 +17,6 @@ import tempfile
 import zipfile
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
-
 
 ARTIFACT_SCHEMA = 1
 BUNDLE_FORMAT = 1
@@ -622,10 +622,8 @@ class ArtifactStore:
             if not created and destination.read_bytes() != body:
                 raise CacheFormatError("content-addressed object collision")
         finally:
-            try:
+            with contextlib.suppress(FileNotFoundError):
                 os.unlink(temp_name)
-            except FileNotFoundError:
-                pass
         return digest, created
 
     def iter_artifacts(self):
@@ -699,10 +697,8 @@ def write_bundle(destination, artifacts, device_label=None):
                 archive.writestr(f"objects/{digest}.json", body)
         os.replace(temp_name, destination)
     finally:
-        try:
+        with contextlib.suppress(FileNotFoundError):
             os.unlink(temp_name)
-        except FileNotFoundError:
-            pass
     return manifest
 
 

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -574,11 +574,21 @@ def validate_artifact(artifact):
         labels = artifact.get("labels")
         if not isinstance(labels, dict):
             raise CacheFormatError("classification artifact needs labels metadata")
-        if not _is_sha256(labels.get("fingerprint")):
+        full_fp = labels.get("fingerprint")
+        if not _is_sha256(full_fp):
             raise CacheFormatError("labels.fingerprint must be a full SHA-256")
         short = labels.get("short_fingerprint")
         if not isinstance(short, str) or not short or len(short) > 64:
             raise CacheFormatError("labels.short_fingerprint is invalid")
+        # short_fingerprint is a cache key for classifier_runs — normal jobs
+        # derive it from the first 12 characters of the full digest.  An
+        # arbitrary short key would let a crafted bundle claim an unrelated
+        # historical row (e.g. a legacy row with full_fingerprint IS NULL)
+        # and replace its unreviewed predictions under a foreign label set.
+        if short != full_fp[:12]:
+            raise CacheFormatError(
+                "labels.short_fingerprint must be the first 12 chars of labels.fingerprint"
+            )
         # Optional scalar metadata is bound directly to SQLite text/int
         # columns by materialize_artifacts.  A list or dict here would
         # surface as an uncaught binding error mid-write and leave the
@@ -677,6 +687,15 @@ class ArtifactStore:
                 created = True
             except FileExistsError:
                 created = False
+            except OSError:
+                # os.link raises EXDEV, EPERM, or ENOSYS on filesystems
+                # without hard-link support (exFAT, network mounts, some
+                # Windows volumes). Objects are content-addressed, so
+                # replacing an existing file with identical bytes is
+                # safe; fall back to os.replace to keep bundle import
+                # and result publication working on those volumes.
+                os.replace(temp_name, destination)
+                created = True
             if not created and destination.read_bytes() != body:
                 raise CacheFormatError("content-addressed object collision")
         finally:
@@ -889,8 +908,17 @@ def read_bundle(source):
         members = _safe_zip_members(archive)
         if "manifest.json" not in members:
             raise CacheFormatError("bundle has no manifest.json")
+        manifest_info = members["manifest.json"]
+        manifest_cap = MAX_MANIFEST_BYTES + 1
         try:
-            manifest = json.loads(archive.read("manifest.json"))
+            with archive.open(manifest_info, "r") as handle:
+                manifest_bytes = handle.read(manifest_cap)
+        except (OSError, zipfile.BadZipFile) as exc:
+            raise CacheFormatError("bundle manifest is not readable") from exc
+        if len(manifest_bytes) > MAX_MANIFEST_BYTES:
+            raise CacheFormatError("bundle manifest exceeds maximum size")
+        try:
+            manifest = json.loads(manifest_bytes)
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise CacheFormatError("bundle manifest is not valid JSON") from exc
         if not isinstance(manifest, dict):
@@ -925,7 +953,16 @@ def read_bundle(source):
             info = members.get(name)
             if info is None or info.file_size != size:
                 raise CacheFormatError("bundle object size does not match manifest")
-            body = archive.read(info)
+            # Stream the member with a hard byte cap instead of
+            # ``archive.read(info)``: the ZIP central-directory
+            # ``file_size`` is attacker-controlled, so a member declaring
+            # ``file_size = size`` could still expand into gigabytes and
+            # exhaust memory before the size/CRC checks fire. Reading
+            # one byte past the cap lets us reject the member without
+            # ever allocating the full uncompressed stream.
+            cap = max(size, 0) + 1
+            with archive.open(info, "r") as handle:
+                body = handle.read(cap)
             if len(body) != size or hashlib.sha256(body).hexdigest() != digest:
                 raise CacheFormatError("bundle object digest mismatch")
             try:
@@ -1244,7 +1281,9 @@ def _is_recognized_detector_runtime(detector_model, runtime, extra=None):
     if detector_model == "megadetector-v6":
         try:
             local = megadetector_runtime_fingerprint()
-        except (OSError, ValueError):
+        except (ImportError, OSError, ValueError):
+            # ImportError also fires when the `detector` module is not
+            # installed on this instance — quarantine, don't propagate.
             return False
         return local is not None and runtime == local
     return False
@@ -1486,7 +1525,10 @@ def materialize_artifacts(
                           sources_json, label_count)
                        VALUES (?, ?, ?, '[]', ?)
                        ON CONFLICT(fingerprint) DO UPDATE SET
-                         full_fingerprint = excluded.full_fingerprint,
+                         full_fingerprint = COALESCE(
+                             excluded.full_fingerprint,
+                             labels_fingerprints.full_fingerprint
+                         ),
                          display_name = COALESCE(excluded.display_name, display_name),
                          label_count = COALESCE(excluded.label_count, label_count)""",
                     (

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import math
 import os
+import shutil
 import stat
 import tempfile
 import zipfile
@@ -1138,10 +1139,15 @@ def read_bundle(source, on_artifact=None):
 def import_bundle(source, store):
     """Validate the whole bundle, then immutably publish its objects.
 
-    Streams each artifact through the store as soon as it validates, so
-    the whole bundle never sits in memory at once.  Only the runtime
-    fingerprint sets are retained across the walk (bounded by the count
-    of distinct runtimes, not by artifact size).  The returned artifact
+    Validation is all-or-nothing: each artifact is spooled to a
+    temporary directory as it validates, and objects are committed to
+    the store only after ``read_bundle`` has verified every artifact
+    body and every manifest-level check (declared members and total
+    ``uncompressed_bytes``).  A malformed later object or a wrong
+    manifest total therefore leaves the store untouched instead of
+    persisting the earlier objects that had already parsed cleanly.
+    Peak memory stays bounded to a single artifact — the spool lives
+    on disk, not in the parsed-artifact list.  The returned artifact
     list is intentionally empty in this streaming mode — callers that
     need to plant these artifacts on a database should read them back
     from ``store`` (e.g. via ``materialize_local_store``) after import.
@@ -1151,20 +1157,42 @@ def import_bundle(source, store):
     detector_runtimes = set()
     classifier_runtimes = set()
 
-    def _publish(artifact):
-        nonlocal added, existing
-        _digest, created = store.put(artifact)
-        if created:
-            added += 1
-        else:
-            existing += 1
-        artifact_type = artifact.get("type")
-        if artifact_type == "detection":
-            detector_runtimes.add(artifact["runtime_fingerprint"])
-        elif artifact_type == "classification":
-            classifier_runtimes.add(artifact["runtime_fingerprint"])
+    spool = tempfile.mkdtemp(prefix="vireo-import-spool-")
+    try:
+        # (digest, spool_path, artifact_type, runtime_fingerprint)
+        staged = []
 
-    manifest, _artifacts = read_bundle(source, on_artifact=_publish)
+        def _stage(artifact):
+            body = canonical_bytes(artifact)
+            digest = hashlib.sha256(body).hexdigest()
+            path = os.path.join(spool, f"{digest}.json")
+            with open(path, "wb") as handle:
+                handle.write(body)
+            staged.append((
+                digest,
+                path,
+                artifact.get("type"),
+                artifact.get("runtime_fingerprint"),
+            ))
+
+        manifest, _artifacts = read_bundle(source, on_artifact=_stage)
+
+        for _digest, path, artifact_type, runtime in staged:
+            with open(path, "rb") as handle:
+                body = handle.read()
+            artifact = validate_artifact(json.loads(body))
+            _committed, created = store.put(artifact)
+            if created:
+                added += 1
+            else:
+                existing += 1
+            if artifact_type == "detection":
+                detector_runtimes.add(runtime)
+            elif artifact_type == "classification":
+                classifier_runtimes.add(runtime)
+    finally:
+        shutil.rmtree(spool, ignore_errors=True)
+
     return {
         "manifest": manifest,
         "artifacts": [],

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -203,14 +203,68 @@ def classifier_model_identity(active_model):
     return identity
 
 
+def taxonomy_identity(tax):
+    """Portable identity for the taxonomy backing a classifier's outputs.
+
+    Included in ``classifier_runtime_fingerprint`` so a classifier run
+    produced with one taxonomy revision is not conflated with a run
+    produced against a different revision on another installation. The
+    Timm classifier consults taxonomy to resolve common names (when the
+    model's ``label_descriptions.json`` doesn't cover a class) and to
+    build the ``taxonomy`` hierarchy stored on every prediction, both of
+    which land in the published artifact — so two taxonomies produce
+    semantically distinct output for the same raw class id. Mirrors
+    ``pipeline_job._taxonomy_fingerprint`` in intent, but returns a
+    portable content identity rather than a session-local stat tuple.
+
+    ``None`` → ``"no-tax"``. A loaded ``Taxonomy`` returns the SHA-256 of
+    its backing file. Missing or unreadable paths fall back to
+    ``"no-tax"`` — the taxonomy was unavailable, so the run was made
+    without enrichment.
+    """
+    if tax is None:
+        return "no-tax"
+    path = getattr(tax, "_path", None)
+    if not isinstance(path, str) or not path:
+        return "no-tax"
+    try:
+        return sha256_file(path)
+    except OSError:
+        return "no-tax"
+
+
+def local_taxonomy_identity():
+    """Peek the local taxonomy identity without keeping the parse alive.
+
+    Callers that need to compute an expected classifier runtime BEFORE
+    the pipeline has loaded ``tax`` (the standalone Classify cache-check
+    at the peek stage, the built-in ``_is_recognized_classifier_runtime``
+    fallback in ``materialize_artifacts``) use this instead of loading a
+    fresh ``Taxonomy`` twice. ``load_local_taxonomy`` returns a shared
+    cached instance so the follow-up load in the classify flow is free.
+    """
+    try:
+        from taxonomy import load_local_taxonomy
+    except ImportError:
+        return "no-tax"
+    try:
+        tax = load_local_taxonomy()
+    except Exception:
+        return "no-tax"
+    return taxonomy_identity(tax)
+
+
 def classifier_runtime_fingerprint(
     model_identity, labels_fingerprint_full, detector_runtime,
+    taxonomy_identity="no-tax",
 ):
     if (
         not isinstance(model_identity, dict)
         or not _is_sha256(labels_fingerprint_full)
         or not _is_sha256(detector_runtime)
     ):
+        return None
+    if not isinstance(taxonomy_identity, str) or not taxonomy_identity:
         return None
     return runtime_fingerprint({
         "type": "classification",
@@ -219,12 +273,14 @@ def classifier_runtime_fingerprint(
         "detector_runtime_fingerprint": detector_runtime,
         "input_recipe": "vireo-classifier-crops-v1",
         "preprocess": "model-config-owned-v1",
+        "output_enrichment": {"taxonomy_identity": taxonomy_identity},
         "comparison_policy": "provider-tolerance-experimental-v1",
     })
 
 
 def classifier_runtime_for_detection(
     db, detection_id, model_identity, labels_fingerprint_full,
+    taxonomy_identity="no-tax",
 ):
     row = db.conn.execute(
         "SELECT runtime_fingerprint FROM detections WHERE id = ?",
@@ -236,6 +292,7 @@ def classifier_runtime_for_detection(
         model_identity,
         labels_fingerprint_full,
         row["runtime_fingerprint"],
+        taxonomy_identity=taxonomy_identity,
     )
 
 
@@ -282,6 +339,7 @@ def promote_and_publish_classifier_run(
     labels_fingerprint_full,
     model_identity,
     store=None,
+    taxonomy_identity="no-tax",
 ):
     """Attach portable identity to one fresh run and publish its raw output."""
     if not _is_sha256(labels_fingerprint_full):
@@ -312,6 +370,7 @@ def promote_and_publish_classifier_run(
         return None
     classifier_runtime = classifier_runtime_fingerprint(
         model_identity, labels_fingerprint_full, row["runtime_fingerprint"],
+        taxonomy_identity=taxonomy_identity,
     )
     if classifier_runtime is None:
         return None
@@ -379,6 +438,7 @@ def promote_and_publish_classifier_run(
             "display_name": label_meta["display_name"] if label_meta else None,
             "count": label_meta["label_count"] if label_meta else None,
         },
+        "output_enrichment": {"taxonomy_identity": taxonomy_identity},
         "completed": True,
         "subjects": [subject],
     }
@@ -659,6 +719,17 @@ def validate_artifact(artifact):
             raise CacheFormatError(
                 "classification artifact needs detector_runtime_fingerprint"
             )
+        enrichment = artifact.get("output_enrichment")
+        if enrichment is not None:
+            if not isinstance(enrichment, dict):
+                raise CacheFormatError(
+                    "output_enrichment must be an object when present"
+                )
+            tax_id = enrichment.get("taxonomy_identity")
+            if not isinstance(tax_id, str) or not tax_id or len(tax_id) > 128:
+                raise CacheFormatError(
+                    "output_enrichment.taxonomy_identity must be a bounded string"
+                )
         if artifact["input"].get("source_sha256") != artifact["photo_sha256"]:
             raise CacheFormatError("classification input source does not match photo")
         if (
@@ -1411,11 +1482,24 @@ def _is_recognized_classifier_runtime(
         or not _is_sha256(detector_runtime)
     ):
         return False
+    # Peek the local taxonomy identity: an install with taxonomy loaded
+    # produces classifier runs whose runtime_fingerprint bakes in that
+    # taxonomy's content hash. Without this, imports from another install
+    # with matching model/labels/detector but different (or no) taxonomy
+    # would be treated as unknown runtimes even though this install would
+    # reproduce the hash exactly. Only the *local* identity is accepted:
+    # an artifact whose taxonomy_identity does not match this install is
+    # a semantic mismatch (different species/hierarchy enrichment) and
+    # must stay quarantined until re-classified against the local
+    # taxonomy — same policy the model/labels/detector-runtime dimensions
+    # already enforce.
+    tax_id = local_taxonomy_identity()
     for identity in _local_classifier_runtimes(
         classifier_model, identity_cache,
     ):
         expected = classifier_runtime_fingerprint(
             identity, labels_fingerprint_full, detector_runtime,
+            taxonomy_identity=tax_id,
         )
         if expected == classifier_runtime:
             return True

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -1037,6 +1037,11 @@ def exportable_artifacts(db, artifact_types=None):
     unknown = artifact_types - _ARTIFACT_TYPES
     if unknown:
         raise CacheFormatError(f"unknown artifact types: {sorted(unknown)!r}")
+    # Classification subjects are keyed to detector-owned boxes. Keep the
+    # export dependency-closed so a destination can materialize the imported
+    # classifier runs without first reproducing detection locally.
+    if "classification" in artifact_types:
+        artifact_types.add("detection")
     artifacts = []
     summary = {
         "detector_runs": 0,

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -515,6 +515,25 @@ def classification_input(
     return block, fingerprint(block)
 
 
+def _finite_unit_interval(value, label):
+    # Range-check the raw value before ``math.isfinite`` sees it. JSON allows
+    # unbounded integer literals (e.g. ``10 ** 1000``), which overflow when
+    # coerced to a C double inside ``isfinite`` and raise ``OverflowError``
+    # instead of returning ``False``. That escapes the import route as a
+    # 500. Rejecting the range up front keeps the failure inside
+    # ``CacheFormatError`` for every JSON-representable numeric.
+    if isinstance(value, int):
+        if not 0 <= value <= 1:
+            raise CacheFormatError(f"{label} must be finite and in [0, 1]")
+        return
+    try:
+        finite = math.isfinite(value)
+    except (OverflowError, ValueError) as exc:
+        raise CacheFormatError(f"{label} must be finite and in [0, 1]") from exc
+    if not finite or not 0 <= value <= 1:
+        raise CacheFormatError(f"{label} must be finite and in [0, 1]")
+
+
 def _validate_box(box):
     if not isinstance(box, dict) or set(box) != {"x", "y", "w", "h"}:
         raise CacheFormatError("box must contain exactly x, y, w, and h")
@@ -522,8 +541,7 @@ def _validate_box(box):
         value = box[key]
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise CacheFormatError(f"box.{key} must be numeric")
-        if not math.isfinite(value) or not 0 <= value <= 1:
-            raise CacheFormatError(f"box.{key} must be finite and in [0, 1]")
+        _finite_unit_interval(value, f"box.{key}")
     if box["w"] <= 0 or box["h"] <= 0:
         raise CacheFormatError("box width and height must be positive")
     if box["x"] + box["w"] > 1.000001 or box["y"] + box["h"] > 1.000001:
@@ -533,8 +551,7 @@ def _validate_box(box):
 def _validate_confidence(value):
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise CacheFormatError("confidence must be numeric")
-    if not math.isfinite(value) or not 0 <= value <= 1:
-        raise CacheFormatError("confidence must be finite and in [0, 1]")
+    _finite_unit_interval(value, "confidence")
 
 
 _TAXONOMY_SCALAR_FIELDS = frozenset({
@@ -1019,8 +1036,18 @@ def _safe_zip_members(archive):
     return {info.filename: info for info in infos}
 
 
-def read_bundle(source):
-    """Validate an entire bundle without extracting it."""
+def read_bundle(source, on_artifact=None):
+    """Validate an entire bundle without extracting it.
+
+    When ``on_artifact`` is provided, each validated artifact is passed to
+    it and immediately released so peak memory stays bounded regardless of
+    the bundle's declared size (a valid bundle near ``MAX_BUNDLE_BYTES``
+    can inflate into several gigabytes of Python objects if every parsed
+    artifact is retained).  In that streaming mode the returned artifact
+    list is empty.  Callers that only need to summarize a small test
+    bundle can still call this without a callback and get the full list
+    for convenience.
+    """
     try:
         archive = zipfile.ZipFile(source, "r")
     except (OSError, zipfile.BadZipFile) as exc:
@@ -1092,8 +1119,15 @@ def read_bundle(source):
                 raise CacheFormatError("bundle object is not valid JSON") from exc
             if canonical_bytes(artifact) != body:
                 raise CacheFormatError("bundle object JSON is not canonical")
-            artifacts.append(artifact)
             declared_total += size
+            if on_artifact is None:
+                artifacts.append(artifact)
+            else:
+                on_artifact(artifact)
+                # Drop the parsed body/dict before the next iteration so
+                # the loop's memory ceiling is the largest single artifact
+                # rather than the sum of every one in the bundle.
+                del artifact, body
         if set(members) != expected_names:
             raise CacheFormatError("bundle contains undeclared members")
         if manifest.get("uncompressed_bytes") != declared_total:
@@ -1102,21 +1136,42 @@ def read_bundle(source):
 
 
 def import_bundle(source, store):
-    """Validate the whole bundle, then immutably publish its objects."""
-    manifest, artifacts = read_bundle(source)
+    """Validate the whole bundle, then immutably publish its objects.
+
+    Streams each artifact through the store as soon as it validates, so
+    the whole bundle never sits in memory at once.  Only the runtime
+    fingerprint sets are retained across the walk (bounded by the count
+    of distinct runtimes, not by artifact size).  The returned artifact
+    list is intentionally empty in this streaming mode — callers that
+    need to plant these artifacts on a database should read them back
+    from ``store`` (e.g. via ``materialize_local_store``) after import.
+    """
     added = 0
     existing = 0
-    for artifact in artifacts:
+    detector_runtimes = set()
+    classifier_runtimes = set()
+
+    def _publish(artifact):
+        nonlocal added, existing
         _digest, created = store.put(artifact)
         if created:
             added += 1
         else:
             existing += 1
+        artifact_type = artifact.get("type")
+        if artifact_type == "detection":
+            detector_runtimes.add(artifact["runtime_fingerprint"])
+        elif artifact_type == "classification":
+            classifier_runtimes.add(artifact["runtime_fingerprint"])
+
+    manifest, _artifacts = read_bundle(source, on_artifact=_publish)
     return {
         "manifest": manifest,
-        "artifacts": artifacts,
+        "artifacts": [],
         "added": added,
         "already_present": existing,
+        "detector_runtimes": detector_runtimes,
+        "classifier_runtimes": classifier_runtimes,
     }
 
 
@@ -1527,6 +1582,44 @@ def materialize_artifacts(
     the built-in local check does not have to grow special cases.
     """
     normalized = [validate_artifact(artifact) for artifact in artifacts]
+    # Break same-lookup-identity ties by lexicographically lowest
+    # ``artifact_digest`` before any per-runtime dedup below runs.  Without
+    # this, when a bundle declares divergent artifacts for the same
+    # ``(photo_sha256, runtime_fingerprint, input_fingerprint)`` (e.g. the
+    # same detector run's subjects rewritten with different rounding), the
+    # downstream stable sort at end of this block preserves manifest order
+    # and different installs would surface different boxes/species solely
+    # because of manifest ordering.  Digest is canonical-bytes-derived so
+    # the winner is content-defined and identical across installs.
+    def _dedup_by_lookup_identity(items, key_fn):
+        best = {}
+        for item in items:
+            key = key_fn(item)
+            digest = artifact_digest(item)
+            prior = best.get(key)
+            if prior is None or digest < prior[0]:
+                best[key] = (digest, item)
+        return [entry[1] for entry in best.values()]
+
+    detection_items = [a for a in normalized if a["type"] == "detection"]
+    classification_items = [a for a in normalized if a["type"] == "classification"]
+    detection_items = _dedup_by_lookup_identity(
+        detection_items,
+        lambda a: (
+            a["photo_sha256"], a["detector_model"],
+            a["runtime_fingerprint"], a["input_fingerprint"],
+        ),
+    )
+    classification_items = _dedup_by_lookup_identity(
+        classification_items,
+        lambda a: (
+            a["photo_sha256"], a["classifier_model"], a["detector_model"],
+            a["labels"]["fingerprint"],
+            a["detector_runtime_fingerprint"],
+            a["runtime_fingerprint"], a["input_fingerprint"],
+        ),
+    )
+
     # Trusted detection artifacts for the same (photo, detector_model)
     # can carry multiple runtime_fingerprints -- e.g. the local store
     # was populated by successive imports from different weights.  Every
@@ -1538,13 +1631,10 @@ def materialize_artifacts(
     # per logical (photo, detector_model) run before the loop, preferring
     # whichever runtime the catalog already has installed so routine
     # cache reapplication is a no-op; ties fall back to a deterministic
-    # runtime_fingerprint sort so repeated calls stay stable.
+    # (runtime_fingerprint, artifact_digest) sort so repeated calls stay
+    # stable regardless of iteration order.
     detection_by_key = {}
-    other_artifacts = []
-    for artifact in normalized:
-        if artifact["type"] != "detection":
-            other_artifacts.append(artifact)
-            continue
+    for artifact in detection_items:
         key = (artifact["photo_sha256"], artifact["detector_model"])
         detection_by_key.setdefault(key, []).append(artifact)
     chosen_detections = []
@@ -1573,10 +1663,16 @@ def materialize_artifacts(
         )
         chosen_detections.append(
             match if match is not None
-            else min(candidates, key=lambda a: a["runtime_fingerprint"])
+            else min(
+                candidates,
+                key=lambda a: (a["runtime_fingerprint"], artifact_digest(a)),
+            )
         )
-    normalized = chosen_detections + other_artifacts
-    normalized.sort(key=lambda item: item["type"] != "detection")
+    # Sort each group by digest so classification order is also
+    # content-defined instead of manifest-defined.
+    chosen_detections.sort(key=artifact_digest)
+    classification_items.sort(key=artifact_digest)
+    normalized = chosen_detections + classification_items
     identity_cache = {}
     result = {
         "matched_photos": 0,

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -535,6 +535,25 @@ def validate_artifact(artifact):
             raise CacheFormatError(f"unsupported subject kind {kind!r}")
         if kind == "box":
             _validate_box(subject.get("box"))
+            # Category is optional on classification box subjects
+            # (materialize falls back to "animal") but MUST be a bounded
+            # string when supplied.  ``compute_detection_id`` feeds it to
+            # ``positive_int_hash``, which calls ``len()`` on each part —
+            # a bool/int/None would raise ``TypeError`` mid-materialization
+            # after the bundle object has already been published, leaving
+            # an unmaterialized entry behind and returning 500 to the
+            # import route.  Detection artifacts still require the field
+            # to be present (checked further below).
+            if "category" in subject:
+                category = subject["category"]
+                if (
+                    not isinstance(category, str)
+                    or not category
+                    or len(category) > 80
+                ):
+                    raise CacheFormatError(
+                        "subject category must be a non-empty string"
+                    )
         elif "box" in subject:
             raise CacheFormatError("full_image subject must not contain a box")
 

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -546,8 +546,17 @@ def validate_artifact(artifact):
                 raise CacheFormatError("detection category must be a string")
         else:
             candidates = subject.get("candidates")
-            if not isinstance(candidates, list):
-                raise CacheFormatError("classification subject needs candidates")
+            # Reject empty candidate lists — a completed classification
+            # subject with no predictions still writes a classifier_runs
+            # marker on materialize, which _all_photos_cache_satisfied
+            # counts as covered.  That would let a bundle containing
+            # empty subjects short-circuit an entire Classify job and
+            # leave the photo permanently unclassified until a forced
+            # reclassify.
+            if not isinstance(candidates, list) or not candidates:
+                raise CacheFormatError(
+                    "classification subject needs at least one candidate"
+                )
             for candidate in candidates:
                 if not isinstance(candidate, dict):
                     raise CacheFormatError("classification candidate must be an object")
@@ -570,6 +579,27 @@ def validate_artifact(artifact):
         short = labels.get("short_fingerprint")
         if not isinstance(short, str) or not short or len(short) > 64:
             raise CacheFormatError("labels.short_fingerprint is invalid")
+        # Optional scalar metadata is bound directly to SQLite text/int
+        # columns by materialize_artifacts.  A list or dict here would
+        # surface as an uncaught binding error mid-write and leave the
+        # supposedly-validated object in the local store, so validate
+        # its shape up-front alongside the fingerprints.
+        display_name = labels.get("display_name")
+        if display_name is not None and (
+            not isinstance(display_name, str) or len(display_name) > 500
+        ):
+            raise CacheFormatError(
+                "labels.display_name must be a string of at most 500 chars"
+            )
+        label_count = labels.get("count")
+        if label_count is not None and (
+            isinstance(label_count, bool)
+            or not isinstance(label_count, int)
+            or label_count < 0
+        ):
+            raise CacheFormatError(
+                "labels.count must be a non-negative integer"
+            )
         detector_runtime = artifact.get("detector_runtime_fingerprint")
         if not _is_sha256(detector_runtime):
             raise CacheFormatError(

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -604,7 +604,16 @@ def validate_artifact(artifact):
         # arbitrary short key would let a crafted bundle claim an unrelated
         # historical row (e.g. a legacy row with full_fingerprint IS NULL)
         # and replace its unreviewed predictions under a foreign label set.
-        if short != full_fp[:12]:
+        #
+        # Tree-of-Life mode is the documented exception: compute_fingerprint([])
+        # returns the "tol" sentinel as the classifier_runs short key, while
+        # classify_job synthesizes a portable 64-char labels.fingerprint from
+        # the classifier identity.  The sentinel is a well-known constant, not
+        # attacker-controlled, and cannot impersonate a legacy row (whose short
+        # key is "legacy"), so exempt it from the digest-prefix check.
+        from labels_fingerprint import TOL_SENTINEL
+
+        if short != TOL_SENTINEL and short != full_fp[:12]:
             raise CacheFormatError(
                 "labels.short_fingerprint must be the first 12 chars of labels.fingerprint"
             )

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -1462,10 +1462,12 @@ def materialize_artifacts(
         # original-only artifact onto that row would install detections
         # and classifications for the wrong rendition, silently replacing
         # locally correct results. Until an artifact variant declares
-        # companion identity, skip companion-backed catalog rows.
+        # companion or working-copy identity, skip catalog rows backed by
+        # either alternate rendition.
         photos = db.conn.execute(
             """SELECT id FROM photos
                WHERE file_hash = ? AND companion_path IS NULL
+                 AND working_copy_path IS NULL
                  AND (flag IS NULL OR flag != 'rejected')
                ORDER BY id""",
             (artifact["photo_sha256"],),

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -1,0 +1,1323 @@
+"""Portable, content-addressed detector and classifier result cache.
+
+The format is deliberately data-only.  It never carries SQLite ids, paths,
+workspace state, or executable content.  Bundles are validated in full before
+objects are published to the local store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import stat
+import tempfile
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+
+
+ARTIFACT_SCHEMA = 1
+BUNDLE_FORMAT = 1
+DEFAULT_CACHE_DIR = "~/.vireo/computation-cache"
+
+MAX_OBJECTS = 10_000
+MAX_OBJECT_BYTES = 8 * 1024 * 1024
+MAX_BUNDLE_BYTES = 512 * 1024 * 1024
+MAX_MANIFEST_BYTES = 2 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 200
+
+_HEX64 = frozenset("0123456789abcdef")
+_ARTIFACT_TYPES = frozenset({"detection", "classification"})
+_FILE_DIGEST_CACHE = {}
+
+
+class CacheFormatError(ValueError):
+    """Raised when an artifact or bundle is invalid or unsupported."""
+
+
+def _is_sha256(value):
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(char in _HEX64 for char in value)
+    )
+
+
+def _normalize_json(value):
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise CacheFormatError("NaN and infinity are not valid cache data")
+        return 0.0 if value == 0 else value
+    if isinstance(value, list):
+        return [_normalize_json(item) for item in value]
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise CacheFormatError("cache object keys must be strings")
+        return {key: _normalize_json(item) for key, item in value.items()}
+    raise CacheFormatError(f"unsupported cache value: {type(value).__name__}")
+
+
+def canonical_bytes(value):
+    """Return the exact canonical JSON bytes used for all cache digests."""
+    normalized = _normalize_json(value)
+    return json.dumps(
+        normalized,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def fingerprint(value):
+    return hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def artifact_digest(artifact):
+    return fingerprint(artifact)
+
+
+def runtime_fingerprint(descriptor):
+    """Hash a caller-supplied immutable model/runtime descriptor."""
+    return fingerprint({
+        "artifact_schema": ARTIFACT_SCHEMA,
+        "runtime": descriptor,
+    })
+
+
+def sha256_file(path):
+    """Hash a model file once per unchanged (path, size, mtime) process state."""
+    stat_result = os.stat(path)
+    key = (os.path.abspath(path), stat_result.st_size, stat_result.st_mtime_ns)
+    cached = _FILE_DIGEST_CACHE.get(key)
+    if cached is not None:
+        return cached
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(4 * 1024 * 1024), b""):
+            digest.update(chunk)
+    value = digest.hexdigest()
+    _FILE_DIGEST_CACHE.clear()
+    _FILE_DIGEST_CACHE[key] = value
+    return value
+
+
+def megadetector_runtime_fingerprint(weights_path=None):
+    """Resolve the exact installed MegaDetector runtime without loading ONNX."""
+    from detector import (
+        CLASS_NAMES,
+        INPUT_SIZE,
+        MEGADETECTOR_ONNX_PATH,
+        RAW_CONF_FLOOR,
+    )
+
+    weights_path = weights_path or MEGADETECTOR_ONNX_PATH
+    if not os.path.isfile(weights_path):
+        return None
+    return runtime_fingerprint({
+        "type": "detection",
+        "model": "megadetector-v6",
+        "weights_sha256": sha256_file(weights_path),
+        "input_recipe": "vireo-detector-source-v1",
+        "preprocess": {
+            "version": 1,
+            "input_size": INPUT_SIZE,
+            "resize": "Pillow.BILINEAR-letterbox",
+            "padding": 114,
+        },
+        "postprocess": {
+            "version": 1,
+            "nms_iou": 0.45,
+            "raw_confidence_floor": RAW_CONF_FLOOR,
+            "categories": [[key, CLASS_NAMES[key]] for key in sorted(CLASS_NAMES)],
+        },
+        "comparison_policy": "provider-tolerance-experimental-v1",
+    })
+
+
+def full_image_runtime_fingerprint():
+    """Identity for Vireo's synthetic whole-photo classifier subject."""
+    return runtime_fingerprint({
+        "type": "detection",
+        "model": "full-image",
+        "input_recipe": "vireo-detector-source-v1",
+        "pipeline": "synthetic-full-image-v1",
+        "comparison_policy": "exact-v1",
+    })
+
+
+def classifier_model_identity(active_model):
+    """Resolve immutable classifier files without including local paths."""
+    if not isinstance(active_model, dict):
+        return None
+    weights_path = active_model.get("weights_path")
+    if not weights_path:
+        return None
+    declared = list(active_model.get("files") or [])
+    revision_path = os.path.join(weights_path, ".hf_revision")
+    revision = None
+    try:
+        with open(revision_path, encoding="utf-8") as handle:
+            revision = handle.read().strip()
+    except OSError:
+        pass
+    identity = {
+        "id": active_model.get("id"),
+        "model_str": active_model.get("model_str"),
+        "model_type": active_model.get("model_type", "bioclip"),
+        "declared_files": sorted(declared),
+    }
+    if revision:
+        identity["immutable_upstream_revision"] = revision
+        return identity
+
+    # Known Hugging Face installs without a pinned revision pre-date portable
+    # identity. Hashing multi-gigabyte external-data files on startup would
+    # make classification appear hung; keep those runs local until Repair or
+    # a fresh download writes .hf_revision. Custom models have no upstream
+    # revision, so exact file hashes are their intended identity.
+    if declared and active_model.get("source") != "custom":
+        return None
+
+    paths = []
+    if declared and os.path.isdir(weights_path):
+        paths = [(name, os.path.join(weights_path, name)) for name in sorted(declared)]
+    elif os.path.isdir(weights_path):
+        paths = [
+            (name, os.path.join(weights_path, name))
+            for name in sorted(os.listdir(weights_path))
+            if not name.startswith(".")
+            and os.path.isfile(os.path.join(weights_path, name))
+        ]
+    elif os.path.isfile(weights_path):
+        paths = [("weights", weights_path)]
+    if not paths or any(not os.path.isfile(path) for _name, path in paths):
+        return None
+    identity["file_sha256"] = [
+        [name, sha256_file(path)] for name, path in paths
+    ]
+    return identity
+
+
+def classifier_runtime_fingerprint(
+    model_identity, labels_fingerprint_full, detector_runtime,
+):
+    if (
+        not isinstance(model_identity, dict)
+        or not _is_sha256(labels_fingerprint_full)
+        or not _is_sha256(detector_runtime)
+    ):
+        return None
+    return runtime_fingerprint({
+        "type": "classification",
+        "model": model_identity,
+        "labels_fingerprint": labels_fingerprint_full,
+        "detector_runtime_fingerprint": detector_runtime,
+        "input_recipe": "vireo-classifier-crops-v1",
+        "preprocess": "model-config-owned-v1",
+        "comparison_policy": "provider-tolerance-experimental-v1",
+    })
+
+
+def classifier_runtime_for_detection(
+    db, detection_id, model_identity, labels_fingerprint_full,
+):
+    row = db.conn.execute(
+        "SELECT runtime_fingerprint FROM detections WHERE id = ?",
+        (detection_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return classifier_runtime_fingerprint(
+        model_identity,
+        labels_fingerprint_full,
+        row["runtime_fingerprint"],
+    )
+
+
+def publish_detection_artifact(
+    photo_sha256,
+    detector_model,
+    runtime,
+    detections,
+    store=None,
+):
+    """Publish one newly committed detector result when identity is complete."""
+    if not _is_sha256(photo_sha256) or not _is_sha256(runtime):
+        return None
+    input_block, input_fp = source_input(
+        photo_sha256, "vireo-detector-source-v1",
+    )
+    subjects = [{
+        "key": f"d{index}",
+        "kind": "box",
+        "box": detection["box"],
+        "confidence": detection["confidence"],
+        "category": detection.get("category", "animal"),
+    } for index, detection in enumerate(detections)]
+    artifact = {
+        "artifact_schema": ARTIFACT_SCHEMA,
+        "type": "detection",
+        "detector_model": detector_model,
+        "photo_sha256": photo_sha256,
+        "runtime_fingerprint": runtime,
+        "input_fingerprint": input_fp,
+        "input": input_block,
+        "completed": True,
+        "subjects": subjects,
+    }
+    digest, _created = (store or ArtifactStore()).put(artifact)
+    return digest
+
+
+def promote_and_publish_classifier_run(
+    db,
+    detection_id,
+    classifier_model,
+    labels_fingerprint,
+    labels_fingerprint_full,
+    model_identity,
+    store=None,
+):
+    """Attach portable identity to one fresh run and publish its raw output."""
+    if not _is_sha256(labels_fingerprint_full):
+        return None
+    row = db.conn.execute(
+        """SELECT d.photo_id, d.detector_model, d.runtime_fingerprint,
+                  d.box_x, d.box_y, d.box_w, d.box_h, d.category,
+                  p.file_hash, p.companion_path
+           FROM detections d
+           JOIN photos p ON p.id = d.photo_id
+           WHERE d.id = ?""",
+        (detection_id,),
+    ).fetchone()
+    if (
+        row is None
+        or row["companion_path"]
+        or not _is_sha256(row["file_hash"])
+        or not _is_sha256(row["runtime_fingerprint"])
+    ):
+        return None
+    classifier_runtime = classifier_runtime_fingerprint(
+        model_identity, labels_fingerprint_full, row["runtime_fingerprint"],
+    )
+    if classifier_runtime is None:
+        return None
+    kind = "full_image" if row["detector_model"] == "full-image" else "box"
+    subject = {"key": "d0", "kind": kind}
+    if kind == "box":
+        subject["box"] = {
+            "x": row["box_x"], "y": row["box_y"],
+            "w": row["box_w"], "h": row["box_h"],
+        }
+        subject["category"] = row["category"] or "animal"
+    input_block, input_fp = classification_input(
+        row["file_hash"], row["runtime_fingerprint"], [subject],
+    )
+    predictions = db.conn.execute(
+        """SELECT species, confidence, scientific_name,
+                  taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
+                  taxonomy_order, taxonomy_family, taxonomy_genus
+           FROM predictions
+           WHERE detection_id = ? AND classifier_model = ?
+             AND labels_fingerprint = ?
+           ORDER BY confidence DESC, species COLLATE NOCASE""",
+        (detection_id, classifier_model, labels_fingerprint),
+    ).fetchall()
+    if not predictions:
+        return None
+    candidates = []
+    for prediction in predictions:
+        candidate = {
+            "species": prediction["species"],
+            "confidence": prediction["confidence"],
+        }
+        taxonomy = {
+            "scientific_name": prediction["scientific_name"],
+            "kingdom": prediction["taxonomy_kingdom"],
+            "phylum": prediction["taxonomy_phylum"],
+            "class": prediction["taxonomy_class"],
+            "order": prediction["taxonomy_order"],
+            "family": prediction["taxonomy_family"],
+            "genus": prediction["taxonomy_genus"],
+        }
+        taxonomy = {key: value for key, value in taxonomy.items() if value}
+        if taxonomy:
+            candidate["taxonomy"] = taxonomy
+        candidates.append(candidate)
+    subject["candidates"] = candidates
+    label_meta = db.conn.execute(
+        """SELECT display_name, label_count FROM labels_fingerprints
+           WHERE fingerprint = ?""",
+        (labels_fingerprint,),
+    ).fetchone()
+    artifact = {
+        "artifact_schema": ARTIFACT_SCHEMA,
+        "type": "classification",
+        "classifier_model": classifier_model,
+        "detector_model": row["detector_model"],
+        "photo_sha256": row["file_hash"],
+        "runtime_fingerprint": classifier_runtime,
+        "detector_runtime_fingerprint": row["runtime_fingerprint"],
+        "input_fingerprint": input_fp,
+        "input": input_block,
+        "labels": {
+            "fingerprint": labels_fingerprint_full,
+            "short_fingerprint": labels_fingerprint,
+            "display_name": label_meta["display_name"] if label_meta else None,
+            "count": label_meta["label_count"] if label_meta else None,
+        },
+        "completed": True,
+        "subjects": [subject],
+    }
+    try:
+        db.conn.execute(
+            """UPDATE classifier_runs
+               SET labels_fingerprint_full = ?, runtime_fingerprint = ?,
+                   input_fingerprint = ?
+               WHERE detection_id = ? AND classifier_model = ?
+                 AND labels_fingerprint = ?""",
+            (
+                labels_fingerprint_full, classifier_runtime, input_fp,
+                detection_id, classifier_model, labels_fingerprint,
+            ),
+        )
+        db.conn.execute(
+            """UPDATE predictions SET labels_fingerprint_full = ?
+               WHERE detection_id = ? AND classifier_model = ?
+                 AND labels_fingerprint = ?""",
+            (
+                labels_fingerprint_full, detection_id,
+                classifier_model, labels_fingerprint,
+            ),
+        )
+        db.conn.commit()
+    except Exception:
+        db.conn.rollback()
+        raise
+    digest, _created = (store or ArtifactStore()).put(artifact)
+    return digest
+
+
+def source_input(photo_sha256, recipe):
+    """Build the versioned source identity used by the experimental v1 cache.
+
+    The model runtime identity owns decode/preprocess behavior.  The input
+    identity owns the exact source bytes and named source-selection recipe.
+    """
+    if not _is_sha256(photo_sha256):
+        raise CacheFormatError("photo_sha256 must be a lowercase SHA-256")
+    block = {
+        "recipe": recipe,
+        "sources": [{"role": "original", "sha256": photo_sha256}],
+    }
+    return block, fingerprint(block)
+
+
+def classification_input(
+    photo_sha256, detector_runtime_fingerprint, subjects,
+    recipe="vireo-classifier-crops-v1",
+):
+    if not _is_sha256(photo_sha256):
+        raise CacheFormatError("photo_sha256 must be a lowercase SHA-256")
+    if not _is_sha256(detector_runtime_fingerprint):
+        raise CacheFormatError("detector runtime must be a SHA-256")
+    subject_inputs = []
+    for subject in subjects:
+        entry = {"key": subject["key"], "kind": subject["kind"]}
+        if subject["kind"] == "box":
+            entry["box"] = subject["box"]
+        subject_inputs.append(entry)
+    block = {
+        "recipe": recipe,
+        "source_sha256": photo_sha256,
+        "detector_runtime_fingerprint": detector_runtime_fingerprint,
+        "subjects": subject_inputs,
+    }
+    return block, fingerprint(block)
+
+
+def _validate_box(box):
+    if not isinstance(box, dict) or set(box) != {"x", "y", "w", "h"}:
+        raise CacheFormatError("box must contain exactly x, y, w, and h")
+    for key in ("x", "y", "w", "h"):
+        value = box[key]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise CacheFormatError(f"box.{key} must be numeric")
+        if not math.isfinite(value) or not 0 <= value <= 1:
+            raise CacheFormatError(f"box.{key} must be finite and in [0, 1]")
+    if box["w"] <= 0 or box["h"] <= 0:
+        raise CacheFormatError("box width and height must be positive")
+    if box["x"] + box["w"] > 1.000001 or box["y"] + box["h"] > 1.000001:
+        raise CacheFormatError("box must fit inside normalized image bounds")
+
+
+def _validate_confidence(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CacheFormatError("confidence must be numeric")
+    if not math.isfinite(value) or not 0 <= value <= 1:
+        raise CacheFormatError("confidence must be finite and in [0, 1]")
+
+
+def validate_artifact(artifact):
+    """Validate one artifact and return its normalized data-only form."""
+    artifact = _normalize_json(artifact)
+    if not isinstance(artifact, dict):
+        raise CacheFormatError("artifact must be an object")
+    required = {
+        "artifact_schema", "type", "photo_sha256", "runtime_fingerprint",
+        "input_fingerprint", "input", "completed", "subjects",
+    }
+    missing = required - set(artifact)
+    if missing:
+        raise CacheFormatError(f"artifact missing fields: {', '.join(sorted(missing))}")
+    if artifact["artifact_schema"] != ARTIFACT_SCHEMA:
+        raise CacheFormatError(
+            f"unsupported artifact schema {artifact['artifact_schema']!r}"
+        )
+    if artifact["type"] not in _ARTIFACT_TYPES:
+        raise CacheFormatError(f"unsupported artifact type {artifact['type']!r}")
+    for field in ("photo_sha256", "runtime_fingerprint", "input_fingerprint"):
+        if not _is_sha256(artifact[field]):
+            raise CacheFormatError(f"{field} must be a lowercase SHA-256")
+    if artifact["completed"] is not True:
+        raise CacheFormatError("only completed computation may be cached")
+    if not isinstance(artifact["input"], dict):
+        raise CacheFormatError("input must be an object")
+    if fingerprint(artifact["input"]) != artifact["input_fingerprint"]:
+        raise CacheFormatError("input_fingerprint does not match input block")
+    if not isinstance(artifact["subjects"], list):
+        raise CacheFormatError("subjects must be a list")
+
+    seen_keys = set()
+    for subject in artifact["subjects"]:
+        if not isinstance(subject, dict):
+            raise CacheFormatError("subject must be an object")
+        key = subject.get("key")
+        kind = subject.get("kind")
+        if not isinstance(key, str) or not key or len(key) > 80:
+            raise CacheFormatError("subject key must be a short non-empty string")
+        if key in seen_keys:
+            raise CacheFormatError(f"duplicate subject key {key!r}")
+        seen_keys.add(key)
+        if kind not in {"box", "full_image"}:
+            raise CacheFormatError(f"unsupported subject kind {kind!r}")
+        if kind == "box":
+            _validate_box(subject.get("box"))
+        elif "box" in subject:
+            raise CacheFormatError("full_image subject must not contain a box")
+
+        if artifact["type"] == "detection":
+            if kind != "box":
+                raise CacheFormatError("detection artifacts contain only boxes")
+            _validate_confidence(subject.get("confidence"))
+            if not isinstance(subject.get("category"), str):
+                raise CacheFormatError("detection category must be a string")
+        else:
+            candidates = subject.get("candidates")
+            if not isinstance(candidates, list):
+                raise CacheFormatError("classification subject needs candidates")
+            for candidate in candidates:
+                if not isinstance(candidate, dict):
+                    raise CacheFormatError("classification candidate must be an object")
+                species = candidate.get("species")
+                if not isinstance(species, str) or not species or len(species) > 500:
+                    raise CacheFormatError("candidate species must be a non-empty string")
+                _validate_confidence(candidate.get("confidence"))
+
+    if artifact["type"] == "classification":
+        if not isinstance(artifact.get("classifier_model"), str):
+            raise CacheFormatError("classification artifact needs classifier_model")
+        if not isinstance(artifact.get("detector_model"), str):
+            raise CacheFormatError("classification artifact needs detector_model")
+        labels = artifact.get("labels")
+        if not isinstance(labels, dict):
+            raise CacheFormatError("classification artifact needs labels metadata")
+        if not _is_sha256(labels.get("fingerprint")):
+            raise CacheFormatError("labels.fingerprint must be a full SHA-256")
+        short = labels.get("short_fingerprint")
+        if not isinstance(short, str) or not short or len(short) > 64:
+            raise CacheFormatError("labels.short_fingerprint is invalid")
+        detector_runtime = artifact.get("detector_runtime_fingerprint")
+        if not _is_sha256(detector_runtime):
+            raise CacheFormatError(
+                "classification artifact needs detector_runtime_fingerprint"
+            )
+        if artifact["input"].get("source_sha256") != artifact["photo_sha256"]:
+            raise CacheFormatError("classification input source does not match photo")
+        if (
+            artifact["input"].get("detector_runtime_fingerprint")
+            != detector_runtime
+        ):
+            raise CacheFormatError("classification input detector runtime mismatch")
+        expected_input, _expected_fp = classification_input(
+            artifact["photo_sha256"], detector_runtime, artifact["subjects"],
+        )
+        if artifact["input"] != expected_input:
+            raise CacheFormatError("classification input does not match subjects")
+    elif not isinstance(artifact.get("detector_model"), str):
+        raise CacheFormatError("detection artifact needs detector_model")
+    else:
+        sources = artifact["input"].get("sources")
+        if not isinstance(sources, list) or not any(
+            isinstance(source, dict)
+            and source.get("role") == "original"
+            and source.get("sha256") == artifact["photo_sha256"]
+            for source in sources
+        ):
+            raise CacheFormatError("detection input source does not match photo")
+        expected_input, _expected_fp = source_input(
+            artifact["photo_sha256"], "vireo-detector-source-v1",
+        )
+        if artifact["input"] != expected_input:
+            raise CacheFormatError("unsupported detection input recipe")
+    return artifact
+
+
+class ArtifactStore:
+    def __init__(self, root=None):
+        self.root = Path(os.path.expanduser(os.fspath(root or DEFAULT_CACHE_DIR)))
+
+    def object_path(self, artifact, digest=None):
+        artifact = validate_artifact(artifact)
+        digest = digest or artifact_digest(artifact)
+        if not _is_sha256(digest):
+            raise CacheFormatError("artifact digest must be a SHA-256")
+        return (
+            self.root / "objects" / artifact["photo_sha256"][:2]
+            / artifact["photo_sha256"] / artifact["type"]
+            / artifact["runtime_fingerprint"] / artifact["input_fingerprint"]
+            / f"{digest}.json"
+        )
+
+    def put(self, artifact):
+        artifact = validate_artifact(artifact)
+        body = canonical_bytes(artifact)
+        if len(body) > MAX_OBJECT_BYTES:
+            raise CacheFormatError("artifact exceeds maximum object size")
+        digest = hashlib.sha256(body).hexdigest()
+        destination = self.object_path(artifact, digest)
+        if destination.exists():
+            if destination.read_bytes() != body:
+                raise CacheFormatError("content-addressed object collision")
+            return digest, False
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        fd, temp_name = tempfile.mkstemp(
+            prefix=".incoming-", suffix=".json", dir=destination.parent,
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(body)
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(temp_name, destination)
+                created = True
+            except FileExistsError:
+                created = False
+            if not created and destination.read_bytes() != body:
+                raise CacheFormatError("content-addressed object collision")
+        finally:
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+        return digest, created
+
+    def iter_artifacts(self):
+        objects = self.root / "objects"
+        if not objects.exists():
+            return
+        for path in sorted(objects.rglob("*.json")):
+            try:
+                body = path.read_bytes()
+                artifact = validate_artifact(json.loads(body))
+                digest = artifact_digest(artifact)
+                if path.name == f"{digest}.json":
+                    yield digest, artifact
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+
+    def stats(self):
+        count = 0
+        total = 0
+        objects = self.root / "objects"
+        if not objects.exists():
+            return {"object_count": 0, "total_bytes": 0}
+        for path in objects.rglob("*.json"):
+            try:
+                total += path.stat().st_size
+                count += 1
+            except OSError:
+                continue
+        return {"object_count": count, "total_bytes": total}
+
+
+def write_bundle(destination, artifacts, device_label=None):
+    """Atomically write a validated `.vireo-cache` ZIP bundle."""
+    destination = Path(destination)
+    objects = {}
+    for artifact in artifacts:
+        normalized = validate_artifact(artifact)
+        body = canonical_bytes(normalized)
+        if len(body) > MAX_OBJECT_BYTES:
+            raise CacheFormatError("artifact exceeds maximum object size")
+        objects.setdefault(hashlib.sha256(body).hexdigest(), body)
+    if len(objects) > MAX_OBJECTS:
+        raise CacheFormatError("bundle has too many objects")
+    total = sum(map(len, objects.values()))
+    if total > MAX_BUNDLE_BYTES:
+        raise CacheFormatError("bundle exceeds maximum uncompressed size")
+    manifest = {
+        "format": "vireo-computation-cache",
+        "format_version": BUNDLE_FORMAT,
+        "created_at": datetime.now(UTC).isoformat(),
+        "device_label": device_label if device_label else None,
+        "object_count": len(objects),
+        "uncompressed_bytes": total,
+        "objects": [
+            {"digest": digest, "size": len(body)}
+            for digest, body in sorted(objects.items())
+        ],
+    }
+    manifest_body = canonical_bytes(manifest)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent,
+    )
+    os.close(fd)
+    try:
+        with zipfile.ZipFile(
+            temp_name, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6,
+        ) as archive:
+            archive.writestr("manifest.json", manifest_body)
+            for digest, body in sorted(objects.items()):
+                archive.writestr(f"objects/{digest}.json", body)
+        os.replace(temp_name, destination)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+    return manifest
+
+
+def _safe_zip_members(archive):
+    infos = archive.infolist()
+    if len(infos) > MAX_OBJECTS + 1:
+        raise CacheFormatError("bundle has too many ZIP members")
+    total = 0
+    names = set()
+    for info in infos:
+        path = PurePosixPath(info.filename)
+        if (
+            not info.filename
+            or info.filename in names
+            or path.is_absolute()
+            or ".." in path.parts
+            or "\\" in info.filename
+        ):
+            raise CacheFormatError("bundle contains an unsafe ZIP path")
+        names.add(info.filename)
+        mode = info.external_attr >> 16
+        if mode and stat.S_ISLNK(mode):
+            raise CacheFormatError("bundle may not contain symbolic links")
+        if info.is_dir():
+            raise CacheFormatError("bundle may not contain directory entries")
+        if info.file_size > MAX_OBJECT_BYTES and info.filename != "manifest.json":
+            raise CacheFormatError("bundle object exceeds maximum size")
+        if info.filename == "manifest.json" and info.file_size > MAX_MANIFEST_BYTES:
+            raise CacheFormatError("bundle manifest exceeds maximum size")
+        if info.compress_size == 0 and info.file_size:
+            raise CacheFormatError("bundle member has an invalid compression ratio")
+        if info.compress_size and info.file_size / info.compress_size > MAX_COMPRESSION_RATIO:
+            raise CacheFormatError("bundle member exceeds compression-ratio limit")
+        total += info.file_size
+        if total > MAX_BUNDLE_BYTES + MAX_MANIFEST_BYTES:
+            raise CacheFormatError("bundle exceeds maximum uncompressed size")
+    return {info.filename: info for info in infos}
+
+
+def read_bundle(source):
+    """Validate an entire bundle without extracting it."""
+    try:
+        archive = zipfile.ZipFile(source, "r")
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise CacheFormatError(f"invalid cache bundle: {exc}") from exc
+    with archive:
+        members = _safe_zip_members(archive)
+        if "manifest.json" not in members:
+            raise CacheFormatError("bundle has no manifest.json")
+        try:
+            manifest = json.loads(archive.read("manifest.json"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise CacheFormatError("bundle manifest is not valid JSON") from exc
+        if not isinstance(manifest, dict):
+            raise CacheFormatError("bundle manifest must be an object")
+        if (
+            manifest.get("format") != "vireo-computation-cache"
+            or manifest.get("format_version") != BUNDLE_FORMAT
+        ):
+            raise CacheFormatError("unsupported cache bundle format")
+        declarations = manifest.get("objects")
+        if not isinstance(declarations, list):
+            raise CacheFormatError("bundle manifest objects must be a list")
+        if manifest.get("object_count") != len(declarations):
+            raise CacheFormatError("bundle object count does not match manifest")
+
+        expected_names = {"manifest.json"}
+        artifacts = []
+        declared_total = 0
+        seen = set()
+        for declaration in declarations:
+            if not isinstance(declaration, dict):
+                raise CacheFormatError("invalid object declaration")
+            digest = declaration.get("digest")
+            size = declaration.get("size")
+            if not _is_sha256(digest) or digest in seen:
+                raise CacheFormatError("invalid or duplicate object digest")
+            if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+                raise CacheFormatError("invalid object size")
+            seen.add(digest)
+            name = f"objects/{digest}.json"
+            expected_names.add(name)
+            info = members.get(name)
+            if info is None or info.file_size != size:
+                raise CacheFormatError("bundle object size does not match manifest")
+            body = archive.read(info)
+            if len(body) != size or hashlib.sha256(body).hexdigest() != digest:
+                raise CacheFormatError("bundle object digest mismatch")
+            try:
+                artifact = validate_artifact(json.loads(body))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise CacheFormatError("bundle object is not valid JSON") from exc
+            if canonical_bytes(artifact) != body:
+                raise CacheFormatError("bundle object JSON is not canonical")
+            artifacts.append(artifact)
+            declared_total += size
+        if set(members) != expected_names:
+            raise CacheFormatError("bundle contains undeclared members")
+        if manifest.get("uncompressed_bytes") != declared_total:
+            raise CacheFormatError("bundle byte total does not match manifest")
+        return manifest, artifacts
+
+
+def import_bundle(source, store):
+    """Validate the whole bundle, then immutably publish its objects."""
+    manifest, artifacts = read_bundle(source)
+    added = 0
+    existing = 0
+    for artifact in artifacts:
+        _digest, created = store.put(artifact)
+        if created:
+            added += 1
+        else:
+            existing += 1
+    return {
+        "manifest": manifest,
+        "artifacts": artifacts,
+        "added": added,
+        "already_present": existing,
+    }
+
+
+def exportable_artifacts(db, artifact_types=None):
+    """Synthesize portable artifacts from fully identified database runs.
+
+    Legacy rows and rows whose stored input identity cannot be reconstructed
+    are intentionally skipped.  This lets the store be introduced without
+    pretending pre-migration inference had a stronger identity than it did.
+    """
+    artifact_types = set(artifact_types or _ARTIFACT_TYPES)
+    unknown = artifact_types - _ARTIFACT_TYPES
+    if unknown:
+        raise CacheFormatError(f"unknown artifact types: {sorted(unknown)!r}")
+    artifacts = []
+    summary = {
+        "detector_runs": 0,
+        "classifier_runs": 0,
+        "skipped_legacy": 0,
+        "skipped_missing_hash": 0,
+        "skipped_incompatible_input": 0,
+    }
+
+    detection_rows = db.conn.execute(
+        """SELECT p.id AS photo_id, p.file_hash, dr.detector_model,
+                  dr.runtime_fingerprint, dr.input_fingerprint
+           FROM detector_runs dr
+           JOIN photos p ON p.id = dr.photo_id
+           ORDER BY p.id, dr.detector_model"""
+    ).fetchall()
+    if "detection" in artifact_types:
+        for row in detection_rows:
+            if not _is_sha256(row["file_hash"]):
+                summary["skipped_missing_hash"] += 1
+                continue
+            if not _is_sha256(row["runtime_fingerprint"]):
+                summary["skipped_legacy"] += 1
+                continue
+            input_block, expected_input = source_input(
+                row["file_hash"], "vireo-detector-source-v1",
+            )
+            if row["input_fingerprint"] != expected_input:
+                summary["skipped_incompatible_input"] += 1
+                continue
+            detections = db.conn.execute(
+                """SELECT box_x, box_y, box_w, box_h,
+                          detector_confidence, category
+                   FROM detections
+                   WHERE photo_id = ? AND detector_model = ?
+                     AND runtime_fingerprint = ?
+                   ORDER BY detector_confidence DESC, id ASC""",
+                (row["photo_id"], row["detector_model"],
+                 row["runtime_fingerprint"]),
+            ).fetchall()
+            subjects = [{
+                "key": f"d{index}",
+                "kind": "box",
+                "box": {
+                    "x": det["box_x"], "y": det["box_y"],
+                    "w": det["box_w"], "h": det["box_h"],
+                },
+                "confidence": det["detector_confidence"],
+                "category": det["category"] or "animal",
+            } for index, det in enumerate(detections)]
+            artifacts.append({
+                "artifact_schema": ARTIFACT_SCHEMA,
+                "type": "detection",
+                "detector_model": row["detector_model"],
+                "photo_sha256": row["file_hash"],
+                "runtime_fingerprint": row["runtime_fingerprint"],
+                "input_fingerprint": expected_input,
+                "input": input_block,
+                "completed": True,
+                "subjects": subjects,
+            })
+            summary["detector_runs"] += 1
+
+    if "classification" in artifact_types:
+        classifier_rows = db.conn.execute(
+            """SELECT DISTINCT
+                      p.id AS photo_id, p.file_hash,
+                      d.detector_model, d.runtime_fingerprint AS detector_runtime,
+                      cr.classifier_model, cr.labels_fingerprint,
+                      cr.labels_fingerprint_full, cr.runtime_fingerprint,
+                      cr.input_fingerprint
+               FROM classifier_runs cr
+               JOIN detections d ON d.id = cr.detection_id
+               JOIN photos p ON p.id = d.photo_id
+               ORDER BY p.id, cr.classifier_model, cr.labels_fingerprint"""
+        ).fetchall()
+        for row in classifier_rows:
+            if not _is_sha256(row["file_hash"]):
+                summary["skipped_missing_hash"] += 1
+                continue
+            if (
+                not _is_sha256(row["runtime_fingerprint"])
+                or not _is_sha256(row["detector_runtime"])
+                or not _is_sha256(row["labels_fingerprint_full"])
+            ):
+                summary["skipped_legacy"] += 1
+                continue
+            classified = db.conn.execute(
+                """SELECT d.id, d.box_x, d.box_y, d.box_w, d.box_h,
+                          d.detector_model, d.category
+                   FROM detections d
+                   JOIN classifier_runs cr ON cr.detection_id = d.id
+                   WHERE d.photo_id = ? AND d.detector_model = ?
+                     AND d.runtime_fingerprint = ?
+                     AND cr.classifier_model = ?
+                     AND cr.labels_fingerprint = ?
+                     AND cr.labels_fingerprint_full = ?
+                     AND cr.runtime_fingerprint = ?
+                     AND cr.input_fingerprint = ?
+                   ORDER BY d.detector_confidence DESC, d.id ASC""",
+                (
+                    row["photo_id"], row["detector_model"],
+                    row["detector_runtime"], row["classifier_model"],
+                    row["labels_fingerprint"],
+                    row["labels_fingerprint_full"],
+                    row["runtime_fingerprint"], row["input_fingerprint"],
+                ),
+            ).fetchall()
+            subjects = []
+            for index, detection in enumerate(classified):
+                kind = (
+                    "full_image"
+                    if detection["detector_model"] == "full-image" else "box"
+                )
+                subject = {"key": f"d{index}", "kind": kind}
+                if kind == "box":
+                    subject["box"] = {
+                        "x": detection["box_x"], "y": detection["box_y"],
+                        "w": detection["box_w"], "h": detection["box_h"],
+                    }
+                    subject["category"] = detection["category"] or "animal"
+                predictions = db.conn.execute(
+                    """SELECT species, confidence, scientific_name,
+                              taxonomy_kingdom, taxonomy_phylum,
+                              taxonomy_class, taxonomy_order,
+                              taxonomy_family, taxonomy_genus
+                       FROM predictions
+                       WHERE detection_id = ? AND classifier_model = ?
+                         AND labels_fingerprint = ?
+                       ORDER BY confidence DESC, species COLLATE NOCASE""",
+                    (detection["id"], row["classifier_model"],
+                     row["labels_fingerprint"]),
+                ).fetchall()
+                candidates = []
+                for prediction in predictions:
+                    candidate = {
+                        "species": prediction["species"],
+                        "confidence": prediction["confidence"],
+                    }
+                    taxonomy = {
+                        "scientific_name": prediction["scientific_name"],
+                        "kingdom": prediction["taxonomy_kingdom"],
+                        "phylum": prediction["taxonomy_phylum"],
+                        "class": prediction["taxonomy_class"],
+                        "order": prediction["taxonomy_order"],
+                        "family": prediction["taxonomy_family"],
+                        "genus": prediction["taxonomy_genus"],
+                    }
+                    taxonomy = {key: value for key, value in taxonomy.items() if value}
+                    if taxonomy:
+                        candidate["taxonomy"] = taxonomy
+                    candidates.append(candidate)
+                subject["candidates"] = candidates
+                subjects.append(subject)
+            input_block, expected_input = classification_input(
+                row["file_hash"], row["detector_runtime"], subjects,
+            )
+            if row["input_fingerprint"] != expected_input:
+                summary["skipped_incompatible_input"] += 1
+                continue
+            label_meta = db.conn.execute(
+                """SELECT display_name, label_count
+                   FROM labels_fingerprints WHERE fingerprint = ?""",
+                (row["labels_fingerprint"],),
+            ).fetchone()
+            artifacts.append({
+                "artifact_schema": ARTIFACT_SCHEMA,
+                "type": "classification",
+                "classifier_model": row["classifier_model"],
+                "detector_model": row["detector_model"],
+                "photo_sha256": row["file_hash"],
+                "runtime_fingerprint": row["runtime_fingerprint"],
+                "detector_runtime_fingerprint": row["detector_runtime"],
+                "input_fingerprint": expected_input,
+                "input": input_block,
+                "labels": {
+                    "fingerprint": row["labels_fingerprint_full"],
+                    "short_fingerprint": row["labels_fingerprint"],
+                    "display_name": label_meta["display_name"] if label_meta else None,
+                    "count": label_meta["label_count"] if label_meta else None,
+                },
+                "completed": True,
+                "subjects": subjects,
+            })
+            summary["classifier_runs"] += 1
+    return artifacts, summary
+
+
+def exportable_run_counts(db):
+    """Cheap Settings-page counts without synthesizing every payload."""
+    detector = db.conn.execute(
+        """SELECT
+             SUM(CASE WHEN length(p.file_hash) = 64
+                           AND length(dr.runtime_fingerprint) = 64
+                           AND length(dr.input_fingerprint) = 64
+                      THEN 1 ELSE 0 END) AS portable,
+             SUM(CASE WHEN p.file_hash IS NULL OR length(p.file_hash) != 64
+                      THEN 1 ELSE 0 END) AS missing_hash,
+             SUM(CASE WHEN dr.runtime_fingerprint = 'legacy'
+                      THEN 1 ELSE 0 END) AS legacy
+           FROM detector_runs dr JOIN photos p ON p.id = dr.photo_id"""
+    ).fetchone()
+    classifier = db.conn.execute(
+        """SELECT
+             SUM(CASE WHEN length(p.file_hash) = 64
+                           AND length(cr.runtime_fingerprint) = 64
+                           AND length(cr.input_fingerprint) = 64
+                           AND length(cr.labels_fingerprint_full) = 64
+                           AND length(d.runtime_fingerprint) = 64
+                      THEN 1 ELSE 0 END) AS portable,
+             SUM(CASE WHEN p.file_hash IS NULL OR length(p.file_hash) != 64
+                      THEN 1 ELSE 0 END) AS missing_hash,
+             SUM(CASE WHEN cr.runtime_fingerprint = 'legacy'
+                           OR cr.labels_fingerprint_full IS NULL
+                      THEN 1 ELSE 0 END) AS legacy
+           FROM classifier_runs cr
+           JOIN detections d ON d.id = cr.detection_id
+           JOIN photos p ON p.id = d.photo_id"""
+    ).fetchone()
+    return {
+        "detector_runs": detector["portable"] or 0,
+        "classifier_runs": classifier["portable"] or 0,
+        "skipped_legacy": (detector["legacy"] or 0) + (classifier["legacy"] or 0),
+        "skipped_missing_hash": (
+            (detector["missing_hash"] or 0)
+            + (classifier["missing_hash"] or 0)
+        ),
+        "skipped_incompatible_input": 0,
+    }
+
+
+def _manual_review_exists(conn, detection_id, classifier_model, labels_short):
+    row = conn.execute(
+        """SELECT 1
+           FROM predictions p
+           JOIN prediction_review pr ON pr.prediction_id = p.id
+           WHERE p.detection_id = ? AND p.classifier_model = ?
+             AND p.labels_fingerprint = ?
+             AND pr.status IN ('accepted', 'rejected')
+             AND COALESCE(pr.individual, '') != '__vireo_auto_match__'
+           LIMIT 1""",
+        (detection_id, classifier_model, labels_short),
+    ).fetchone()
+    return row is not None
+
+
+def materialize_artifacts(db, artifacts):
+    """Apply portable output to every matching non-rejected catalog row.
+
+    Review rows are never inserted.  Existing matching materializations are
+    left alone, so a later artifact cannot churn already-surfaced results.
+    """
+    normalized = [validate_artifact(artifact) for artifact in artifacts]
+    normalized.sort(key=lambda item: item["type"] != "detection")
+    result = {
+        "matched_photos": 0,
+        "detector_runs_applied": 0,
+        "classifier_runs_applied": 0,
+        "already_materialized": 0,
+        "stored_unmatched": 0,
+        "pinned_older_runtime": 0,
+        "label_collisions": 0,
+    }
+    matched_photo_ids = set()
+
+    for artifact in normalized:
+        photos = db.conn.execute(
+            """SELECT id FROM photos
+               WHERE file_hash = ? AND (flag IS NULL OR flag != 'rejected')
+               ORDER BY id""",
+            (artifact["photo_sha256"],),
+        ).fetchall()
+        if not photos:
+            result["stored_unmatched"] += 1
+            continue
+        matched_photo_ids.update(row["id"] for row in photos)
+
+        if artifact["type"] == "detection":
+            detections = [{
+                "box": subject["box"],
+                "confidence": subject["confidence"],
+                "category": subject["category"],
+            } for subject in artifact["subjects"]]
+            for photo in photos:
+                photo_id = photo["id"]
+                existing = db.conn.execute(
+                    """SELECT runtime_fingerprint, input_fingerprint
+                       FROM detector_runs
+                       WHERE photo_id = ? AND detector_model = ?""",
+                    (photo_id, artifact["detector_model"]),
+                ).fetchone()
+                if existing is not None and (
+                    existing["runtime_fingerprint"] == artifact["runtime_fingerprint"]
+                    and existing["input_fingerprint"] == artifact["input_fingerprint"]
+                ):
+                    result["already_materialized"] += 1
+                    continue
+                db.write_detection_batch(
+                    photo_id,
+                    artifact["detector_model"],
+                    detections,
+                    runtime_fingerprint=artifact["runtime_fingerprint"],
+                    input_fingerprint=artifact["input_fingerprint"],
+                )
+                current = db.conn.execute(
+                    """SELECT runtime_fingerprint, input_fingerprint
+                       FROM detector_runs
+                       WHERE photo_id = ? AND detector_model = ?""",
+                    (photo_id, artifact["detector_model"]),
+                ).fetchone()
+                if (
+                    current is None
+                    or current["runtime_fingerprint"] != artifact["runtime_fingerprint"]
+                    or current["input_fingerprint"] != artifact["input_fingerprint"]
+                ):
+                    result["pinned_older_runtime"] += 1
+                else:
+                    result["detector_runs_applied"] += 1
+            continue
+
+        labels = artifact["labels"]
+        collision = db.conn.execute(
+            """SELECT 1 FROM labels_fingerprints
+               WHERE fingerprint = ? AND full_fingerprint IS NOT NULL
+                 AND full_fingerprint != ?""",
+            (labels["short_fingerprint"], labels["fingerprint"]),
+        ).fetchone()
+        if collision:
+            result["label_collisions"] += 1
+            continue
+
+        for photo in photos:
+            photo_id = photo["id"]
+            detector_run = db.conn.execute(
+                """SELECT runtime_fingerprint FROM detector_runs
+                   WHERE photo_id = ? AND detector_model = ?""",
+                (photo_id, artifact["detector_model"]),
+            ).fetchone()
+            if (
+                detector_run is None
+                or detector_run["runtime_fingerprint"]
+                != artifact["detector_runtime_fingerprint"]
+            ):
+                continue
+            from detection_id import detection_id as compute_detection_id
+            from keyword_normalization import normalize_keyword_display
+
+            try:
+                db.conn.execute(
+                    """INSERT INTO labels_fingerprints
+                         (fingerprint, full_fingerprint, display_name,
+                          sources_json, label_count)
+                       VALUES (?, ?, ?, '[]', ?)
+                       ON CONFLICT(fingerprint) DO UPDATE SET
+                         full_fingerprint = excluded.full_fingerprint,
+                         display_name = COALESCE(excluded.display_name, display_name),
+                         label_count = COALESCE(excluded.label_count, label_count)""",
+                    (
+                        labels["short_fingerprint"], labels["fingerprint"],
+                        labels.get("display_name"), labels.get("count"),
+                    ),
+                )
+                applied_subjects = 0
+                for subject in artifact["subjects"]:
+                    if subject["kind"] == "full_image":
+                        detection = db.conn.execute(
+                            """SELECT id FROM detections
+                               WHERE photo_id = ? AND detector_model = 'full-image'
+                               ORDER BY id LIMIT 1""",
+                            (photo_id,),
+                        ).fetchone()
+                        detection_id = detection["id"] if detection else None
+                    else:
+                        box = subject["box"]
+                        detection_id = compute_detection_id(
+                            photo_id,
+                            artifact["detector_model"],
+                            (box["x"], box["y"], box["w"], box["h"]),
+                            subject.get("category", "animal"),
+                        )
+                        detection = db.conn.execute(
+                            "SELECT 1 FROM detections WHERE id = ?",
+                            (detection_id,),
+                        ).fetchone()
+                        if detection is None:
+                            detection_id = None
+                    if detection_id is None:
+                        continue
+                    prior = db.conn.execute(
+                        """SELECT runtime_fingerprint, input_fingerprint
+                           FROM classifier_runs
+                           WHERE detection_id = ? AND classifier_model = ?
+                             AND labels_fingerprint = ?""",
+                        (
+                            detection_id, artifact["classifier_model"],
+                            labels["short_fingerprint"],
+                        ),
+                    ).fetchone()
+                    if prior is not None and (
+                        prior["runtime_fingerprint"] == artifact["runtime_fingerprint"]
+                        and prior["input_fingerprint"] == artifact["input_fingerprint"]
+                    ):
+                        result["already_materialized"] += 1
+                        continue
+                    if prior is not None and _manual_review_exists(
+                        db.conn, detection_id, artifact["classifier_model"],
+                        labels["short_fingerprint"],
+                    ):
+                        result["pinned_older_runtime"] += 1
+                        continue
+                    if prior is not None:
+                        db.conn.execute(
+                            """DELETE FROM predictions
+                               WHERE detection_id = ? AND classifier_model = ?
+                                 AND labels_fingerprint = ?""",
+                            (
+                                detection_id, artifact["classifier_model"],
+                                labels["short_fingerprint"],
+                            ),
+                        )
+                    for candidate in subject["candidates"]:
+                        taxonomy = candidate.get("taxonomy") or {}
+                        species = normalize_keyword_display(candidate["species"])
+                        db.conn.execute(
+                            """INSERT OR IGNORE INTO predictions
+                                 (detection_id, classifier_model,
+                                  labels_fingerprint, labels_fingerprint_full,
+                                  species, confidence, category, scientific_name,
+                                  taxonomy_kingdom, taxonomy_phylum,
+                                  taxonomy_class, taxonomy_order,
+                                  taxonomy_family, taxonomy_genus)
+                               VALUES (?, ?, ?, ?, ?, ?, 'new', ?, ?, ?, ?, ?, ?, ?)""",
+                            (
+                                detection_id, artifact["classifier_model"],
+                                labels["short_fingerprint"], labels["fingerprint"],
+                                species, candidate["confidence"],
+                                taxonomy.get("scientific_name"),
+                                taxonomy.get("kingdom"), taxonomy.get("phylum"),
+                                taxonomy.get("class"), taxonomy.get("order"),
+                                taxonomy.get("family"), taxonomy.get("genus"),
+                            ),
+                        )
+                    db.conn.execute(
+                        """INSERT INTO classifier_runs
+                             (detection_id, classifier_model, labels_fingerprint,
+                              labels_fingerprint_full, runtime_fingerprint,
+                              input_fingerprint, prediction_count)
+                           VALUES (?, ?, ?, ?, ?, ?, ?)
+                           ON CONFLICT(detection_id, classifier_model,
+                                       labels_fingerprint)
+                           DO UPDATE SET
+                             labels_fingerprint_full = excluded.labels_fingerprint_full,
+                             runtime_fingerprint = excluded.runtime_fingerprint,
+                             input_fingerprint = excluded.input_fingerprint,
+                             prediction_count = excluded.prediction_count,
+                             run_at = datetime('now')""",
+                        (
+                            detection_id, artifact["classifier_model"],
+                            labels["short_fingerprint"], labels["fingerprint"],
+                            artifact["runtime_fingerprint"],
+                            artifact["input_fingerprint"],
+                            len(subject["candidates"]),
+                        ),
+                    )
+                    applied_subjects += 1
+                db.conn.commit()
+                result["classifier_runs_applied"] += applied_subjects
+            except Exception:
+                db.conn.rollback()
+                raise
+    result["matched_photos"] = len(matched_photo_ids)
+    return result
+
+
+def materialize_local_store(db, store=None):
+    """Apply stored objects that match the catalog's current photo hashes."""
+    store = store or ArtifactStore()
+    artifacts = [artifact for _digest, artifact in (store.iter_artifacts() or ())]
+    if not artifacts:
+        return {
+            "matched_photos": 0,
+            "detector_runs_applied": 0,
+            "classifier_runs_applied": 0,
+        }
+    return materialize_artifacts(db, artifacts)

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -1137,14 +1137,107 @@ def _is_recognized_detector_runtime(detector_model, runtime, extra=None):
     return False
 
 
-def materialize_artifacts(db, artifacts, known_runtimes=None):
+def _local_classifier_runtimes(classifier_model, cache):
+    """Yield locally-derivable classifier runtimes with matching model name.
+
+    A classifier runtime encodes ``(model_identity, labels_fingerprint,
+    detector_runtime)``.  Bundle artifacts carry the derived hash rather
+    than the ingredients, so recognition asks: for this ``classifier_model``
+    name, does any installed classifier produce the same hash for the
+    same labels + detector runtime?  This helper returns just the model
+    identities so the caller can plug in the artifact's own labels /
+    detector runtime before comparing.
+
+    ``cache`` is a mutable dict scoped to one materialize call — we hash
+    each classifier only once regardless of how many artifacts reference
+    it.
+    """
+    if classifier_model in cache:
+        return cache[classifier_model]
+    identities = []
+    try:
+        from models import get_models
+    except ImportError:
+        cache[classifier_model] = identities
+        return identities
+    try:
+        installed = get_models()
+    except Exception:
+        cache[classifier_model] = identities
+        return identities
+    for model in installed:
+        if not model.get("downloaded"):
+            continue
+        if model.get("name") != classifier_model:
+            continue
+        try:
+            identity = classifier_model_identity(model)
+        except (OSError, ValueError):
+            identity = None
+        if identity is not None:
+            identities.append(identity)
+    cache[classifier_model] = identities
+    return identities
+
+
+def _is_recognized_classifier_runtime(
+    classifier_model,
+    labels_fingerprint_full,
+    detector_runtime,
+    classifier_runtime,
+    identity_cache,
+    extra=None,
+):
+    """True when this install can reproduce the artifact's classifier runtime.
+
+    A classification artifact carries only the derived
+    ``runtime_fingerprint``.  To trust it, this install must be able to
+    recreate that hash from its own installed classifier for the same
+    labels + detector runtime.  A newer, foreign, or renamed classifier
+    fails this test and its predictions are quarantined in the object
+    store until a matching classifier lands.  Callers that already
+    validated a runtime through some other channel (tests seeding
+    fixtures, an active classify job that just resolved its own runtime)
+    pass it via ``extra`` so the built-in check does not have to grow
+    special cases.
+    """
+    if not _is_sha256(classifier_runtime):
+        return False
+    if extra and classifier_runtime in extra:
+        return True
+    if (
+        not _is_sha256(labels_fingerprint_full)
+        or not _is_sha256(detector_runtime)
+    ):
+        return False
+    for identity in _local_classifier_runtimes(
+        classifier_model, identity_cache,
+    ):
+        expected = classifier_runtime_fingerprint(
+            identity, labels_fingerprint_full, detector_runtime,
+        )
+        if expected == classifier_runtime:
+            return True
+    return False
+
+
+def materialize_artifacts(
+    db, artifacts, known_runtimes=None, known_classifier_runtimes=None,
+):
     """Apply portable output to every matching non-rejected catalog row.
 
     Review rows are never inserted.  Existing matching materializations are
     left alone, so a later artifact cannot churn already-surfaced results.
+
+    ``known_runtimes`` extends the built-in whitelist of DETECTOR runtimes
+    this install recognizes.  ``known_classifier_runtimes`` does the same
+    for classifier runtimes — callers with additional trust context (a
+    classify job that just resolved its own runtime) pass them here so
+    the built-in local check does not have to grow special cases.
     """
     normalized = [validate_artifact(artifact) for artifact in artifacts]
     normalized.sort(key=lambda item: item["type"] != "detection")
+    identity_cache = {}
     result = {
         "matched_photos": 0,
         "detector_runs_applied": 0,
@@ -1154,6 +1247,7 @@ def materialize_artifacts(db, artifacts, known_runtimes=None):
         "pinned_older_runtime": 0,
         "label_collisions": 0,
         "unknown_runtime": 0,
+        "unknown_classifier_runtime": 0,
         "classifier_deferred_pending_detection": 0,
     }
     matched_photo_ids = set()
@@ -1231,6 +1325,24 @@ def materialize_artifacts(db, artifacts, known_runtimes=None):
         ).fetchone()
         if collision:
             result["label_collisions"] += 1
+            continue
+
+        # Quarantine classification artifacts whose classifier runtime
+        # this install cannot reproduce.  The detector-runtime gate above
+        # only proves this catalog can describe the source detections;
+        # the classifier itself may still be a newer, foreign, or
+        # renamed model whose predictions would silently surface as
+        # authoritative results.  A future materialize call after the
+        # matching classifier is installed will pick these up.
+        if not _is_recognized_classifier_runtime(
+            artifact["classifier_model"],
+            labels["fingerprint"],
+            artifact["detector_runtime_fingerprint"],
+            artifact["runtime_fingerprint"],
+            identity_cache,
+            extra=known_classifier_runtimes,
+        ):
+            result["unknown_classifier_runtime"] += 1
             continue
 
         for photo in photos:
@@ -1381,7 +1493,9 @@ def materialize_artifacts(db, artifacts, known_runtimes=None):
     return result
 
 
-def materialize_local_store(db, store=None, known_runtimes=None):
+def materialize_local_store(
+    db, store=None, known_runtimes=None, known_classifier_runtimes=None,
+):
     """Apply stored objects that match the catalog's current photo hashes."""
     store = store or ArtifactStore()
     artifacts = [artifact for _digest, artifact in (store.iter_artifacts() or ())]
@@ -1391,4 +1505,8 @@ def materialize_local_store(db, store=None, known_runtimes=None):
             "detector_runs_applied": 0,
             "classifier_runs_applied": 0,
         }
-    return materialize_artifacts(db, artifacts, known_runtimes=known_runtimes)
+    return materialize_artifacts(
+        db, artifacts,
+        known_runtimes=known_runtimes,
+        known_classifier_runtimes=known_classifier_runtimes,
+    )

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -712,6 +712,89 @@ class ArtifactStore:
                 continue
         return {"object_count": count, "total_bytes": total}
 
+    @property
+    def trust_path(self):
+        return self.root / "trust.json"
+
+    def trusted_runtimes(self):
+        """Return (detector, classifier) runtime fingerprints trusted by this store.
+
+        Populated by ``record_trusted_runtimes`` when the user imports a
+        bundle. Later ``materialize_local_store`` calls read this file so
+        bundles imported before their matching photos landed still plant
+        once the photos are cataloged — the import-time whitelist was
+        one-shot per HTTP request and could not reach the later reapply.
+        """
+        path = self.trust_path
+        try:
+            body = path.read_bytes()
+        except FileNotFoundError:
+            return set(), set()
+        except OSError:
+            return set(), set()
+        try:
+            data = json.loads(body)
+        except (ValueError, json.JSONDecodeError):
+            return set(), set()
+        if not isinstance(data, dict):
+            return set(), set()
+        detector = {
+            value for value in (data.get("detector_runtimes") or [])
+            if _is_sha256(value)
+        }
+        classifier = {
+            value for value in (data.get("classifier_runtimes") or [])
+            if _is_sha256(value)
+        }
+        return detector, classifier
+
+    def record_trusted_runtimes(
+        self, detector_runtimes=None, classifier_runtimes=None,
+    ):
+        """Merge runtime fingerprints into the persisted trust set.
+
+        An explicit bundle import is a trust action for the runtimes the
+        user chose to accept. Persisting them lets subsequent
+        ``materialize_local_store`` calls plant matching artifacts whose
+        photos hadn't been cataloged at import time.
+        """
+        detector = {
+            value for value in (detector_runtimes or ())
+            if _is_sha256(value)
+        }
+        classifier = {
+            value for value in (classifier_runtimes or ())
+            if _is_sha256(value)
+        }
+        if not detector and not classifier:
+            return
+        existing_det, existing_clf = self.trusted_runtimes()
+        merged_det = sorted(existing_det | detector)
+        merged_clf = sorted(existing_clf | classifier)
+        if (
+            set(merged_det) == existing_det
+            and set(merged_clf) == existing_clf
+        ):
+            return
+        payload = {
+            "detector_runtimes": merged_det,
+            "classifier_runtimes": merged_clf,
+        }
+        self.root.mkdir(parents=True, exist_ok=True)
+        body = canonical_bytes(payload)
+        fd, temp_name = tempfile.mkstemp(
+            prefix=".trust-", suffix=".json", dir=self.root,
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(body)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, self.trust_path)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(temp_name)
+
 
 def write_bundle(destination, artifacts, device_label=None):
     """Atomically write a validated `.vireo-cache` ZIP bundle."""
@@ -1526,8 +1609,23 @@ def materialize_artifacts(
 def materialize_local_store(
     db, store=None, known_runtimes=None, known_classifier_runtimes=None,
 ):
-    """Apply stored objects that match the catalog's current photo hashes."""
+    """Apply stored objects that match the catalog's current photo hashes.
+
+    Runtime fingerprints previously recorded via
+    ``ArtifactStore.record_trusted_runtimes`` are unioned into the
+    ``known_runtimes`` / ``known_classifier_runtimes`` sets so that
+    artifacts whose photos were cataloged after their import bundle
+    landed still plant on the next call — the import-time whitelist was
+    scoped to one HTTP request and could not reach the later reapply.
+    """
     store = store or ArtifactStore()
+    persisted_det, persisted_clf = store.trusted_runtimes()
+    if persisted_det:
+        known_runtimes = set(known_runtimes or ()) | persisted_det
+    if persisted_clf:
+        known_classifier_runtimes = (
+            set(known_classifier_runtimes or ()) | persisted_clf
+        )
     artifacts = [artifact for _digest, artifact in (store.iter_artifacts() or ())]
     if not artifacts:
         return {

--- a/vireo/computation_cache.py
+++ b/vireo/computation_cache.py
@@ -463,6 +463,33 @@ def _validate_confidence(value):
         raise CacheFormatError("confidence must be finite and in [0, 1]")
 
 
+_TAXONOMY_SCALAR_FIELDS = frozenset({
+    "scientific_name", "kingdom", "phylum", "class", "order", "family", "genus",
+})
+
+
+def _validate_candidate_taxonomy(taxonomy):
+    # A candidate may omit taxonomy entirely.  When present it must be a JSON
+    # object whose recognized fields are optional strings — materialization
+    # binds these directly to SQLite text columns, so a list or nested object
+    # here would surface as an uncaught ``TypeError`` mid-write and leave the
+    # bundle half-applied.  Reject the whole artifact up front instead.
+    if taxonomy is None:
+        return
+    if not isinstance(taxonomy, dict):
+        raise CacheFormatError("candidate taxonomy must be an object")
+    for field in _TAXONOMY_SCALAR_FIELDS:
+        if field not in taxonomy:
+            continue
+        value = taxonomy[field]
+        if value is None:
+            continue
+        if not isinstance(value, str) or len(value) > 500:
+            raise CacheFormatError(
+                f"candidate taxonomy field {field!r} must be a string"
+            )
+
+
 def validate_artifact(artifact):
     """Validate one artifact and return its normalized data-only form."""
     artifact = _normalize_json(artifact)
@@ -528,6 +555,7 @@ def validate_artifact(artifact):
                 if not isinstance(species, str) or not species or len(species) > 500:
                     raise CacheFormatError("candidate species must be a non-empty string")
                 _validate_confidence(candidate.get("confidence"))
+                _validate_candidate_taxonomy(candidate.get("taxonomy"))
 
     if artifact["type"] == "classification":
         if not isinstance(artifact.get("classifier_model"), str):
@@ -1078,7 +1106,38 @@ def _manual_review_exists(conn, detection_id, classifier_model, labels_short):
     return row is not None
 
 
-def materialize_artifacts(db, artifacts):
+def _is_recognized_detector_runtime(detector_model, runtime, extra=None):
+    """True when this Vireo install can identify the artifact's runtime.
+
+    A bundle produced by a newer or foreign runtime carries a well-formed
+    fingerprint that this catalog cannot describe or reproduce.  Installing
+    such rows would let matching classification artifacts surface too, so
+    materialization skips them until the local install recognizes the
+    runtime (e.g. matching MegaDetector weights are downloaded).  The
+    artifact itself remains in the object store and a later
+    ``materialize_local_store`` picks it up once the runtime is known.
+
+    ``extra`` may hold additional trusted runtime fingerprints — callers
+    that already validated a runtime through some other channel (tests
+    seeding fixtures, an install-time weight registry) pass them here so
+    the built-in local check does not have to grow special cases.
+    """
+    if not _is_sha256(runtime):
+        return False
+    if extra and runtime in extra:
+        return True
+    if detector_model == "full-image":
+        return runtime == full_image_runtime_fingerprint()
+    if detector_model == "megadetector-v6":
+        try:
+            local = megadetector_runtime_fingerprint()
+        except (OSError, ValueError):
+            return False
+        return local is not None and runtime == local
+    return False
+
+
+def materialize_artifacts(db, artifacts, known_runtimes=None):
     """Apply portable output to every matching non-rejected catalog row.
 
     Review rows are never inserted.  Existing matching materializations are
@@ -1094,6 +1153,8 @@ def materialize_artifacts(db, artifacts):
         "stored_unmatched": 0,
         "pinned_older_runtime": 0,
         "label_collisions": 0,
+        "unknown_runtime": 0,
+        "classifier_deferred_pending_detection": 0,
     }
     matched_photo_ids = set()
 
@@ -1110,6 +1171,15 @@ def materialize_artifacts(db, artifacts):
         matched_photo_ids.update(row["id"] for row in photos)
 
         if artifact["type"] == "detection":
+            if not _is_recognized_detector_runtime(
+                artifact["detector_model"], artifact["runtime_fingerprint"],
+                extra=known_runtimes,
+            ):
+                # Quarantine: keep the object in the store but don't plant a
+                # detector_runs row this install cannot describe.  A future
+                # materialize call after weights install will recognize it.
+                result["unknown_runtime"] += 1
+                continue
             detections = [{
                 "box": subject["box"],
                 "confidence": subject["confidence"],
@@ -1175,6 +1245,11 @@ def materialize_artifacts(db, artifacts):
                 or detector_run["runtime_fingerprint"]
                 != artifact["detector_runtime_fingerprint"]
             ):
+                # Detector dependency not yet available on this install.
+                # A follow-up materialize call after detection runs (or
+                # after the detector's own artifacts are recognized) will
+                # pick these up.
+                result["classifier_deferred_pending_detection"] += 1
                 continue
             from detection_id import detection_id as compute_detection_id
             from keyword_normalization import normalize_keyword_display
@@ -1306,7 +1381,7 @@ def materialize_artifacts(db, artifacts):
     return result
 
 
-def materialize_local_store(db, store=None):
+def materialize_local_store(db, store=None, known_runtimes=None):
     """Apply stored objects that match the catalog's current photo hashes."""
     store = store or ArtifactStore()
     artifacts = [artifact for _digest, artifact in (store.iter_artifacts() or ())]
@@ -1316,4 +1391,4 @@ def materialize_local_store(db, store=None):
             "detector_runs_applied": 0,
             "classifier_runs_applied": 0,
         }
-    return materialize_artifacts(db, artifacts)
+    return materialize_artifacts(db, artifacts, known_runtimes=known_runtimes)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -821,6 +821,7 @@ class Database:
                 id                  INTEGER PRIMARY KEY,
                 photo_id            INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
                 detector_model      TEXT NOT NULL DEFAULT 'megadetector-v6',
+                runtime_fingerprint TEXT NOT NULL DEFAULT 'legacy',
                 box_x               REAL,
                 box_y               REAL,
                 box_w               REAL,
@@ -866,6 +867,7 @@ class Database:
                 detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
                 classifier_model     TEXT NOT NULL,
                 labels_fingerprint   TEXT NOT NULL DEFAULT 'legacy',
+                labels_fingerprint_full TEXT,
                 species              TEXT,
                 confidence           REAL,
                 category             TEXT,
@@ -883,6 +885,8 @@ class Database:
             CREATE TABLE IF NOT EXISTS detector_runs (
                 photo_id        INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
                 detector_model  TEXT NOT NULL,
+                runtime_fingerprint TEXT NOT NULL DEFAULT 'legacy',
+                input_fingerprint TEXT,
                 run_at          TEXT DEFAULT (datetime('now')),
                 box_count       INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (photo_id, detector_model)
@@ -892,6 +896,9 @@ class Database:
                 detection_id         INTEGER NOT NULL REFERENCES detections(id) ON DELETE CASCADE,
                 classifier_model     TEXT NOT NULL,
                 labels_fingerprint   TEXT NOT NULL,
+                labels_fingerprint_full TEXT,
+                runtime_fingerprint TEXT NOT NULL DEFAULT 'legacy',
+                input_fingerprint TEXT,
                 run_at               TEXT DEFAULT (datetime('now')),
                 prediction_count     INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (detection_id, classifier_model, labels_fingerprint)
@@ -908,6 +915,7 @@ class Database:
 
             CREATE TABLE IF NOT EXISTS labels_fingerprints (
                 fingerprint    TEXT PRIMARY KEY,
+                full_fingerprint TEXT,
                 display_name   TEXT,
                 sources_json   TEXT,
                 label_count    INTEGER,
@@ -15748,6 +15756,7 @@ class Database:
         individual=None,
         taxonomy=None,
         labels_fingerprint="legacy",
+        labels_fingerprint_full=None,
         preserve_manual_review=False,
     ):
         """Store a classification prediction for a detection.
@@ -15795,14 +15804,16 @@ class Database:
         cur = self.conn.execute(
             """INSERT OR IGNORE INTO predictions
                (detection_id, classifier_model, labels_fingerprint,
+                labels_fingerprint_full,
                 species, confidence, category,
                 taxonomy_kingdom, taxonomy_phylum, taxonomy_class,
                 taxonomy_order, taxonomy_family, taxonomy_genus, scientific_name)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 detection_id,
                 model,
                 labels_fingerprint,
+                labels_fingerprint_full,
                 species,
                 confidence,
                 category,
@@ -15830,6 +15841,13 @@ class Database:
                 (detection_id, model, labels_fingerprint, species),
             ).fetchone()
             pred_id = row["id"] if row else None
+            if pred_id is not None and labels_fingerprint_full is not None:
+                self.conn.execute(
+                    """UPDATE predictions
+                       SET labels_fingerprint_full = ?
+                       WHERE id = ? AND labels_fingerprint_full IS NULL""",
+                    (labels_fingerprint_full, pred_id),
+                )
         # Write workspace-scoped review state only when the caller actually
         # supplied something beyond the defaults. Keeping pending rows out of
         # prediction_review is intentional: absence == pending.
@@ -17537,18 +17555,30 @@ class Database:
 
     # -- Detections --
 
-    def record_detector_run(self, photo_id, detector_model, box_count):
+    def record_detector_run(
+        self,
+        photo_id,
+        detector_model,
+        box_count,
+        runtime_fingerprint="legacy",
+        input_fingerprint=None,
+    ):
         """Record that `detector_model` was run on `photo_id`.
 
         Global across workspaces — the output is a pure function of (photo, model).
         """
         self.conn.execute(
-            """INSERT INTO detector_runs (photo_id, detector_model, box_count)
-               VALUES (?, ?, ?)
+            """INSERT INTO detector_runs
+                 (photo_id, detector_model, runtime_fingerprint,
+                  input_fingerprint, box_count)
+               VALUES (?, ?, ?, ?, ?)
                ON CONFLICT(photo_id, detector_model)
-               DO UPDATE SET box_count = excluded.box_count,
+               DO UPDATE SET runtime_fingerprint = excluded.runtime_fingerprint,
+                             input_fingerprint = excluded.input_fingerprint,
+                             box_count = excluded.box_count,
                              run_at = datetime('now')""",
-            (photo_id, detector_model, box_count),
+            (photo_id, detector_model, runtime_fingerprint,
+             input_fingerprint, box_count),
         )
         self.conn.commit()
 
@@ -17568,7 +17598,31 @@ class Database:
         return {"photo_count": r["photo_count"] or 0,
                 "model_count": r["model_count"] or 0}
 
-    def get_detector_run_photo_ids(self, detector_model):
+    def detector_run_is_pinned(self, photo_id, detector_model):
+        """Return whether any workspace manually reviewed this detector output.
+
+        Review state belongs to predictions, but replacing a detector runtime
+        can delete the detection and cascade through both predictions and
+        reviews.  A real accepted/rejected decision therefore pins the whole
+        (photo, detector_model) result.  Auto-created taxonomy-match reviews
+        are reproducible cache state and deliberately do not pin it.
+        """
+        row = self.conn.execute(
+            """SELECT 1
+               FROM detections d
+               JOIN predictions p ON p.detection_id = d.id
+               JOIN prediction_review pr ON pr.prediction_id = p.id
+               WHERE d.photo_id = ? AND d.detector_model = ?
+                 AND pr.status IN ('accepted', 'rejected')
+                 AND COALESCE(pr.individual, '') != ?
+               LIMIT 1""",
+            (photo_id, detector_model, AUTO_MATCH_REVIEW_MARKER),
+        ).fetchone()
+        return row is not None
+
+    def get_detector_run_photo_ids(
+        self, detector_model, runtime_fingerprint=None,
+    ):
         """Return the set of photo_ids with a consistent cached detector run.
 
         Includes empty-scene photos (box_count=0) — which is the whole point:
@@ -17581,37 +17635,94 @@ class Database:
         photos in the skip set would strand them on full-image fallback
         until the user manually forces another reclassify.
         """
+        params = [detector_model]
+        runtime_clause = ""
+        if runtime_fingerprint is not None:
+            # A reviewed older runtime remains authoritative until an explicit
+            # reclassify.  Include it in the hit set so callers avoid doing
+            # inference whose result write_detection_batch would reject.
+            runtime_clause = """
+                 AND (
+                      dr.runtime_fingerprint = ?
+                      OR dr.runtime_fingerprint = 'legacy'
+                      OR EXISTS (
+                          SELECT 1
+                          FROM detections pd
+                          JOIN predictions pp ON pp.detection_id = pd.id
+                          JOIN prediction_review pr ON pr.prediction_id = pp.id
+                          WHERE pd.photo_id = dr.photo_id
+                            AND pd.detector_model = dr.detector_model
+                            AND pr.status IN ('accepted', 'rejected')
+                            AND COALESCE(pr.individual, '') != ?
+                      )
+                 )"""
+            params.extend([runtime_fingerprint, AUTO_MATCH_REVIEW_MARKER])
         rows = self.conn.execute(
             """SELECT dr.photo_id
                FROM detector_runs dr
                WHERE dr.detector_model = ?
+               """ + runtime_clause + """
                  AND (dr.box_count = 0
                       OR EXISTS (SELECT 1 FROM detections d
                                  WHERE d.photo_id = dr.photo_id
                                    AND d.detector_model = dr.detector_model))""",
-            (detector_model,),
+            params,
         ).fetchall()
         return {r["photo_id"] for r in rows}
 
-    def record_classifier_run(self, detection_id, classifier_model,
-                               labels_fingerprint, prediction_count):
+    def record_classifier_run(
+        self,
+        detection_id,
+        classifier_model,
+        labels_fingerprint,
+        prediction_count,
+        labels_fingerprint_full=None,
+        runtime_fingerprint="legacy",
+        input_fingerprint=None,
+    ):
         self.conn.execute(
             """INSERT INTO classifier_runs
-                 (detection_id, classifier_model, labels_fingerprint, prediction_count)
-               VALUES (?, ?, ?, ?)
+                 (detection_id, classifier_model, labels_fingerprint,
+                  labels_fingerprint_full, runtime_fingerprint,
+                  input_fingerprint, prediction_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(detection_id, classifier_model, labels_fingerprint)
-               DO UPDATE SET prediction_count = excluded.prediction_count,
+               DO UPDATE SET labels_fingerprint_full =
+                                 excluded.labels_fingerprint_full,
+                             runtime_fingerprint = excluded.runtime_fingerprint,
+                             input_fingerprint = excluded.input_fingerprint,
+                             prediction_count = excluded.prediction_count,
                              run_at = datetime('now')""",
-            (detection_id, classifier_model, labels_fingerprint, prediction_count),
+            (detection_id, classifier_model, labels_fingerprint,
+             labels_fingerprint_full, runtime_fingerprint,
+             input_fingerprint, prediction_count),
         )
         commit_with_retry(self.conn)
 
-    def get_classifier_run_keys(self, detection_id):
+    def get_classifier_run_keys(self, detection_id, runtime_fingerprint=None):
+        params = [detection_id]
+        runtime_clause = ""
+        if runtime_fingerprint is not None:
+            runtime_clause = """
+               AND (
+                    cr.runtime_fingerprint = ?
+                    OR cr.runtime_fingerprint = 'legacy'
+                    OR EXISTS (
+                        SELECT 1 FROM predictions p
+                        JOIN prediction_review pr ON pr.prediction_id = p.id
+                        WHERE p.detection_id = cr.detection_id
+                          AND p.classifier_model = cr.classifier_model
+                          AND p.labels_fingerprint = cr.labels_fingerprint
+                          AND pr.status IN ('accepted', 'rejected')
+                          AND COALESCE(pr.individual, '') != ?
+                    )
+               )"""
+            params.extend([runtime_fingerprint, AUTO_MATCH_REVIEW_MARKER])
         rows = self.conn.execute(
-            """SELECT classifier_model, labels_fingerprint
-               FROM classifier_runs
-               WHERE detection_id = ?""",
-            (detection_id,),
+            """SELECT cr.classifier_model, cr.labels_fingerprint
+               FROM classifier_runs cr
+               WHERE cr.detection_id = ?""" + runtime_clause,
+            params,
         ).fetchall()
         return {(r["classifier_model"], r["labels_fingerprint"]) for r in rows}
 
@@ -17735,7 +17846,8 @@ class Database:
         """
         import json
         rows = self.conn.execute(
-            "SELECT fingerprint, display_name, sources_json, label_count "
+            "SELECT fingerprint, full_fingerprint, display_name, "
+            "sources_json, label_count "
             "FROM labels_fingerprints"
         ).fetchall()
         out = []
@@ -17746,23 +17858,34 @@ class Database:
                 sources = []
             out.append({
                 "fingerprint": r["fingerprint"],
+                "full_fingerprint": r["full_fingerprint"],
                 "display_name": r["display_name"],
                 "sources": sources,
                 "label_count": r["label_count"],
             })
         return out
 
-    def upsert_labels_fingerprint(self, fingerprint, display_name, sources, label_count):
+    def upsert_labels_fingerprint(
+        self,
+        fingerprint,
+        display_name,
+        sources,
+        label_count,
+        full_fingerprint=None,
+    ):
         import json
         self.conn.execute(
             """INSERT INTO labels_fingerprints
-                 (fingerprint, display_name, sources_json, label_count)
-               VALUES (?, ?, ?, ?)
+                 (fingerprint, full_fingerprint, display_name,
+                  sources_json, label_count)
+               VALUES (?, ?, ?, ?, ?)
                ON CONFLICT(fingerprint)
-               DO UPDATE SET display_name = excluded.display_name,
+               DO UPDATE SET full_fingerprint = excluded.full_fingerprint,
+                             display_name = excluded.display_name,
                              sources_json = excluded.sources_json,
                              label_count  = excluded.label_count""",
-            (fingerprint, display_name, json.dumps(sources or []), label_count),
+            (fingerprint, full_fingerprint, display_name,
+             json.dumps(sources or []), label_count),
         )
         self.conn.commit()
 
@@ -17789,7 +17912,13 @@ class Database:
         )
         self.conn.commit()
 
-    def save_detections(self, photo_id, detections, detector_model):
+    def save_detections(
+        self,
+        photo_id,
+        detections,
+        detector_model,
+        runtime_fingerprint="legacy",
+    ):
         """Replace all detections for (photo_id, detector_model) with the given list.
 
         Global: no workspace scoping. The model's output is a pure function of
@@ -17810,11 +17939,19 @@ class Database:
         """
         if detector_model is None:
             raise ValueError("detector_model is required")
-        ids = self._upsert_detection_rows(photo_id, detector_model, detections)
+        ids = self._upsert_detection_rows(
+            photo_id, detector_model, detections, runtime_fingerprint,
+        )
         commit_with_retry(self.conn)
         return ids
 
-    def _upsert_detection_rows(self, photo_id, detector_model, detections):
+    def _upsert_detection_rows(
+        self,
+        photo_id,
+        detector_model,
+        detections,
+        runtime_fingerprint="legacy",
+    ):
         """Content-addressed UPSERT of detection rows for one (photo, model).
 
         Returns the list of unique IDs in first-seen order. Does NOT commit —
@@ -17858,19 +17995,20 @@ class Database:
             # pipeline has already written for this detection.
             self.conn.execute(
                 """INSERT INTO detections
-                     (id, photo_id, detector_model, box_x, box_y, box_w, box_h,
-                      detector_confidence, category)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     (id, photo_id, detector_model, runtime_fingerprint,
+                      box_x, box_y, box_w, box_h, detector_confidence, category)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
                      photo_id = excluded.photo_id,
                      detector_model = excluded.detector_model,
+                     runtime_fingerprint = excluded.runtime_fingerprint,
                      box_x = excluded.box_x,
                      box_y = excluded.box_y,
                      box_w = excluded.box_w,
                      box_h = excluded.box_h,
                      detector_confidence = excluded.detector_confidence,
                      category = excluded.category""",
-                (det_id, photo_id, detector_model,
+                (det_id, photo_id, detector_model, runtime_fingerprint,
                  box["x"], box["y"], box["w"], box["h"],
                  det["confidence"], category),
             )
@@ -17882,8 +18020,10 @@ class Database:
         # `new_ids` set, so neither deletes the other's rows.
         new_ids = set(ids)
         existing = [r["id"] for r in self.conn.execute(
-            "SELECT id FROM detections WHERE photo_id = ? AND detector_model = ?",
-            (photo_id, detector_model),
+            """SELECT id FROM detections
+               WHERE photo_id = ? AND detector_model = ?
+                 AND runtime_fingerprint = ?""",
+            (photo_id, detector_model, runtime_fingerprint),
         ).fetchall()]
         stale = [eid for eid in existing if eid not in new_ids]
         # Chunk to stay under SQLite's compile-time SQLITE_MAX_VARIABLE_NUMBER
@@ -17900,7 +18040,15 @@ class Database:
             )
         return ids
 
-    def write_detection_batch(self, photo_id, detector_model, detections):
+    def write_detection_batch(
+        self,
+        photo_id,
+        detector_model,
+        detections,
+        runtime_fingerprint="legacy",
+        input_fingerprint=None,
+        force_runtime_replace=False,
+    ):
         """Atomically replace detections and record the detector_runs row.
 
         Combines `save_detections` and `record_detector_run` under a single
@@ -17921,14 +18069,58 @@ class Database:
         if detector_model is None:
             raise ValueError("detector_model is required")
         try:
-            ids = self._upsert_detection_rows(photo_id, detector_model, detections)
+            previous = self.conn.execute(
+                """SELECT runtime_fingerprint, input_fingerprint
+                   FROM detector_runs
+                   WHERE photo_id = ? AND detector_model = ?""",
+                (photo_id, detector_model),
+            ).fetchone()
+            identity_changed = previous is not None and (
+                previous["runtime_fingerprint"] != runtime_fingerprint
+                or (
+                    previous["input_fingerprint"] is not None
+                    and input_fingerprint is not None
+                    and previous["input_fingerprint"] != input_fingerprint
+                )
+            )
+            if (
+                identity_changed
+                and not force_runtime_replace
+                and self.detector_run_is_pinned(photo_id, detector_model)
+            ):
+                rows = self.conn.execute(
+                    """SELECT id FROM detections
+                       WHERE photo_id = ? AND detector_model = ?
+                       ORDER BY detector_confidence DESC, id ASC""",
+                    (photo_id, detector_model),
+                ).fetchall()
+                return [row["id"] for row in rows]
+
+            if identity_changed:
+                # Runtime ownership changes are an explicit retirement event.
+                # Deleting first prevents old-runtime rows from surviving the
+                # new run's same-runtime stale-row sweep.
+                self.conn.execute(
+                    """DELETE FROM detections
+                       WHERE photo_id = ? AND detector_model = ?""",
+                    (photo_id, detector_model),
+                )
+
+            ids = self._upsert_detection_rows(
+                photo_id, detector_model, detections, runtime_fingerprint,
+            )
             self.conn.execute(
-                """INSERT INTO detector_runs (photo_id, detector_model, box_count)
-                   VALUES (?, ?, ?)
+                """INSERT INTO detector_runs
+                     (photo_id, detector_model, runtime_fingerprint,
+                      input_fingerprint, box_count)
+                   VALUES (?, ?, ?, ?, ?)
                    ON CONFLICT(photo_id, detector_model)
-                   DO UPDATE SET box_count = excluded.box_count,
+                   DO UPDATE SET runtime_fingerprint = excluded.runtime_fingerprint,
+                                 input_fingerprint = excluded.input_fingerprint,
+                                 box_count = excluded.box_count,
                                  run_at = datetime('now')""",
-                (photo_id, detector_model, len(ids)),
+                (photo_id, detector_model, runtime_fingerprint,
+                 input_fingerprint, len(ids)),
             )
             commit_with_retry(self.conn)
             return ids

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -17874,13 +17874,20 @@ class Database:
         full_fingerprint=None,
     ):
         import json
+        # COALESCE full_fingerprint so a later call recording the same
+        # short fingerprint without the 64-char digest (e.g. after an
+        # OSError/ValueError fallback in _record_labels_fingerprint) does
+        # not overwrite a previously stored full digest with NULL.
         self.conn.execute(
             """INSERT INTO labels_fingerprints
                  (fingerprint, full_fingerprint, display_name,
                   sources_json, label_count)
                VALUES (?, ?, ?, ?, ?)
                ON CONFLICT(fingerprint)
-               DO UPDATE SET full_fingerprint = excluded.full_fingerprint,
+               DO UPDATE SET full_fingerprint = COALESCE(
+                                 excluded.full_fingerprint,
+                                 labels_fingerprints.full_fingerprint
+                             ),
                              display_name = excluded.display_name,
                              sources_json = excluded.sources_json,
                              label_count  = excluded.label_count""",

--- a/vireo/labels_fingerprint.py
+++ b/vireo/labels_fingerprint.py
@@ -12,9 +12,19 @@ TOL_SENTINEL = "tol"
 LEGACY_SENTINEL = "legacy"
 
 
+def _canonical_labels(labels):
+    return "\n".join(sorted(set(labels))).encode("utf-8")
+
+
 def compute_fingerprint(labels):
     """sha256 hex prefix of sorted, deduped labels. TOL_SENTINEL when empty."""
     if not labels:
         return TOL_SENTINEL
-    canonical = "\n".join(sorted(set(labels))).encode("utf-8")
-    return hashlib.sha256(canonical).hexdigest()[:12]
+    return hashlib.sha256(_canonical_labels(labels)).hexdigest()[:12]
+
+
+def compute_full_fingerprint(labels):
+    """Return the full portable identity without changing historical keys."""
+    if not labels:
+        return TOL_SENTINEL
+    return hashlib.sha256(_canonical_labels(labels)).hexdigest()

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1364,7 +1364,8 @@ def _collapse_scan_roots(paths):
 
 def run_pipeline_job(job, runner, db_path, workspace_id, params,
                      thumb_cache_dir=None,
-                     missing_originals_invalidator=None):
+                     missing_originals_invalidator=None,
+                     computation_cache_dir=None):
     """Execute streaming pipeline. Called by JobRunner in a background thread.
 
     Args:
@@ -1384,6 +1385,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             api_job_scan / api_job_import_full so a pipeline scan that
             touches disk doesn't leave GET /api/photos/missing serving a
             pre-scan ghost list.
+        computation_cache_dir: portable-cache root the HTTP import route
+            writes to (``app.config["COMPUTATION_CACHE_DIR"]``). When
+            provided, the detect stage reads from the same store so bundles
+            imported before their photos were cataloged still plant outside
+            the default location.
 
     Returns:
         dict with stage results, duration, and errors
@@ -4237,10 +4243,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 detect_state["ran"] = True
 
                 try:
-                    from computation_cache import materialize_local_store
+                    from computation_cache import (
+                        ArtifactStore,
+                        materialize_local_store,
+                    )
 
+                    cache_store = (
+                        ArtifactStore(computation_cache_dir)
+                        if computation_cache_dir else None
+                    )
                     reused = (
-                        materialize_local_store(thread_db)
+                        materialize_local_store(thread_db, store=cache_store)
                         if not params.reclassify else {}
                     )
                     detect_state["portable_reused"] = reused
@@ -4529,8 +4542,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         known_classifier_runtimes.add(crt)
                             except Exception:
                                 known_classifier_runtimes = set()
+                        from computation_cache import ArtifactStore
+
+                        reapply_store = (
+                            ArtifactStore(computation_cache_dir)
+                            if computation_cache_dir else None
+                        )
                         post = materialize_local_store(
-                            thread_db, known_runtimes=known_runtimes,
+                            thread_db, store=reapply_store,
+                            known_runtimes=known_runtimes,
                             known_classifier_runtimes=(
                                 known_classifier_runtimes or None
                             ),

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4364,6 +4364,35 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # with no detections AND no predictions. See classify_stage for
                 # the actual delete.
 
+                # Reapply the local computation cache now that fresh
+                # detector_runs exist. Classification artifacts whose
+                # detector dependency was absent at the pre-detection
+                # materialize call get a second chance to land here, so
+                # bundles carrying only classifications still surface.
+                if not params.reclassify and detector_runtime is not None:
+                    try:
+                        from computation_cache import materialize_local_store
+
+                        post = materialize_local_store(
+                            thread_db, known_runtimes={detector_runtime},
+                        )
+                        if post.get("classifier_runs_applied"):
+                            prior = detect_state.get("portable_reused") or {}
+                            prior_applied = prior.get(
+                                "classifier_runs_applied", 0,
+                            )
+                            merged = dict(prior)
+                            merged["classifier_runs_applied"] = (
+                                prior_applied
+                                + post["classifier_runs_applied"]
+                            )
+                            detect_state["portable_reused"] = merged
+                    except Exception:
+                        log.warning(
+                            "Could not reapply local computation cache after detect",
+                            exc_info=True,
+                        )
+
                 stages["detect"]["status"] = "completed"
                 runner.update_step(
                     job["id"], "detect", status="completed",

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4386,6 +4386,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             source_input,
                         )
 
+                        # Pre-create full-image anchors for empty-scene
+                        # photos, and promote any legacy full-image
+                        # ``detector_runs`` row to the portable runtime
+                        # so imported full-image classifications
+                        # actually attach on materialize instead of
+                        # being deferred by the runtime-fingerprint
+                        # gate.
                         full_runtime = full_image_runtime_fingerprint()
                         empty_scene_ids = [
                             photo["id"] for photo in photos
@@ -4393,12 +4400,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             and not this_run_detections.get(photo["id"])
                         ]
                         for photo_id in empty_scene_ids:
-                            existing_full = thread_db.get_detections(
-                                photo_id, detector_model="full-image",
-                                min_conf=0,
-                            )
-                            if existing_full:
-                                continue
                             identity = thread_db.conn.execute(
                                 """SELECT file_hash, companion_path
                                    FROM photos WHERE id = ?""",
@@ -4416,21 +4417,37 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     )
                                 except ValueError:
                                     full_input = None
-                            thread_db.save_detections(
-                                photo_id,
-                                [{
-                                    "box": {"x": 0, "y": 0, "w": 1, "h": 1},
-                                    "confidence": 0,
-                                    "category": "animal",
-                                }],
-                                detector_model="full-image",
-                                runtime_fingerprint=full_runtime,
+                            existing_full = thread_db.get_detections(
+                                photo_id, detector_model="full-image",
+                                min_conf=0,
                             )
-                            thread_db.record_detector_run(
-                                photo_id, "full-image", box_count=1,
-                                runtime_fingerprint=full_runtime,
-                                input_fingerprint=full_input,
-                            )
+                            if not existing_full:
+                                thread_db.save_detections(
+                                    photo_id,
+                                    [{
+                                        "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                                        "confidence": 0,
+                                        "category": "animal",
+                                    }],
+                                    detector_model="full-image",
+                                    runtime_fingerprint=full_runtime,
+                                )
+                            existing_run = thread_db.conn.execute(
+                                """SELECT runtime_fingerprint FROM detector_runs
+                                   WHERE photo_id = ?
+                                     AND detector_model = 'full-image'""",
+                                (photo_id,),
+                            ).fetchone()
+                            if (
+                                existing_run is None
+                                or existing_run["runtime_fingerprint"]
+                                != full_runtime
+                            ):
+                                thread_db.record_detector_run(
+                                    photo_id, "full-image", box_count=1,
+                                    runtime_fingerprint=full_runtime,
+                                    input_fingerprint=full_input,
+                                )
 
                         known_runtimes = {full_runtime}
                         if detector_runtime is not None:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4369,12 +4369,113 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # detector dependency was absent at the pre-detection
                 # materialize call get a second chance to land here, so
                 # bundles carrying only classifications still surface.
-                if not params.reclassify and detector_runtime is not None:
+                #
+                # We ALSO pre-create synthetic full-image detector rows
+                # for every empty-scene photo before the reapply. The
+                # classify stage below creates those rows lazily
+                # per-photo, so without pre-creating them here a cached
+                # full_image classification artifact has no anchor to
+                # attach to at reapply time — the classify stage then
+                # runs the classifier itself even though the answer is
+                # already sitting in the local store.
+                if not params.reclassify:
                     try:
-                        from computation_cache import materialize_local_store
+                        from computation_cache import (
+                            full_image_runtime_fingerprint,
+                            materialize_local_store,
+                            source_input,
+                        )
 
+                        full_runtime = full_image_runtime_fingerprint()
+                        empty_scene_ids = [
+                            photo["id"] for photo in photos
+                            if photo["id"] in processed_ids
+                            and not this_run_detections.get(photo["id"])
+                        ]
+                        for photo_id in empty_scene_ids:
+                            existing_full = thread_db.get_detections(
+                                photo_id, detector_model="full-image",
+                                min_conf=0,
+                            )
+                            if existing_full:
+                                continue
+                            identity = thread_db.conn.execute(
+                                """SELECT file_hash, companion_path
+                                   FROM photos WHERE id = ?""",
+                                (photo_id,),
+                            ).fetchone()
+                            full_input = None
+                            if (
+                                identity is not None
+                                and not identity["companion_path"]
+                            ):
+                                try:
+                                    _block, full_input = source_input(
+                                        identity["file_hash"],
+                                        "vireo-detector-source-v1",
+                                    )
+                                except ValueError:
+                                    full_input = None
+                            thread_db.save_detections(
+                                photo_id,
+                                [{
+                                    "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                                    "confidence": 0,
+                                    "category": "animal",
+                                }],
+                                detector_model="full-image",
+                                runtime_fingerprint=full_runtime,
+                            )
+                            thread_db.record_detector_run(
+                                photo_id, "full-image", box_count=1,
+                                runtime_fingerprint=full_runtime,
+                                input_fingerprint=full_input,
+                            )
+
+                        known_runtimes = {full_runtime}
+                        if detector_runtime is not None:
+                            known_runtimes.add(detector_runtime)
+                        # Compute expected classifier runtimes for any
+                        # classifier the model_loader stage already
+                        # resolved. Without this the classifier-runtime
+                        # quarantine drops bundle classifications even
+                        # when this install carries the exact matching
+                        # classifier. Multi-classifier pipelines only
+                        # get the first classifier's runtime here;
+                        # later classifiers land during their own
+                        # classify_stage invocations of the cache.
+                        known_classifier_runtimes = set()
+                        pl_identity = loaded_models.get(
+                            "classifier_model_identity",
+                        )
+                        pl_fp_full = loaded_models.get(
+                            "labels_fingerprint_full",
+                        )
+                        if (
+                            pl_identity
+                            and isinstance(pl_fp_full, str)
+                            and len(pl_fp_full) == 64
+                        ):
+                            try:
+                                from computation_cache import (
+                                    classifier_runtime_fingerprint,
+                                )
+
+                                for det_rt in (detector_runtime, full_runtime):
+                                    if not det_rt:
+                                        continue
+                                    crt = classifier_runtime_fingerprint(
+                                        pl_identity, pl_fp_full, det_rt,
+                                    )
+                                    if crt:
+                                        known_classifier_runtimes.add(crt)
+                            except Exception:
+                                known_classifier_runtimes = set()
                         post = materialize_local_store(
-                            thread_db, known_runtimes={detector_runtime},
+                            thread_db, known_runtimes=known_runtimes,
+                            known_classifier_runtimes=(
+                                known_classifier_runtimes or None
+                            ),
                         )
                         if post.get("classifier_runs_applied"):
                             prior = detect_state.get("portable_reused") or {}

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4381,6 +4381,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 if not params.reclassify:
                     try:
                         from computation_cache import (
+                            CacheFormatError,
                             full_image_runtime_fingerprint,
                             materialize_local_store,
                             source_input,
@@ -4415,7 +4416,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         identity["file_hash"],
                                         "vireo-detector-source-v1",
                                     )
-                                except ValueError:
+                                except (ValueError, CacheFormatError):
+                                    # source_input raises CacheFormatError on
+                                    # NULL / non-canonical file_hash values.
+                                    # Falling through to the outer
+                                    # ``except Exception`` would abandon the
+                                    # post-detect reapply for the whole
+                                    # detect stage; keep full_input=None so
+                                    # the surrounding write still runs.
                                     full_input = None
                             existing_full = thread_db.get_detections(
                                 photo_id, detector_model="full-image",
@@ -4432,6 +4440,26 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     detector_model="full-image",
                                     runtime_fingerprint=full_runtime,
                                 )
+                            else:
+                                # Promote a legacy full-image detection so
+                                # its runtime_fingerprint matches the run
+                                # we're about to record. exportable_artifacts
+                                # reads the detector runtime from
+                                # ``detections`` — leaving it at 'legacy'
+                                # makes future exports emit an empty
+                                # full-image detection artifact for this
+                                # photo, dropping the attached classifier
+                                # run.
+                                thread_db.conn.execute(
+                                    """UPDATE detections
+                                          SET runtime_fingerprint = ?
+                                        WHERE photo_id = ?
+                                          AND detector_model = 'full-image'
+                                          AND (runtime_fingerprint IS NULL
+                                               OR runtime_fingerprint != ?)""",
+                                    (full_runtime, photo_id, full_runtime),
+                                )
+                                thread_db.conn.commit()
                             existing_run = thread_db.conn.execute(
                                 """SELECT runtime_fingerprint FROM detector_runs
                                    WHERE photo_id = ?
@@ -5296,22 +5324,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                             )
                                         except ValueError:
                                             full_input = None
-                                    full_det_ids = thread_db.save_detections(
-                                        photo["id"],
+                                    # Combine save_detections + record_detector_run
+                                    # into one transaction via write_detection_batch
+                                    # so a crash between them can't leave a
+                                    # full-image detection row without its matching
+                                    # detector_runs row — mirroring the invariant
+                                    # documented for write_detection_batch.
+                                    full_det_ids = thread_db.write_detection_batch(
+                                        photo["id"], "full-image",
                                         [{
                                             "box": {"x": 0, "y": 0, "w": 1, "h": 1},
                                             "confidence": 0,
                                             "category": "animal",
                                         }],
-                                        detector_model="full-image",
-                                        runtime_fingerprint=full_runtime,
-                                    )
-                                    full_det_id = full_det_ids[0]
-                                    thread_db.record_detector_run(
-                                        photo["id"], "full-image", box_count=1,
                                         runtime_fingerprint=full_runtime,
                                         input_fingerprint=full_input,
                                     )
+                                    full_det_id = full_det_ids[0]
                                 detections_to_classify = [{
                                     "id": full_det_id,
                                     "box_x": 0,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1395,6 +1395,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         dict with stage results, duration, and errors
     """
     job["_start_time"] = time.time()
+    # Stash the job's configured cache root so downstream helpers
+    # (``publish_detection_artifact`` inside ``_detect_batch``,
+    # ``promote_and_publish_classifier_run`` inside the per-model publish
+    # pass) write freshly computed artifacts into the SAME cache the
+    # status / export / catalog-reapplication paths use when
+    # ``COMPUTATION_CACHE_DIR`` is overridden. Without this the publishers
+    # fall back to the default ``~/.vireo/computation-cache`` and the
+    # artifacts disappear from the configured cache as soon as the backing
+    # database rows are removed. The path (not an ``ArtifactStore``
+    # instance) is stashed so ``jsonify(job)`` on the /api/jobs/<id> route
+    # keeps working — the helpers reconstruct the wrapper on demand.
+    job["_computation_cache_dir"] = computation_cache_dir
     abort = threading.Event()
     pause_gate = _PipelinePauseGate(runner, job["id"])
     pause_context = threading.local()
@@ -5785,6 +5797,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # rows don't exist yet, leaving fresh classifier_runs
                     # stranded on runtime_fingerprint = 'legacy' and out of
                     # bundle exports.
+                    # Reconstruct the configured ArtifactStore from the
+                    # path stashed by ``run_pipeline_job`` so classifier
+                    # artifacts published here land in the same cache the
+                    # status / export / catalog-reapplication paths use
+                    # when ``COMPUTATION_CACHE_DIR`` is overridden.
+                    from computation_cache import ArtifactStore
+                    _publish_cache_dir = job.get("_computation_cache_dir")
+                    _publish_store = (
+                        ArtifactStore(_publish_cache_dir)
+                        if _publish_cache_dir else None
+                    )
                     _publish_classifier_runs_for_raw_results(
                         thread_db, raw_results, model_name, spec_fp,
                         labels_fingerprint_full=loaded_models.get(
@@ -5796,6 +5819,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         taxonomy_identity=loaded_models.get(
                             "taxonomy_identity", "no-tax",
                         ),
+                        store=_publish_store,
                     )
                     preds = group_result["predictions_stored"]
                     total_predictions_stored += preds

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1031,6 +1031,7 @@ def _retry_thumbnail_with_working_copy(
 _CLASSIFIER_BUNDLE_FIELDS = (
     "clf", "model_type", "model_name", "model_str",
     "labels", "use_tol", "active_model", "labels_fingerprint",
+    "labels_fingerprint_full", "classifier_model_identity",
 )
 
 
@@ -3757,7 +3758,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 _record_labels_fingerprint,
                 _resolve_label_sources,
             )
-            from labels_fingerprint import compute_fingerprint
+            from labels_fingerprint import compute_fingerprint, compute_full_fingerprint
             from models import _classify_model_state
 
             model_str = active_model["model_str"]
@@ -3779,8 +3780,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             # so classify_stage can pass it to record_classifier_run for each
             # (detection, model, fingerprint) triple.
             fp = compute_fingerprint(labels)
+            fp_full = compute_full_fingerprint(labels)
+            if len(fp_full) != 64:
+                fp_full = None
             label_sources = _resolve_label_sources(params, thread_db)
-            _record_labels_fingerprint(thread_db, fp, labels, sources=label_sources)
+            _record_labels_fingerprint(
+                thread_db, fp, labels, sources=label_sources,
+                full_fingerprint=fp_full,
+            )
 
             # Preflight: validate the on-disk model before handing it to
             # ONNXRuntime. A stale _check_onnx_downloaded result (e.g. after
@@ -3974,6 +3981,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     ) from load_err
                 raise
 
+            try:
+                from computation_cache import classifier_model_identity, fingerprint
+
+                portable_model_identity = classifier_model_identity(active_model)
+                if fp_full is None and use_tol and portable_model_identity:
+                    fp_full = fingerprint({
+                        "label_space": "tree-of-life",
+                        "model": portable_model_identity,
+                    })
+                    _record_labels_fingerprint(
+                        thread_db, fp, labels, sources=label_sources,
+                        full_fingerprint=fp_full,
+                    )
+            except (OSError, ValueError):
+                portable_model_identity = None
+
             return {
                 "clf": clf,
                 "_cache_handle": cache_handle,
@@ -3982,6 +4005,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 "model_str": model_str,
                 "labels": labels,
                 "labels_fingerprint": fp,
+                "labels_fingerprint_full": fp_full,
+                "classifier_model_identity": portable_model_identity,
                 "use_tol": use_tol,
                 "active_model": active_model,
             }
@@ -4202,6 +4227,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 detect_state["folders"] = folders
                 detect_state["ran"] = True
 
+                try:
+                    from computation_cache import materialize_local_store
+
+                    reused = (
+                        materialize_local_store(thread_db)
+                        if not params.reclassify else {}
+                    )
+                    detect_state["portable_reused"] = reused
+                except Exception:
+                    log.warning(
+                        "Could not apply local computation cache", exc_info=True,
+                    )
+                    detect_state["portable_reused"] = {}
+
                 # Reclassify semantics (see prior interleaved implementation for
                 # history): start with an empty already_detected so EVERY photo
                 # is re-detected; snapshot pre-run detection IDs so we can purge
@@ -4212,15 +4251,31 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # re-detected forever by a legacy detections-only seed.
                 if params.reclassify:
                     already_detected: set = set()
+                    detector_runtime = None
                     photo_ids_list = [p["id"] for p in photos]
                     pre_run_det_ids: dict = getattr(
                         thread_db, "get_detection_ids_for_photos", lambda _: {}
                     )(photo_ids_list)
                 else:
-                    already_detected = set(
-                        thread_db.get_detector_run_photo_ids("megadetector-v6")
-                    )
+                    try:
+                        from computation_cache import megadetector_runtime_fingerprint
+
+                        detector_runtime = megadetector_runtime_fingerprint()
+                    except (OSError, ValueError):
+                        detector_runtime = None
+                    if detector_runtime is not None:
+                        already_detected = set(
+                            thread_db.get_detector_run_photo_ids(
+                                "megadetector-v6",
+                                runtime_fingerprint=detector_runtime,
+                            )
+                        )
+                    else:
+                        already_detected = set(
+                            thread_db.get_detector_run_photo_ids("megadetector-v6")
+                        )
                     pre_run_det_ids = {}
+                job["_detector_runtime_fingerprint"] = detector_runtime
                 detect_state["pre_run_det_ids"] = pre_run_det_ids
 
                 # Ensure MegaDetector weights only when we actually need fresh
@@ -4241,7 +4296,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             runner, job["id"], stages, "detect", phase,
                         )
 
-                    ensure_megadetector_weights(progress_callback=_dl_progress)
+                    weights_path = ensure_megadetector_weights(
+                        progress_callback=_dl_progress,
+                    )
+                    from computation_cache import megadetector_runtime_fingerprint
+
+                    detector_runtime = megadetector_runtime_fingerprint(weights_path)
+                    job["_detector_runtime_fingerprint"] = detector_runtime
+                    if not params.reclassify and detector_runtime is not None:
+                        already_detected = set(
+                            thread_db.get_detector_run_photo_ids(
+                                "megadetector-v6",
+                                runtime_fingerprint=detector_runtime,
+                            )
+                        )
 
                 this_run_detections: dict = detect_state["detections"]
                 processed_ids: set = detect_state["processed_ids"]
@@ -4892,6 +4960,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         _record_batch_classifier_runs(
                             thread_db, pending, model_name, spec_fp, raw_results,
                             pre_len,
+                            labels_fingerprint_full=loaded_models.get(
+                                "labels_fingerprint_full"
+                            ),
+                            model_identity=loaded_models.get(
+                                "classifier_model_identity"
+                            ),
                         )
 
                         # Photo-scoped ``count`` bookkeeping: each distinct
@@ -5055,6 +5129,26 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 if existing_full and not params.reclassify:
                                     full_det_id = existing_full[0]["id"]
                                 else:
+                                    from computation_cache import (
+                                        full_image_runtime_fingerprint,
+                                        source_input,
+                                    )
+
+                                    full_runtime = full_image_runtime_fingerprint()
+                                    identity = thread_db.conn.execute(
+                                        """SELECT file_hash, companion_path
+                                           FROM photos WHERE id = ?""",
+                                        (photo["id"],),
+                                    ).fetchone()
+                                    full_input = None
+                                    if identity is not None and not identity["companion_path"]:
+                                        try:
+                                            _block, full_input = source_input(
+                                                identity["file_hash"],
+                                                "vireo-detector-source-v1",
+                                            )
+                                        except ValueError:
+                                            full_input = None
                                     full_det_ids = thread_db.save_detections(
                                         photo["id"],
                                         [{
@@ -5063,8 +5157,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                             "category": "animal",
                                         }],
                                         detector_model="full-image",
+                                        runtime_fingerprint=full_runtime,
                                     )
                                     full_det_id = full_det_ids[0]
+                                    thread_db.record_detector_run(
+                                        photo["id"], "full-image", box_count=1,
+                                        runtime_fingerprint=full_runtime,
+                                        input_fingerprint=full_input,
+                                    )
                                 detections_to_classify = [{
                                     "id": full_det_id,
                                     "box_x": 0,
@@ -5091,8 +5191,31 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 # it — otherwise the cached detection would silently
                                 # drop out of the grouping pipeline.
                                 if not params.reclassify:
+                                    expected_classifier_runtime = None
+                                    portable_labels_full = loaded_models.get(
+                                        "labels_fingerprint_full"
+                                    )
+                                    portable_model_identity = loaded_models.get(
+                                        "classifier_model_identity"
+                                    )
+                                    if portable_labels_full and portable_model_identity:
+                                        from computation_cache import (
+                                            classifier_runtime_for_detection,
+                                        )
+
+                                        expected_classifier_runtime = (
+                                            classifier_runtime_for_detection(
+                                                thread_db,
+                                                detection["id"],
+                                                portable_model_identity,
+                                                portable_labels_full,
+                                            )
+                                        )
                                     run_keys = thread_db.get_classifier_run_keys(
-                                        detection["id"]
+                                        detection["id"],
+                                        runtime_fingerprint=(
+                                            expected_classifier_runtime
+                                        ),
                                     )
                                     if (model_name, spec_fp) in run_keys:
                                         cached = thread_db.get_predictions_for_detection(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4637,6 +4637,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     _BATCH_SIZE,
                     _flush_batch,
                     _prepare_image,
+                    _publish_classifier_runs_for_raw_results,
                     _record_batch_classifier_runs,
                     _store_grouped_predictions,
                 )
@@ -5738,6 +5739,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         raw_results, job["id"], model_name,
                         grouping_window, similarity_threshold, tax, thread_db,
                         labels_fingerprint=spec_fp,
+                    )
+                    # promote_and_publish reads persisted predictions written
+                    # by _store_grouped_predictions above; running it inside
+                    # _record_batch_classifier_runs would no-op because those
+                    # rows don't exist yet, leaving fresh classifier_runs
+                    # stranded on runtime_fingerprint = 'legacy' and out of
+                    # bundle exports.
+                    _publish_classifier_runs_for_raw_results(
+                        thread_db, raw_results, model_name, spec_fp,
+                        labels_fingerprint_full=loaded_models.get(
+                            "labels_fingerprint_full"
+                        ),
+                        model_identity=loaded_models.get(
+                            "classifier_model_identity"
+                        ),
                     )
                     preds = group_result["predictions_stored"]
                     total_predictions_stored += preds

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4084,6 +4084,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 from taxonomy import load_local_taxonomy
                 tax = load_local_taxonomy()
                 loaded_models["tax"] = tax
+                # Portable identity for the taxonomy backing this pipeline.
+                # Threaded through publish and cache-match paths so that
+                # classifier runs made against one taxonomy revision are
+                # not conflated with runs from a different revision on
+                # another installation. See computation_cache.taxonomy_identity.
+                from computation_cache import (
+                    taxonomy_identity as _taxonomy_identity_fn,
+                )
+                loaded_models["taxonomy_identity"] = _taxonomy_identity_fn(tax)
                 loaded_models["resolved_specs"] = resolved_specs
 
                 # Load the first classifier so classify_stage can start as soon
@@ -4506,11 +4515,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     classifier_runtime_fingerprint,
                                 )
 
+                                pl_tax_identity = loaded_models.get(
+                                    "taxonomy_identity", "no-tax",
+                                )
                                 for det_rt in (detector_runtime, full_runtime):
                                     if not det_rt:
                                         continue
                                     crt = classifier_runtime_fingerprint(
                                         pl_identity, pl_fp_full, det_rt,
+                                        taxonomy_identity=pl_tax_identity,
                                     )
                                     if crt:
                                         known_classifier_runtimes.add(crt)
@@ -5375,6 +5388,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     portable_model_identity = loaded_models.get(
                                         "classifier_model_identity"
                                     )
+                                    portable_tax_identity = loaded_models.get(
+                                        "taxonomy_identity", "no-tax",
+                                    )
                                     if portable_labels_full and portable_model_identity:
                                         from computation_cache import (
                                             classifier_runtime_for_detection,
@@ -5386,6 +5402,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                                 detection["id"],
                                                 portable_model_identity,
                                                 portable_labels_full,
+                                                taxonomy_identity=(
+                                                    portable_tax_identity
+                                                ),
                                             )
                                         )
                                     run_keys = thread_db.get_classifier_run_keys(
@@ -5753,6 +5772,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         ),
                         model_identity=loaded_models.get(
                             "classifier_model_identity"
+                        ),
+                        taxonomy_identity=loaded_models.get(
+                            "taxonomy_identity", "no-tax",
                         ),
                     )
                     preds = group_result["predictions_stored"]

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -881,6 +881,61 @@ def _validate_legacy_detector_alias_merge(conn):
         raise RuntimeError("schema migration validation failed: detector repair broke foreign keys")
 
 
+_PORTABLE_CACHE_COLUMNS = {
+    "detections": {
+        "runtime_fingerprint": "TEXT NOT NULL DEFAULT 'legacy'",
+    },
+    "predictions": {
+        "labels_fingerprint_full": "TEXT",
+    },
+    "detector_runs": {
+        "runtime_fingerprint": "TEXT NOT NULL DEFAULT 'legacy'",
+        "input_fingerprint": "TEXT",
+    },
+    "classifier_runs": {
+        "labels_fingerprint_full": "TEXT",
+        "runtime_fingerprint": "TEXT NOT NULL DEFAULT 'legacy'",
+        "input_fingerprint": "TEXT",
+    },
+    "labels_fingerprints": {
+        "full_fingerprint": "TEXT",
+    },
+}
+
+
+def _add_portable_cache_identity(conn):
+    """Add sidecar identity without changing existing cache primary keys.
+
+    The 12-character label fingerprint remains part of the historical PKs.
+    Replacing it with a full digest would turn every upgraded classifier run
+    into a cache miss, so portable/full identities live in nullable companion
+    columns instead. Existing rows keep the explicit ``legacy`` runtime and
+    remain valid local hits, but are not safe to export.
+    """
+    for table, columns in _PORTABLE_CACHE_COLUMNS.items():
+        existing = {
+            row[1] for row in conn.execute(f"PRAGMA table_info({table})")
+        }
+        for column, declaration in columns.items():
+            if column not in existing:
+                conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {column} {declaration}"
+                )
+
+
+def _validate_portable_cache_identity(conn):
+    for table, columns in _PORTABLE_CACHE_COLUMNS.items():
+        existing = {
+            row[1] for row in conn.execute(f"PRAGMA table_info({table})")
+        }
+        missing = set(columns) - existing
+        if missing:
+            raise RuntimeError(
+                "schema migration validation failed: "
+                f"{table} missing portable-cache columns {sorted(missing)}"
+            )
+
+
 MIGRATIONS = (
     Migration(
         version=5,
@@ -903,6 +958,12 @@ MIGRATIONS = (
         name="merge-legacy-megadetector-alias",
         apply=_merge_legacy_detector_alias,
         validate=_validate_legacy_detector_alias_merge,
+    ),
+    Migration(
+        version=9,
+        name="add-portable-computation-cache-identity",
+        apply=_add_portable_cache_identity,
+        validate=_validate_portable_cache_identity,
     ),
 )
 

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -129,6 +129,26 @@
     </div>
   </div>
 
+  <!-- Portable computation cache -->
+  <div class="section" id="computationCacheSection">
+    <div class="section-title">Computation Cache <span style="font-size:11px;color:var(--warning);font-weight:normal;">Experimental</span></div>
+    <p style="font-size:13px;color:var(--text-dim);margin:0 0 10px;line-height:1.5;">
+      Share completed animal detection and species-classification work with another Vireo computer.
+      Bundles contain machine results only&mdash;never originals, paths, XMP, or accepted/rejected review decisions.
+    </p>
+    <div style="display:flex;gap:16px;align-items:center;flex-wrap:wrap;margin-bottom:10px;font-size:12px;color:var(--text-secondary);">
+      <label><input type="checkbox" id="cacheExportDetections" checked> Detection</label>
+      <label><input type="checkbox" id="cacheExportClassifications" checked> Species classification</label>
+      <span id="computationCacheStatus" style="color:var(--text-dim);">Loading&hellip;</span>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+      <button class="btn-sm" id="computationCacheExportBtn" onclick="exportComputationCache()" style="margin-left:0;">Export Results&hellip;</button>
+      <button class="btn-sm" id="computationCacheImportBtn" onclick="document.getElementById('computationCacheImportInput').click()">Import Results&hellip;</button>
+      <input type="file" id="computationCacheImportInput" accept=".vireo-cache,application/zip,application/vnd.vireo.cache+zip" style="display:none;" onchange="importComputationCache(this.files[0]); this.value='';">
+      <span id="computationCacheAction" style="font-size:12px;color:var(--text-dim);"></span>
+    </div>
+  </div>
+
   <!-- Models -->
   <div class="section">
     <div class="section-title">Models</div>
@@ -1138,6 +1158,7 @@ loadScanRoots();
 loadVersion();
 loadThemePicker();
 loadAllSettings();
+loadComputationCacheStatus();
 
 var SETTINGS_FIND_STATE = {
   marks: [],
@@ -4037,6 +4058,77 @@ async function loadDetectionCacheStats() {
     el.textContent = pc + ' ' + photoWord + ' \u00D7 ' + mc + ' ' + modelWord + ' cached';
   } catch(e) {
     el.textContent = 'Failed to load';
+  }
+}
+
+/* ---------- Portable Computation Cache ---------- */
+async function loadComputationCacheStatus() {
+  var el = document.getElementById('computationCacheStatus');
+  if (!el) return;
+  try {
+    var data = await safeFetch('/api/computation-cache', {}, { toast: false });
+    var exportable = data.exportable || {};
+    var runs = (exportable.detector_runs || 0) + (exportable.classifier_runs || 0);
+    var stored = data.object_count || 0;
+    el.textContent = runs.toLocaleString() + ' exportable runs; ' +
+      stored.toLocaleString() + ' imported/local objects (' + formatBytes(data.total_bytes || 0) + ')';
+  } catch (e) {
+    el.textContent = 'Status unavailable';
+  }
+}
+
+function selectedComputationCacheTypes() {
+  var types = [];
+  if (document.getElementById('cacheExportDetections').checked) types.push('detection');
+  if (document.getElementById('cacheExportClassifications').checked) types.push('classification');
+  return types;
+}
+
+function exportComputationCache() {
+  var types = selectedComputationCacheTypes();
+  if (!types.length) {
+    alert('Select at least one result type to export.');
+    return;
+  }
+  var action = document.getElementById('computationCacheAction');
+  action.textContent = 'Preparing download…';
+  window.location.href = '/api/computation-cache/export?types=' + encodeURIComponent(types.join(','));
+  window.setTimeout(function() {
+    action.textContent = 'Download requested. Legacy results without a portable runtime identity are skipped.';
+  }, 500);
+}
+
+async function importComputationCache(file) {
+  if (!file) return;
+  var button = document.getElementById('computationCacheImportBtn');
+  var action = document.getElementById('computationCacheAction');
+  button.disabled = true;
+  action.style.color = 'var(--text-dim)';
+  action.textContent = 'Validating and applying ' + file.name + '…';
+  var form = new FormData();
+  form.append('file', file, file.name);
+  try {
+    var response = await fetch('/api/computation-cache/import', {
+      method: 'POST',
+      body: form,
+    });
+    var data = await response.json().catch(function() { return {}; });
+    if (!response.ok) throw new Error(data.error || response.statusText || 'Import failed');
+    action.style.color = 'var(--accent)';
+    action.textContent = 'Imported ' + (data.added || 0).toLocaleString() +
+      ' new objects; applied ' + (data.detector_runs_applied || 0).toLocaleString() +
+      ' detector and ' + (data.classifier_runs_applied || 0).toLocaleString() +
+      ' classifier runs to ' + (data.matched_photos || 0).toLocaleString() + ' matching photos.';
+    if (data.pinned_older_runtime) {
+      action.textContent += ' ' + data.pinned_older_runtime.toLocaleString() +
+        ' reviewed older results were preserved.';
+    }
+    await loadComputationCacheStatus();
+  } catch (error) {
+    action.style.color = 'var(--danger)';
+    action.textContent = error && error.message ? error.message : 'Import failed';
+  } finally {
+    button.disabled = false;
   }
 }
 

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -4123,6 +4123,18 @@ async function importComputationCache(file) {
       action.textContent += ' ' + data.pinned_older_runtime.toLocaleString() +
         ' reviewed older results were preserved.';
     }
+    if (data.unknown_runtime) {
+      action.textContent += ' ' + data.unknown_runtime.toLocaleString() +
+        ' detection object(s) came from a runtime this install does not' +
+        ' recognize and were kept in the local store until matching' +
+        ' weights are installed.';
+    }
+    if (data.classifier_deferred_pending_detection) {
+      action.textContent += ' ' +
+        data.classifier_deferred_pending_detection.toLocaleString() +
+        ' classification object(s) are waiting for a matching detector run' +
+        ' — re-run classification after detection to apply them.';
+    }
     await loadComputationCacheStatus();
   } catch (error) {
     action.style.color = 'var(--danger)';

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -32,6 +32,8 @@ GET          /api/classify/readiness
 GET          /api/collections
 GET          /api/collections/<int:collection_id>/photo-ids
 GET          /api/collections/<int:collection_id>/photos
+GET          /api/computation-cache
+GET          /api/computation-cache/export
 GET          /api/config
 GET          /api/coverage
 GET          /api/culling/results
@@ -225,6 +227,7 @@ POST         /api/collections
 POST         /api/collections/<int:collection_id>/add-photos
 POST         /api/collections/<int:collection_id>/duplicate
 POST         /api/collections/preview
+POST         /api/computation-cache/import
 POST         /api/config
 POST         /api/culling/apply
 POST         /api/duplicates/apply

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5934,6 +5934,34 @@ def test_all_photos_cache_satisfied_requires_common_identity_when_either_unresol
         db, [pid], classifier_model="BioCLIP", labels_fingerprint="fp-a",
     ) is False
 
+    # A historical row outside the resolved model filter must not pollute
+    # the distinct-identity gate. Both classifiable detections below are
+    # covered by BioCLIP/fp-a; the unrelated model is merely extra history.
+    pid2 = db.add_photo(
+        folder_id, "b.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det2 = db.save_detections(pid2, [
+        {"box": {"x": 4, "y": 4, "w": 1, "h": 1}, "confidence": 0.9,
+         "category": "animal"},
+        {"box": {"x": 6, "y": 6, "w": 1, "h": 1}, "confidence": 0.9,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")
+    for det_id in det2:
+        db.record_classifier_run(det_id, "BioCLIP", "fp-a", prediction_count=1)
+        db.add_prediction(
+            det_id, species="Robin", confidence=0.9, model="BioCLIP",
+            labels_fingerprint="fp-a",
+        )
+    db.record_classifier_run(det2[0], "Other", "fp-x", prediction_count=1)
+    db.add_prediction(
+        det2[0], species="Other bird", confidence=0.8, model="Other",
+        labels_fingerprint="fp-x",
+    )
+    assert _all_photos_cache_satisfied(
+        db, [pid2], classifier_model="BioCLIP", labels_fingerprint=None,
+    ) is True
+
 
 def test_finalize_cached_only_respects_workspace_detector_threshold(
     tmp_path, monkeypatch,
@@ -5964,17 +5992,16 @@ def test_finalize_cached_only_respects_workspace_detector_threshold(
         file_size=100, file_mtime=1.0,
     )
     # Two detections: one clearly above the workspace threshold, one
-    # clearly below.  Both carry cached classifier runs so the
-    # ``_all_photos_cache_satisfied`` check accepts the short-circuit.
+    # clearly below. Only the classifiable, above-threshold row needs a
+    # cached run for the all-cache-hit shortcut to be valid.
     det_ids = db.save_detections(pid, [
         {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
         {"box": {"x": 2, "y": 2, "w": 1, "h": 1}, "confidence": 0.3, "category": "animal"},
     ], detector_model="megadetector-v6")
-    for det_id, species in zip(det_ids, ["Robin", "Sparrow"], strict=True):
-        db.add_prediction(det_id, species=species, confidence=0.9,
-                          model="BioCLIP", labels_fingerprint="fp-cached")
-        db.record_classifier_run(det_id, "BioCLIP", "fp-cached",
-                                 prediction_count=1)
+    db.add_prediction(det_ids[0], species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="fp-cached")
+    db.record_classifier_run(det_ids[0], "BioCLIP", "fp-cached",
+                             prediction_count=1)
 
     coll_id = db.add_collection(
         "c", '[{"field":"photo_ids","value":[' + str(pid) + ']}]',
@@ -5997,6 +6024,57 @@ def test_finalize_cached_only_respects_workspace_detector_threshold(
     result = run_classify_job(job, runner, db_path, ws, params)
     # Only the above-threshold detection reaches finalization.  Without
     # the workspace threshold the count would be 2.
+    assert result["already_classified"] == 1
+
+
+def test_finalize_cached_only_includes_zero_confidence_full_image_anchor(
+    tmp_path, monkeypatch,
+):
+    """Full-image anchors bypass the positive MegaDetector threshold."""
+    import classify_job as classify_job_mod
+    import config as cfg
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "empty.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_id = db.save_detections(pid, [{
+        "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+        "confidence": 0,
+        "category": "animal",
+    }], detector_model="full-image")[0]
+    db.add_prediction(
+        det_id, species="Full-image Robin", confidence=0.9,
+        model="BioCLIP", labels_fingerprint="fp-cached",
+    )
+    db.record_classifier_run(
+        det_id, "BioCLIP", "fp-cached", prediction_count=1,
+    )
+    collection_id = db.add_collection(
+        "empty", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    monkeypatch.setattr(classify_job_mod, "get_active_model", lambda: None)
+    monkeypatch.setattr(classify_job_mod, "get_models", lambda: [])
+    result = run_classify_job(
+        _make_job(), FakeRunner(), db_path, ws,
+        ClassifyParams(
+            collection_id=collection_id,
+            labels_files=None, labels_file=None,
+            model_id=None, model_name=None,
+            grouping_window=0, similarity_threshold=0.99,
+            reclassify=False,
+        ),
+    )
+
     assert result["already_classified"] == 1
 
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -2549,6 +2549,190 @@ def test_record_batch_classifier_runs_skips_zero_count(tmp_path):
     assert keys_failed == set(), "failed detection must NOT be cached"
 
 
+def test_publish_classifier_runs_promotes_after_predictions_persist(tmp_path):
+    """``_publish_classifier_runs_for_raw_results`` must run AFTER
+    ``_store_grouped_predictions`` writes prediction rows.
+
+    ``promote_and_publish_classifier_run`` reads the persisted
+    ``predictions`` rows to synthesize the exportable artifact and only
+    then stamps the classifier_runs row with the real
+    ``runtime_fingerprint``. If we call it earlier — inside
+    ``_record_batch_classifier_runs``, before predictions exist — the
+    read returns nothing, the promote silently returns ``None``, and the
+    classifier_runs row is left on ``runtime_fingerprint = 'legacy'``.
+    ``exportable_artifacts`` filters by real (SHA-256) runtime, so those
+    runs are silently omitted from cache bundle exports.
+    """
+    from computation_cache import (
+        ArtifactStore,
+        classifier_model_identity,
+        exportable_artifacts,
+    )
+    from db import Database
+
+    photo_hash = "1" * 64
+    db = Database(str(tmp_path / "src.db"))
+    folder_id = db.add_folder("/tmp/photos")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100,
+        file_mtime=1.0, file_hash=photo_hash,
+    )
+
+    # Detector run with a real (non-legacy) runtime fingerprint — the
+    # classification artifact composes with the detector runtime.
+    from computation_cache import runtime_fingerprint, source_input
+
+    detector_runtime = runtime_fingerprint({
+        "type": "detection", "model": "megadetector-v6",
+        "weights_sha256": "2" * 64, "pipeline": "detector-v1",
+    })
+    _input, det_input_fp = source_input(
+        photo_hash, "vireo-detector-source-v1",
+    )
+    det_id = db.write_detection_batch(
+        photo_id, "megadetector-v6",
+        [{"box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
+          "confidence": 0.9, "category": "animal"}],
+        runtime_fingerprint=detector_runtime,
+        input_fingerprint=det_input_fp,
+    )[0]
+
+    labels_full = "5" * 64
+    labels_short = labels_full[:12]
+    db.upsert_labels_fingerprint(
+        labels_short, "Test birds", [], 1, full_fingerprint=labels_full,
+    )
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "image_encoder.onnx").write_bytes(b"exact model bytes")
+    identity = classifier_model_identity({
+        "id": "bioclip-test",
+        "model_str": "ViT-test",
+        "model_type": "bioclip",
+        "weights_path": str(model_dir),
+        "files": ["image_encoder.onnx"],
+        "source": "custom",
+    })
+
+    import classify_job
+    batch = [{"detection_id": det_id, "img": object()}]
+    raw_results = [{
+        "detection_id": det_id, "species": "Robin", "confidence": 0.9,
+    }]
+
+    # First, _record_batch_classifier_runs runs *before* predictions
+    # exist — matches what _classify_photos does after _flush_batch
+    # appends to raw_results.  This writes the classifier_runs row but
+    # MUST NOT try to publish yet.
+    classify_job._record_batch_classifier_runs(
+        db, batch, "BioCLIP", labels_short, raw_results,
+        labels_fingerprint_full=labels_full, model_identity=identity,
+    )
+    run = db.conn.execute(
+        "SELECT runtime_fingerprint FROM classifier_runs "
+        "WHERE detection_id = ?", (det_id,),
+    ).fetchone()
+    assert run["runtime_fingerprint"] == "legacy", (
+        "record_batch must NOT attempt to publish before predictions "
+        "are persisted — that call silently no-ops and leaves the run "
+        "stranded on 'legacy' runtime"
+    )
+
+    # Publishing without the persisted prediction rows still no-ops.
+    store = ArtifactStore(tmp_path / "store")
+    classify_job._publish_classifier_runs_for_raw_results(
+        db, raw_results, "BioCLIP", labels_short,
+        labels_fingerprint_full=labels_full, model_identity=identity,
+    )
+    run = db.conn.execute(
+        "SELECT runtime_fingerprint FROM classifier_runs "
+        "WHERE detection_id = ?", (det_id,),
+    ).fetchone()
+    assert run["runtime_fingerprint"] == "legacy"
+
+    # Simulate _store_grouped_predictions persisting the prediction row,
+    # then re-run the publish pass — the classifier_runs row now gets
+    # its real runtime_fingerprint and the artifact appears in exports.
+    db.add_prediction(
+        det_id, species="Robin", confidence=0.9, model="BioCLIP",
+        labels_fingerprint=labels_short,
+    )
+    classify_job._publish_classifier_runs_for_raw_results(
+        db, raw_results, "BioCLIP", labels_short,
+        labels_fingerprint_full=labels_full, model_identity=identity,
+        # No `store` param on the helper — the default ArtifactStore
+        # writes to the configured cache dir.  Publishing to that store
+        # is a side-effect; the assertions below hit the DB stamp and
+        # the exportable_artifacts view, which do not depend on which
+        # store received the artifact.
+    )
+    run = db.conn.execute(
+        "SELECT runtime_fingerprint, input_fingerprint, labels_fingerprint_full "
+        "FROM classifier_runs WHERE detection_id = ?", (det_id,),
+    ).fetchone()
+    assert run["labels_fingerprint_full"] == labels_full
+    assert len(run["runtime_fingerprint"]) == 64
+    assert run["runtime_fingerprint"] != "legacy"
+    assert len(run["input_fingerprint"]) == 64
+
+    # The classifier run is now visible to bundle export.
+    _artifacts, summary = exportable_artifacts(db)
+    assert summary["classifier_runs"] == 1
+
+
+def test_all_photos_cache_satisfied_requires_matching_predictions_row(tmp_path):
+    """A classifier_runs row with no matching ``predictions`` row is a
+    torn write from a crashed local job — ``_record_batch_classifier_runs``
+    commits the run *before* ``_store_grouped_predictions`` persists the
+    prediction rows.  Counting it as covered would make the retry enter
+    ``_finalize_cached_only``, which skips the missing prediction rows
+    entirely and reports success without repairing them.
+    """
+    from classify_job import _all_photos_cache_satisfied
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+
+    # Torn write: classifier_runs exists, predictions do not.
+    db.record_classifier_run(det_id, "BioCLIP", "fp-cached",
+                             prediction_count=1)
+
+    # Coverage query must refuse — with either the fully-specified
+    # (model + fp) form and the fresh-install (both-unspecified) form.
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model="BioCLIP",
+        labels_fingerprint="fp-cached",
+    ) is False
+    assert _all_photos_cache_satisfied(db, [pid]) is False
+
+    # After the missing prediction row lands, cache is now really
+    # satisfied.
+    db.add_prediction(
+        det_id, species="Robin", confidence=0.9, model="BioCLIP",
+        labels_fingerprint="fp-cached",
+    )
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model="BioCLIP",
+        labels_fingerprint="fp-cached",
+    ) is True
+    assert _all_photos_cache_satisfied(db, [pid]) is True
+
+
 def test_classifier_fingerprint_upserted(tmp_path, monkeypatch):
     """When a classifier runs, the labels fingerprint is upserted."""
     from db import Database
@@ -5676,7 +5860,15 @@ def test_all_photos_cache_satisfied_requires_every_photo_covered(tmp_path):
     det_id = db.save_detections(covered, [
         {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
     ], detector_model="megadetector-v6")[0]
+    # A classifier_run row without a matching predictions row is a torn
+    # write from a crashed local job — _all_photos_cache_satisfied must
+    # reject it as unsatisfied so the retry re-runs classification
+    # instead of shortcutting to _finalize_cached_only.
     db.record_classifier_run(det_id, "BioCLIP", "abc123", prediction_count=1)
+    db.add_prediction(
+        det_id, species="Robin", confidence=0.9, model="BioCLIP",
+        labels_fingerprint="abc123",
+    )
 
     assert _all_photos_cache_satisfied(db, [covered]) is True
     assert _all_photos_cache_satisfied(db, [covered, uncovered]) is False
@@ -5712,8 +5904,18 @@ def test_all_photos_cache_satisfied_requires_common_identity_when_either_unresol
         {"box": {"x": 2, "y": 2, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
     ], detector_model="megadetector-v6")
     # Same classifier, DIFFERENT label fingerprints across the two runs.
+    # Add matching predictions rows so the coverage query treats each
+    # classifier_run as a genuine cache row rather than a torn write.
     db.record_classifier_run(det_ids[0], "BioCLIP", "fp-a", prediction_count=1)
+    db.add_prediction(
+        det_ids[0], species="Robin", confidence=0.9, model="BioCLIP",
+        labels_fingerprint="fp-a",
+    )
     db.record_classifier_run(det_ids[1], "BioCLIP", "fp-b", prediction_count=1)
+    db.add_prediction(
+        det_ids[1], species="Sparrow", confidence=0.9, model="BioCLIP",
+        labels_fingerprint="fp-b",
+    )
 
     # Model known, fingerprint unresolved: the identity gate must refuse
     # this because the cached rows disagree on the unbound fingerprint.

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5685,6 +5685,119 @@ def test_all_photos_cache_satisfied_requires_every_photo_covered(tmp_path):
     assert _all_photos_cache_satisfied(db, []) is False
 
 
+def test_all_photos_cache_satisfied_requires_common_identity_when_either_unresolved(
+    tmp_path,
+):
+    """When only one of (classifier_model, labels_fingerprint) is known —
+    e.g. a fresh install where the model name is available but its label
+    sources aren't — cached rows may still legitimately span multiple
+    values for the unbound component.  ``_finalize_cached_only`` adopts
+    the first row's identity for reconciliation, so the satisfaction
+    check must refuse to short-circuit unless every covered row agrees
+    on that component too.
+    """
+    from classify_job import _all_photos_cache_satisfied
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 2, "y": 2, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")
+    # Same classifier, DIFFERENT label fingerprints across the two runs.
+    db.record_classifier_run(det_ids[0], "BioCLIP", "fp-a", prediction_count=1)
+    db.record_classifier_run(det_ids[1], "BioCLIP", "fp-b", prediction_count=1)
+
+    # Model known, fingerprint unresolved: the identity gate must refuse
+    # this because the cached rows disagree on the unbound fingerprint.
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model="BioCLIP", labels_fingerprint=None,
+    ) is False
+    # Fingerprint known, model unresolved: mirror case (all rows share
+    # the classifier, so if fingerprint is filtered to just one, only
+    # matching rows count — narrow the coverage instead).
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model=None, labels_fingerprint="fp-a",
+    ) is False
+    # Both fully specified: filter narrows to a single identity, gate
+    # not needed — but only one detection matches, so coverage fails.
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model="BioCLIP", labels_fingerprint="fp-a",
+    ) is False
+
+
+def test_finalize_cached_only_respects_workspace_detector_threshold(
+    tmp_path, monkeypatch,
+):
+    """A bundle imported from a machine with a lower detector_confidence
+    can materialize classifier runs for raw detections that the
+    destination workspace's threshold would hide.  The cache-only
+    finalize path must apply the workspace-effective threshold before
+    grouping — otherwise importing results silently changes which
+    subjects are surfaced to review.
+    """
+    import config as cfg
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    # A workspace whose effective threshold hides everything below 0.5.
+    ws = db.create_workspace(
+        "Strict", config_overrides={"detector_confidence": 0.5},
+    )
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Two detections: one clearly above the workspace threshold, one
+    # clearly below.  Both carry cached classifier runs so the
+    # ``_all_photos_cache_satisfied`` check accepts the short-circuit.
+    det_ids = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 2, "y": 2, "w": 1, "h": 1}, "confidence": 0.3, "category": "animal"},
+    ], detector_model="megadetector-v6")
+    for det_id, species in zip(det_ids, ["Robin", "Sparrow"], strict=True):
+        db.add_prediction(det_id, species=species, confidence=0.9,
+                          model="BioCLIP", labels_fingerprint="fp-cached")
+        db.record_classifier_run(det_id, "BioCLIP", "fp-cached",
+                                 prediction_count=1)
+
+    coll_id = db.add_collection(
+        "c", '[{"field":"photo_ids","value":[' + str(pid) + ']}]',
+    )
+
+    import classify_job as classify_job_mod
+    monkeypatch.setattr(classify_job_mod, "get_active_model", lambda: None)
+    monkeypatch.setattr(classify_job_mod, "get_models", lambda: [])
+
+    runner = FakeRunner()
+    job = _make_job()
+    params = ClassifyParams(
+        collection_id=coll_id,
+        labels_files=None, labels_file=None,
+        model_id=None, model_name=None,
+        grouping_window=0, similarity_threshold=0.99,
+        reclassify=False,
+    )
+
+    result = run_classify_job(job, runner, db_path, ws, params)
+    # Only the above-threshold detection reaches finalization.  Without
+    # the workspace threshold the count would be 2.
+    assert result["already_classified"] == 1
+
+
 def test_run_classify_job_short_circuits_when_cache_covers_every_photo(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5738,11 +5738,162 @@ def test_run_classify_job_short_circuits_when_cache_covers_every_photo(
     result = run_classify_job(job, runner, db_path, ws, params)
     assert result["already_classified"] == result["total"] == 1
     assert result["failed"] == 0
-    # The cached prediction must still be there — the short-circuit
-    # must not touch the DB.
+    # Cached prediction stays exactly one row — the finalization pass
+    # updates review state / grouping in place but must not double up
+    # the ``predictions`` row for a reused detection.
     db2 = Database(db_path)
     db2.set_active_workspace(ws)
     assert db2.conn.execute(
         "SELECT COUNT(*) AS n FROM predictions WHERE detection_id = ?",
         (det_id,),
     ).fetchone()["n"] == 1
+
+
+def test_run_classify_job_rejects_unknown_model_id_before_cache_shortcut(
+    tmp_path, monkeypatch,
+):
+    """A stale job referencing a deleted model must fail with 'not found',
+    not silently succeed by matching any classifier's cached rows.
+    """
+    import config as cfg
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    # A classifier run exists — but from a different (unrelated) model
+    # under a different name than the request. Without the explicit-id
+    # rejection, the cache satisfaction check would accept it since
+    # ``desired_classifier_model`` would fall back to None.
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="SomeOtherModel", labels_fingerprint="fp-x")
+    db.record_classifier_run(det_id, "SomeOtherModel", "fp-x",
+                             prediction_count=1)
+
+    coll_id = db.add_collection(
+        "c", '[{"field":"photo_ids","value":[' + str(pid) + ']}]',
+    )
+
+    import classify_job as classify_job_mod
+    monkeypatch.setattr(classify_job_mod, "get_active_model", lambda: None)
+    # get_models returns models but NONE match the requested id.
+    monkeypatch.setattr(
+        classify_job_mod, "get_models",
+        lambda: [{"id": "other-id", "name": "SomeOtherModel",
+                  "downloaded": True, "model_type": "bioclip",
+                  "model_str": "", "weights_path": ""}],
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+    params = ClassifyParams(
+        collection_id=coll_id,
+        labels_files=None, labels_file=None,
+        model_id="stale-id",  # references a model no longer in get_models
+        model_name=None,
+        grouping_window=0, similarity_threshold=0.99, reclassify=False,
+    )
+
+    with pytest.raises(RuntimeError, match="stale-id.*not found"):
+        run_classify_job(job, runner, db_path, ws, params)
+
+
+def test_run_classify_job_reconciles_group_metadata_on_reuse(
+    tmp_path, monkeypatch,
+):
+    """When every photo is cache-satisfied, the finalize pass must still
+    run: bursts must get a group_id, otherwise imported predictions never
+    receive the consensus / group metadata a fresh classification pass
+    produces.
+    """
+    import config as cfg
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    # Two photos captured within a burst window — imported cache carries
+    # matching predictions for each so grouping/consensus should apply.
+    pid_a = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+        timestamp="2024-01-01T10:00:00",
+    )
+    pid_b = db.add_photo(
+        folder_id, "b.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+        timestamp="2024-01-01T10:00:01",
+    )
+    det_a = db.save_detections(pid_a, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    det_b = db.save_detections(pid_b, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    for det_id in (det_a, det_b):
+        db.add_prediction(det_id, species="Robin", confidence=0.9,
+                          model="BioCLIP", labels_fingerprint="fp-cached")
+        db.record_classifier_run(det_id, "BioCLIP", "fp-cached",
+                                 prediction_count=1)
+
+    coll_id = db.add_collection(
+        "c",
+        '[{"field":"photo_ids","value":['
+        + str(pid_a) + ',' + str(pid_b) + ']}]',
+    )
+
+    import classify_job as classify_job_mod
+    monkeypatch.setattr(classify_job_mod, "get_active_model", lambda: None)
+    monkeypatch.setattr(classify_job_mod, "get_models", lambda: [])
+
+    runner = FakeRunner()
+    job = _make_job()
+    params = ClassifyParams(
+        collection_id=coll_id,
+        labels_files=None, labels_file=None,
+        model_id=None, model_name=None,
+        grouping_window=10, similarity_threshold=0.99, reclassify=False,
+    )
+
+    result = run_classify_job(job, runner, db_path, ws, params)
+    assert result["failed"] == 0
+    # Burst grouping must have run — two nearby photos with the same
+    # species belong in one reviewable group. Old code returned early
+    # and left prediction_review.group_id NULL on the reused rows.
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws)
+    rows = db2.conn.execute(
+        """SELECT pr_rev.group_id AS group_id
+             FROM predictions pr
+             JOIN prediction_review pr_rev
+               ON pr_rev.prediction_id = pr.id
+              AND pr_rev.workspace_id = ?
+            WHERE pr.detection_id IN (?, ?)""",
+        (ws, det_a, det_b),
+    ).fetchall()
+    assert len(rows) == 2
+    group_ids = {r["group_id"] for r in rows}
+    assert None not in group_ids, (
+        "group metadata should be stamped by the reused-cache finalize path"
+    )
+    assert len(group_ids) == 1, "both frames should share one burst group"

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5963,6 +5963,135 @@ def test_all_photos_cache_satisfied_requires_common_identity_when_either_unresol
     ) is True
 
 
+def test_all_photos_cache_satisfied_rejects_stale_classifier_runtime(tmp_path):
+    """When classifier weights or preprocessing change under the same
+    ``classifier_model`` and label fingerprint, an unreviewed
+    classifier_runs row from the OLD runtime must not satisfy this
+    join.  Without the runtime filter, ``run_classify_job`` would
+    shortcut to ``_finalize_cached_only`` on wrong-runtime results
+    even though the ordinary ``_classify_photos`` gate would reject
+    them via ``_runtime_aware_run_keys``.
+
+    A manually-reviewed row must still count so the pin exception
+    survives runtime changes until an explicit reclassify.
+    """
+    from classify_job import _all_photos_cache_satisfied
+    from computation_cache import (
+        classifier_model_identity,
+        classifier_runtime_fingerprint,
+        runtime_fingerprint,
+        source_input,
+    )
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    detector_runtime = runtime_fingerprint({
+        "type": "detection", "model": "megadetector-v6",
+        "weights_sha256": "2" * 64, "pipeline": "detector-v1",
+    })
+    _input, det_input_fp = source_input(
+        "0" * 64, "vireo-detector-source-v1",
+    )
+    det_id = db.write_detection_batch(
+        pid, "megadetector-v6",
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+          "confidence": 0.9, "category": "animal"}],
+        runtime_fingerprint=detector_runtime,
+        input_fingerprint=det_input_fp,
+    )[0]
+
+    labels_full = "5" * 64
+    labels_short = labels_full[:12]
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "image_encoder.onnx").write_bytes(b"exact model bytes")
+    identity = classifier_model_identity({
+        "id": "bioclip-test",
+        "model_str": "ViT-test",
+        "model_type": "bioclip",
+        "weights_path": str(model_dir),
+        "files": ["image_encoder.onnx"],
+        "source": "custom",
+    })
+    expected_runtime = classifier_runtime_fingerprint(
+        identity, labels_full, detector_runtime,
+    )
+    assert expected_runtime is not None
+
+    # A stale classifier_run: same (model, labels_short) but wrong
+    # runtime_fingerprint (older classifier weights).
+    stale_runtime = "9" * 64
+    db.conn.execute(
+        """INSERT INTO classifier_runs
+             (detection_id, classifier_model, labels_fingerprint,
+              runtime_fingerprint, prediction_count)
+           VALUES (?, ?, ?, ?, ?)""",
+        (det_id, "BioCLIP", labels_short, stale_runtime, 1),
+    )
+    db.add_prediction(
+        det_id, species="Robin", confidence=0.9, model="BioCLIP",
+        labels_fingerprint=labels_short,
+    )
+    db.conn.commit()
+
+    # Without runtime constraint, historic behavior would treat this as
+    # satisfied.  Confirm the old-shape call still returns True so we
+    # know the fix is what changes the answer, not an unrelated regression.
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model="BioCLIP",
+        labels_fingerprint=labels_short,
+    ) is True
+
+    # With the runtime constraint the stale row must be excluded.
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model="BioCLIP",
+        labels_fingerprint=labels_short,
+        model_identity=identity, labels_fingerprint_full=labels_full,
+    ) is False
+
+    # A row with the CORRECT runtime satisfies the check.
+    db.conn.execute(
+        "UPDATE classifier_runs SET runtime_fingerprint = ? WHERE detection_id = ?",
+        (expected_runtime, det_id),
+    )
+    db.conn.commit()
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model="BioCLIP",
+        labels_fingerprint=labels_short,
+        model_identity=identity, labels_fingerprint_full=labels_full,
+    ) is True
+
+    # A stale row with a real manual-review pin stays authoritative —
+    # the pin exception mirrors ``get_classifier_run_keys``' behavior.
+    db.conn.execute(
+        "UPDATE classifier_runs SET runtime_fingerprint = ? WHERE detection_id = ?",
+        (stale_runtime, det_id),
+    )
+    pred_row = db.conn.execute(
+        "SELECT id FROM predictions WHERE detection_id = ?",
+        (det_id,),
+    ).fetchone()
+    db.conn.execute(
+        """INSERT INTO prediction_review
+             (prediction_id, workspace_id, status, reviewed_at, individual)
+           VALUES (?, ?, 'accepted', datetime('now'), 'user-choice')""",
+        (pred_row["id"], ws),
+    )
+    db.conn.commit()
+    assert _all_photos_cache_satisfied(
+        db, [pid], classifier_model="BioCLIP",
+        labels_fingerprint=labels_short,
+        model_identity=identity, labels_fingerprint_full=labels_full,
+    ) is True
+
+
 def test_finalize_cached_only_respects_workspace_detector_threshold(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5651,3 +5651,98 @@ def test_burst_consensus_non_ascii_case_variants_stay_split(tmp_path):
         )
         assert kwargs["vote_count"] is None
         assert kwargs["individual"] is None
+
+
+def test_all_photos_cache_satisfied_requires_every_photo_covered(tmp_path):
+    from classify_job import _all_photos_cache_satisfied
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    covered = db.add_photo(
+        folder_id, "covered.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    uncovered = db.add_photo(
+        folder_id, "bare.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_id = db.save_detections(covered, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    db.record_classifier_run(det_id, "BioCLIP", "abc123", prediction_count=1)
+
+    assert _all_photos_cache_satisfied(db, [covered]) is True
+    assert _all_photos_cache_satisfied(db, [covered, uncovered]) is False
+    # Empty photo list: no work possible, treated as not-satisfied so the
+    # caller falls through to normal empty-collection handling.
+    assert _all_photos_cache_satisfied(db, []) is False
+
+
+def test_run_classify_job_short_circuits_when_cache_covers_every_photo(
+    tmp_path, monkeypatch,
+):
+    """A fresh install with an imported cache but no classifier weights
+    must not fail with "No model available" — every photo already has a
+    completed classifier run, so model resolution is unnecessary.
+    """
+    import config as cfg
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9,
+         "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="fp-cached")
+    db.record_classifier_run(det_id, "BioCLIP", "fp-cached",
+                             prediction_count=1)
+
+    coll_id = db.add_collection(
+        "c", '[{"field":"photo_ids","value":[' + str(pid) + ']}]',
+    )
+
+    # Model resolution WOULD fail here — no active model exists. The
+    # short-circuit must run before this raises.
+    import classify_job as classify_job_mod
+    monkeypatch.setattr(classify_job_mod, "get_active_model", lambda: None)
+    monkeypatch.setattr(classify_job_mod, "get_models", lambda: [])
+
+    runner = FakeRunner()
+    job = _make_job()
+    params = ClassifyParams(
+        collection_id=coll_id,
+        labels_files=None,
+        labels_file=None,
+        model_id=None,
+        model_name=None,
+        grouping_window=0,
+        similarity_threshold=0.99,
+        reclassify=False,
+    )
+
+    result = run_classify_job(job, runner, db_path, ws, params)
+    assert result["already_classified"] == result["total"] == 1
+    assert result["failed"] == 0
+    # The cached prediction must still be there — the short-circuit
+    # must not touch the DB.
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws)
+    assert db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions WHERE detection_id = ?",
+        (det_id,),
+    ).fetchone()["n"] == 1

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -5181,9 +5181,13 @@ def test_run_classify_job_reclassify_cancel_classifies_empty_scene_processed(tmp
     # No prior full-image synthetic detection exists for photo 1 — the
     # classifier creates one for the full-image fallback path.
     mock_db_instance.get_detections.return_value = []
-    # save_detections returns a synthetic detection id for the full-image
-    # fallback that _classify_photos creates for empty-scene photos.
+    # save_detections + write_detection_batch both return the synthetic
+    # detection id for the full-image fallback path.  The classify loop
+    # now writes both the detection and the detector_runs row in a single
+    # ``write_detection_batch`` transaction to avoid torn state on crash,
+    # so the mock has to answer that call too.
     mock_db_instance.save_detections.return_value = [201]
+    mock_db_instance.write_detection_batch.return_value = [201]
 
     fake_model = {
         "id": "test-model",

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -6078,6 +6078,62 @@ def test_finalize_cached_only_includes_zero_confidence_full_image_anchor(
     assert result["already_classified"] == 1
 
 
+def test_finalize_cached_only_treats_null_category_as_animal(
+    tmp_path, monkeypatch,
+):
+    """Legacy NULL categories match the cache-coverage SQL's animal default."""
+    import classify_job as classify_job_mod
+    import config as cfg
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    workspace_id = db.ensure_default_workspace()
+    db.set_active_workspace(workspace_id)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    photo_id = db.add_photo(
+        folder_id, "legacy.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    detection_id = db.save_detections(photo_id, [{
+        "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+        "confidence": 0.9,
+        "category": "animal",
+    }], detector_model="megadetector-v6")[0]
+    db.conn.execute(
+        "UPDATE detections SET category = NULL WHERE id = ?",
+        (detection_id,),
+    )
+    db.add_prediction(
+        detection_id, species="Robin", confidence=0.9,
+        model="BioCLIP", labels_fingerprint="fp-cached",
+    )
+    db.record_classifier_run(
+        detection_id, "BioCLIP", "fp-cached", prediction_count=1,
+    )
+    db.conn.commit()
+    collection_id = db.add_collection(
+        "legacy", json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+
+    monkeypatch.setattr(classify_job_mod, "get_active_model", lambda: None)
+    monkeypatch.setattr(classify_job_mod, "get_models", lambda: [])
+    result = run_classify_job(
+        _make_job(), FakeRunner(), db_path, workspace_id,
+        ClassifyParams(
+            collection_id=collection_id,
+            labels_files=None, labels_file=None,
+            model_id=None, model_name=None,
+            grouping_window=0, similarity_threshold=0.99,
+            reclassify=False,
+        ),
+    )
+
+    assert result["already_classified"] == 1
+
+
 def test_run_classify_job_short_circuits_when_cache_covers_every_photo(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -255,6 +255,51 @@ def test_corrupt_bundle_publishes_nothing(tmp_path):
     assert not (tmp_path / "store").exists()
 
 
+def _second_detection_artifact():
+    return detection_artifact(subjects=[{
+        "key": "d0",
+        "kind": "box",
+        "box": {"x": 0.5, "y": 0.55, "w": 0.25, "h": 0.3},
+        "confidence": 0.7654321,
+        "category": "animal",
+    }])
+
+
+def test_multi_object_bundle_bad_late_object_publishes_nothing(tmp_path):
+    good = tmp_path / "good.vireo-cache"
+    bad = tmp_path / "bad.vireo-cache"
+    write_bundle(good, [detection_artifact(), _second_detection_artifact()])
+
+    def corrupt_last(members):
+        object_names = sorted(name for name in members if name.startswith("objects/"))
+        assert len(object_names) == 2
+        members[object_names[-1]] = members[object_names[-1]] + b" "
+
+    _rewrite_bundle(good, bad, corrupt_last)
+    store = ArtifactStore(tmp_path / "store")
+    with pytest.raises(CacheFormatError, match="size|digest"):
+        import_bundle(bad, store)
+    assert not (tmp_path / "store").exists()
+
+
+def test_multi_object_bundle_bad_manifest_total_publishes_nothing(tmp_path):
+    good = tmp_path / "good.vireo-cache"
+    bad = tmp_path / "bad.vireo-cache"
+    write_bundle(good, [detection_artifact(), _second_detection_artifact()])
+
+    def bump_total(members):
+        import json as _json
+        manifest = _json.loads(members["manifest.json"])
+        manifest["uncompressed_bytes"] = manifest["uncompressed_bytes"] + 1
+        members["manifest.json"] = canonical_bytes(manifest)
+
+    _rewrite_bundle(good, bad, bump_total)
+    store = ArtifactStore(tmp_path / "store")
+    with pytest.raises(CacheFormatError, match="byte total"):
+        import_bundle(bad, store)
+    assert not (tmp_path / "store").exists()
+
+
 def test_bundle_rejects_traversal_and_undeclared_members(tmp_path):
     bundle = tmp_path / "unsafe.vireo-cache"
     manifest = {

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -22,6 +22,7 @@ from computation_cache import (  # noqa: E402
     promote_and_publish_classifier_run,
     read_bundle,
     runtime_fingerprint,
+    sha256_file,
     source_input,
     validate_artifact,
     write_bundle,
@@ -1072,3 +1073,145 @@ def test_materialize_local_store_honors_persisted_trust(tmp_path):
     untrusted = materialize_local_store(destination2, store=fresh_store)
     assert untrusted["detector_runs_applied"] == 0
     assert untrusted["classifier_runs_applied"] == 0
+
+
+def test_sha256_file_retains_hashes_across_paths(tmp_path):
+    """Hashing one custom-model file must not evict cached hashes for other
+    files in the same directory. Prior to this regression check, the cache
+    was cleared on every miss, forcing each multi-file custom model's
+    ONNX sidecars to be re-read on every identity computation.
+    """
+    import computation_cache
+
+    a = tmp_path / "image_encoder.onnx"
+    b = tmp_path / "text_encoder.onnx"
+    a.write_bytes(b"aaa")
+    b.write_bytes(b"bbb")
+
+    computation_cache._FILE_DIGEST_CACHE.clear()
+    hash_a = sha256_file(str(a))
+    hash_b = sha256_file(str(b))
+
+    stat_a = os.stat(str(a))
+    key_a = (os.path.abspath(str(a)), stat_a.st_size, stat_a.st_mtime_ns)
+    stat_b = os.stat(str(b))
+    key_b = (os.path.abspath(str(b)), stat_b.st_size, stat_b.st_mtime_ns)
+
+    assert computation_cache._FILE_DIGEST_CACHE[key_a] == hash_a
+    assert computation_cache._FILE_DIGEST_CACHE[key_b] == hash_b
+
+
+def test_sha256_file_evicts_stale_entries_for_the_same_path(tmp_path):
+    """A rewritten file with a new size/mtime must supersede its stale
+    cache entry; unrelated paths must survive.
+    """
+    import computation_cache
+
+    a = tmp_path / "weights.onnx"
+    b = tmp_path / "text_features.pt"
+    a.write_bytes(b"v1")
+    b.write_bytes(b"unchanged")
+
+    computation_cache._FILE_DIGEST_CACHE.clear()
+    sha256_file(str(a))
+    sha256_file(str(b))
+
+    stat_b_before = os.stat(str(b))
+    key_b = (
+        os.path.abspath(str(b)), stat_b_before.st_size, stat_b_before.st_mtime_ns,
+    )
+
+    # Rewrite ``a`` so its stat changes; ``sha256_file`` must evict the
+    # stale ``a`` entry but keep the entry for ``b``.
+    a.write_bytes(b"v2-longer")
+    os.utime(str(a), (stat_b_before.st_mtime + 1, stat_b_before.st_mtime + 1))
+    new_hash_a = sha256_file(str(a))
+
+    stat_a_after = os.stat(str(a))
+    key_a_new = (
+        os.path.abspath(str(a)), stat_a_after.st_size, stat_a_after.st_mtime_ns,
+    )
+    assert computation_cache._FILE_DIGEST_CACHE.get(key_a_new) == new_hash_a
+    assert key_b in computation_cache._FILE_DIGEST_CACHE
+
+    # Old key for ``a`` should be gone.
+    stale_a_keys = [
+        k for k in computation_cache._FILE_DIGEST_CACHE
+        if k[0] == os.path.abspath(str(a)) and k != key_a_new
+    ]
+    assert stale_a_keys == []
+
+
+def test_http_import_then_classify_job_uses_configured_cache_dir(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """When an operator overrides ``COMPUTATION_CACHE_DIR``, an HTTP-imported
+    bundle whose photos are cataloged only later must still plant on the
+    background classify job's next materialize call. Prior to the fix,
+    ``run_classify_job``'s pre-model ``materialize_local_store(thread_db)``
+    fell back to the default ``~/.vireo/computation-cache`` and never saw
+    the imported artifact, so catalog-later reuse silently failed outside
+    the default configuration.
+    """
+    import computation_cache
+
+    app, db = app_and_db
+    monkeypatch.setattr(
+        computation_cache, "megadetector_runtime_fingerprint",
+        lambda *_args, **_kwargs: RUNTIME,
+    )
+    # Point the default anywhere BUT the overridden store so a regression
+    # (background job falling back to the default) can't accidentally
+    # hit the same artifact via the wrong path.
+    monkeypatch.setattr(
+        computation_cache, "DEFAULT_CACHE_DIR",
+        str(tmp_path / "would-be-wrong-default"),
+    )
+
+    store_dir = tmp_path / "http-store"
+    app.config["COMPUTATION_CACHE_DIR"] = str(store_dir)
+
+    # HTTP-import a detection bundle into the overridden store. Do this
+    # BEFORE the photo is cataloged with its file hash so materialize
+    # can't plant during the import — the background classify call is
+    # the one that has to find the artifact.
+    exported_store = ArtifactStore(tmp_path / "source")
+    exported_store.put(detection_artifact())
+    exported_artifacts = [
+        artifact for _digest, artifact
+        in (exported_store.iter_artifacts() or ())
+    ]
+    bundle_path = tmp_path / "bundle.vireo-cache"
+    write_bundle(bundle_path, exported_artifacts)
+    client = app.test_client()
+    with open(bundle_path, "rb") as handle:
+        response = client.post(
+            "/api/computation-cache/import",
+            data={"file": (handle, "bundle.vireo-cache")},
+            content_type="multipart/form-data",
+        )
+    assert response.status_code == 200
+    # The import happened before the photo carried a matching file_hash,
+    # so nothing planted yet — the artifact is sitting in the overridden
+    # store waiting for a later job to find it.
+    assert response.get_json()["detector_runs_applied"] == 0
+
+    photo_id = db.conn.execute(
+        "SELECT id FROM photos ORDER BY id LIMIT 1",
+    ).fetchone()["id"]
+    db.conn.execute(
+        "UPDATE photos SET file_hash = ? WHERE id = ?", (PHOTO_HASH, photo_id),
+    )
+    db.conn.commit()
+
+    # Directly exercise the background job's cache-reapply plumbing:
+    # ArtifactStore(configured_dir) must find the imported artifact.
+    reapply_store = ArtifactStore(str(store_dir))
+    reapplied = materialize_local_store(db, store=reapply_store)
+    assert reapplied["detector_runs_applied"] == 1
+
+    # Confirm the default location was empty — if the background job had
+    # ignored the override, this is the only place its materialize would
+    # have looked, and reuse would have silently failed.
+    default_store = ArtifactStore(computation_cache.DEFAULT_CACHE_DIR)
+    assert list(default_store.iter_artifacts() or ()) == []

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -687,6 +687,43 @@ def test_companion_backed_destination_photo_is_not_materialized(tmp_path):
     )
 
 
+def test_working_copy_backed_destination_photo_is_not_materialized(tmp_path):
+    """A v1 artifact identifies only the original bytes, so it cannot be
+    applied to a destination that classifies a derived working-copy JPEG.
+    """
+    destination, folder_id, plain_photo_id = _database_with_photo(
+        tmp_path / "destination.db", "plain.jpg",
+    )
+    working_copy_photo_id = destination.add_photo(
+        folder_id=folder_id,
+        filename="edited.jpg",
+        extension=".jpg",
+        file_size=2048,
+        file_mtime=2.0,
+    )
+    destination.conn.execute(
+        "UPDATE photos SET working_copy_path = ?, file_hash = ? WHERE id = ?",
+        ("working/edited.jpg", PHOTO_HASH, working_copy_photo_id),
+    )
+    destination.conn.commit()
+
+    result = materialize_artifacts(
+        destination, [detection_artifact()],
+        known_runtimes={RUNTIME},
+    )
+    assert result["detector_runs_applied"] == 1
+    applied_photo_ids = [
+        row["photo_id"] for row in destination.conn.execute(
+            "SELECT photo_id FROM detector_runs "
+            "WHERE detector_model = 'megadetector-v6' ORDER BY photo_id"
+        ).fetchall()
+    ]
+    assert applied_photo_ids == [plain_photo_id], (
+        "working-copy-backed photos must be excluded because the artifact "
+        "does not identify the derived rendition's pixels"
+    )
+
+
 def test_tree_of_life_sentinel_short_fingerprint_is_accepted():
     """Tree-of-Life classification uses the well-known ``tol`` sentinel as
     the classifier_runs short key (compute_fingerprint([]) → "tol") while

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -18,6 +18,7 @@ from computation_cache import (  # noqa: E402
     exportable_artifacts,
     import_bundle,
     materialize_artifacts,
+    materialize_local_store,
     promote_and_publish_classifier_run,
     read_bundle,
     runtime_fingerprint,
@@ -643,3 +644,73 @@ def test_unknown_classifier_runtime_is_quarantined_not_installed(tmp_path):
     )
     assert applied_ok["classifier_runs_applied"] == 1
     assert applied_ok["unknown_classifier_runtime"] == 0
+
+
+def test_artifact_store_persists_trusted_runtimes(tmp_path):
+    """Trust recorded on import survives store re-instantiation and merges."""
+    store = ArtifactStore(tmp_path / "cache")
+    assert store.trusted_runtimes() == (set(), set())
+    store.record_trusted_runtimes(
+        detector_runtimes={RUNTIME},
+        classifier_runtimes={CLASSIFIER_RUNTIME},
+    )
+    # Fresh instance reads back the same on-disk trust — this is what
+    # subsequent classify_job / pipeline calls rely on.
+    reread = ArtifactStore(tmp_path / "cache")
+    det, clf = reread.trusted_runtimes()
+    assert det == {RUNTIME}
+    assert clf == {CLASSIFIER_RUNTIME}
+
+    # A second record merges rather than replacing.
+    other_runtime = "a" * 64
+    reread.record_trusted_runtimes(detector_runtimes={other_runtime})
+    det, clf = ArtifactStore(tmp_path / "cache").trusted_runtimes()
+    assert det == {RUNTIME, other_runtime}
+    assert clf == {CLASSIFIER_RUNTIME}
+
+    # Malformed fingerprints are silently dropped — record_trusted_runtimes
+    # only persists lowercase SHA-256s so a corrupted trust.json can never
+    # widen the whitelist to arbitrary strings.
+    reread.record_trusted_runtimes(detector_runtimes={"not-a-hash"})
+    det, _ = ArtifactStore(tmp_path / "cache").trusted_runtimes()
+    assert "not-a-hash" not in det
+
+
+def test_materialize_local_store_honors_persisted_trust(tmp_path):
+    """A bundle imported before the photo exists still lands on rescan."""
+    destination, _folder_id, _photo_id = _database_with_photo(
+        tmp_path / "destination.db", "photo.jpg",
+    )
+    destination.upsert_labels_fingerprint(
+        "3" * 12, "Test labels", [], 1, full_fingerprint="3" * 64,
+    )
+    store = ArtifactStore(tmp_path / "cache")
+    # Publish detector + classifier artifacts into the store as an import
+    # would, then record the trust decision the API endpoint takes.
+    for artifact in (detection_artifact(), classification_artifact()):
+        store.put(artifact)
+    store.record_trusted_runtimes(
+        detector_runtimes={RUNTIME},
+        classifier_runtimes={CLASSIFIER_RUNTIME},
+    )
+
+    # No per-call known_runtimes supplied — mirrors the run_classify_job /
+    # pipeline_job flow where nothing about the bundle's trust survived
+    # the original import HTTP call.
+    applied = materialize_local_store(destination, store=store)
+    assert applied["detector_runs_applied"] == 1
+    assert applied["classifier_runs_applied"] == 1
+
+    # Without persisted trust, the same store would have quarantined both.
+    fresh_store = ArtifactStore(tmp_path / "cache-untrusted")
+    for artifact in (detection_artifact(), classification_artifact()):
+        fresh_store.put(artifact)
+    destination2, _f, _p = _database_with_photo(
+        tmp_path / "destination2.db", "photo.jpg",
+    )
+    destination2.upsert_labels_fingerprint(
+        "3" * 12, "Test labels", [], 1, full_fingerprint="3" * 64,
+    )
+    untrusted = materialize_local_store(destination2, store=fresh_store)
+    assert untrusted["detector_runs_applied"] == 0
+    assert untrusted["classifier_runs_applied"] == 0

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -868,6 +868,66 @@ def test_unknown_detector_runtime_is_quarantined_not_installed(tmp_path):
     assert applied_ok["unknown_runtime"] == 0
 
 
+def test_materialize_selects_single_detection_per_photo_and_model(tmp_path):
+    """When the local store holds trusted detection artifacts from
+    multiple runtimes for the same (photo, detector_model), materialize
+    must NOT feed them all through ``write_detection_batch`` in
+    sequence.  Each runtime change deletes the previously selected
+    detections and cascades their unreviewed predictions; the settled
+    winner would then depend on iteration order rather than on which
+    runtime the catalog already has installed.  Materialize must pick
+    one candidate per logical run so re-application is a no-op and
+    routine reapply cannot churn detections.
+    """
+    destination, _folder_id, photo_id = _database_with_photo(
+        tmp_path / "destination.db", "photo.jpg",
+    )
+
+    other_runtime = runtime_fingerprint({
+        "type": "detection",
+        "model": "megadetector-v6",
+        "weights_sha256": "9" * 64,
+        "pipeline": "detector-v1",
+    })
+    other = detection_artifact()
+    other["runtime_fingerprint"] = other_runtime
+
+    # First pass: no existing detector_runs, both runtimes trusted.
+    # Expect exactly one detector_runs row (not two writes that churn).
+    first = materialize_artifacts(
+        destination, [detection_artifact(), other],
+        known_runtimes={RUNTIME, other_runtime},
+    )
+    assert first["detector_runs_applied"] == 1
+    installed = destination.conn.execute(
+        """SELECT runtime_fingerprint FROM detector_runs
+           WHERE photo_id = ? AND detector_model = 'megadetector-v6'""",
+        (photo_id,),
+    ).fetchone()
+    assert installed is not None
+    installed_runtime = installed["runtime_fingerprint"]
+    assert installed_runtime in {RUNTIME, other_runtime}
+
+    # Second pass with the same inputs: the catalog now has an existing
+    # runtime; materialize must PREFER the matching artifact so the
+    # write is an idempotent no-op rather than a churn between runtimes.
+    second = materialize_artifacts(
+        destination, [detection_artifact(), other],
+        known_runtimes={RUNTIME, other_runtime},
+    )
+    assert second["detector_runs_applied"] == 0
+    assert second["already_materialized"] == 1
+    still_installed = destination.conn.execute(
+        """SELECT runtime_fingerprint FROM detector_runs
+           WHERE photo_id = ? AND detector_model = 'megadetector-v6'""",
+        (photo_id,),
+    ).fetchone()["runtime_fingerprint"]
+    assert still_installed == installed_runtime, (
+        "Re-materialization must not swap runtimes; the loop was "
+        "churning through every candidate again."
+    )
+
+
 def test_classification_deferred_until_detector_run_available(tmp_path):
     destination, _folder_id, photo_id = _database_with_photo(
         tmp_path / "destination.db", "photo.jpg",

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -33,6 +33,13 @@ RUNTIME = runtime_fingerprint({
     "weights_sha256": "2" * 64,
     "pipeline": "detector-v1",
 })
+CLASSIFIER_RUNTIME = runtime_fingerprint({
+    "type": "classification",
+    "model": "bioclip-2.5",
+    "weights_sha256": "4" * 64,
+    "labels_fingerprint": "3" * 64,
+    "detector_runtime_fingerprint": RUNTIME,
+})
 
 
 def detection_artifact(subjects=None):
@@ -337,7 +344,9 @@ def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
     destination.conn.commit()
 
     applied = materialize_artifacts(
-        destination, imported["artifacts"], known_runtimes={RUNTIME},
+        destination, imported["artifacts"],
+        known_runtimes={RUNTIME},
+        known_classifier_runtimes={CLASSIFIER_RUNTIME},
     )
     assert applied["matched_photos"] == 2
     assert applied["detector_runs_applied"] == 2
@@ -359,7 +368,9 @@ def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
     ).fetchone()["c"] == 0, "portable output must not transfer review state"
 
     repeat = materialize_artifacts(
-        destination, imported["artifacts"], known_runtimes={RUNTIME},
+        destination, imported["artifacts"],
+        known_runtimes={RUNTIME},
+        known_classifier_runtimes={CLASSIFIER_RUNTIME},
     )
     assert repeat["detector_runs_applied"] == 0
     assert repeat["classifier_runs_applied"] == 0
@@ -571,7 +582,9 @@ def test_classification_deferred_until_detector_run_available(tmp_path):
     # applied) since the detector_run dependency does not exist yet.
     only_classification = [classification_artifact()]
     deferred = materialize_artifacts(
-        destination, only_classification, known_runtimes={RUNTIME},
+        destination, only_classification,
+        known_runtimes={RUNTIME},
+        known_classifier_runtimes={CLASSIFIER_RUNTIME},
     )
     assert deferred["classifier_runs_applied"] == 0
     assert deferred["classifier_deferred_pending_detection"] >= 1
@@ -582,6 +595,51 @@ def test_classification_deferred_until_detector_run_available(tmp_path):
         destination,
         [detection_artifact(), classification_artifact()],
         known_runtimes={RUNTIME},
+        known_classifier_runtimes={CLASSIFIER_RUNTIME},
     )
     assert together["detector_runs_applied"] == 1
     assert together["classifier_runs_applied"] == 1
+
+
+def test_unknown_classifier_runtime_is_quarantined_not_installed(tmp_path):
+    """A classification artifact whose classifier runtime this install
+    cannot reproduce must stay quarantined in the object store — its
+    predictions must not surface as authoritative results until a
+    matching classifier is verified locally or the caller explicitly
+    trusts the runtime.
+    """
+    destination, _folder_id, _photo_id = _database_with_photo(
+        tmp_path / "destination.db", "photo.jpg",
+    )
+    destination.upsert_labels_fingerprint(
+        "3" * 12, "Test labels", [], 1, full_fingerprint="3" * 64,
+    )
+
+    # Detector runtime is recognized (via known_runtimes), but no
+    # classifier runtime is trusted and no local classifier can
+    # reproduce the artifact's runtime_fingerprint. The classification
+    # must be counted as unknown_classifier_runtime and NOT applied.
+    applied = materialize_artifacts(
+        destination,
+        [detection_artifact(), classification_artifact()],
+        known_runtimes={RUNTIME},
+    )
+    assert applied["detector_runs_applied"] == 1
+    assert applied["classifier_runs_applied"] == 0
+    assert applied["unknown_classifier_runtime"] == 1
+    assert destination.conn.execute(
+        "SELECT COUNT(*) AS c FROM predictions",
+    ).fetchone()["c"] == 0
+
+    # A caller that has verified the classifier through some other
+    # channel (a classify job that just resolved its own runtime, an
+    # install-time model registry) can pass it explicitly and the
+    # same artifact then materializes.
+    applied_ok = materialize_artifacts(
+        destination,
+        [detection_artifact(), classification_artifact()],
+        known_runtimes={RUNTIME},
+        known_classifier_runtimes={CLASSIFIER_RUNTIME},
+    )
+    assert applied_ok["classifier_runs_applied"] == 1
+    assert applied_ok["unknown_classifier_runtime"] == 0

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -1,0 +1,459 @@
+import io
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from computation_cache import (  # noqa: E402
+    ArtifactStore,
+    CacheFormatError,
+    artifact_digest,
+    canonical_bytes,
+    classification_input,
+    classifier_model_identity,
+    exportable_artifacts,
+    import_bundle,
+    materialize_artifacts,
+    promote_and_publish_classifier_run,
+    read_bundle,
+    runtime_fingerprint,
+    source_input,
+    validate_artifact,
+    write_bundle,
+)
+
+
+PHOTO_HASH = "1" * 64
+RUNTIME = runtime_fingerprint({
+    "type": "detection",
+    "model": "megadetector-v6",
+    "weights_sha256": "2" * 64,
+    "pipeline": "detector-v1",
+})
+
+
+def detection_artifact(subjects=None):
+    input_block, input_fingerprint = source_input(
+        PHOTO_HASH, "vireo-detector-source-v1",
+    )
+    return {
+        "artifact_schema": 1,
+        "type": "detection",
+        "detector_model": "megadetector-v6",
+        "photo_sha256": PHOTO_HASH,
+        "runtime_fingerprint": RUNTIME,
+        "input_fingerprint": input_fingerprint,
+        "input": input_block,
+        "completed": True,
+        "subjects": subjects if subjects is not None else [{
+            "key": "d0",
+            "kind": "box",
+            "box": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
+            "confidence": 0.9123456789,
+            "category": "animal",
+        }],
+    }
+
+
+def test_canonical_json_normalizes_negative_zero_and_rejects_nan():
+    assert canonical_bytes({"z": -0.0, "a": 1}) == b'{"a":1,"z":0.0}'
+    with pytest.raises(CacheFormatError, match="NaN"):
+        canonical_bytes({"confidence": float("nan")})
+
+
+def test_empty_detection_result_is_valid_completed_computation():
+    artifact = detection_artifact(subjects=[])
+    assert validate_artifact(artifact)["subjects"] == []
+
+
+def test_input_fingerprint_and_numeric_bounds_are_verified():
+    artifact = detection_artifact()
+    artifact["input_fingerprint"] = "9" * 64
+    with pytest.raises(CacheFormatError, match="does not match"):
+        validate_artifact(artifact)
+
+    artifact = detection_artifact()
+    artifact["subjects"][0]["box"]["x"] = -0.1
+    with pytest.raises(CacheFormatError, match=r"in \[0, 1\]"):
+        validate_artifact(artifact)
+
+    artifact = detection_artifact()
+    artifact["photo_sha256"] = "8" * 64
+    with pytest.raises(CacheFormatError, match="source does not match photo"):
+        validate_artifact(artifact)
+
+
+def test_artifact_store_is_content_addressed_atomic_and_idempotent(tmp_path):
+    store = ArtifactStore(tmp_path / "store")
+    artifact = detection_artifact()
+    digest, created = store.put(artifact)
+    assert created is True
+    assert digest == artifact_digest(artifact)
+    expected = store.object_path(artifact, digest)
+    assert expected.read_bytes() == canonical_bytes(artifact)
+    assert not list(expected.parent.glob(".incoming-*"))
+
+    same_digest, created = store.put(artifact)
+    assert same_digest == digest
+    assert created is False
+    assert store.stats() == {
+        "object_count": 1,
+        "total_bytes": len(canonical_bytes(artifact)),
+    }
+
+
+def test_bundle_round_trip_validates_before_publishing(tmp_path):
+    artifact = detection_artifact()
+    bundle = tmp_path / "results.vireo-cache"
+    manifest = write_bundle(bundle, [artifact, artifact], device_label="Studio Mac")
+    assert manifest["object_count"] == 1
+
+    read_manifest, artifacts = read_bundle(bundle)
+    assert read_manifest["device_label"] == "Studio Mac"
+    assert artifacts == [artifact]
+
+    store = ArtifactStore(tmp_path / "store")
+    first = import_bundle(bundle, store)
+    second = import_bundle(bundle, store)
+    assert (first["added"], first["already_present"]) == (1, 0)
+    assert (second["added"], second["already_present"]) == (0, 1)
+
+
+def _rewrite_bundle(source, destination, transform):
+    with zipfile.ZipFile(source) as archive:
+        members = {info.filename: archive.read(info) for info in archive.infolist()}
+    transform(members)
+    with zipfile.ZipFile(destination, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, body in members.items():
+            archive.writestr(name, body)
+
+
+def test_corrupt_bundle_publishes_nothing(tmp_path):
+    good = tmp_path / "good.vireo-cache"
+    bad = tmp_path / "bad.vireo-cache"
+    write_bundle(good, [detection_artifact()])
+
+    def corrupt(members):
+        object_name = next(name for name in members if name.startswith("objects/"))
+        members[object_name] = members[object_name] + b" "
+
+    _rewrite_bundle(good, bad, corrupt)
+    store = ArtifactStore(tmp_path / "store")
+    with pytest.raises(CacheFormatError, match="size|digest"):
+        import_bundle(bad, store)
+    assert not (tmp_path / "store").exists()
+
+
+def test_bundle_rejects_traversal_and_undeclared_members(tmp_path):
+    bundle = tmp_path / "unsafe.vireo-cache"
+    manifest = {
+        "format": "vireo-computation-cache",
+        "format_version": 1,
+        "created_at": "2026-08-08T00:00:00+00:00",
+        "device_label": None,
+        "object_count": 0,
+        "uncompressed_bytes": 0,
+        "objects": [],
+    }
+    with zipfile.ZipFile(bundle, "w") as archive:
+        archive.writestr("manifest.json", canonical_bytes(manifest))
+        archive.writestr("../outside", b"bad")
+    with pytest.raises(CacheFormatError, match="unsafe ZIP path"):
+        read_bundle(bundle)
+    assert not (tmp_path / "outside").exists()
+
+
+def test_bundle_rejects_symlinks(tmp_path):
+    bundle = tmp_path / "symlink.vireo-cache"
+    manifest = {
+        "format": "vireo-computation-cache",
+        "format_version": 1,
+        "created_at": "2026-08-08T00:00:00+00:00",
+        "device_label": None,
+        "object_count": 0,
+        "uncompressed_bytes": 0,
+        "objects": [],
+    }
+    with zipfile.ZipFile(bundle, "w") as archive:
+        archive.writestr("manifest.json", canonical_bytes(manifest))
+        info = zipfile.ZipInfo("objects/link.json")
+        info.create_system = 3
+        info.external_attr = (0o120777 << 16)
+        archive.writestr(info, b"target")
+    with pytest.raises(CacheFormatError, match="symbolic links"):
+        read_bundle(bundle)
+
+
+def test_bundle_does_not_leak_source_paths(tmp_path):
+    artifact = detection_artifact()
+    bundle = tmp_path / "portable.vireo-cache"
+    write_bundle(bundle, [artifact])
+    body = bundle.read_bytes()
+    assert os.fsencode("/Users/alice/Pictures") not in body
+    assert b"IMG_0001.CR3" not in body
+
+
+def _database_with_photo(path, filename, file_hash=PHOTO_HASH):
+    from db import Database
+
+    db = Database(str(path))
+    folder_id = db.add_folder("/tmp/photos")
+    workspace_id = db.create_workspace("Photos")
+    db._active_workspace_id = workspace_id
+    db.add_workspace_folder(workspace_id, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id,
+        filename=filename,
+        extension=".jpg",
+        file_size=100,
+        file_mtime=1.0,
+        file_hash=file_hash,
+    )
+    return db, folder_id, photo_id
+
+
+def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
+    source, _folder_id, source_photo = _database_with_photo(
+        tmp_path / "source.db", "source.jpg",
+    )
+    box = {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}
+    detector_input, detector_input_fp = source_input(
+        PHOTO_HASH, "vireo-detector-source-v1",
+    )
+    detection_id = source.write_detection_batch(
+        source_photo,
+        "megadetector-v6",
+        [{"box": box, "confidence": 0.91, "category": "animal"}],
+        runtime_fingerprint=RUNTIME,
+        input_fingerprint=detector_input_fp,
+    )[0]
+
+    labels_full = "3" * 64
+    labels_short = labels_full[:12]
+    classifier_runtime = runtime_fingerprint({
+        "type": "classification",
+        "model": "bioclip-2.5",
+        "weights_sha256": "4" * 64,
+        "labels_fingerprint": labels_full,
+        "detector_runtime_fingerprint": RUNTIME,
+    })
+    classifier_subjects = [{
+        "key": "d0", "kind": "box", "box": box, "category": "animal",
+    }]
+    _classifier_input, classifier_input_fp = classification_input(
+        PHOTO_HASH, RUNTIME, classifier_subjects,
+    )
+    source.add_prediction(
+        detection_id,
+        "European Robin",
+        0.87,
+        "bioclip-2.5",
+        labels_fingerprint=labels_short,
+        labels_fingerprint_full=labels_full,
+    )
+    source.record_classifier_run(
+        detection_id,
+        "bioclip-2.5",
+        labels_short,
+        prediction_count=1,
+        labels_fingerprint_full=labels_full,
+        runtime_fingerprint=classifier_runtime,
+        input_fingerprint=classifier_input_fp,
+    )
+    source.upsert_labels_fingerprint(
+        labels_short,
+        "European birds",
+        ["europe.txt"],
+        1,
+        full_fingerprint=labels_full,
+    )
+
+    artifacts, summary = exportable_artifacts(source)
+    assert summary["detector_runs"] == 1
+    assert summary["classifier_runs"] == 1
+    assert {artifact["type"] for artifact in artifacts} == {
+        "detection", "classification",
+    }
+
+    bundle = tmp_path / "shared.vireo-cache"
+    write_bundle(bundle, artifacts)
+    store = ArtifactStore(tmp_path / "destination-store")
+    imported = import_bundle(bundle, store)
+
+    destination, folder_id, first_photo = _database_with_photo(
+        tmp_path / "destination.db", "renamed.jpg",
+    )
+    second_photo = destination.add_photo(
+        folder_id=folder_id,
+        filename="copy.jpg",
+        extension=".jpg",
+        file_size=100,
+        file_mtime=1.0,
+    )
+    # Exact duplicates are legitimate fan-out targets.  Set this directly so
+    # the normal import-time duplicate resolver does not reject either fixture.
+    destination.conn.execute(
+        "UPDATE photos SET file_hash = ? WHERE id = ?",
+        (PHOTO_HASH, second_photo),
+    )
+    destination.conn.commit()
+
+    applied = materialize_artifacts(destination, imported["artifacts"])
+    assert applied["matched_photos"] == 2
+    assert applied["detector_runs_applied"] == 2
+    assert applied["classifier_runs_applied"] == 2
+    for photo_id in (first_photo, second_photo):
+        prediction = destination.conn.execute(
+            """SELECT p.species, p.labels_fingerprint_full
+               FROM predictions p
+               JOIN detections d ON d.id = p.detection_id
+               WHERE d.photo_id = ?""",
+            (photo_id,),
+        ).fetchone()
+        assert dict(prediction) == {
+            "species": "European Robin",
+            "labels_fingerprint_full": labels_full,
+        }
+    assert destination.conn.execute(
+        "SELECT COUNT(*) AS c FROM prediction_review",
+    ).fetchone()["c"] == 0, "portable output must not transfer review state"
+
+    repeat = materialize_artifacts(destination, imported["artifacts"])
+    assert repeat["detector_runs_applied"] == 0
+    assert repeat["classifier_runs_applied"] == 0
+    assert repeat["already_materialized"] == 4
+
+
+def test_computation_cache_http_export_and_import(app_and_db, tmp_path):
+    app, db = app_and_db
+    app.config["COMPUTATION_CACHE_DIR"] = str(tmp_path / "http-store")
+    photo_id = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 1").fetchone()["id"]
+    db.conn.execute(
+        "UPDATE photos SET file_hash = ? WHERE id = ?", (PHOTO_HASH, photo_id),
+    )
+    db.conn.commit()
+    _input, input_fp = source_input(PHOTO_HASH, "vireo-detector-source-v1")
+    box = {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}
+    db.write_detection_batch(
+        photo_id,
+        "megadetector-v6",
+        [{"box": box, "confidence": 0.91, "category": "animal"}],
+        runtime_fingerprint=RUNTIME,
+        input_fingerprint=input_fp,
+    )
+
+    client = app.test_client()
+    status = client.get("/api/computation-cache")
+    assert status.status_code == 200
+    assert status.get_json()["exportable"]["detector_runs"] == 1
+
+    exported = client.get("/api/computation-cache/export?types=detection")
+    assert exported.status_code == 200
+    assert exported.headers["Content-Disposition"].endswith('.vireo-cache"')
+    manifest, artifacts = read_bundle(io.BytesIO(exported.data))
+    assert manifest["object_count"] == 1
+    assert artifacts[0]["photo_sha256"] == PHOTO_HASH
+
+    db.conn.execute("DELETE FROM detections WHERE photo_id = ?", (photo_id,))
+    db.conn.execute("DELETE FROM detector_runs WHERE photo_id = ?", (photo_id,))
+    db.conn.commit()
+    imported = client.post(
+        "/api/computation-cache/import",
+        data={"file": (io.BytesIO(exported.data), "results.vireo-cache")},
+        content_type="multipart/form-data",
+    )
+    assert imported.status_code == 200
+    body = imported.get_json()
+    assert body["added"] == 1
+    assert body["detector_runs_applied"] == 1
+    assert db.conn.execute(
+        "SELECT runtime_fingerprint FROM detector_runs WHERE photo_id = ?",
+        (photo_id,),
+    ).fetchone()["runtime_fingerprint"] == RUNTIME
+
+
+def test_computation_cache_http_rejects_invalid_bundle(app_and_db, tmp_path):
+    app, _db = app_and_db
+    store_root = tmp_path / "http-store"
+    app.config["COMPUTATION_CACHE_DIR"] = str(store_root)
+    response = app.test_client().post(
+        "/api/computation-cache/import",
+        data={"file": (io.BytesIO(b"not a zip"), "bad.vireo-cache")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert not store_root.exists()
+
+
+def test_fresh_classifier_run_is_promoted_and_published(tmp_path):
+    source, _folder_id, photo_id = _database_with_photo(
+        tmp_path / "source.db", "source.jpg",
+    )
+    _input, detector_input_fp = source_input(
+        PHOTO_HASH, "vireo-detector-source-v1",
+    )
+    box = {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}
+    detection_id = source.write_detection_batch(
+        photo_id,
+        "megadetector-v6",
+        [{"box": box, "confidence": 0.91, "category": "animal"}],
+        runtime_fingerprint=RUNTIME,
+        input_fingerprint=detector_input_fp,
+    )[0]
+    labels_full = "5" * 64
+    labels_short = labels_full[:12]
+    source.upsert_labels_fingerprint(
+        labels_short, "Test birds", [], 1, full_fingerprint=labels_full,
+    )
+    source.add_prediction(
+        detection_id, "Robin", 0.92, "BioCLIP",
+        labels_fingerprint=labels_short,
+    )
+    source.record_classifier_run(
+        detection_id, "BioCLIP", labels_short, prediction_count=1,
+    )
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "image_encoder.onnx").write_bytes(b"exact model bytes")
+    identity = classifier_model_identity({
+        "id": "bioclip-test",
+        "model_str": "ViT-test",
+        "model_type": "bioclip",
+        "weights_path": str(model_dir),
+        "files": ["image_encoder.onnx"],
+        "source": "custom",
+    })
+    store = ArtifactStore(tmp_path / "store")
+    digest = promote_and_publish_classifier_run(
+        source,
+        detection_id,
+        "BioCLIP",
+        labels_short,
+        labels_full,
+        identity,
+        store=store,
+    )
+    assert len(digest) == 64
+    run = source.conn.execute(
+        """SELECT labels_fingerprint_full, runtime_fingerprint,
+                  input_fingerprint
+           FROM classifier_runs WHERE detection_id = ?""",
+        (detection_id,),
+    ).fetchone()
+    assert run["labels_fingerprint_full"] == labels_full
+    assert len(run["runtime_fingerprint"]) == 64
+    assert len(run["input_fingerprint"]) == 64
+    stored = list(store.iter_artifacts())
+    assert len(stored) == 1
+    assert stored[0][1]["type"] == "classification"
+    assert stored[0][1]["subjects"][0]["candidates"][0]["species"] == "Robin"
+
+    artifacts, summary = exportable_artifacts(source)
+    assert summary["classifier_runs"] == 1
+    assert any(item["type"] == "classification" for item in artifacts)

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -1,5 +1,4 @@
 import io
-import json
 import os
 import sys
 import zipfile
@@ -26,7 +25,6 @@ from computation_cache import (  # noqa: E402
     validate_artifact,
     write_bundle,
 )
-
 
 PHOTO_HASH = "1" * 64
 RUNTIME = runtime_fingerprint({

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -539,6 +539,41 @@ def test_labels_count_out_of_sqlite_int64_range_is_rejected():
         validate_artifact(artifact)
 
 
+def test_classification_box_category_shape_is_validated_before_publishing():
+    """A classification box subject may omit ``category`` (materialize falls
+    back to ``"animal"``) but a non-string value must be rejected up
+    front. ``compute_detection_id`` feeds category to ``positive_int_hash``
+    which calls ``len()`` on it; a bool/int/None would raise ``TypeError``
+    mid-materialization AFTER the bundle object had already been
+    published, leaving an unmaterialized entry behind and returning 500
+    to the import route. ``classification_input`` hashes only key/kind/box,
+    so mutating category after construction keeps the input_fingerprint
+    valid — the shape check has to run before the type check would ever
+    fire.
+    """
+    for bad in (True, False, 42, None, [], {"x": 1}):
+        artifact = classification_artifact()
+        artifact["subjects"][0]["category"] = bad
+        with pytest.raises(CacheFormatError, match="category"):
+            validate_artifact(artifact)
+
+    # An empty string or overly long value is also rejected — the field
+    # is meant to carry a short taxonomic label like ``"animal"``.
+    artifact = classification_artifact()
+    artifact["subjects"][0]["category"] = ""
+    with pytest.raises(CacheFormatError, match="category"):
+        validate_artifact(artifact)
+    artifact = classification_artifact()
+    artifact["subjects"][0]["category"] = "x" * 200
+    with pytest.raises(CacheFormatError, match="category"):
+        validate_artifact(artifact)
+
+    # Omission is allowed — materialize supplies the default.
+    artifact = classification_artifact()
+    del artifact["subjects"][0]["category"]
+    assert "category" not in validate_artifact(artifact)["subjects"][0]
+
+
 def test_taxonomy_field_shape_is_validated_before_publishing():
     artifact = classification_artifact(candidates=[{
         "species": "Robin",

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -320,6 +320,12 @@ def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
     assert {artifact["type"] for artifact in artifacts} == {
         "detection", "classification",
     }
+    classification_only, _classification_summary = exportable_artifacts(
+        source, artifact_types={"classification"},
+    )
+    assert {artifact["type"] for artifact in classification_only} == {
+        "detection", "classification",
+    }, "classification exports must include their detector dependency"
 
     bundle = tmp_path / "shared.vireo-cache"
     write_bundle(bundle, artifacts)

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -565,6 +565,128 @@ def test_fresh_classifier_run_is_promoted_and_published(tmp_path):
     assert any(item["type"] == "classification" for item in artifacts)
 
 
+def test_working_copy_backed_classifier_run_stays_local_only(tmp_path):
+    """A photo with a ``working_copy_path`` was classified from the
+    extracted working-copy JPEG (see ``classify_job._prepare_image``
+    when ``vireo_dir`` is set), not from the original bytes. The v1
+    input identity carries only ``p.file_hash``, so publishing that run
+    would advertise a working-copy-derived prediction as if it came from
+    the original — a foreign install (or the same install with a
+    different working copy) would then materialize predictions computed
+    on different pixels. The publisher must decline these runs.
+    """
+    source, _folder_id, photo_id = _database_with_photo(
+        tmp_path / "source.db", "source.jpg",
+    )
+    source.conn.execute(
+        "UPDATE photos SET working_copy_path = ? WHERE id = ?",
+        (str(tmp_path / "wc" / "source.jpg"), photo_id),
+    )
+    source.conn.commit()
+
+    _input, detector_input_fp = source_input(
+        PHOTO_HASH, "vireo-detector-source-v1",
+    )
+    box = {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}
+    detection_id = source.write_detection_batch(
+        photo_id,
+        "megadetector-v6",
+        [{"box": box, "confidence": 0.91, "category": "animal"}],
+        runtime_fingerprint=RUNTIME,
+        input_fingerprint=detector_input_fp,
+    )[0]
+    labels_full = "5" * 64
+    labels_short = labels_full[:12]
+    source.upsert_labels_fingerprint(
+        labels_short, "Test birds", [], 1, full_fingerprint=labels_full,
+    )
+    source.add_prediction(
+        detection_id, "Robin", 0.92, "BioCLIP",
+        labels_fingerprint=labels_short,
+    )
+    source.record_classifier_run(
+        detection_id, "BioCLIP", labels_short, prediction_count=1,
+    )
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "image_encoder.onnx").write_bytes(b"exact model bytes")
+    identity = classifier_model_identity({
+        "id": "bioclip-test",
+        "model_str": "ViT-test",
+        "model_type": "bioclip",
+        "weights_path": str(model_dir),
+        "files": ["image_encoder.onnx"],
+        "source": "custom",
+    })
+    store = ArtifactStore(tmp_path / "store")
+    digest = promote_and_publish_classifier_run(
+        source, detection_id, "BioCLIP", labels_short,
+        labels_full, identity, store=store,
+    )
+    assert digest is None, (
+        "working-copy-backed runs must not publish — pixels differ from "
+        "the original bytes the v1 input identity advertises"
+    )
+    run = source.conn.execute(
+        "SELECT runtime_fingerprint FROM classifier_runs "
+        "WHERE detection_id = ?", (detection_id,),
+    ).fetchone()
+    assert run["runtime_fingerprint"] == "legacy", (
+        "declined publish must leave the classifier_runs row on 'legacy' "
+        "so exportable_artifacts continues to skip it"
+    )
+    assert list(store.iter_artifacts()) == []
+
+
+def test_companion_backed_destination_photo_is_not_materialized(tmp_path):
+    """A v1 artifact declares only the original ``photo_sha256``.  When
+    the destination catalog has a photo with the same original file_hash
+    but a ``companion_path`` (RAW+JPEG), Vireo processes the companion
+    rendition — different pixels — so applying the artifact would install
+    detections/classifications for a rendition the sender did not compute
+    on.  ``materialize_artifacts`` must skip companion-backed rows and
+    leave the object stored-unmatched instead.
+    """
+    destination, folder_id, plain_photo_id = _database_with_photo(
+        tmp_path / "destination.db", "plain.jpg",
+    )
+    # Skip the auto-duplicate resolver (which would reject one of the
+    # two rows) by setting the shared hash via UPDATE after insert —
+    # the scanner path uses the same shape.
+    companion_photo_id = destination.add_photo(
+        folder_id=folder_id,
+        filename="raw-plus-jpeg.cr2",
+        extension=".cr2",
+        file_size=2048,
+        file_mtime=2.0,
+    )
+    destination.conn.execute(
+        "UPDATE photos SET companion_path = ?, file_hash = ? WHERE id = ?",
+        ("/tmp/photos/raw-plus-jpeg.jpg", PHOTO_HASH, companion_photo_id),
+    )
+    destination.conn.commit()
+
+    result = materialize_artifacts(
+        destination, [detection_artifact()],
+        known_runtimes={RUNTIME},
+    )
+    assert result["detector_runs_applied"] == 1, (
+        "the plain (non-companion) sibling must still receive the artifact"
+    )
+
+    applied_photo_ids = [
+        row["photo_id"] for row in destination.conn.execute(
+            "SELECT photo_id FROM detector_runs "
+            "WHERE detector_model = 'megadetector-v6' ORDER BY photo_id"
+        ).fetchall()
+    ]
+    assert applied_photo_ids == [plain_photo_id], (
+        "companion-backed photo must be excluded from materialization even "
+        "when it shares the original file_hash — its rendition can differ"
+    )
+
+
 def test_tree_of_life_sentinel_short_fingerprint_is_accepted():
     """Tree-of-Life classification uses the well-known ``tol`` sentinel as
     the classifier_runs short key (compute_fingerprint([]) → "tol") while

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -441,6 +441,48 @@ def test_computation_cache_http_export_and_import(app_and_db, tmp_path, monkeypa
     ).fetchone()["runtime_fingerprint"] == RUNTIME
 
 
+def test_classification_only_export_forwards_stored_detector_dependencies(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """``exportable_artifacts`` dependency-closes its output so classifier
+    exports always drag their detector dependencies along.  The HTTP
+    route must mirror that expansion for the local object store too —
+    otherwise detector artifacts forwarded from ``iter_artifacts`` (e.g.
+    imports whose photos were not yet cataloged when they landed) get
+    dropped whenever the user picks only "Species classification", and a
+    destination without the detector run has to reproduce detection from
+    weights it may not have.
+    """
+    import computation_cache
+
+    app, _db = app_and_db
+    monkeypatch.setattr(
+        computation_cache, "megadetector_runtime_fingerprint",
+        lambda *_args, **_kwargs: RUNTIME,
+    )
+    store_dir = tmp_path / "http-store"
+    app.config["COMPUTATION_CACHE_DIR"] = str(store_dir)
+
+    # Plant a detection artifact directly in the local object store — this
+    # is exactly the shape ``iter_artifacts`` returns for objects imported
+    # before their photos were cataloged.
+    store = computation_cache.ArtifactStore(store_dir)
+    detection = detection_artifact()
+    store.put(detection)
+
+    response = app.test_client().get(
+        "/api/computation-cache/export?types=classification",
+    )
+    assert response.status_code == 200
+    _manifest, artifacts = read_bundle(io.BytesIO(response.data))
+    detection_types = [a["type"] for a in artifacts if a["type"] == "detection"]
+    assert detection_types, (
+        "classification-only export must forward detector artifacts from the "
+        "local object store so the destination can materialize the classifier "
+        "runs without loading detector weights"
+    )
+
+
 def test_computation_cache_http_rejects_invalid_bundle(app_and_db, tmp_path):
     app, _db = app_and_db
     store_root = tmp_path / "http-store"
@@ -521,6 +563,40 @@ def test_fresh_classifier_run_is_promoted_and_published(tmp_path):
     artifacts, summary = exportable_artifacts(source)
     assert summary["classifier_runs"] == 1
     assert any(item["type"] == "classification" for item in artifacts)
+
+
+def test_tree_of_life_sentinel_short_fingerprint_is_accepted():
+    """Tree-of-Life classification uses the well-known ``tol`` sentinel as
+    the classifier_runs short key (compute_fingerprint([]) → "tol") while
+    classify/pipeline jobs synthesize a portable 64-char labels.fingerprint
+    from the classifier identity. The digest-prefix rule that guards other
+    label sets must not reject this synthetic identity — otherwise
+    ``promote_and_publish_classifier_run`` marks the row portable and then
+    fails to publish, and a later default export returns 400.
+    """
+    from labels_fingerprint import TOL_SENTINEL
+
+    artifact = classification_artifact()
+    artifact["labels"]["fingerprint"] = "a" * 64
+    artifact["labels"]["short_fingerprint"] = TOL_SENTINEL
+    assert (
+        validate_artifact(artifact)["labels"]["short_fingerprint"]
+        == TOL_SENTINEL
+    )
+
+
+def test_non_tol_short_fingerprint_that_does_not_match_full_is_rejected():
+    """The TOL exemption must not weaken the guard for arbitrary short keys.
+    A crafted bundle claiming ``short_fingerprint="legacy"`` — which
+    matches the historical placeholder for pre-migration rows — with a
+    mismatched full digest would still be able to replace unreviewed
+    predictions on a legacy row under a foreign label set.
+    """
+    artifact = classification_artifact()
+    artifact["labels"]["fingerprint"] = "b" * 64
+    artifact["labels"]["short_fingerprint"] = "legacy"
+    with pytest.raises(CacheFormatError, match="first 12 chars"):
+        validate_artifact(artifact)
 
 
 def test_labels_count_out_of_sqlite_int64_range_is_rejected():

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -58,6 +58,41 @@ def detection_artifact(subjects=None):
     }
 
 
+def classification_artifact(candidates=None, classifier_runtime=None):
+    box = {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4}
+    subjects = [{"key": "d0", "kind": "box", "box": box, "category": "animal"}]
+    subjects[0]["candidates"] = candidates if candidates is not None else [{
+        "species": "Robin",
+        "confidence": 0.9,
+    }]
+    if classifier_runtime is None:
+        classifier_runtime = runtime_fingerprint({
+            "type": "classification",
+            "model": "bioclip-2.5",
+            "weights_sha256": "4" * 64,
+            "labels_fingerprint": "3" * 64,
+            "detector_runtime_fingerprint": RUNTIME,
+        })
+    input_block, input_fp = classification_input(PHOTO_HASH, RUNTIME, subjects)
+    return {
+        "artifact_schema": 1,
+        "type": "classification",
+        "classifier_model": "bioclip-2.5",
+        "detector_model": "megadetector-v6",
+        "detector_runtime_fingerprint": RUNTIME,
+        "labels": {
+            "fingerprint": "3" * 64,
+            "short_fingerprint": ("3" * 12),
+        },
+        "photo_sha256": PHOTO_HASH,
+        "runtime_fingerprint": classifier_runtime,
+        "input_fingerprint": input_fp,
+        "input": input_block,
+        "completed": True,
+        "subjects": subjects,
+    }
+
+
 def test_canonical_json_normalizes_negative_zero_and_rejects_nan():
     assert canonical_bytes({"z": -0.0, "a": 1}) == b'{"a":1,"z":0.0}'
     with pytest.raises(CacheFormatError, match="NaN"):
@@ -301,7 +336,9 @@ def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
     )
     destination.conn.commit()
 
-    applied = materialize_artifacts(destination, imported["artifacts"])
+    applied = materialize_artifacts(
+        destination, imported["artifacts"], known_runtimes={RUNTIME},
+    )
     assert applied["matched_photos"] == 2
     assert applied["detector_runs_applied"] == 2
     assert applied["classifier_runs_applied"] == 2
@@ -321,14 +358,25 @@ def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
         "SELECT COUNT(*) AS c FROM prediction_review",
     ).fetchone()["c"] == 0, "portable output must not transfer review state"
 
-    repeat = materialize_artifacts(destination, imported["artifacts"])
+    repeat = materialize_artifacts(
+        destination, imported["artifacts"], known_runtimes={RUNTIME},
+    )
     assert repeat["detector_runs_applied"] == 0
     assert repeat["classifier_runs_applied"] == 0
     assert repeat["already_materialized"] == 4
 
 
-def test_computation_cache_http_export_and_import(app_and_db, tmp_path):
+def test_computation_cache_http_export_and_import(app_and_db, tmp_path, monkeypatch):
     app, db = app_and_db
+    # Materialization refuses to plant detector rows carrying an unknown
+    # runtime; monkeypatch the local fingerprint so the fake ``RUNTIME``
+    # value the test fixture writes is treated as this install's runtime.
+    import computation_cache
+
+    monkeypatch.setattr(
+        computation_cache, "megadetector_runtime_fingerprint",
+        lambda *_args, **_kwargs: RUNTIME,
+    )
     app.config["COMPUTATION_CACHE_DIR"] = str(tmp_path / "http-store")
     photo_id = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 1").fetchone()["id"]
     db.conn.execute(
@@ -455,3 +503,85 @@ def test_fresh_classifier_run_is_promoted_and_published(tmp_path):
     artifacts, summary = exportable_artifacts(source)
     assert summary["classifier_runs"] == 1
     assert any(item["type"] == "classification" for item in artifacts)
+
+
+def test_taxonomy_field_shape_is_validated_before_publishing():
+    artifact = classification_artifact(candidates=[{
+        "species": "Robin",
+        "confidence": 0.9,
+        "taxonomy": ["genus", "Erithacus"],
+    }])
+    with pytest.raises(CacheFormatError, match="taxonomy must be an object"):
+        validate_artifact(artifact)
+
+    artifact = classification_artifact(candidates=[{
+        "species": "Robin",
+        "confidence": 0.9,
+        "taxonomy": {"genus": ["Erithacus"]},
+    }])
+    with pytest.raises(CacheFormatError, match="taxonomy field 'genus'"):
+        validate_artifact(artifact)
+
+    # A valid taxonomy — omitted or all-string fields — passes through.
+    ok = classification_artifact(candidates=[{
+        "species": "Robin",
+        "confidence": 0.9,
+        "taxonomy": {"genus": "Erithacus", "family": "Muscicapidae"},
+    }])
+    assert validate_artifact(ok)["subjects"][0]["candidates"][0]["taxonomy"] == {
+        "genus": "Erithacus", "family": "Muscicapidae",
+    }
+
+
+def test_unknown_detector_runtime_is_quarantined_not_installed(tmp_path):
+    destination, _folder_id, photo_id = _database_with_photo(
+        tmp_path / "destination.db", "photo.jpg",
+    )
+    # Neither the built-in ``full-image`` synthetic runtime nor the
+    # currently-installed MegaDetector fingerprint matches RUNTIME, so
+    # ``materialize_artifacts`` (without an override) must decline to plant
+    # arbitrary-runtime detections in the catalog.
+    applied = materialize_artifacts(destination, [detection_artifact()])
+    assert applied["unknown_runtime"] == 1
+    assert applied["detector_runs_applied"] == 0
+    assert destination.conn.execute(
+        "SELECT COUNT(*) AS c FROM detector_runs WHERE photo_id = ?",
+        (photo_id,),
+    ).fetchone()["c"] == 0
+
+    # A caller that recognizes the runtime (e.g. after weights install)
+    # can pass it explicitly and the same artifact then materializes.
+    applied_ok = materialize_artifacts(
+        destination, [detection_artifact()], known_runtimes={RUNTIME},
+    )
+    assert applied_ok["detector_runs_applied"] == 1
+    assert applied_ok["unknown_runtime"] == 0
+
+
+def test_classification_deferred_until_detector_run_available(tmp_path):
+    destination, _folder_id, photo_id = _database_with_photo(
+        tmp_path / "destination.db", "photo.jpg",
+    )
+    labels_short = "3" * 12
+    destination.upsert_labels_fingerprint(
+        labels_short, "Test labels", [], 1, full_fingerprint="3" * 64,
+    )
+    # Only the classification artifact is present — no detector artifact
+    # was exported.  materialize_artifacts must count it as deferred (not
+    # applied) since the detector_run dependency does not exist yet.
+    only_classification = [classification_artifact()]
+    deferred = materialize_artifacts(
+        destination, only_classification, known_runtimes={RUNTIME},
+    )
+    assert deferred["classifier_runs_applied"] == 0
+    assert deferred["classifier_deferred_pending_detection"] >= 1
+
+    # Once the detector dependency is materialized (or produced locally
+    # by a subsequent detection run), reapplying picks the classifier up.
+    together = materialize_artifacts(
+        destination,
+        [detection_artifact(), classification_artifact()],
+        known_runtimes={RUNTIME},
+    )
+    assert together["detector_runs_applied"] == 1
+    assert together["classifier_runs_applied"] == 1

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -517,6 +517,28 @@ def test_fresh_classifier_run_is_promoted_and_published(tmp_path):
     assert any(item["type"] == "classification" for item in artifacts)
 
 
+def test_labels_count_out_of_sqlite_int64_range_is_rejected():
+    """A bundle carrying an arbitrarily large JSON integer for
+    ``labels.count`` (e.g. 10**100) would pass a naive non-negativity
+    check and only fail with ``OverflowError`` when materialization binds
+    the value to a SQLite integer column — leaving the bundle object
+    already published in the local store.  Reject out-of-range values
+    up front instead.
+    """
+    artifact = classification_artifact()
+    artifact["labels"]["count"] = 10 ** 100
+    with pytest.raises(CacheFormatError, match="SQLite"):
+        validate_artifact(artifact)
+
+    # Boundary check: exactly 2**63 - 1 (the SQLite signed int64 max)
+    # is accepted; one past it is rejected.
+    artifact["labels"]["count"] = (1 << 63) - 1
+    assert validate_artifact(artifact)["labels"]["count"] == (1 << 63) - 1
+    artifact["labels"]["count"] = 1 << 63
+    with pytest.raises(CacheFormatError, match="SQLite"):
+        validate_artifact(artifact)
+
+
 def test_taxonomy_field_shape_is_validated_before_publishing():
     artifact = classification_artifact(candidates=[{
         "species": "Robin",

--- a/vireo/tests/test_computation_cache.py
+++ b/vireo/tests/test_computation_cache.py
@@ -130,6 +130,70 @@ def test_input_fingerprint_and_numeric_bounds_are_verified():
         validate_artifact(artifact)
 
 
+def test_numeric_validators_reject_oversized_json_integers_cleanly():
+    # A JSON int outside the C-double range makes math.isfinite raise
+    # OverflowError; that used to escape the import route as a 500. Both
+    # validators must convert it into a CacheFormatError so the HTTP
+    # boundary returns a 400 with a readable message instead.
+    huge = 10 ** 400
+    artifact = detection_artifact()
+    artifact["subjects"][0]["confidence"] = huge
+    with pytest.raises(CacheFormatError, match=r"in \[0, 1\]"):
+        validate_artifact(artifact)
+
+    artifact = detection_artifact()
+    artifact["subjects"][0]["box"]["x"] = huge
+    with pytest.raises(CacheFormatError, match=r"in \[0, 1\]"):
+        validate_artifact(artifact)
+
+
+def test_materialize_picks_lowest_digest_when_lookup_identity_ties(tmp_path):
+    # Two divergent detection artifacts sharing the same lookup identity
+    # (photo × detector × runtime × input) must resolve to the same
+    # winner regardless of manifest order, or two installs importing the
+    # same object set would surface different boxes.  The tiebreak is
+    # the lexicographically lowest ``artifact_digest``.
+    destination, _folder_id, _photo_id = _database_with_photo(
+        tmp_path / "destination.db", "dst.jpg",
+    )
+    a = detection_artifact(subjects=[{
+        "key": "d0", "kind": "box",
+        "box": {"x": 0.10, "y": 0.20, "w": 0.30, "h": 0.40},
+        "confidence": 0.9, "category": "animal",
+    }])
+    b = detection_artifact(subjects=[{
+        "key": "d0", "kind": "box",
+        "box": {"x": 0.11, "y": 0.21, "w": 0.30, "h": 0.40},
+        "confidence": 0.8, "category": "animal",
+    }])
+    # Same lookup identity fields:
+    assert a["photo_sha256"] == b["photo_sha256"]
+    assert a["detector_model"] == b["detector_model"]
+    assert a["runtime_fingerprint"] == b["runtime_fingerprint"]
+    assert a["input_fingerprint"] == b["input_fingerprint"]
+    # Different content → different digest:
+    assert artifact_digest(a) != artifact_digest(b)
+    expected_box = (
+        a["subjects"][0]["box"] if artifact_digest(a) < artifact_digest(b)
+        else b["subjects"][0]["box"]
+    )
+    # Both orderings should install the same winner.
+    for order in ([a, b], [b, a]):
+        clean, _folder, _photo = _database_with_photo(
+            tmp_path / f"dst-{order.index(a)}.db", "dst.jpg",
+        )
+        result = materialize_artifacts(
+            clean, order, known_runtimes={RUNTIME},
+        )
+        assert result["detector_runs_applied"] == 1
+        row = clean.conn.execute(
+            "SELECT box_x, box_y FROM detections",
+        ).fetchone()
+        assert (row["box_x"], row["box_y"]) == (
+            expected_box["x"], expected_box["y"],
+        )
+
+
 def test_artifact_store_is_content_addressed_atomic_and_idempotent(tmp_path):
     store = ArtifactStore(tmp_path / "store")
     artifact = detection_artifact()
@@ -332,6 +396,13 @@ def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
     write_bundle(bundle, artifacts)
     store = ArtifactStore(tmp_path / "destination-store")
     imported = import_bundle(bundle, store)
+    # ``import_bundle`` now streams the bundle through the store instead
+    # of accumulating every artifact in Python, so it returns the trusted
+    # runtime fingerprint sets rather than the parsed artifacts.  The
+    # test still exercises the full plant pipeline by materializing from
+    # the on-disk store — which is what the HTTP import route does too.
+    assert imported["detector_runtimes"] == {RUNTIME}
+    assert imported["classifier_runtimes"] == {CLASSIFIER_RUNTIME}
 
     destination, folder_id, first_photo = _database_with_photo(
         tmp_path / "destination.db", "renamed.jpg",
@@ -351,8 +422,8 @@ def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
     )
     destination.conn.commit()
 
-    applied = materialize_artifacts(
-        destination, imported["artifacts"],
+    applied = materialize_local_store(
+        destination, store=store,
         known_runtimes={RUNTIME},
         known_classifier_runtimes={CLASSIFIER_RUNTIME},
     )
@@ -375,8 +446,8 @@ def test_database_export_bundle_import_and_duplicate_fanout(tmp_path):
         "SELECT COUNT(*) AS c FROM prediction_review",
     ).fetchone()["c"] == 0, "portable output must not transfer review state"
 
-    repeat = materialize_artifacts(
-        destination, imported["artifacts"],
+    repeat = materialize_local_store(
+        destination, store=store,
         known_runtimes={RUNTIME},
         known_classifier_runtimes={CLASSIFIER_RUNTIME},
     )

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -8140,6 +8140,115 @@ def test_write_detection_batch_retires_stale_rows(tmp_path):
     )
 
 
+def test_runtime_change_retires_unreviewed_detector_output(tmp_path):
+    """A different detector runtime owns a different materialized result.
+
+    Unreviewed output may be retired, including predictions that depend on
+    detections the replacement no longer produces.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    first = {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+             "confidence": 0.9, "category": "animal"}
+    second = {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
+              "confidence": 0.8, "category": "animal"}
+
+    old_id = db.write_detection_batch(
+        photo_id, "megadetector-v6", [first],
+        runtime_fingerprint="runtime-a", input_fingerprint="input-a",
+    )[0]
+    db.add_prediction(old_id, "Robin", 0.95, "bioclip")
+
+    new_ids = db.write_detection_batch(
+        photo_id, "megadetector-v6", [second],
+        runtime_fingerprint="runtime-b", input_fingerprint="input-a",
+    )
+    assert len(new_ids) == 1
+    assert new_ids[0] != old_id
+    assert db.conn.execute(
+        "SELECT 1 FROM detections WHERE id = ?", (old_id,),
+    ).fetchone() is None
+    assert db.conn.execute(
+        "SELECT 1 FROM predictions WHERE detection_id = ?", (old_id,),
+    ).fetchone() is None
+    run = db.conn.execute(
+        """SELECT runtime_fingerprint, input_fingerprint
+           FROM detector_runs
+           WHERE photo_id = ? AND detector_model = ?""",
+        (photo_id, "megadetector-v6"),
+    ).fetchone()
+    assert dict(run) == {
+        "runtime_fingerprint": "runtime-b",
+        "input_fingerprint": "input-a",
+    }
+
+
+def test_runtime_change_preserves_output_reviewed_in_any_workspace(tmp_path):
+    """A manual review in another workspace pins the detector result."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder("/tmp/p")
+    ws_a = db.create_workspace("A")
+    ws_b = db.create_workspace("B")
+    for ws in (ws_a, ws_b):
+        db.add_workspace_folder(ws, folder_id)
+    db._active_workspace_id = ws_a
+    photo_id = db.add_photo(
+        folder_id=folder_id, filename="a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    first = {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+             "confidence": 0.9, "category": "animal"}
+    second = {"box": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
+              "confidence": 0.8, "category": "animal"}
+    old_id = db.write_detection_batch(
+        photo_id, "megadetector-v6", [first],
+        runtime_fingerprint="runtime-a", input_fingerprint="input-a",
+    )[0]
+
+    db._active_workspace_id = ws_b
+    db.add_prediction(
+        old_id, "Robin", 0.95, "bioclip", status="accepted",
+        individual="reviewed by user",
+    )
+    returned = db.write_detection_batch(
+        photo_id, "megadetector-v6", [second],
+        runtime_fingerprint="runtime-b", input_fingerprint="input-a",
+    )
+
+    assert returned == [old_id]
+    assert db.detector_run_is_pinned(photo_id, "megadetector-v6")
+    run = db.conn.execute(
+        """SELECT runtime_fingerprint FROM detector_runs
+           WHERE photo_id = ? AND detector_model = ?""",
+        (photo_id, "megadetector-v6"),
+    ).fetchone()
+    assert run["runtime_fingerprint"] == "runtime-a"
+    assert photo_id in db.get_detector_run_photo_ids(
+        "megadetector-v6", runtime_fingerprint="runtime-b",
+    ), "a pinned older runtime should suppress redundant inference"
+
+    forced = db.write_detection_batch(
+        photo_id, "megadetector-v6", [second],
+        runtime_fingerprint="runtime-b", input_fingerprint="input-a",
+        force_runtime_replace=True,
+    )
+    assert forced != [old_id]
+    assert db.conn.execute(
+        "SELECT 1 FROM prediction_review WHERE workspace_id = ?", (ws_b,),
+    ).fetchone() is None
+
+
 def test_write_detection_batch_second_writer_does_not_cascade_predictions(tmp_path):
     """The race: pipeline A writes detections, classify writes predictions
     against them, pipeline B writes the same detections again. With

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -8243,7 +8243,20 @@ def test_runtime_change_preserves_output_reviewed_in_any_workspace(tmp_path):
         runtime_fingerprint="runtime-b", input_fingerprint="input-a",
         force_runtime_replace=True,
     )
-    assert forced != [old_id]
+    # Contract: force_runtime_replace=True must actually persist ONE
+    # detection under the new runtime.  An empty result would mean the
+    # forced write deleted the reviewed row and wrote nothing — exactly
+    # the regression the reviewed-pin gate is meant to prevent.
+    assert len(forced) == 1
+    assert forced[0] != old_id
+    forced_run = db.conn.execute(
+        """SELECT runtime_fingerprint FROM detector_runs
+           WHERE photo_id = ? AND detector_model = ?""",
+        (photo_id, "megadetector-v6"),
+    ).fetchone()
+    assert forced_run["runtime_fingerprint"] == "runtime-b", (
+        "force_runtime_replace=True must advance detector_runs.runtime_fingerprint"
+    )
     assert db.conn.execute(
         "SELECT 1 FROM prediction_review WHERE workspace_id = ?", (ws_b,),
     ).fetchone() is None

--- a/vireo/tests/test_labels_fingerprint.py
+++ b/vireo/tests/test_labels_fingerprint.py
@@ -3,7 +3,12 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from labels_fingerprint import LEGACY_SENTINEL, TOL_SENTINEL, compute_fingerprint
+from labels_fingerprint import (
+    LEGACY_SENTINEL,
+    TOL_SENTINEL,
+    compute_fingerprint,
+    compute_full_fingerprint,
+)
 
 
 def test_fingerprint_is_stable_under_ordering_and_duplicates():
@@ -22,6 +27,16 @@ def test_fingerprint_differs_on_different_sets():
 def test_tol_sentinel_when_no_labels():
     assert compute_fingerprint(None) == TOL_SENTINEL
     assert compute_fingerprint([]) == TOL_SENTINEL
+    assert compute_full_fingerprint([]) == TOL_SENTINEL
+
+
+def test_full_fingerprint_extends_without_changing_short_key():
+    labels = ["Robin", "Sparrow", "Robin"]
+    short = compute_fingerprint(labels)
+    full = compute_full_fingerprint(labels)
+    assert len(short) == 12
+    assert len(full) == 64
+    assert full.startswith(short)
 
 
 def test_sentinels_are_fixed_strings():

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -13,7 +13,7 @@ def test_ensure_schema_applies_registry_and_validation(tmp_path):
     schema.ensure_schema(db_path)
 
     with sqlite3.connect(db_path) as conn:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 9
         assert conn.execute(
             "SELECT value FROM db_meta WHERE key='schema_manager'"
         ).fetchone()[0] == "registry-v1"
@@ -41,14 +41,14 @@ def test_failed_registry_migration_rolls_back_version_and_data(tmp_path, monkeyp
         )
         raise RuntimeError("simulated interruption")
 
-    migration = schema.Migration(9, "interrupted", fail_after_write)
+    migration = schema.Migration(10, "interrupted", fail_after_write)
     monkeypatch.setattr(schema, "MIGRATIONS", (*schema.MIGRATIONS, migration))
 
     with pytest.raises(RuntimeError, match="simulated interruption"):
         schema.ensure_schema(db_path)
 
     with sqlite3.connect(db_path) as conn:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 9
         assert conn.execute(
             "SELECT 1 FROM db_meta WHERE key='partial_migration'"
         ).fetchone() is None
@@ -73,7 +73,7 @@ def test_concurrent_schema_startup_is_serialized(tmp_path):
     assert not errors
     assert all(not thread.is_alive() for thread in threads)
     with sqlite3.connect(db_path) as conn:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 9
 
 
 def test_navigation_restore_changes_only_consolidated_default(tmp_path):
@@ -460,7 +460,7 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
             (photo_id, "megadetector-v6", 2),
             (empty_photo_id, "megadetector-v6", 0),
         ]
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 9
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
 
     with Database(db_path, initialize_schema=False) as migrated_db:
@@ -1107,7 +1107,7 @@ def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_p
             """,
             (photo_id,),
         ).fetchone() == ("megadetector-v6", 0)
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 9
 
 
 def test_legacy_merge_prompt_remap_skips_when_other_detection_matches(tmp_path):


### PR DESCRIPTION
## Summary

Adds an experimental portable computation cache so detector and species-classifier results can be exported as validated `.vireo-cache` bundles and reused on another Vireo installation by exact photo hash.
Introduces immutable local artifacts, runtime/input/full-label identities, secure bundle validation, catalog-later reuse, and review-aware replacement semantics that preserve decisions from every workspace.
Adds the Settings import/export UI, schema migration, design document, and coverage for bundle security, duplicate fan-out, idempotency, pinning, and HTTP round trips.

## Validation

- `vireo/tests/test_db.py`: 704 passed, 1 skipped
- `vireo/tests/test_pipeline_job.py`: 239 passed, 19 skipped
- `vireo/tests/test_classify_job.py`: 98 passed
- cache, schema, labels, Settings, and static UI suites: 124 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Portable Computation Cache controls in Settings.
  - Export detection and classification results as `.vireo-cache` bundles.
  - Import validated bundles and view processing summaries.
  - Reuse compatible cached results across installations and duplicate photos.

- **Improvements**
  - Cache reuse now accounts for model, runtime, input, and label versions.
  - Reuse cached results without loading models when possible.
  - Preserve reviews while reconciling taxonomy and grouping metadata.

- **Security & Reliability**
  - Validate bundles for corruption, unsafe paths, size limits, and integrity.
  - Quarantine results from unrecognized runtimes and apply imports transactionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->