### PR TITLE
Move Free up card space to a dedicated /card-cleanup page

### DIFF
--- a/docs/superpowers/specs/2026-08-08-card-cleanup-page-design.md
+++ b/docs/superpowers/specs/2026-08-08-card-cleanup-page-design.md
@@ -1,0 +1,76 @@
+# Card cleanup gets its own page — design
+
+**Date:** 2026-08-08
+**Status:** Approved in discussion with maintainer (relocation follow-up to
+PR #1436); lightweight spec — the feature's behavior is unchanged and
+governed by `2026-08-07-card-cleanup-design.md`.
+**Scope:** Move the "Free up card space" UI from a collapsed section on the
+import page to a dedicated page with a navbar entry; add an inline
+integrity-audit affordance; keep the post-import entry point as a link.
+No backend behavior changes to scan/delete.
+
+## Problem
+
+The tool lives inside the import page although its task is the opposite of
+importing, so a user arriving cold (days after an import) doesn't find it.
+Worse, its enabling dependency — the integrity audit that stamps
+`hash_status='ok'` — lives on the audit page, so the first-run experience
+on a pre-existing archive dead-ends: everything lands in "kept — run the
+integrity audit" with no way to do that from where you're standing
+(observed in production 2026-08-08: 5,523/5,523 files kept for exactly
+this reason).
+
+## Design
+
+1. **New page** `vireo/templates/card_cleanup.html`, served at
+   `/card-cleanup` (route follows the existing page-route pattern in
+   app.py). Standalone page in the codebase's one-file-per-page style
+   (includes `_navbar.html`, inline CSS/JS). Contains the entire
+   scan → preview → delete flow moved from import.html, preserving the
+   existing ids/function names (`card-cleanup-*` / `cardCleanup*`) and
+   ALL user-facing copy verbatim — including the byte-exact confirmation
+   dialog from the parent spec, the incomplete-preview banner, and the
+   honest summary states. The section is no longer collapsed: on its own
+   page it renders expanded.
+2. **Support code the section leaned on in import.html** (folder browser,
+   `formatBytes`, progress/`field-error`/modal CSS): the new page brings
+   its OWN minimal copies scoped to its needs — a single-select folder
+   browser (the card-cleanup `browserMode` variant), `formatBytes`, and
+   the small CSS set. Deliberate duplication over a shared-include
+   refactor of import.html: the parent PR's reviewers accepted mirrored
+   code at this scale, and un-inlining import.html's browser is exactly
+   the kind of unrelated refactor the parent spec declined.
+3. **Inline audit affordance.** When the rendered preview's kept bucket
+   contains the `KEEP_NOT_VERIFIED` reason ("not verified by a checksummed
+   import — run the integrity audit"), show a callout above the buckets:
+   how many kept files carry that reason, one sentence explaining that
+   the archive copies must be checksum-verified before deletion is
+   allowed, a **Verify archive hashes** button that starts the existing
+   `verify-hashes` job (`POST /api/jobs/verify-hashes`) with the page's
+   standard progress rendering, and — on completion — a **Re-scan card**
+   affordance. Include the SMB cost warning: verification re-reads
+   archive files; on a VPN'd mount this is slow, best run close to the
+   NAS. No new backend endpoints.
+4. **Navbar**: add "Card cleanup" to `_navbar.html` in the tools/pages
+   list (match existing nav idiom and ordering conventions).
+5. **Import page**: remove the moved section and its JS; keep the
+   card-safety-pill entry point, now a link to
+   `/card-cleanup?source=<path>` (URL-encoded). The new page pre-fills
+   its source input from the `source` query parameter. Multi-source
+   imports pass the first source; the new page keeps the existing
+   "remaining sources" hint behavior.
+6. **No API changes.** Scan/delete/manifest endpoints, job types, and
+   manifest format are untouched.
+
+## Testing
+
+- Page route test: `GET /card-cleanup` → 200, contains the section
+  markup (mirrors existing page-route tests).
+- Existing card-cleanup API tests unchanged and green.
+- Import page test (if any asserts the section's presence) updated; a
+  test asserts import.html no longer contains the section container and
+  DOES contain the pill link.
+- JS of both changed templates re-checked with node --check; no
+  duplicate ids on either served page.
+- Manual visual QA remains pending for the human (both themes), as with
+  the parent PR.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -158,6 +158,8 @@ ALL_PAGES = [
     {"id": "dashboard",       "label": "Dashboard",       "href": "/dashboard"},
     {"id": "storage",         "label": "Storage",         "href": "/storage"},
     {"id": "audit",           "label": "Audit",           "href": "/audit"},
+    {"id": "card_cleanup",    "label": "Card cleanup",    "href": "/card-cleanup",
+     "keywords": "card cleanup free space delete verified memory card format sd"},
     {"id": "move",            "label": "Move",            "href": "/move"},
     {"id": "id_conflicts",    "label": "ID Conflicts",    "href": "/id-conflicts",
      "keywords": "compare conflict prediction model disagreement species keyword classify review"},

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -241,6 +241,11 @@ def load_manifest(manifest_dir, scan_job_id,
 
 
 KEEP_NOT_IN_CATALOG = "not in catalog — not imported yet"
+# The card-cleanup page keys its "Verify archive hashes" callout off this
+# reason: card_cleanup.html matches the tail "run the integrity audit" in
+# each kept entry to count the files an audit would unblock. Reword this
+# and the callout silently stops appearing — change both together, and
+# test_audit_callout_reason_stays_in_sync guards the pair.
 KEEP_NOT_VERIFIED = (
     "not verified by a checksummed import — run the integrity audit"
 )

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -249,6 +249,16 @@ KEEP_NOT_IN_CATALOG = "not in catalog — not imported yet"
 KEEP_NOT_VERIFIED = (
     "not verified by a checksummed import — run the integrity audit"
 )
+# Codex P2: distinguished from KEEP_NOT_VERIFIED so the callout does NOT
+# offer to re-verify these — the archive rows have already been checked
+# and the verdict was modified/corrupt/unreadable. Re-running verify
+# reproduces the same bad verdict rather than establishing an "ok" copy;
+# the remedy lives on the Audit page (accept current hash, restore from
+# backup, or investigate). The Audit-callout tail must NOT appear here or
+# these files would be counted alongside the truly-unchecked ones.
+KEEP_ARCHIVE_HASH_FAILED = (
+    "archive copy failed a prior integrity check — see the Audit page"
+)
 KEEP_INSIDE_SOURCE = "only catalog copy is inside the selected source"
 KEEP_ARCHIVE_UNREACHABLE = "archive file not reachable"
 KEEP_ARCHIVE_CHANGED = "archive file changed since verification"
@@ -281,13 +291,28 @@ def qualify_rows(rows, source_root_real, card_path, contains_check=None):
     if contains_check is None:
         def contains_check(child_real):
             return path_guard.contains_resolved(source_root_real, child_real)
-    reason = KEEP_NOT_VERIFIED
+    # Codex P2: KEEP_NOT_VERIFIED reads to the user as "the audit hasn't
+    # run yet — running it would unblock this", so it must apply only when
+    # a NULL hash_status row is why the file is being kept. Rows with a
+    # non-NULL, non-"ok" status (modified/corrupt/unreadable) have already
+    # been verified; re-running verification reproduces the same verdict
+    # and the remedy lives on the Audit page, so those rows fall back to
+    # KEEP_ARCHIVE_HASH_FAILED instead. A specific reason from an "ok"
+    # row that failed a later gate (unreachable / changed / inside source)
+    # still wins over both — that's the closest-to-success signal we have.
+    saw_never_checked = False
+    saw_check_failed = False
+    reason = None
     try:
         card_st = os.stat(card_path)
     except OSError:
         return None, KEEP_UNREADABLE
     for row in rows:
         if row["hash_status"] != "ok":
+            if row["hash_status"] is None:
+                saw_never_checked = True
+            else:
+                saw_check_failed = True
             continue
         if not row["folder_path"]:
             continue
@@ -342,6 +367,21 @@ def qualify_rows(rows, source_root_real, card_path, contains_check=None):
             reason = KEEP_INSIDE_SOURCE
             continue
         return archive_path, None
+    if reason is None:
+        # No "ok" row got as far as a specific rejection — fall back to
+        # the most accurate blame for what's on file. NULL wins the tie:
+        # a mix of never-checked and check-failed rows is still remediable
+        # by an audit (a never-checked row could turn "ok" and unlock the
+        # file), whereas the failed rows are just extra failed rows.
+        if saw_never_checked:
+            reason = KEEP_NOT_VERIFIED
+        elif saw_check_failed:
+            reason = KEEP_ARCHIVE_HASH_FAILED
+        else:
+            # No non-ok rows and no ok row got a specific reason — the
+            # only shapes left are ok rows with an empty folder_path. Kept
+            # for a stat-shaped reason we can't state precisely.
+            reason = KEEP_ARCHIVE_UNREACHABLE
     return None, reason
 
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -376,7 +376,7 @@ ALL_NAV_IDS = frozenset({
     "import",
     "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
     "misses", "highlights", "life_list", "browse", "edit", "map", "location_review", "variants",
-    "dashboard", "storage", "audit", "move", "id_conflicts",
+    "dashboard", "storage", "audit", "card_cleanup", "move", "id_conflicts",
     "settings", "workspace", "lightroom", "shortcuts",
     "keywords", "duplicates", "logs",
 })

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2382,6 +2382,8 @@ window.NAV_ALL_PAGES = [
   {id: 'dashboard',       label: 'Dashboard',       href: '/dashboard'},
   {id: 'storage',         label: 'Storage',         href: '/storage'},
   {id: 'audit',           label: 'Audit',           href: '/audit'},
+  {id: 'card_cleanup',    label: 'Card cleanup',    href: '/card-cleanup',
+   keywords: 'card cleanup free space delete verified memory card format sd'},
   {id: 'move',            label: 'Move',            href: '/move'},
   {id: 'id_conflicts',    label: 'ID Conflicts',    href: '/id-conflicts',
    keywords: 'compare conflict prediction model disagreement species keyword classify review'},

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -1103,8 +1103,19 @@ async function cardCleanupConfirmDelete() {
     cardCleanupWatchJob(data.job_id, 'delete', 'Starting deletion…');
   } catch (e) {
     cardCleanupCloseConfirm();
-    cardCleanupSetBusy(false);
-    cardCleanupSetError(String(e.message || e));
+    // The POST failed at the network layer, so the server may have
+    // accepted the delete and queued the destructive job before the
+    // connection dropped — we simply don't know (Codex P2 review).
+    // Unlocking here would let a second job start and hijack the page's
+    // jobId while the deletion continues unseen, so keep Scan / Verify /
+    // Delete disabled and send the user to the Jobs page for the actual
+    // outcome. A page reload rebuilds the busy state from a fresh
+    // manifest once they've confirmed what happened.
+    cardCleanupSetError(
+      'The delete request never got a response, so we cannot tell whether ' +
+      'the server queued the deletion. Check the Jobs page for a delete ' +
+      'that started around now, then reload this page to work with the ' +
+      'card again. (' + String(e.message || e) + ')');
   } finally {
     confirmBtn.disabled = false;
   }

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -886,6 +886,12 @@ async function cardCleanupStartAudit() {
 
 // The buttons are already re-enabled by cardCleanupSetBusy(false) in
 // cardCleanupFinishJob's cleanup; this only reports what the run found.
+// Verification can flip previously-ok rows to modified/corrupt/unreadable,
+// so the preview's deletable count/bytes may no longer describe what a
+// deletion would actually touch. Disable Delete until the user takes the
+// re-scan surfaced below — the backend re-checks and skips invalid rows,
+// but the confirmation dialog would still show stale totals against a
+// valid subset the user never agreed to.
 function cardCleanupFinishAudit(job, status, jobError) {
   const statusEl = document.getElementById('card-cleanup-audit-status');
   if (status === 'completed' || status === 'cancelled') {
@@ -893,6 +899,10 @@ function cardCleanupFinishAudit(job, status, jobError) {
     // could not have covered (other workspaces' folders).
     cardCleanupState.auditCompleted = true;
   }
+  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
+  deleteBtn.disabled = true;
+  document.getElementById('card-cleanup-delete-hint').textContent
+    = 'Verification may have changed which files count as verified — re-scan the card before deleting.';
   if (status === 'completed' && job && job.result) {
     const r = job.result;
     const problems = (r.modified || 0) + (r.corrupt || 0) + (r.unreadable || 0);

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -1066,6 +1066,16 @@ async function cardCleanupConfirmDelete() {
   }
   const confirmBtn = document.getElementById('card-cleanup-confirm-btn');
   confirmBtn.disabled = true;
+  // Lock the page before the POST goes out (Codex P2 review). The confirm
+  // dialog can be dismissed (backdrop click, Escape) while this request is
+  // pending; if Scan and Verify stayed live in that gap, a second job could
+  // start and its watch would overwrite this delete's jobId — including the
+  // destructive path. Setting busy now disables Scan/Verify/Delete regardless
+  // of whether the dialog is still up when the response arrives. Clear it on
+  // any definitive failure so the user isn't left with dead buttons.
+  cardCleanupSetBusy(true, {
+    deleteHint: 'Deletion is starting…',
+  });
   try {
     const resp = await fetch('/api/card-cleanup/delete', {
       method: 'POST',
@@ -1075,6 +1085,8 @@ async function cardCleanupConfirmDelete() {
     const data = await resp.json();
     cardCleanupCloseConfirm();
     if (!resp.ok) {
+      // Nothing was queued — hand the buttons back before showing the error.
+      cardCleanupSetBusy(false);
       if (resp.status === 404) {
         // The manifest is gone, so the preview above no longer describes
         // anything that can be deleted — take it down with the error.
@@ -1088,10 +1100,10 @@ async function cardCleanupConfirmDelete() {
     }
     cardCleanupSetError('');
     document.getElementById('card-cleanup-result').style.display = 'none';
-    cardCleanupSetBusy(true);
     cardCleanupWatchJob(data.job_id, 'delete', 'Starting deletion…');
   } catch (e) {
     cardCleanupCloseConfirm();
+    cardCleanupSetBusy(false);
     cardCleanupSetError(String(e.message || e));
   } finally {
     confirmBtn.disabled = false;

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -175,6 +175,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
         <div class="card-cleanup-audit" id="card-cleanup-hash-failed"
              style="display:none;">
           <div id="card-cleanup-hash-failed-text"></div>
+          <span class="hint" id="card-cleanup-hash-failed-scope"></span>
         </div>
         <details class="card-cleanup-bucket" id="card-cleanup-deletable-details">
           <summary id="card-cleanup-deletable-summary"></summary>
@@ -822,6 +823,15 @@ function cardCleanupRenderHashFailedCallout(manifest) {
     'check (modified, corrupt, or unreadable). Re-running verification ' +
     'would only reproduce that verdict — open the Audit page to accept ' +
     'the current bytes, restore from backup, or investigate.';
+  // Scope honesty (Codex P2 review): the card scan matches photos across
+  // ALL workspaces, but the Audit page only lists flagged rows for the
+  // CURRENT workspace. If the failed archive copy belongs to a folder in
+  // a different workspace, the suggested Audit remedy is unreachable
+  // from here — say so up front, matching the audit callout's approach.
+  document.getElementById('card-cleanup-hash-failed-scope').textContent =
+    'The Audit page shows flagged rows for the current workspace only. ' +
+    'If the failed archive copy lives in a folder from a different ' +
+    'workspace, switch to that workspace to find it there.';
   callout.style.display = '';
 }
 

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -882,20 +882,59 @@ async function cardCleanupStartAudit() {
   document.getElementById('card-cleanup-audit-rescan-btn').style.display = 'none';
   document.getElementById('card-cleanup-audit-status').textContent = '';
   cardCleanupSetError('');
+  // Failure handling here mirrors cardCleanupConfirmDelete (Codex P1 review
+  // on commit 5afcb0ba). Only a definitive HTTP response proves whether the
+  // server queued the audit — an fetch rejection or an unreadable body
+  // could mean api_job_verify_hashes() is already running. If the page
+  // unlocked in that gap, delete_verified() would trust the currently
+  // committed hash_status plus archive size/mtime rather than re-hashing
+  // archive bytes, so a concurrent delete could qualify a row on its old
+  // `ok` verdict while the audit is flipping it to modified/corrupt/
+  // unreadable — and remove the good card copy. Keep Scan/Verify/Delete
+  // disabled on any ambiguous outcome and send the user to Jobs, only
+  // unlocking when the server proves nothing was queued.
+  let resp;
   try {
-    const resp = await fetch('/api/jobs/verify-hashes', {
+    resp = await fetch('/api/jobs/verify-hashes', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: '{}',
     });
-    const data = await resp.json();
-    if (!resp.ok) throw new Error(data.error || 'verification failed to start');
-    cardCleanupWatchJob(data.job_id, 'audit', 'Starting hash verification…');
   } catch (e) {
-    // Nothing started, so nothing is running: give the buttons back.
-    cardCleanupSetBusy(false);
-    cardCleanupSetError(String(e.message || e));
+    cardCleanupSetError(
+      'The verify request never got a response, so we cannot tell whether ' +
+      'the server queued the audit. Check the Jobs page for a verify-hashes ' +
+      'job that started around now, then reload this page to work with the ' +
+      'card again. (' + String(e.message || e) + ')');
+    return;
   }
+  if (!resp.ok) {
+    // The server proved nothing was queued — hand the buttons back before
+    // showing the error.
+    cardCleanupSetBusy(false);
+    let msg = 'verification failed to start';
+    try {
+      const data = await resp.json();
+      if (data && data.error) msg = data.error;
+    } catch (_) { /* keep default */ }
+    cardCleanupSetError(msg);
+    return;
+  }
+  let data;
+  try {
+    data = await resp.json();
+  } catch (e) {
+    // 2xx response, unreadable body: the audit may already be running.
+    // Same reasoning as the network catch above — keep the page locked and
+    // route the user to Jobs rather than freeing the destructive path.
+    cardCleanupSetError(
+      'The verify request returned OK but its response could not be read, ' +
+      'so the audit may already be running. Check the Jobs page for a ' +
+      'verify-hashes job that started around now, then reload this page to ' +
+      'work with the card again. (' + String(e.message || e) + ')');
+    return;
+  }
+  cardCleanupWatchJob(data.job_id, 'audit', 'Starting hash verification…');
 }
 
 // The buttons are already re-enabled by cardCleanupSetBusy(false) in

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -711,7 +711,9 @@ function cardCleanupRenderAuditCallout(manifest) {
     return;
   }
   document.getElementById('card-cleanup-audit-text').textContent =
-    cardCleanupFileCount(pending) + ' are kept only because the archive ' +
+    cardCleanupFileCount(pending) +
+    (pending === 1 ? ' is' : ' are') +
+    ' kept only because the archive ' +
     'copy has never been checksum-verified. Vireo will not delete a card ' +
     'file until its archive copy passes a checksum check, and the ' +
     'integrity audit is what performs that check.';

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -167,6 +167,15 @@ body { display: flex; flex-direction: column; height: 100vh; }
           </div>
           <div class="hint" id="card-cleanup-audit-status" style="margin-top:6px;"></div>
         </div>
+        <!-- Shown when kept entries are held back because their archive
+             copies failed a prior integrity check. Distinct from the
+             audit callout above: re-running verify would just reproduce
+             the same failed verdict, so this points at the Audit page
+             (accept/restore) instead of offering a verify button. -->
+        <div class="card-cleanup-audit" id="card-cleanup-hash-failed"
+             style="display:none;">
+          <div id="card-cleanup-hash-failed-text"></div>
+        </div>
         <details class="card-cleanup-bucket" id="card-cleanup-deletable-details">
           <summary id="card-cleanup-deletable-summary"></summary>
           <ul class="staging-details" id="card-cleanup-deletable-list"></ul>
@@ -304,6 +313,12 @@ function cardCleanupSetBusy(running, opts) {
 // card_cleanup.KEEP_NOT_VERIFIED — matched on the distinctive tail so a
 // reason with extra detail appended still counts.
 const CARD_CLEANUP_AUDIT_REASON = 'run the integrity audit';
+// The manifest reason that this page's hash-failed callout answers.
+// Mirrors card_cleanup.KEEP_ARCHIVE_HASH_FAILED — kept distinct from
+// CARD_CLEANUP_AUDIT_REASON so a check-failed row cannot pretend to be a
+// never-checked one and get double-counted (or vice versa). Same tail
+// match as above; test_hash_failed_callout_reason_stays_in_sync pins it.
+const CARD_CLEANUP_HASH_FAILED_REASON = 'see the Audit page';
 
 function formatBytes(n) {
   n = Number(n || 0);
@@ -715,6 +730,7 @@ function cardCleanupRenderManifest(manifest) {
     ' ignored (not photo files Vireo imports)';
 
   cardCleanupRenderAuditCallout(manifest);
+  cardCleanupRenderHashFailedCallout(manifest);
 
   cardCleanupBindBucket('deletable', 'card-cleanup-deletable-details',
     'card-cleanup-deletable-list');
@@ -776,6 +792,36 @@ function cardCleanupRenderAuditCallout(manifest) {
   document.getElementById('card-cleanup-audit-btn').disabled = false;
   document.getElementById('card-cleanup-audit-rescan-btn').style.display = 'none';
   document.getElementById('card-cleanup-audit-status').textContent = '';
+  callout.style.display = '';
+}
+
+/* ---------- Hash-failed affordance ----------
+   Kept entries whose archive copies were checked and came back
+   modified/corrupt/unreadable. They look like unverified rows to a
+   casual read of the kept list but re-running verification would just
+   reproduce the same bad verdict — the remedy is on the Audit page. */
+function cardCleanupHashFailedCount(manifest) {
+  return (manifest.entries || []).filter(entry =>
+    entry.bucket === 'kept'
+    && String(entry.reason || '').indexOf(
+        CARD_CLEANUP_HASH_FAILED_REASON) !== -1
+  ).length;
+}
+
+function cardCleanupRenderHashFailedCallout(manifest) {
+  const callout = document.getElementById('card-cleanup-hash-failed');
+  const failed = cardCleanupHashFailedCount(manifest);
+  if (!failed) {
+    callout.style.display = 'none';
+    return;
+  }
+  document.getElementById('card-cleanup-hash-failed-text').textContent =
+    cardCleanupFileCount(failed) +
+    (failed === 1 ? ' is' : ' are') +
+    ' kept because the archive copy has already failed an integrity ' +
+    'check (modified, corrupt, or unreadable). Re-running verification ' +
+    'would only reproduce that verdict — open the Audit page to accept ' +
+    'the current bytes, restore from backup, or investigate.';
   callout.style.display = '';
 }
 
@@ -925,6 +971,7 @@ function cardCleanupResetPreview() {
   document.getElementById('card-cleanup-preview').style.display = 'none';
   document.getElementById('card-cleanup-incomplete').style.display = 'none';
   document.getElementById('card-cleanup-audit').style.display = 'none';
+  document.getElementById('card-cleanup-hash-failed').style.display = 'none';
   const deleteBtn = document.getElementById('card-cleanup-delete-btn');
   deleteBtn.disabled = true;
   document.getElementById('card-cleanup-delete-hint').textContent = '';

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -157,6 +157,8 @@ body { display: flex; flex-direction: column; height: 100vh; }
         <div class="card-cleanup-audit" id="card-cleanup-audit" style="display:none;">
           <div id="card-cleanup-audit-text"></div>
           <span class="hint" id="card-cleanup-audit-cost"></span>
+          <span class="hint" id="card-cleanup-audit-scope-note"
+                style="display:none;"></span>
           <div class="row" style="margin-top:8px;margin-bottom:0;">
             <button class="btn btn-primary" type="button" id="card-cleanup-audit-btn"
                     onclick="cardCleanupStartAudit()">Verify archive hashes</button>
@@ -257,6 +259,7 @@ const cardCleanupState = {
   listsRendered: {},    // bucket -> true once its <li>s are in the DOM
   confirmEscHandler: null,
   busyRestore: null,    // delete button/hint state saved while a job runs
+  auditCompleted: false, // a verify-hashes run finished during this page visit
 };
 
 /* Exactly one job at a time. Starting a second one while this page is
@@ -756,15 +759,45 @@ function cardCleanupRenderAuditCallout(manifest) {
     'copy has never been checksum-verified. Vireo will not delete a card ' +
     'file until its archive copy passes a checksum check, and the ' +
     'integrity audit is what performs that check.';
+  // Scope honesty (Codex P2 review): the card scan matches photos across
+  // ALL workspaces, but the verify-hashes job covers only the folders in
+  // the CURRENT workspace. If some of these files' archive copies live
+  // in another workspace's folders, verifying here will not touch them —
+  // say so up front, and cardCleanupRenderStillUnverifiedHint says it
+  // again, specifically, when a post-audit re-scan proves it happened.
   document.getElementById('card-cleanup-audit-cost').textContent =
-    'Verifying re-reads and re-checksums every file in the archive, not ' +
-    'just these — over a VPN’d network mount that is slow, so it is ' +
-    'best run on a machine close to the NAS.';
+    'Verifying re-reads and re-checksums every archive file in the ' +
+    'current workspace, not just these — over a VPN’d network mount ' +
+    'that is slow, so it is best run on a machine close to the NAS. ' +
+    'Archive copies that belong to a different workspace are not ' +
+    'covered; switch to that workspace to verify them.';
+  cardCleanupRenderStillUnverifiedHint(pending);
   document.getElementById('card-cleanup-audit-btn').style.display = '';
   document.getElementById('card-cleanup-audit-btn').disabled = false;
   document.getElementById('card-cleanup-audit-rescan-btn').style.display = 'none';
   document.getElementById('card-cleanup-audit-status').textContent = '';
   callout.style.display = '';
+}
+
+/* After a verification has run, files still pending on the next scan are
+   exactly the ones verification could not reach — most likely archive
+   copies in folders that belong to a different workspace (the scan
+   matches globally; verify-hashes covers only the current workspace's
+   folders). Say that specifically instead of letting the callout loop. */
+function cardCleanupRenderStillUnverifiedHint(pending) {
+  const note = document.getElementById('card-cleanup-audit-scope-note');
+  if (!cardCleanupState.auditCompleted || !pending) {
+    note.style.display = 'none';
+    note.textContent = '';
+    return;
+  }
+  note.textContent =
+    'Still unverified after the last verification run: these files’ ' +
+    'archive copies were not covered by it — most likely they belong to ' +
+    'folders in a different workspace (or the run was cancelled before ' +
+    'reaching them). Switch to the workspace that holds those folders ' +
+    'and verify there, then re-scan here.';
+  note.style.display = 'block';
 }
 
 async function cardCleanupStartAudit() {
@@ -799,6 +832,11 @@ async function cardCleanupStartAudit() {
 // cardCleanupFinishJob's cleanup; this only reports what the run found.
 function cardCleanupFinishAudit(job, status, jobError) {
   const statusEl = document.getElementById('card-cleanup-audit-status');
+  if (status === 'completed' || status === 'cancelled') {
+    // Lets the next re-scan's callout explain files that verification
+    // could not have covered (other workspaces' folders).
+    cardCleanupState.auditCompleted = true;
+  }
   if (status === 'completed' && job && job.result) {
     const r = job.result;
     const problems = (r.modified || 0) + (r.corrupt || 0) + (r.unreadable || 0);

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -1,0 +1,1040 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/png" href="/favicon.ico">
+<link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
+<link rel="stylesheet" href="/static/vireo-base.css">
+<title>Vireo - Card Cleanup</title>
+<style>
+/* Page CSS is a deliberate minimal copy of the import page's: this flow
+   moved off that page and has to keep looking like itself. Only the
+   classes this page actually uses were brought over. */
+body { display: flex; flex-direction: column; height: 100vh; }
+.content { flex: 1; overflow-y: auto; padding: 20px; }
+.card-cleanup-wrap { max-width: 760px; margin: 0 auto; display: flex; flex-direction: column; gap: 16px; }
+.page-title { font-size: 20px; color: var(--text-primary); }
+.card { background: var(--bg-secondary); border: 1px solid var(--border-primary); border-radius: 8px; padding: 16px; }
+.card h3 { margin: 0 0 10px 0; font-size: 14px; color: var(--text-primary); }
+.row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; flex-wrap: wrap; }
+.row label { font-size: 12px; color: var(--text-secondary); }
+.row input[type=text] {
+  background: var(--bg-tertiary); color: var(--text-primary);
+  border: 1px solid var(--border-secondary); border-radius: 4px;
+  padding: 6px 10px; font-size: 12px; outline: none; flex: 1; min-width: 220px;
+}
+.row input[type=text]:focus { border-color: var(--accent); }
+.btn { background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border-secondary); border-radius: 4px; padding: 6px 12px; font-size: 12px; cursor: pointer; }
+.btn-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn:disabled { opacity: 0.5; cursor: default; }
+.hint { font-size: 11px; color: var(--text-secondary); }
+.field-error {
+  display: none; width: 100%; margin: -2px 0 8px; padding-left: 2px;
+  color: var(--danger); font-size: 12px; font-weight: 600;
+}
+.field-error.visible { display: block; }
+.field-error .retry-link {
+  background: none; border: none; padding: 0; cursor: pointer;
+  color: inherit; font: inherit; text-decoration: underline;
+}
+.progress-bar { height: 8px; background: var(--bg-tertiary); border-radius: 4px; overflow: hidden; }
+.progress-bar > div { height: 100%; background: var(--accent); width: 0; transition: width 0.2s; }
+.staging-details { margin: 8px 0 0 0; padding-left: 18px; font-size: 11px; color: var(--text-secondary); max-height: 120px; overflow: auto; }
+.folder-browser-overlay {
+  display: none; position: fixed; inset: 0; z-index: 1001;
+  background: rgba(0, 0, 0, 0.45); align-items: center; justify-content: center;
+}
+.folder-browser-overlay.open { display: flex; }
+.folder-browser-panel {
+  width: min(720px, calc(100vw - 32px)); max-height: calc(100vh - 64px);
+  background: var(--bg-secondary); border: 1px solid var(--border-primary);
+  border-radius: 8px; box-shadow: 0 18px 60px rgba(0,0,0,0.35);
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.folder-browser-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 16px; border-bottom: 1px solid var(--border-primary);
+}
+.folder-browser-header h3 { margin: 0; }
+.folder-browser-close { background: none; border: none; color: var(--text-secondary); font-size: 22px; cursor: pointer; }
+.folder-browser-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 10px; min-height: 0; }
+.folder-browser-shortcuts { display: flex; gap: 8px; flex-wrap: wrap; }
+.folder-browser-path { font-size: 12px; color: var(--text-secondary); overflow-wrap: anywhere; }
+.folder-browser-list {
+  height: 320px; overflow: auto; border: 1px solid var(--border-primary);
+  border-radius: 6px; background: var(--bg-tertiary);
+}
+.folder-browser-item {
+  padding: 8px 10px; font-size: 12px; color: var(--text-primary);
+  cursor: pointer; border-bottom: 1px solid color-mix(in srgb, var(--border-primary) 60%, transparent);
+  display: flex; align-items: center; gap: 8px;
+}
+.folder-browser-item:hover { background: var(--bg-hover, rgba(255,255,255,0.05)); }
+.folder-browser-item-name {
+  flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.folder-browser-empty { padding: 14px; font-size: 12px; color: var(--text-secondary); }
+.folder-browser-actions {
+  display: flex; gap: 8px; justify-content: flex-end;
+  padding: 12px 16px; border-top: 1px solid var(--border-primary);
+}
+.card-cleanup-bucket { margin-top: 6px; }
+.card-cleanup-bucket > summary { cursor: pointer; font-size: 12px; color: var(--text-primary); }
+/* Same callout shape as the import page's .managed-archive-callout, in
+   warning colours: an incomplete preview must not read as a quiet
+   footnote. */
+.card-cleanup-warning {
+  font-size: 12px; color: var(--text-primary); margin: 8px 0;
+  padding: 8px 10px; border-radius: 6px; overflow-wrap: anywhere;
+  background: color-mix(in srgb, var(--warning, #bf8700) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning, #bf8700) 45%, transparent);
+}
+/* The audit callout is an offer, not a problem — neutral chrome so it
+   doesn't compete with the incomplete-preview warning above it. */
+.card-cleanup-audit {
+  font-size: 12px; color: var(--text-primary); margin: 8px 0;
+  padding: 10px; border-radius: 6px;
+  background: var(--bg-tertiary); border: 1px solid var(--border-primary);
+}
+.card-cleanup-audit .hint { display: block; margin-top: 6px; }
+/* Taller than .staging-details: these lists run to thousands of files. */
+#card-cleanup-section .staging-details { max-height: 220px; }
+.card-cleanup-confirm-list { margin: 0; padding-left: 18px; font-size: 13px; color: var(--text-primary); }
+.card-cleanup-confirm-list li { margin-bottom: 10px; overflow-wrap: anywhere; }
+</style>
+</head>
+<body>
+{% include '_navbar.html' %}
+
+<div class="content">
+  <div class="card-cleanup-wrap">
+    <h2 class="page-title">Free up card space</h2>
+
+    <!-- Free up card space: deletes card files ONLY where the same bytes
+         are already verified in the archive. Reached from the navbar or
+         from the import page's result card, which links here with the
+         finished import's card path in ?source=. -->
+    <div class="card" id="card-cleanup-section">
+      <div class="hint">
+        Checks a memory card against the archive and deletes only the files
+        whose archive copy is verified. Everything else stays on the card.
+      </div>
+      <div class="row" id="card-cleanup-picker-row" style="margin-top:10px;">
+        <button class="btn btn-primary" type="button" id="card-cleanup-browse-btn"
+                data-testid="card-cleanup-browse-btn"
+                onclick="cardCleanupBrowse()">Browse...</button>
+        <input type="text" id="card-cleanup-source" list="volumeDatalist"
+               aria-label="Card folder to check"
+               placeholder="or type a card/folder path">
+        <datalist id="volumeDatalist"></datalist>
+      </div>
+      <div class="hint" id="card-cleanup-source-note" style="display:none;"></div>
+      <div class="row">
+        <label><input type="checkbox" id="card-cleanup-recursive" checked> Include subfolders</label>
+      </div>
+      <div class="row">
+        <button class="btn btn-primary" type="button" id="card-cleanup-scan-btn"
+                onclick="cardCleanupStartScan()">Scan card</button>
+        <button class="btn" type="button" id="card-cleanup-cancel-btn"
+                style="display:none;" onclick="cardCleanupCancelJob()">Cancel</button>
+      </div>
+      <div class="field-error" id="card-cleanup-error" role="alert" aria-live="assertive"></div>
+      <div id="card-cleanup-progress" style="display:none;">
+        <div class="row"><span class="hint" id="card-cleanup-phase"></span></div>
+        <div class="progress-bar"><div id="card-cleanup-progress-fill"></div></div>
+      </div>
+      <div id="card-cleanup-preview" style="display:none;">
+        <div class="card-cleanup-warning" id="card-cleanup-incomplete" style="display:none;">
+          <div id="card-cleanup-incomplete-text"></div>
+          <details class="card-cleanup-bucket" id="card-cleanup-walk-errors-details">
+            <summary id="card-cleanup-walk-errors-summary"></summary>
+            <ul class="staging-details" id="card-cleanup-walk-errors"></ul>
+          </details>
+        </div>
+        <div class="hint" id="card-cleanup-scanned-root" style="margin-bottom:6px;"></div>
+        <!-- Shown only when the scan's own kept reasons say the integrity
+             audit is what is missing. -->
+        <div class="card-cleanup-audit" id="card-cleanup-audit" style="display:none;">
+          <div id="card-cleanup-audit-text"></div>
+          <span class="hint" id="card-cleanup-audit-cost"></span>
+          <div class="row" style="margin-top:8px;margin-bottom:0;">
+            <button class="btn btn-primary" type="button" id="card-cleanup-audit-btn"
+                    onclick="cardCleanupStartAudit()">Verify archive hashes</button>
+            <button class="btn" type="button" id="card-cleanup-audit-rescan-btn"
+                    style="display:none;" onclick="cardCleanupStartScan()">Re-scan card</button>
+          </div>
+          <div class="hint" id="card-cleanup-audit-status" style="margin-top:6px;"></div>
+        </div>
+        <details class="card-cleanup-bucket" id="card-cleanup-deletable-details">
+          <summary id="card-cleanup-deletable-summary"></summary>
+          <ul class="staging-details" id="card-cleanup-deletable-list"></ul>
+        </details>
+        <details class="card-cleanup-bucket" id="card-cleanup-kept-details">
+          <summary id="card-cleanup-kept-summary"></summary>
+          <ul class="staging-details" id="card-cleanup-kept-list"></ul>
+        </details>
+        <details class="card-cleanup-bucket" id="card-cleanup-ignored-details">
+          <summary id="card-cleanup-ignored-summary"></summary>
+          <ul class="staging-details" id="card-cleanup-ignored-list"></ul>
+        </details>
+        <div class="row" style="margin-top:12px;">
+          <button class="btn btn-primary" type="button" id="card-cleanup-delete-btn"
+                  disabled onclick="cardCleanupOpenConfirm()">Delete verified files</button>
+          <span class="hint" id="card-cleanup-delete-hint"></span>
+        </div>
+      </div>
+      <div id="card-cleanup-result" style="display:none;">
+        <div class="hint" id="card-cleanup-result-summary" style="margin-top:10px;"></div>
+        <ul class="staging-details" id="card-cleanup-result-list" style="display:none;"></ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Single-select folder browser: a minimal copy of the import page's,
+     kept to the one mode this page needs (pick one card folder). -->
+<div class="folder-browser-overlay" id="cardFolderBrowser" data-testid="card-folder-browser">
+  <div class="folder-browser-panel" role="dialog" aria-modal="true" aria-labelledby="folderBrowserTitle">
+    <div class="folder-browser-header">
+      <h3 id="folderBrowserTitle">Select Card Folder</h3>
+      <button class="folder-browser-close" type="button" onclick="closeCardFolderBrowser()">&times;</button>
+    </div>
+    <div class="folder-browser-body">
+      <div class="folder-browser-shortcuts">
+        <button class="btn" type="button" onclick="browseCardFolderTo(null)">Home</button>
+        <button class="btn" type="button" onclick="browseCardFolderTo('__pictures__')">Pictures</button>
+        <button class="btn" type="button" onclick="browseCardFolderTo('__volumes__')">Volumes</button>
+      </div>
+      <div class="folder-browser-path" id="folderBrowserPath"></div>
+      <div class="folder-browser-list" id="folderBrowserList"></div>
+    </div>
+    <div class="folder-browser-actions">
+      <button class="btn" type="button" onclick="closeCardFolderBrowser()">Cancel</button>
+      <button class="btn btn-primary" type="button" id="folderBrowserSelectBtn" onclick="selectCardBrowserFolder()">Select This Folder</button>
+    </div>
+  </div>
+</div>
+
+<!-- Delete confirmation. Reuses the folder browser's overlay/panel classes:
+     they are this page's only modal chrome, named after their first user. -->
+<div class="folder-browser-overlay" id="card-cleanup-confirm"
+     data-testid="card-cleanup-confirm">
+  <div class="folder-browser-panel" role="dialog" aria-modal="true"
+       aria-labelledby="card-cleanup-confirm-title">
+    <div class="folder-browser-header">
+      <h3 id="card-cleanup-confirm-title">Delete verified files from the card?</h3>
+      <button class="folder-browser-close" type="button"
+              onclick="cardCleanupCloseConfirm()">&times;</button>
+    </div>
+    <div class="folder-browser-body">
+      <div id="card-cleanup-confirm-count" class="folder-browser-path"></div>
+      <ul class="card-cleanup-confirm-list">
+        <li>Deletion is permanent — memory cards have no trash.</li>
+        <li>After deletion, the archive holds the only copy of these photos.</li>
+        <li>What "verified" means: each file's archive copy passed a checksum check (at import or integrity audit) and is confirmed unchanged since by size and timestamp; the card copy itself is re-checksummed at the moment of deletion. Archive bytes are not re-downloaded.</li>
+      </ul>
+    </div>
+    <div class="folder-browser-actions">
+      <button class="btn" type="button" onclick="cardCleanupCloseConfirm()">Cancel</button>
+      <button class="btn btn-primary" type="button" id="card-cleanup-confirm-btn"
+              onclick="cardCleanupConfirmDelete()">Delete verified files</button>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ---------- Free up card space ----------
+   Deletes card files only where the archive copy is verified. Every count
+   and byte total shown here is read straight out of the scan manifest —
+   this page never estimates, and it marks the preview incomplete
+   whenever the card walk hit a folder it could not read. */
+const cardCleanupState = {
+  scanJobId: null,      // manifest key of the last scan we started
+  jobId: null,          // job currently streaming (scan, delete, or audit)
+  finishedJobId: null,  // guards the double 'complete' + 'error' callback
+  es: null,             // this page's job stream
+  manifest: null,
+  listsRendered: {},    // bucket -> true once its <li>s are in the DOM
+  confirmEscHandler: null,
+};
+
+// The manifest reason that this page's audit callout answers. Mirrors
+// card_cleanup.KEEP_NOT_VERIFIED — matched on the distinctive tail so a
+// reason with extra detail appended still counts.
+const CARD_CLEANUP_AUDIT_REASON = 'run the integrity audit';
+
+function formatBytes(n) {
+  n = Number(n || 0);
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) { n /= 1024; i += 1; }
+  return (i === 0 ? String(n) : n.toFixed(n >= 10 ? 1 : 2)) + ' ' + units[i];
+}
+
+function cardEscapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (ch) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[ch]));
+}
+
+function cardCleanupFileCount(n) {
+  const count = Number(n || 0);
+  return count.toLocaleString() + (count === 1 ? ' file' : ' files');
+}
+
+function cardCleanupSetError(msg, opts) {
+  const el = document.getElementById('card-cleanup-error');
+  el.textContent = '';
+  el.classList.toggle('visible', !!msg);
+  if (!msg) return;
+  el.append(msg);
+  if (opts && opts.rescan) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'retry-link';
+    btn.textContent = 'Re-scan';
+    btn.addEventListener('click', () => cardCleanupStartScan());
+    el.append(' ', btn);
+  }
+}
+
+/* ---------- Single-select folder browser ----------
+   Minimal copy of the import page's browser: same /api/browse and
+   /api/volumes endpoints, one folder at a time, no photo counts. */
+let cardBrowserPath = '';
+let cardBrowserHomePath = '';
+let cardBrowserSeq = 0;
+let cardBrowserEscHandler = null;
+
+async function cardCleanupBrowse() {
+  // Same shape as the import page's browseForSource(): native picker
+  // when the desktop shell offers one, in-page browser otherwise.
+  if (typeof pickDirectory === 'function') {
+    const seqBeforePicker = cardBrowserSeq;
+    const result = await pickDirectory('Select the card folder');
+    if (result) {
+      const path = Array.isArray(result) ? result[0] : result;
+      if (path) document.getElementById('card-cleanup-source').value = path;
+      return;
+    }
+    if (typeof isTauri === 'function' && isTauri()) return;
+    if (cardBrowserSeq !== seqBeforePicker) {
+      openCardFolderBrowser({ skipInitialBrowse: true });
+      return;
+    }
+  }
+  openCardFolderBrowser();
+}
+
+function openCardFolderBrowser(opts = {}) {
+  const overlay = document.getElementById('cardFolderBrowser');
+  overlay.classList.add('open');
+  overlay.onclick = (e) => {
+    if (e.target === overlay) closeCardFolderBrowser();
+  };
+  if (cardBrowserEscHandler) {
+    document.removeEventListener('keydown', cardBrowserEscHandler);
+  }
+  cardBrowserEscHandler = (e) => {
+    if (e.key === 'Escape') closeCardFolderBrowser();
+  };
+  document.addEventListener('keydown', cardBrowserEscHandler);
+  document.body.style.overflow = 'hidden';
+  const firstAction = overlay.querySelector('button');
+  if (firstAction) firstAction.focus();
+  const startPath = (document.getElementById('card-cleanup-source').value || '').trim();
+  if (!opts.skipInitialBrowse) browseCardFolderTo(startPath || null);
+}
+
+function closeCardFolderBrowser() {
+  document.getElementById('cardFolderBrowser').classList.remove('open');
+  if (cardBrowserEscHandler) {
+    document.removeEventListener('keydown', cardBrowserEscHandler);
+    cardBrowserEscHandler = null;
+  }
+  document.body.style.overflow = '';
+}
+
+async function browseCardFolderTo(path) {
+  const seq = ++cardBrowserSeq;
+  // Clear the stale selection while this async navigation is pending.
+  // Without this, clicking "Select This Folder" during a slow or failing
+  // fetch submits the previous folder instead of the one requested.
+  cardBrowserPath = '';
+  const selectBtn = document.getElementById('folderBrowserSelectBtn');
+  if (selectBtn) selectBtn.disabled = true;
+  document.getElementById('folderBrowserPath').textContent = 'Loading…';
+  document.getElementById('folderBrowserList').innerHTML =
+    '<div class="folder-browser-empty">Loading…</div>';
+  let url = '/api/browse';
+  if (path === '__pictures__') {
+    if (!cardBrowserHomePath) {
+      try {
+        const homeResp = await fetch('/api/browse');
+        if (seq !== cardBrowserSeq || !homeResp.ok) return;
+        const home = await homeResp.json();
+        cardBrowserHomePath = home.path || '';
+      } catch (e) {
+        return;
+      }
+    }
+    url = '/api/browse?path=' + encodeURIComponent(cardBrowserHomePath + '/Pictures');
+  } else if (path === '__volumes__') {
+    if (navigator.userAgent.indexOf('Mac') < 0) {
+      try {
+        const resp = await fetch('/api/volumes');
+        if (seq !== cardBrowserSeq || !resp.ok) return;
+        const volumes = await resp.json();
+        cardBrowserPath = '';
+        renderCardFolderBrowser({ path: '', dirs: volumes || [] }, { syntheticRoot: true });
+      } catch (e) { /* ignore */ }
+      return;
+    }
+    url = '/api/browse?path=' + encodeURIComponent('/Volumes');
+  } else if (path) {
+    url = '/api/browse?path=' + encodeURIComponent(path);
+  }
+
+  try {
+    const resp = await fetch(url);
+    if (seq !== cardBrowserSeq) return;
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      document.getElementById('folderBrowserPath').textContent =
+        data.error || 'Could not open folder.';
+      document.getElementById('folderBrowserList').innerHTML =
+        '<div class="folder-browser-empty">Could not open folder.</div>';
+      return;
+    }
+    const data = await resp.json();
+    cardBrowserPath = data.path || '';
+    if (!path) cardBrowserHomePath = cardBrowserPath;
+    renderCardFolderBrowser(data);
+  } catch (e) {
+    document.getElementById('folderBrowserPath').textContent = String(e.message || e);
+    document.getElementById('folderBrowserList').innerHTML =
+      '<div class="folder-browser-empty">Could not open folder.</div>';
+  }
+}
+
+function renderCardFolderBrowser(data, opts) {
+  document.getElementById('folderBrowserPath').textContent = data.path || 'Volumes';
+  const list = document.getElementById('folderBrowserList');
+  const dirs = data.dirs || [];
+  let html = '';
+  const syntheticRoot = opts && opts.syntheticRoot;
+  let parent = '';
+  if (data.path && data.path.indexOf('\\') !== -1) {
+    parent = data.path.replace(/[\\\/]?[^\\\/]+[\\\/]?$/, '') || data.path;
+    if (/^[A-Za-z]:$/.test(parent)) parent += '\\';
+  } else if (data.path) {
+    parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
+  }
+  if (data.path && data.path !== '/' && parent && parent !== data.path) {
+    html += '<div class="folder-browser-item" data-browse-path="' + cardEscapeHtml(parent) + '" data-parent-link="1">' +
+      '<span class="folder-browser-item-name">&#128193; ..</span></div>';
+  }
+  dirs.forEach((d) => {
+    html += '<div class="folder-browser-item" data-browse-path="' + cardEscapeHtml(d.path) + '">' +
+      '<span class="folder-browser-item-name">&#128193; ' + cardEscapeHtml(d.name || d.path) + '</span></div>';
+  });
+  if (!html) {
+    html = '<div class="folder-browser-empty">' +
+      (syntheticRoot ? 'No volumes found.' : 'No subfolders.') + '</div>';
+  }
+  list.innerHTML = html;
+  // Single-select: a click navigates into the folder, and the actions bar
+  // selects wherever you are standing.
+  list.onclick = (e) => {
+    const item = e.target.closest('.folder-browser-item[data-browse-path]');
+    if (!item) return;
+    browseCardFolderTo(item.getAttribute('data-browse-path'));
+  };
+  const selectBtn = document.getElementById('folderBrowserSelectBtn');
+  if (selectBtn) selectBtn.disabled = !cardBrowserPath;
+}
+
+function selectCardBrowserFolder() {
+  if (!cardBrowserPath) return;
+  document.getElementById('card-cleanup-source').value = cardBrowserPath;
+  closeCardFolderBrowser();
+}
+
+async function cardCleanupStartScan() {
+  if (cardCleanupState.jobId) return;  // a run is already streaming
+  const source = (document.getElementById('card-cleanup-source').value || '').trim();
+  const recursive = document.getElementById('card-cleanup-recursive').checked;
+  if (!source) {
+    cardCleanupSetError('Choose the card folder to check.');
+    return;
+  }
+  cardCleanupSetError('');
+  cardCleanupResetPreview();
+  document.getElementById('card-cleanup-result').style.display = 'none';
+  const scanBtn = document.getElementById('card-cleanup-scan-btn');
+  scanBtn.disabled = true;
+  try {
+    const resp = await fetch('/api/card-cleanup/scan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source, recursive }),
+    });
+    const data = await resp.json();
+    // The 400s here are written for the user (archive overlap, unreadable
+    // path) — show the server's own words rather than a generic failure.
+    if (!resp.ok) throw new Error(data.error || 'scan failed to start');
+    cardCleanupState.scanJobId = data.job_id;
+    cardCleanupWatchJob(data.job_id, 'scan', 'Starting scan…');
+  } catch (e) {
+    scanBtn.disabled = false;
+    cardCleanupSetError(String(e.message || e));
+  }
+}
+
+function cardCleanupWatchJob(jobId, kind, startingPhase) {
+  cardCleanupState.jobId = jobId;
+  cardCleanupState.finishedJobId = null;
+  document.getElementById('card-cleanup-progress').style.display = '';
+  document.getElementById('card-cleanup-phase').textContent = startingPhase;
+  document.getElementById('card-cleanup-progress-fill').style.width = '0%';
+  const cancelBtn = document.getElementById('card-cleanup-cancel-btn');
+  cancelBtn.style.display = '';
+  cancelBtn.disabled = false;
+  cancelBtn.textContent = 'Cancel';
+  if (cardCleanupState.es) { cardCleanupState.es.close(); cardCleanupState.es = null; }
+  cardCleanupState.es =
+    new EventSource('/api/jobs/' + encodeURIComponent(jobId) + '/stream');
+  cardCleanupState.es.addEventListener('progress', (evt) => {
+    try { cardCleanupRenderProgress(JSON.parse(evt.data)); } catch (e) { /* ignore */ }
+  });
+  cardCleanupState.es.addEventListener('complete', () => {
+    cardCleanupCloseStream();
+    cardCleanupFinishJob(jobId, kind);
+  });
+  cardCleanupState.es.addEventListener('error', () => {
+    // Stream dropped (server restart, network) — fall back to polling the
+    // job rather than pretending progress continues.
+    cardCleanupCloseStream();
+    cardCleanupFinishJob(jobId, kind);
+  });
+}
+
+function cardCleanupCloseStream() {
+  if (cardCleanupState.es) {
+    cardCleanupState.es.close();
+    cardCleanupState.es = null;
+  }
+}
+
+function cardCleanupRenderProgress(data) {
+  const parts = [];
+  if (data.phase) parts.push(data.phase);
+  if (data.total) {
+    parts.push(Number(data.current || 0).toLocaleString() + ' / ' +
+      Number(data.total).toLocaleString());
+  }
+  if (data.current_file) parts.push(data.current_file);
+  document.getElementById('card-cleanup-phase').textContent = parts.join(' · ');
+  const pct = data.total ? Math.round(100 * data.current / data.total) : 0;
+  document.getElementById('card-cleanup-progress-fill').style.width = pct + '%';
+}
+
+async function cardCleanupFinishJob(jobId, kind) {
+  // 'complete' and 'error' can both fire for one job; only finish once.
+  if (cardCleanupState.finishedJobId === jobId) return;
+  cardCleanupState.finishedJobId = jobId;
+  let job = null;
+  // The stream is already gone by the time we poll, so say what the page
+  // is actually doing instead of leaving the last SSE line under a bar
+  // that has stopped moving.
+  document.getElementById('card-cleanup-phase').textContent =
+    'Checking job status…';
+  for (let i = 0; i < 30; i++) {
+    // A poll that throws (server restarting, network dropped — the very
+    // conditions that killed the stream) must not escape as an unhandled
+    // rejection: that would skip the cleanup below and leave a frozen bar,
+    // a live Cancel button pointing at a stale job, and a disabled Scan
+    // button until reload. Treat it as one failed attempt and keep going
+    // toward the timeout path.
+    try {
+      const resp = await fetch('/api/jobs/' + encodeURIComponent(jobId));
+      if (resp.ok) {
+        const polled = await resp.json();
+        if (polled.status && polled.status !== 'running'
+            && polled.status !== 'queued') {
+          job = polled;
+          break;
+        }
+      }
+    } catch (e) { /* retry below */ }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  cardCleanupState.jobId = null;
+  document.getElementById('card-cleanup-cancel-btn').style.display = 'none';
+  document.getElementById('card-cleanup-progress').style.display = 'none';
+  document.getElementById('card-cleanup-scan-btn').disabled = false;
+  const status = job && job.status;
+  const jobError = job && (job.errors || [])[0];
+  if (kind === 'scan') {
+    if (status === 'completed') {
+      await cardCleanupLoadManifest();
+    } else if (status === 'cancelled') {
+      cardCleanupSetError(
+        'Scan cancelled — no files were checked against the archive, and ' +
+        'nothing was deleted. Scan again when you are ready.');
+    } else if (status) {
+      cardCleanupSetError('Scan ' + status + ' — no preview was produced' +
+        (jobError ? ': ' + jobError : '.'));
+    } else {
+      cardCleanupSetError(
+        'The scan is still running but this page lost track of it — ' +
+        'check the Jobs page.');
+    }
+    return;
+  }
+  if (kind === 'audit') {
+    cardCleanupFinishAudit(job, status, jobError);
+    return;
+  }
+  // Delete: the per-file outcome lives in the job result, so a job that
+  // ended without one has to say so rather than imply a clean run.
+  if (job && job.result) {
+    cardCleanupRenderDeleteResult(job.result);
+  } else if (status) {
+    cardCleanupSetError('Deletion ' + status +
+      ' and its summary could not be loaded' +
+      (jobError ? ': ' + jobError : '') + ' — check the Jobs page for what ' +
+      'was deleted, then re-scan the card.');
+  } else {
+    cardCleanupSetError(
+      'The deletion is still running but this page lost track of it — ' +
+      'check the Jobs page.');
+  }
+}
+
+async function cardCleanupLoadManifest() {
+  try {
+    const resp = await fetch('/api/card-cleanup/' +
+      encodeURIComponent(cardCleanupState.scanJobId) + '/manifest');
+    const data = await resp.json();
+    if (resp.status === 404) {
+      cardCleanupState.scanJobId = null;
+      cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
+      return;
+    }
+    if (!resp.ok) throw new Error(data.error || 'the preview could not be loaded');
+    cardCleanupRenderManifest(data);
+  } catch (e) {
+    cardCleanupSetError(String(e.message || e));
+  }
+}
+
+function cardCleanupRenderManifest(manifest) {
+  cardCleanupState.manifest = manifest;
+  cardCleanupState.listsRendered = {};
+  const totals = manifest.totals || {};
+  const deletable = totals.deletable || { count: 0, bytes: 0 };
+  const kept = totals.kept || { count: 0, bytes: 0 };
+  const ignored = totals.ignored || { count: 0 };
+  const walkErrors = (manifest.walk_errors || []).map(String);
+
+  // Unmissable and above the numbers: a walk that skipped folders means
+  // the counts below are a floor, not the whole card.
+  const incomplete = document.getElementById('card-cleanup-incomplete');
+  if (walkErrors.length) {
+    incomplete.style.display = '';
+    document.getElementById('card-cleanup-incomplete-text').textContent =
+      'Some folders could not be read; this preview is incomplete. Files ' +
+      'that were not seen will never be deleted.';
+    document.getElementById('card-cleanup-walk-errors-summary').textContent =
+      walkErrors.length.toLocaleString() + ' folder ' +
+      (walkErrors.length === 1 ? 'error' : 'errors');
+    cardCleanupFillList('card-cleanup-walk-errors', walkErrors);
+  } else {
+    incomplete.style.display = 'none';
+  }
+
+  document.getElementById('card-cleanup-scanned-root').textContent =
+    'Checked ' + (manifest.source_root || '') +
+    (manifest.recursive
+      ? ' and its subfolders'
+      : ' only (subfolders were not included)');
+
+  document.getElementById('card-cleanup-deletable-summary').textContent =
+    cardCleanupFileCount(deletable.count) + ' / ' +
+    formatBytes(deletable.bytes) +
+    ' verified in the archive — safe to delete';
+  document.getElementById('card-cleanup-kept-summary').textContent =
+    cardCleanupFileCount(kept.count) + ' / ' + formatBytes(kept.bytes) +
+    ' not verified — will be kept';
+  document.getElementById('card-cleanup-ignored-summary').textContent =
+    cardCleanupFileCount(ignored.count) +
+    ' ignored (not photo files Vireo imports)';
+
+  cardCleanupRenderAuditCallout(manifest);
+
+  cardCleanupBindBucket('deletable', 'card-cleanup-deletable-details',
+    'card-cleanup-deletable-list');
+  cardCleanupBindBucket('kept', 'card-cleanup-kept-details',
+    'card-cleanup-kept-list');
+  cardCleanupBindBucket('ignored', 'card-cleanup-ignored-details',
+    'card-cleanup-ignored-list');
+
+  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
+  deleteBtn.disabled = deletable.count === 0;
+  document.getElementById('card-cleanup-delete-hint').textContent =
+    deletable.count === 0
+      ? 'Nothing on this card is verified in the archive, so there is ' +
+        'nothing safe to delete.'
+      : 'Deletes the ' + cardCleanupFileCount(deletable.count) +
+        ' listed as verified above, and nothing else.';
+  document.getElementById('card-cleanup-preview').style.display = '';
+}
+
+/* ---------- Integrity-audit affordance ----------
+   The scan itself tells us when the archive audit is the missing step:
+   every kept entry whose reason is KEEP_NOT_VERIFIED. The count below is
+   those entries, not an estimate. */
+function cardCleanupAuditPendingCount(manifest) {
+  return (manifest.entries || []).filter(entry =>
+    entry.bucket === 'kept'
+    && String(entry.reason || '').indexOf(CARD_CLEANUP_AUDIT_REASON) !== -1
+  ).length;
+}
+
+function cardCleanupRenderAuditCallout(manifest) {
+  const callout = document.getElementById('card-cleanup-audit');
+  const pending = cardCleanupAuditPendingCount(manifest);
+  if (!pending) {
+    callout.style.display = 'none';
+    return;
+  }
+  document.getElementById('card-cleanup-audit-text').textContent =
+    cardCleanupFileCount(pending) + ' are kept only because the archive ' +
+    'copy has never been checksum-verified. Vireo will not delete a card ' +
+    'file until its archive copy passes a checksum check, and the ' +
+    'integrity audit is what performs that check.';
+  document.getElementById('card-cleanup-audit-cost').textContent =
+    'Verifying re-reads and re-checksums every file in the archive, not ' +
+    'just these — over a VPN’d network mount that is slow, so it is ' +
+    'best run on a machine close to the NAS.';
+  document.getElementById('card-cleanup-audit-btn').style.display = '';
+  document.getElementById('card-cleanup-audit-btn').disabled = false;
+  document.getElementById('card-cleanup-audit-rescan-btn').style.display = 'none';
+  document.getElementById('card-cleanup-audit-status').textContent = '';
+  callout.style.display = '';
+}
+
+async function cardCleanupStartAudit() {
+  if (cardCleanupState.jobId) return;  // a run is already streaming
+  const btn = document.getElementById('card-cleanup-audit-btn');
+  btn.disabled = true;
+  document.getElementById('card-cleanup-audit-rescan-btn').style.display = 'none';
+  document.getElementById('card-cleanup-audit-status').textContent = '';
+  cardCleanupSetError('');
+  try {
+    const resp = await fetch('/api/jobs/verify-hashes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || 'verification failed to start');
+    cardCleanupWatchJob(data.job_id, 'audit', 'Starting hash verification…');
+  } catch (e) {
+    btn.disabled = false;
+    cardCleanupSetError(String(e.message || e));
+  }
+}
+
+function cardCleanupFinishAudit(job, status, jobError) {
+  const btn = document.getElementById('card-cleanup-audit-btn');
+  const statusEl = document.getElementById('card-cleanup-audit-status');
+  btn.disabled = false;
+  if (status === 'completed' && job && job.result) {
+    const r = job.result;
+    const problems = (r.modified || 0) + (r.corrupt || 0) + (r.unreadable || 0);
+    const parts = [cardCleanupFileCount(r.checked) + ' checked'];
+    if (r.baselined) {
+      parts.push(Number(r.baselined).toLocaleString() +
+        ' baselined (no prior hash)');
+    }
+    if (r.missing) {
+      parts.push(Number(r.missing).toLocaleString() +
+        ' missing (see the Audit page)');
+    }
+    parts.push(problems
+      ? problems.toLocaleString() + ' problems found (see the Audit page)'
+      : 'no problems');
+    if (r.cancelled) parts.push('cancelled before the whole archive was read');
+    statusEl.textContent = parts.join(' · ') +
+      '. The preview above is from the earlier scan — re-scan the card to ' +
+      'see what is verified now.';
+  } else if (status === 'cancelled') {
+    statusEl.textContent =
+      'Verification cancelled — the files it had already checked keep ' +
+      'their new verdicts; the rest are unchanged.';
+  } else if (status) {
+    statusEl.textContent = 'Verification ' + status +
+      (jobError ? ': ' + jobError : '.') +
+      ' Check the Jobs page for what it managed to check.';
+  } else {
+    statusEl.textContent =
+      'The verification is still running but this page lost track of it — ' +
+      'check the Jobs page.';
+  }
+  document.getElementById('card-cleanup-audit-rescan-btn').style.display = '';
+}
+
+// Bucket lists run to thousands of rows, so build them the first time the
+// user opens that group rather than on every scan.
+function cardCleanupBindBucket(bucket, detailsId, listId) {
+  const details = document.getElementById(detailsId);
+  details.open = false;
+  details.ontoggle = () => {
+    if (!details.open || cardCleanupState.listsRendered[bucket]) return;
+    if (!cardCleanupState.manifest) return;
+    cardCleanupState.listsRendered[bucket] = true;
+    // Spec ("UX flow"): verified rows show path, size, and the matched
+    // archive copy that justifies the deletion; kept rows show size and
+    // the per-file reason. All fields come straight from the manifest.
+    const lines = (cardCleanupState.manifest.entries || [])
+      .filter(entry => entry.bucket === bucket)
+      .map(entry => {
+        const size = (typeof entry.size === 'number')
+          ? ' (' + formatBytes(entry.size) + ')' : '';
+        if (bucket === 'kept') {
+          return entry.path + size + ' — ' + (entry.reason || 'not verified');
+        }
+        if (bucket === 'deletable') {
+          return entry.path + size
+            + ' → verified copy: ' + (entry.archive_path || 'unknown');
+        }
+        return entry.path;
+      });
+    cardCleanupFillList(listId, lines);
+  };
+}
+
+function cardCleanupFillList(listId, lines) {
+  const list = document.getElementById(listId);
+  list.innerHTML = '';
+  const frag = document.createDocumentFragment();
+  if (!lines.length) {
+    const li = document.createElement('li');
+    li.textContent = 'No files in this group.';
+    frag.appendChild(li);
+  }
+  lines.forEach((line) => {
+    const li = document.createElement('li');
+    li.textContent = line;
+    frag.appendChild(li);
+  });
+  list.appendChild(frag);
+}
+
+function cardCleanupResetPreview() {
+  cardCleanupState.manifest = null;
+  cardCleanupState.listsRendered = {};
+  document.getElementById('card-cleanup-preview').style.display = 'none';
+  document.getElementById('card-cleanup-incomplete').style.display = 'none';
+  document.getElementById('card-cleanup-audit').style.display = 'none';
+  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
+  deleteBtn.disabled = true;
+  document.getElementById('card-cleanup-delete-hint').textContent = '';
+  [
+    'card-cleanup-deletable-details', 'card-cleanup-kept-details',
+    'card-cleanup-ignored-details', 'card-cleanup-walk-errors-details',
+  ].forEach((id) => { document.getElementById(id).open = false; });
+}
+
+function cardCleanupOpenConfirm() {
+  const manifest = cardCleanupState.manifest;
+  if (!manifest) return;
+  const deletable = (manifest.totals || {}).deletable || { count: 0, bytes: 0 };
+  if (!deletable.count) return;
+  document.getElementById('card-cleanup-confirm-count').textContent =
+    'Deleting ' + cardCleanupFileCount(deletable.count) + ' (' +
+    formatBytes(deletable.bytes) + ') from ' +
+    (manifest.source_root || 'the card') + '.';
+  const overlay = document.getElementById('card-cleanup-confirm');
+  overlay.classList.add('open');
+  overlay.onclick = (e) => { if (e.target === overlay) cardCleanupCloseConfirm(); };
+  if (cardCleanupState.confirmEscHandler) {
+    document.removeEventListener('keydown', cardCleanupState.confirmEscHandler);
+  }
+  cardCleanupState.confirmEscHandler = (e) => {
+    if (e.key === 'Escape') cardCleanupCloseConfirm();
+  };
+  document.addEventListener('keydown', cardCleanupState.confirmEscHandler);
+  document.body.style.overflow = 'hidden';
+  // Focus the dialog's first control (the close button), not the delete
+  // button — a stray Enter must not delete anything.
+  const firstAction = overlay.querySelector('button');
+  if (firstAction) firstAction.focus();
+}
+
+function cardCleanupCloseConfirm() {
+  document.getElementById('card-cleanup-confirm').classList.remove('open');
+  if (cardCleanupState.confirmEscHandler) {
+    document.removeEventListener('keydown', cardCleanupState.confirmEscHandler);
+    cardCleanupState.confirmEscHandler = null;
+  }
+  document.body.style.overflow = '';
+}
+
+async function cardCleanupConfirmDelete() {
+  const confirmBtn = document.getElementById('card-cleanup-confirm-btn');
+  confirmBtn.disabled = true;
+  try {
+    const resp = await fetch('/api/card-cleanup/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scan_job_id: cardCleanupState.scanJobId }),
+    });
+    const data = await resp.json();
+    cardCleanupCloseConfirm();
+    if (!resp.ok) {
+      if (resp.status === 404) {
+        // The manifest is gone, so the preview above no longer describes
+        // anything that can be deleted — take it down with the error.
+        cardCleanupState.scanJobId = null;
+        cardCleanupResetPreview();
+        cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
+      } else {
+        cardCleanupSetError(data.error || 'deletion failed to start');
+      }
+      return;
+    }
+    cardCleanupSetError('');
+    document.getElementById('card-cleanup-result').style.display = 'none';
+    document.getElementById('card-cleanup-delete-btn').disabled = true;
+    document.getElementById('card-cleanup-scan-btn').disabled = true;
+    cardCleanupWatchJob(data.job_id, 'delete', 'Starting deletion…');
+  } catch (e) {
+    cardCleanupCloseConfirm();
+    cardCleanupSetError(String(e.message || e));
+  } finally {
+    confirmBtn.disabled = false;
+  }
+}
+
+function cardCleanupRenderDeleteResult(result) {
+  const res = result || {};
+  const skipped = res.skipped || [];
+  const failed = res.failed || [];
+  // The job result bounds these lists to a sample; *_total carries the
+  // exact count (falls back to list length for pre-trim results).
+  const skippedTotal = (typeof res.skipped_total === 'number')
+    ? res.skipped_total : skipped.length;
+  const failedTotal = (typeof res.failed_total === 'number')
+    ? res.failed_total : failed.length;
+  const parts = ['Deleted ' + cardCleanupFileCount(res.deleted) +
+    ' (' + formatBytes(res.deleted_bytes) + ')'];
+  if (skippedTotal) {
+    parts.push(skippedTotal.toLocaleString() + ' skipped');
+  }
+  if (failedTotal) {
+    parts.push(failedTotal.toLocaleString() + ' failed');
+  }
+  if (res.cancelled) {
+    parts.push('Cancelled — ' + Number(res.remaining || 0).toLocaleString() +
+      ' files not yet processed.');
+  }
+  document.getElementById('card-cleanup-result').style.display = '';
+  document.getElementById('card-cleanup-result-summary').textContent =
+    parts.join(' · ');
+  const lines = [];
+  skipped.forEach((s) => {
+    lines.push('Skipped: ' + s.path + ' — ' + (s.reason || 'no reason given'));
+  });
+  if (skippedTotal > skipped.length) {
+    lines.push('…and ' + (skippedTotal - skipped.length).toLocaleString() +
+      ' more skipped files not listed here (the counts above are exact).');
+  }
+  failed.forEach((f) => {
+    lines.push('Failed: ' + f.path + ' — ' + (f.error || 'no error given'));
+  });
+  if (failedTotal > failed.length) {
+    lines.push('…and ' + (failedTotal - failed.length).toLocaleString() +
+      ' more failed files not listed here (the counts above are exact).');
+  }
+  const list = document.getElementById('card-cleanup-result-list');
+  if (lines.length) {
+    list.style.display = '';
+    cardCleanupFillList('card-cleanup-result-list', lines);
+  } else {
+    list.style.display = 'none';
+    list.innerHTML = '';
+  }
+  // The manifest describes files that are now gone, so the preview above
+  // is history. Say so instead of leaving a live-looking Delete button.
+  document.getElementById('card-cleanup-delete-btn').disabled = true;
+  document.getElementById('card-cleanup-delete-hint').textContent =
+    'These numbers describe the scan that ran before this deletion — ' +
+    'scan again to see what is still on the card.';
+}
+
+async function cardCleanupCancelJob() {
+  const jobId = cardCleanupState.jobId;
+  if (!jobId) return;
+  const btn = document.getElementById('card-cleanup-cancel-btn');
+  btn.disabled = true;
+  btn.textContent = 'Cancelling…';
+  try {
+    const resp = await fetch(
+      '/api/jobs/' + encodeURIComponent(jobId) + '/cancel', { method: 'POST' });
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      btn.disabled = false;
+      btn.textContent = 'Cancel';
+      cardCleanupSetError(data.error || 'Unable to cancel the job.');
+    }
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = 'Cancel';
+    cardCleanupSetError(String(e.message || e));
+  }
+}
+
+async function loadVolumeSuggestions() {
+  try {
+    const resp = await fetch('/api/volumes');
+    if (!resp.ok) return;
+    const volumes = await resp.json();
+    const dl = document.getElementById('volumeDatalist');
+    (volumes || []).forEach((v) => {
+      const opt = document.createElement('option');
+      opt.value = v.path || v;
+      dl.appendChild(opt);
+    });
+  } catch (e) { /* suggestions only */ }
+}
+
+// The import page's result card links here with the finished import's card
+// path; multi-source imports pass the first one in ?source= and the rest
+// in ?others= so this page can name them instead of silently dropping them.
+function cardCleanupApplyQueryParams() {
+  const params = new URLSearchParams(window.location.search);
+  const source = (params.get('source') || '').trim();
+  if (source) document.getElementById('card-cleanup-source').value = source;
+  const others = params.getAll('others').filter(s => s && s.trim());
+  const note = document.getElementById('card-cleanup-source-note');
+  if (others.length) {
+    note.style.display = '';
+    note.textContent =
+      'That import used ' + (others.length + 1) +
+      ' source folders; this filled in the first one. Check the others one ' +
+      'at a time: ' + others.join(', ');
+  } else {
+    note.style.display = 'none';
+    note.textContent = '';
+  }
+}
+
+cardCleanupApplyQueryParams();
+loadVolumeSuggestions();
+</script>
+</body>
+</html>

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -16,7 +16,6 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .card-cleanup-wrap { max-width: 760px; margin: 0 auto; display: flex; flex-direction: column; gap: 16px; }
 .page-title { font-size: 20px; color: var(--text-primary); }
 .card { background: var(--bg-secondary); border: 1px solid var(--border-primary); border-radius: 8px; padding: 16px; }
-.card h3 { margin: 0 0 10px 0; font-size: 14px; color: var(--text-primary); }
 .row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; flex-wrap: wrap; }
 .row label { font-size: 12px; color: var(--text-secondary); }
 .row input[type=text] {
@@ -257,7 +256,46 @@ const cardCleanupState = {
   manifest: null,
   listsRendered: {},    // bucket -> true once its <li>s are in the DOM
   confirmEscHandler: null,
+  busyRestore: null,    // delete button/hint state saved while a job runs
 };
+
+/* Exactly one job at a time. Starting a second one while this page is
+   watching a job would close the first job's stream and overwrite
+   `jobId`, so that job's completion handler would never run: the finished
+   run would be orphaned from the page (blank status, stuck buttons) while
+   it kept going on the server. Rather than let a click do that silently,
+   the three start buttons are disabled for the duration of any run — and
+   the Delete button, being the destructive one, says why. */
+function cardCleanupSetBusy(running, opts) {
+  const scanBtn = document.getElementById('card-cleanup-scan-btn');
+  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
+  const auditBtn = document.getElementById('card-cleanup-audit-btn');
+  const deleteHint = document.getElementById('card-cleanup-delete-hint');
+  if (running) {
+    // Whether Delete may be pressed depends on the manifest (and on
+    // whether a deletion already ran), so restore what was there rather
+    // than recomputing it.
+    if (cardCleanupState.busyRestore === null) {
+      cardCleanupState.busyRestore = {
+        deleteDisabled: deleteBtn.disabled,
+        deleteHint: deleteHint.textContent,
+      };
+    }
+    scanBtn.disabled = true;
+    auditBtn.disabled = true;
+    deleteBtn.disabled = true;
+    if (opts && opts.deleteHint) deleteHint.textContent = opts.deleteHint;
+    return;
+  }
+  const restore = cardCleanupState.busyRestore;
+  cardCleanupState.busyRestore = null;
+  scanBtn.disabled = false;
+  auditBtn.disabled = false;
+  if (restore) {
+    deleteBtn.disabled = restore.deleteDisabled;
+    deleteHint.textContent = restore.deleteHint;
+  }
+}
 
 // The manifest reason that this page's audit callout answers. Mirrors
 // card_cleanup.KEEP_NOT_VERIFIED — matched on the distinctive tail so a
@@ -472,8 +510,7 @@ async function cardCleanupStartScan() {
   cardCleanupSetError('');
   cardCleanupResetPreview();
   document.getElementById('card-cleanup-result').style.display = 'none';
-  const scanBtn = document.getElementById('card-cleanup-scan-btn');
-  scanBtn.disabled = true;
+  cardCleanupSetBusy(true);
   try {
     const resp = await fetch('/api/card-cleanup/scan', {
       method: 'POST',
@@ -487,7 +524,7 @@ async function cardCleanupStartScan() {
     cardCleanupState.scanJobId = data.job_id;
     cardCleanupWatchJob(data.job_id, 'scan', 'Starting scan…');
   } catch (e) {
-    scanBtn.disabled = false;
+    cardCleanupSetBusy(false);
     cardCleanupSetError(String(e.message || e));
   }
 }
@@ -573,7 +610,9 @@ async function cardCleanupFinishJob(jobId, kind) {
   cardCleanupState.jobId = null;
   document.getElementById('card-cleanup-cancel-btn').style.display = 'none';
   document.getElementById('card-cleanup-progress').style.display = 'none';
-  document.getElementById('card-cleanup-scan-btn').disabled = false;
+  // Buttons come back first; the per-kind branches below then overwrite
+  // the Delete button and its hint with what this run's outcome means.
+  cardCleanupSetBusy(false);
   const status = job && job.status;
   const jobError = job && (job.errors || [])[0];
   if (kind === 'scan') {
@@ -730,8 +769,13 @@ function cardCleanupRenderAuditCallout(manifest) {
 
 async function cardCleanupStartAudit() {
   if (cardCleanupState.jobId) return;  // a run is already streaming
-  const btn = document.getElementById('card-cleanup-audit-btn');
-  btn.disabled = true;
+  // Verification changes what counts as verified, so the preview's Delete
+  // button describes a state that is being rewritten underneath it. Say
+  // that where the Delete button is, not only up here.
+  cardCleanupSetBusy(true, {
+    deleteHint: 'Verification is running — deletion is available when it ' +
+      'finishes.',
+  });
   document.getElementById('card-cleanup-audit-rescan-btn').style.display = 'none';
   document.getElementById('card-cleanup-audit-status').textContent = '';
   cardCleanupSetError('');
@@ -745,15 +789,16 @@ async function cardCleanupStartAudit() {
     if (!resp.ok) throw new Error(data.error || 'verification failed to start');
     cardCleanupWatchJob(data.job_id, 'audit', 'Starting hash verification…');
   } catch (e) {
-    btn.disabled = false;
+    // Nothing started, so nothing is running: give the buttons back.
+    cardCleanupSetBusy(false);
     cardCleanupSetError(String(e.message || e));
   }
 }
 
+// The buttons are already re-enabled by cardCleanupSetBusy(false) in
+// cardCleanupFinishJob's cleanup; this only reports what the run found.
 function cardCleanupFinishAudit(job, status, jobError) {
-  const btn = document.getElementById('card-cleanup-audit-btn');
   const statusEl = document.getElementById('card-cleanup-audit-status');
-  btn.disabled = false;
   if (status === 'completed' && job && job.result) {
     const r = job.result;
     const problems = (r.modified || 0) + (r.corrupt || 0) + (r.unreadable || 0);
@@ -852,6 +897,10 @@ function cardCleanupResetPreview() {
 }
 
 function cardCleanupOpenConfirm() {
+  // Defence in depth: cardCleanupSetBusy already disables this button
+  // while a scan, deletion, or verification is running, and starting a
+  // deletion on top of one of those would strand the running job.
+  if (cardCleanupState.jobId) return;
   const manifest = cardCleanupState.manifest;
   if (!manifest) return;
   const deletable = (manifest.totals || {}).deletable || { count: 0, bytes: 0 };
@@ -887,6 +936,15 @@ function cardCleanupCloseConfirm() {
 }
 
 async function cardCleanupConfirmDelete() {
+  // A job that started while this dialog was open (or one the page picked
+  // up again) must not be replaced by the delete watch below — say so
+  // instead of quietly doing nothing or stranding it.
+  if (cardCleanupState.jobId) {
+    cardCleanupCloseConfirm();
+    cardCleanupSetError('Another job is still running — nothing was ' +
+      'deleted. Wait for it to finish, then delete.');
+    return;
+  }
   const confirmBtn = document.getElementById('card-cleanup-confirm-btn');
   confirmBtn.disabled = true;
   try {
@@ -911,8 +969,7 @@ async function cardCleanupConfirmDelete() {
     }
     cardCleanupSetError('');
     document.getElementById('card-cleanup-result').style.display = 'none';
-    document.getElementById('card-cleanup-delete-btn').disabled = true;
-    document.getElementById('card-cleanup-scan-btn').disabled = true;
+    cardCleanupSetBusy(true);
     cardCleanupWatchJob(data.job_id, 'delete', 'Starting deletion…');
   } catch (e) {
     cardCleanupCloseConfirm();

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -686,10 +686,22 @@ async function cardCleanupFinishJob(jobId, kind) {
 }
 
 async function cardCleanupLoadManifest() {
+  // Codex P2 (commit 16a3f8e4): capture the scan we are loading FOR so a
+  // response that arrives after a second scan has taken ownership of
+  // scanJobId cannot render scan #1's manifest over scan #2's state.
+  // Without this guard, cardCleanupFinishJob unlocks the buttons before
+  // awaiting the manifest; a user who changes the source and starts
+  // scan #2 during that await would see scan #1's totals/source rendered
+  // by the late response and the confirmation dialog would advertise a
+  // set the delete POST (which uses the current scanJobId) would not
+  // actually operate on. It would also clobber the 404-clears-scanJobId
+  // path and the error message.
+  const requestedScanJobId = cardCleanupState.scanJobId;
   try {
     const resp = await fetch('/api/card-cleanup/' +
-      encodeURIComponent(cardCleanupState.scanJobId) + '/manifest');
+      encodeURIComponent(requestedScanJobId) + '/manifest');
     const data = await resp.json();
+    if (cardCleanupState.scanJobId !== requestedScanJobId) return;
     if (resp.status === 404) {
       cardCleanupState.scanJobId = null;
       cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
@@ -698,6 +710,7 @@ async function cardCleanupLoadManifest() {
     if (!resp.ok) throw new Error(data.error || 'the preview could not be loaded');
     cardCleanupRenderManifest(data);
   } catch (e) {
+    if (cardCleanupState.scanJobId !== requestedScanJobId) return;
     cardCleanupSetError(String(e.message || e));
   }
 }

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -606,25 +606,39 @@ async function cardCleanupFinishJob(jobId, kind) {
   // that has stopped moving.
   document.getElementById('card-cleanup-phase').textContent =
     'Checking job status…';
-  for (let i = 0; i < 30; i++) {
+  // Poll until the job actually reaches a terminal state (CodeRabbit
+  // review): a transient stream drop used to fall into a 30-second poll
+  // that then gave up — re-enabling the buttons while the job kept
+  // running on the server, exactly the orphaning the busy discipline
+  // exists to prevent. Scans and audits here legitimately run for many
+  // minutes, so poll indefinitely — 1s for the first 30 attempts, then
+  // 10s — and stop only on a terminal status or when the server says it
+  // no longer knows the job (a restart pruned it: several consecutive
+  // 404s), which gets the honest lost-track copy below.
+  let notFound = 0;
+  for (let i = 0; ; i++) {
     // A poll that throws (server restarting, network dropped — the very
     // conditions that killed the stream) must not escape as an unhandled
     // rejection: that would skip the cleanup below and leave a frozen bar,
     // a live Cancel button pointing at a stale job, and a disabled Scan
-    // button until reload. Treat it as one failed attempt and keep going
-    // toward the timeout path.
+    // button until reload. Treat it as one failed attempt and keep going.
     try {
       const resp = await fetch('/api/jobs/' + encodeURIComponent(jobId));
       if (resp.ok) {
+        notFound = 0;
         const polled = await resp.json();
         if (polled.status && polled.status !== 'running'
             && polled.status !== 'queued') {
           job = polled;
           break;
         }
+        if (polled.progress) cardCleanupRenderProgress(polled.progress);
+      } else if (resp.status === 404) {
+        notFound += 1;
+        if (notFound >= 3) break;
       }
     } catch (e) { /* retry below */ }
-    await new Promise(r => setTimeout(r, 1000));
+    await new Promise(r => setTimeout(r, i < 30 ? 1000 : 10000));
   }
   cardCleanupState.jobId = null;
   document.getElementById('card-cleanup-cancel-btn').style.display = 'none';

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -224,26 +224,6 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .advanced-import { margin-top: 10px; font-size: 12px; color: var(--text-secondary); }
 .advanced-import summary { cursor: pointer; }
 .metadata-repair { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border-primary); }
-/* Free up card space. The section is a <details class="card">, so its
-   summary has to carry the same weight as the other cards' <h3>. */
-#card-cleanup-section > summary {
-  cursor: pointer; font-size: 14px; font-weight: 600; color: var(--text-primary);
-}
-#card-cleanup-section[open] > summary { margin-bottom: 10px; }
-.card-cleanup-bucket { margin-top: 6px; }
-.card-cleanup-bucket > summary { cursor: pointer; font-size: 12px; color: var(--text-primary); }
-/* Same callout shape as .managed-archive-callout, in warning colours: an
-   incomplete preview must not read as a quiet footnote. */
-.card-cleanup-warning {
-  font-size: 12px; color: var(--text-primary); margin: 8px 0;
-  padding: 8px 10px; border-radius: 6px; overflow-wrap: anywhere;
-  background: color-mix(in srgb, var(--warning, #bf8700) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--warning, #bf8700) 45%, transparent);
-}
-/* Taller than .staging-details: these lists run to thousands of files. */
-#card-cleanup-section .staging-details { max-height: 220px; }
-.card-cleanup-confirm-list { margin: 0; padding-left: 18px; font-size: 13px; color: var(--text-primary); }
-.card-cleanup-confirm-list li { margin-bottom: 10px; overflow-wrap: anywhere; }
 </style>
 </head>
 <body>
@@ -499,10 +479,11 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div class="row">
         <span class="pill" id="safeToFormatPill"></span>
         <!-- Shown by renderResult() only for copy imports that have a card
-             path to hand to the scanner. -->
+             path to hand to the scanner. Opens the Card cleanup page with
+             this import's card folder pre-filled. -->
         <button class="btn" type="button" id="btnFreeUpCardSpace"
                 style="display:none;"
-                onclick="cardCleanupOpenFromImport()">Free up card space…</button>
+                onclick="openCardCleanupPage()">Free up card space…</button>
       </div>
       <ul class="unsafe-list" id="unsafeList" style="display:none;"></ul>
       <div id="resultSummary" class="hint" style="margin-top:6px;"></div>
@@ -519,72 +500,6 @@ body { display: flex; flex-direction: column; height: 100vh; }
         <a href="/browse">Open Browse</a> &nbsp;·&nbsp; <a href="/jobs">Open Jobs</a>
       </div>
     </div>
-
-    <!-- Free up card space: deletes card files ONLY where the same bytes
-         are already verified in the archive. Collapsed by default; the
-         result card's "Free up card space…" button opens it and pre-fills
-         the source with the import's card path. -->
-    <details class="card" id="card-cleanup-section">
-      <summary>Free up card space</summary>
-      <div class="hint">
-        Checks a memory card against the archive and deletes only the files
-        whose archive copy is verified. Everything else stays on the card.
-      </div>
-      <div class="row" id="card-cleanup-picker-row" style="margin-top:10px;">
-        <button class="btn btn-primary" type="button" id="card-cleanup-browse-btn"
-                data-testid="card-cleanup-browse-btn"
-                onclick="cardCleanupBrowse()">Browse...</button>
-        <input type="text" id="card-cleanup-source" list="volumeDatalist"
-               aria-label="Card folder to check"
-               placeholder="or type a card/folder path">
-      </div>
-      <div class="hint" id="card-cleanup-source-note" style="display:none;"></div>
-      <div class="row">
-        <label><input type="checkbox" id="card-cleanup-recursive" checked> Include subfolders</label>
-      </div>
-      <div class="row">
-        <button class="btn btn-primary" type="button" id="card-cleanup-scan-btn"
-                onclick="cardCleanupStartScan()">Scan card</button>
-        <button class="btn" type="button" id="card-cleanup-cancel-btn"
-                style="display:none;" onclick="cardCleanupCancelJob()">Cancel</button>
-      </div>
-      <div class="field-error" id="card-cleanup-error" role="alert" aria-live="assertive"></div>
-      <div id="card-cleanup-progress" style="display:none;">
-        <div class="row"><span class="hint" id="card-cleanup-phase"></span></div>
-        <div class="progress-bar"><div id="card-cleanup-progress-fill"></div></div>
-      </div>
-      <div id="card-cleanup-preview" style="display:none;">
-        <div class="card-cleanup-warning" id="card-cleanup-incomplete" style="display:none;">
-          <div id="card-cleanup-incomplete-text"></div>
-          <details class="card-cleanup-bucket" id="card-cleanup-walk-errors-details">
-            <summary id="card-cleanup-walk-errors-summary"></summary>
-            <ul class="staging-details" id="card-cleanup-walk-errors"></ul>
-          </details>
-        </div>
-        <div class="hint" id="card-cleanup-scanned-root" style="margin-bottom:6px;"></div>
-        <details class="card-cleanup-bucket" id="card-cleanup-deletable-details">
-          <summary id="card-cleanup-deletable-summary"></summary>
-          <ul class="staging-details" id="card-cleanup-deletable-list"></ul>
-        </details>
-        <details class="card-cleanup-bucket" id="card-cleanup-kept-details">
-          <summary id="card-cleanup-kept-summary"></summary>
-          <ul class="staging-details" id="card-cleanup-kept-list"></ul>
-        </details>
-        <details class="card-cleanup-bucket" id="card-cleanup-ignored-details">
-          <summary id="card-cleanup-ignored-summary"></summary>
-          <ul class="staging-details" id="card-cleanup-ignored-list"></ul>
-        </details>
-        <div class="row" style="margin-top:12px;">
-          <button class="btn btn-primary" type="button" id="card-cleanup-delete-btn"
-                  disabled onclick="cardCleanupOpenConfirm()">Delete verified files</button>
-          <span class="hint" id="card-cleanup-delete-hint"></span>
-        </div>
-      </div>
-      <div id="card-cleanup-result" style="display:none;">
-        <div class="hint" id="card-cleanup-result-summary" style="margin-top:10px;"></div>
-        <ul class="staging-details" id="card-cleanup-result-list" style="display:none;"></ul>
-      </div>
-    </details>
 
   </div>
 </div>
@@ -612,33 +527,6 @@ body { display: flex; flex-direction: column; height: 100vh; }
   </div>
 </div>
 
-<!-- Delete confirmation. Reuses the folder browser's overlay/panel classes:
-     they are this page's only modal chrome, named after their first user. -->
-<div class="folder-browser-overlay" id="card-cleanup-confirm"
-     data-testid="card-cleanup-confirm">
-  <div class="folder-browser-panel" role="dialog" aria-modal="true"
-       aria-labelledby="card-cleanup-confirm-title">
-    <div class="folder-browser-header">
-      <h3 id="card-cleanup-confirm-title">Delete verified files from the card?</h3>
-      <button class="folder-browser-close" type="button"
-              onclick="cardCleanupCloseConfirm()">&times;</button>
-    </div>
-    <div class="folder-browser-body">
-      <div id="card-cleanup-confirm-count" class="folder-browser-path"></div>
-      <ul class="card-cleanup-confirm-list">
-        <li>Deletion is permanent — memory cards have no trash.</li>
-        <li>After deletion, the archive holds the only copy of these photos.</li>
-        <li>What "verified" means: each file's archive copy passed a checksum check (at import or integrity audit) and is confirmed unchanged since by size and timestamp; the card copy itself is re-checksummed at the moment of deletion. Archive bytes are not re-downloaded.</li>
-      </ul>
-    </div>
-    <div class="folder-browser-actions">
-      <button class="btn" type="button" onclick="cardCleanupCloseConfirm()">Cancel</button>
-      <button class="btn btn-primary" type="button" id="card-cleanup-confirm-btn"
-              onclick="cardCleanupConfirmDelete()">Delete verified files</button>
-    </div>
-  </div>
-</div>
-
 <script>
 /* Import page: adds folders in place or copies them to an archive, renders
    live progress from the job's SSE stream, and only shows safe-to-format
@@ -646,6 +534,9 @@ body { display: flex; flex-direction: column; height: 100vh; }
 let sources = [];
 let activeJobId = null;
 let es = null;
+// Card folders the finished import copied from — handed to the Card
+// cleanup page by the result card's "Free up card space…" button.
+let cardCleanupImportSources = [];
 let stagingResultsByPath = {};
 let sourceCounts = {};
 let sourceCountRequestSeq = 0;
@@ -1517,20 +1408,11 @@ async function browseForDestination() {
   openImportFolderBrowser('destination');
 }
 
-// Modes: 'source' (multi-select, photo counts), 'destination' and
-// 'card-cleanup' (both single-select — every `=== 'source'` branch below
-// is the multi-select path, so card-cleanup follows destination's).
 function openImportFolderBrowser(mode, opts = {}) {
-  browserMode = (mode === 'destination' || mode === 'card-cleanup')
-    ? mode : 'source';
+  browserMode = mode === 'destination' ? 'destination' : 'source';
   const overlay = document.getElementById('importFolderBrowser');
-  const titles = {
-    source: 'Select Source Folders',
-    destination: 'Select Destination Folder',
-    'card-cleanup': 'Select Card Folder',
-  };
   document.getElementById('folderBrowserTitle').textContent =
-    titles[browserMode];
+    browserMode === 'source' ? 'Select Source Folders' : 'Select Destination Folder';
   browserSelectedPaths = [];
   browserSelectAnchorPath = '';
   updateImportBrowserSelection();
@@ -1546,12 +1428,9 @@ function openImportFolderBrowser(mode, opts = {}) {
   document.body.style.overflow = 'hidden';
   const firstAction = overlay.querySelector('button');
   if (firstAction) firstAction.focus();
-  let startPath = '';
-  if (browserMode === 'destination') {
-    startPath = (document.getElementById('destInput').value || '').trim();
-  } else if (browserMode === 'card-cleanup') {
-    startPath = (document.getElementById('card-cleanup-source').value || '').trim();
-  }
+  const startPath = browserMode === 'destination'
+    ? (document.getElementById('destInput').value || '').trim()
+    : '';
   if (!opts.skipInitialBrowse) browseImportFolderTo(startPath || null);
 }
 
@@ -1665,7 +1544,7 @@ function renderImportFolderBrowser(data, opts) {
   list.onclick = (e) => {
     const item = e.target.closest('.folder-browser-item[data-browse-path]');
     if (!item) return;
-    if (item.getAttribute('data-parent-link') === '1' || browserMode !== 'source') {
+    if (item.getAttribute('data-parent-link') === '1' || browserMode === 'destination') {
       browseImportFolderTo(item.getAttribute('data-browse-path'));
       return;
     }
@@ -1797,12 +1676,6 @@ function updateImportBrowserSelection() {
 }
 
 function selectImportBrowserFolder() {
-  if (browserMode === 'card-cleanup') {
-    if (!browserPath) return;
-    document.getElementById('card-cleanup-source').value = browserPath;
-    closeImportFolderBrowser();
-    return;
-  }
   if (browserMode === 'destination') {
     if (!browserPath) return;
     const destination = document.getElementById('destInput');
@@ -4240,7 +4113,7 @@ function renderResult(res, status) {
     }
   }
   // Copy imports leave a second copy on the card, so offer the cleanup
-  // section here — including (especially) when the card is NOT safe to
+  // page here — including (especially) when the card is NOT safe to
   // format, where deleting only the verified subset is the point. The
   // finished job's config carries the card paths the user picked.
   const importedSources = (((lastFinishedImportJob || {}).config || {}).sources
@@ -4606,524 +4479,19 @@ async function initImportPage() {
     browseForSource();
   }
 }
-/* ---------- Free up card space ----------
-   Deletes card files only where the archive copy is verified. Every count
-   and byte total shown here is read straight out of the scan manifest —
-   this section never estimates, and it marks the preview incomplete
-   whenever the card walk hit a folder it could not read. */
-const cardCleanupState = {
-  scanJobId: null,      // manifest key of the last scan we started
-  jobId: null,          // job currently streaming (scan or delete)
-  finishedJobId: null,  // guards the double 'complete' + 'error' callback
-  es: null,             // this section's stream; never the page's `es`
-  manifest: null,
-  listsRendered: {},    // bucket -> true once its <li>s are in the DOM
-  confirmEscHandler: null,
-};
-let cardCleanupImportSources = [];
 
-function cardCleanupFileCount(n) {
-  const count = Number(n || 0);
-  return count.toLocaleString() + (count === 1 ? ' file' : ' files');
-}
-
-function cardCleanupSetError(msg, opts) {
-  const el = document.getElementById('card-cleanup-error');
-  el.textContent = '';
-  el.classList.toggle('visible', !!msg);
-  if (!msg) return;
-  el.append(msg);
-  if (opts && opts.rescan) {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'retry-link';
-    btn.textContent = 'Re-scan';
-    btn.addEventListener('click', () => cardCleanupStartScan());
-    el.append(' ', btn);
-  }
-}
-
-async function cardCleanupBrowse() {
-  // Same shape as browseForSource()/browseForDestination(): native picker
-  // when the desktop shell offers one, in-page browser otherwise.
-  if (typeof pickDirectory === 'function') {
-    const seqBeforePicker = browserSeq;
-    const result = await pickDirectory('Select the card folder');
-    if (result) {
-      const path = Array.isArray(result) ? result[0] : result;
-      if (path) document.getElementById('card-cleanup-source').value = path;
-      return;
-    }
-    if (typeof isTauri === 'function' && isTauri()) return;
-    if (browserSeq !== seqBeforePicker) {
-      openImportFolderBrowser('card-cleanup', { skipInitialBrowse: true });
-      return;
-    }
-  }
-  openImportFolderBrowser('card-cleanup');
-}
-
-// Entry point from the card-safety pill: open the section pre-filled with
-// the finished import's source folder.
-function cardCleanupOpenFromImport() {
-  const section = document.getElementById('card-cleanup-section');
-  section.open = true;
-  const input = document.getElementById('card-cleanup-source');
-  const note = document.getElementById('card-cleanup-source-note');
+// Entry point from the card-safety pill. The cleanup flow lives on its own
+// page (/card-cleanup); hand it this import's card folder so the user does
+// not have to find it again. Multi-source imports send the first folder as
+// `source` and the rest as `others`, which that page names in its hint.
+function openCardCleanupPage() {
+  const params = new URLSearchParams();
   if (cardCleanupImportSources.length) {
-    input.value = cardCleanupImportSources[0];
-    document.getElementById('card-cleanup-recursive').checked = true;
-    cardCleanupResetPreview();
-    cardCleanupSetError('');
-    document.getElementById('card-cleanup-result').style.display = 'none';
+    params.set('source', cardCleanupImportSources[0]);
+    cardCleanupImportSources.slice(1).forEach((s) => params.append('others', s));
   }
-  if (cardCleanupImportSources.length > 1) {
-    note.style.display = '';
-    note.textContent =
-      'That import used ' + cardCleanupImportSources.length +
-      ' source folders; this filled in the first one. Check the others one ' +
-      'at a time: ' + cardCleanupImportSources.slice(1).join(', ');
-  } else {
-    note.style.display = 'none';
-    note.textContent = '';
-  }
-  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  input.focus({ preventScroll: true });
-}
-
-async function cardCleanupStartScan() {
-  if (cardCleanupState.jobId) return;  // a run is already streaming
-  const source = (document.getElementById('card-cleanup-source').value || '').trim();
-  const recursive = document.getElementById('card-cleanup-recursive').checked;
-  if (!source) {
-    cardCleanupSetError('Choose the card folder to check.');
-    return;
-  }
-  cardCleanupSetError('');
-  cardCleanupResetPreview();
-  document.getElementById('card-cleanup-result').style.display = 'none';
-  const scanBtn = document.getElementById('card-cleanup-scan-btn');
-  scanBtn.disabled = true;
-  try {
-    const resp = await fetch('/api/card-cleanup/scan', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ source, recursive }),
-    });
-    const data = await resp.json();
-    // The 400s here are written for the user (archive overlap, unreadable
-    // path) — show the server's own words rather than a generic failure.
-    if (!resp.ok) throw new Error(data.error || 'scan failed to start');
-    cardCleanupState.scanJobId = data.job_id;
-    cardCleanupWatchJob(data.job_id, 'scan', 'Starting scan…');
-  } catch (e) {
-    scanBtn.disabled = false;
-    cardCleanupSetError(String(e.message || e));
-  }
-}
-
-function cardCleanupWatchJob(jobId, kind, startingPhase) {
-  cardCleanupState.jobId = jobId;
-  cardCleanupState.finishedJobId = null;
-  document.getElementById('card-cleanup-progress').style.display = '';
-  document.getElementById('card-cleanup-phase').textContent = startingPhase;
-  document.getElementById('card-cleanup-progress-fill').style.width = '0%';
-  const cancelBtn = document.getElementById('card-cleanup-cancel-btn');
-  cancelBtn.style.display = '';
-  cancelBtn.disabled = false;
-  cancelBtn.textContent = 'Cancel';
-  if (cardCleanupState.es) { cardCleanupState.es.close(); cardCleanupState.es = null; }
-  cardCleanupState.es =
-    new EventSource('/api/jobs/' + encodeURIComponent(jobId) + '/stream');
-  cardCleanupState.es.addEventListener('progress', (evt) => {
-    try { cardCleanupRenderProgress(JSON.parse(evt.data)); } catch (e) { /* ignore */ }
-  });
-  cardCleanupState.es.addEventListener('complete', () => {
-    cardCleanupCloseStream();
-    cardCleanupFinishJob(jobId, kind);
-  });
-  cardCleanupState.es.addEventListener('error', () => {
-    // Stream dropped (server restart, network) — fall back to polling the
-    // job rather than pretending progress continues. Same as watchJob().
-    cardCleanupCloseStream();
-    cardCleanupFinishJob(jobId, kind);
-  });
-}
-
-function cardCleanupCloseStream() {
-  if (cardCleanupState.es) {
-    cardCleanupState.es.close();
-    cardCleanupState.es = null;
-  }
-}
-
-function cardCleanupRenderProgress(data) {
-  const parts = [];
-  if (data.phase) parts.push(data.phase);
-  if (data.total) {
-    parts.push(Number(data.current || 0).toLocaleString() + ' / ' +
-      Number(data.total).toLocaleString());
-  }
-  if (data.current_file) parts.push(data.current_file);
-  document.getElementById('card-cleanup-phase').textContent = parts.join(' · ');
-  const pct = data.total ? Math.round(100 * data.current / data.total) : 0;
-  document.getElementById('card-cleanup-progress-fill').style.width = pct + '%';
-}
-
-async function cardCleanupFinishJob(jobId, kind) {
-  // 'complete' and 'error' can both fire for one job; only finish once.
-  if (cardCleanupState.finishedJobId === jobId) return;
-  cardCleanupState.finishedJobId = jobId;
-  let job = null;
-  // The stream is already gone by the time we poll, so say what the page
-  // is actually doing instead of leaving the last SSE line under a bar
-  // that has stopped moving.
-  document.getElementById('card-cleanup-phase').textContent =
-    'Checking job status…';
-  for (let i = 0; i < 30; i++) {
-    // A poll that throws (server restarting, network dropped — the very
-    // conditions that killed the stream) must not escape as an unhandled
-    // rejection: that would skip the cleanup below and leave a frozen bar,
-    // a live Cancel button pointing at a stale job, and a disabled Scan
-    // button until reload. Treat it as one failed attempt and keep going
-    // toward the timeout path.
-    try {
-      const resp = await fetch('/api/jobs/' + encodeURIComponent(jobId));
-      if (resp.ok) {
-        const polled = await resp.json();
-        if (polled.status && polled.status !== 'running'
-            && polled.status !== 'queued') {
-          job = polled;
-          break;
-        }
-      }
-    } catch (e) { /* retry below */ }
-    await new Promise(r => setTimeout(r, 1000));
-  }
-  cardCleanupState.jobId = null;
-  document.getElementById('card-cleanup-cancel-btn').style.display = 'none';
-  document.getElementById('card-cleanup-progress').style.display = 'none';
-  document.getElementById('card-cleanup-scan-btn').disabled = false;
-  const status = job && job.status;
-  const jobError = job && (job.errors || [])[0];
-  if (kind === 'scan') {
-    if (status === 'completed') {
-      await cardCleanupLoadManifest();
-    } else if (status === 'cancelled') {
-      cardCleanupSetError(
-        'Scan cancelled — no files were checked against the archive, and ' +
-        'nothing was deleted. Scan again when you are ready.');
-    } else if (status) {
-      cardCleanupSetError('Scan ' + status + ' — no preview was produced' +
-        (jobError ? ': ' + jobError : '.'));
-    } else {
-      cardCleanupSetError(
-        'The scan is still running but this page lost track of it — ' +
-        'check the Jobs page.');
-    }
-    return;
-  }
-  // Delete: the per-file outcome lives in the job result, so a job that
-  // ended without one has to say so rather than imply a clean run.
-  if (job && job.result) {
-    cardCleanupRenderDeleteResult(job.result);
-  } else if (status) {
-    cardCleanupSetError('Deletion ' + status +
-      ' and its summary could not be loaded' +
-      (jobError ? ': ' + jobError : '') + ' — check the Jobs page for what ' +
-      'was deleted, then re-scan the card.');
-  } else {
-    cardCleanupSetError(
-      'The deletion is still running but this page lost track of it — ' +
-      'check the Jobs page.');
-  }
-}
-
-async function cardCleanupLoadManifest() {
-  try {
-    const resp = await fetch('/api/card-cleanup/' +
-      encodeURIComponent(cardCleanupState.scanJobId) + '/manifest');
-    const data = await resp.json();
-    if (resp.status === 404) {
-      cardCleanupState.scanJobId = null;
-      cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
-      return;
-    }
-    if (!resp.ok) throw new Error(data.error || 'the preview could not be loaded');
-    cardCleanupRenderManifest(data);
-  } catch (e) {
-    cardCleanupSetError(String(e.message || e));
-  }
-}
-
-function cardCleanupRenderManifest(manifest) {
-  cardCleanupState.manifest = manifest;
-  cardCleanupState.listsRendered = {};
-  const totals = manifest.totals || {};
-  const deletable = totals.deletable || { count: 0, bytes: 0 };
-  const kept = totals.kept || { count: 0, bytes: 0 };
-  const ignored = totals.ignored || { count: 0 };
-  const walkErrors = (manifest.walk_errors || []).map(String);
-
-  // Unmissable and above the numbers: a walk that skipped folders means
-  // the counts below are a floor, not the whole card.
-  const incomplete = document.getElementById('card-cleanup-incomplete');
-  if (walkErrors.length) {
-    incomplete.style.display = '';
-    document.getElementById('card-cleanup-incomplete-text').textContent =
-      'Some folders could not be read; this preview is incomplete. Files ' +
-      'that were not seen will never be deleted.';
-    document.getElementById('card-cleanup-walk-errors-summary').textContent =
-      walkErrors.length.toLocaleString() + ' folder ' +
-      (walkErrors.length === 1 ? 'error' : 'errors');
-    cardCleanupFillList('card-cleanup-walk-errors', walkErrors);
-  } else {
-    incomplete.style.display = 'none';
-  }
-
-  document.getElementById('card-cleanup-scanned-root').textContent =
-    'Checked ' + (manifest.source_root || '') +
-    (manifest.recursive
-      ? ' and its subfolders'
-      : ' only (subfolders were not included)');
-
-  document.getElementById('card-cleanup-deletable-summary').textContent =
-    cardCleanupFileCount(deletable.count) + ' / ' +
-    formatBytes(deletable.bytes) +
-    ' verified in the archive — safe to delete';
-  document.getElementById('card-cleanup-kept-summary').textContent =
-    cardCleanupFileCount(kept.count) + ' / ' + formatBytes(kept.bytes) +
-    ' not verified — will be kept';
-  document.getElementById('card-cleanup-ignored-summary').textContent =
-    cardCleanupFileCount(ignored.count) +
-    ' ignored (not photo files Vireo imports)';
-
-  cardCleanupBindBucket('deletable', 'card-cleanup-deletable-details',
-    'card-cleanup-deletable-list');
-  cardCleanupBindBucket('kept', 'card-cleanup-kept-details',
-    'card-cleanup-kept-list');
-  cardCleanupBindBucket('ignored', 'card-cleanup-ignored-details',
-    'card-cleanup-ignored-list');
-
-  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
-  deleteBtn.disabled = deletable.count === 0;
-  document.getElementById('card-cleanup-delete-hint').textContent =
-    deletable.count === 0
-      ? 'Nothing on this card is verified in the archive, so there is ' +
-        'nothing safe to delete.'
-      : 'Deletes the ' + cardCleanupFileCount(deletable.count) +
-        ' listed as verified above, and nothing else.';
-  document.getElementById('card-cleanup-preview').style.display = '';
-}
-
-// Bucket lists run to thousands of rows, so build them the first time the
-// user opens that group rather than on every scan.
-function cardCleanupBindBucket(bucket, detailsId, listId) {
-  const details = document.getElementById(detailsId);
-  details.open = false;
-  details.ontoggle = () => {
-    if (!details.open || cardCleanupState.listsRendered[bucket]) return;
-    if (!cardCleanupState.manifest) return;
-    cardCleanupState.listsRendered[bucket] = true;
-    // Spec ("UX flow"): verified rows show path, size, and the matched
-    // archive copy that justifies the deletion; kept rows show size and
-    // the per-file reason. All fields come straight from the manifest.
-    const lines = (cardCleanupState.manifest.entries || [])
-      .filter(entry => entry.bucket === bucket)
-      .map(entry => {
-        const size = (typeof entry.size === 'number')
-          ? ' (' + formatBytes(entry.size) + ')' : '';
-        if (bucket === 'kept') {
-          return entry.path + size + ' — ' + (entry.reason || 'not verified');
-        }
-        if (bucket === 'deletable') {
-          return entry.path + size
-            + ' → verified copy: ' + (entry.archive_path || 'unknown');
-        }
-        return entry.path;
-      });
-    cardCleanupFillList(listId, lines);
-  };
-}
-
-function cardCleanupFillList(listId, lines) {
-  const list = document.getElementById(listId);
-  list.innerHTML = '';
-  const frag = document.createDocumentFragment();
-  if (!lines.length) {
-    const li = document.createElement('li');
-    li.textContent = 'No files in this group.';
-    frag.appendChild(li);
-  }
-  lines.forEach((line) => {
-    const li = document.createElement('li');
-    li.textContent = line;
-    frag.appendChild(li);
-  });
-  list.appendChild(frag);
-}
-
-function cardCleanupResetPreview() {
-  cardCleanupState.manifest = null;
-  cardCleanupState.listsRendered = {};
-  document.getElementById('card-cleanup-preview').style.display = 'none';
-  document.getElementById('card-cleanup-incomplete').style.display = 'none';
-  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
-  deleteBtn.disabled = true;
-  document.getElementById('card-cleanup-delete-hint').textContent = '';
-  [
-    'card-cleanup-deletable-details', 'card-cleanup-kept-details',
-    'card-cleanup-ignored-details', 'card-cleanup-walk-errors-details',
-  ].forEach((id) => { document.getElementById(id).open = false; });
-}
-
-function cardCleanupOpenConfirm() {
-  const manifest = cardCleanupState.manifest;
-  if (!manifest) return;
-  const deletable = (manifest.totals || {}).deletable || { count: 0, bytes: 0 };
-  if (!deletable.count) return;
-  document.getElementById('card-cleanup-confirm-count').textContent =
-    'Deleting ' + cardCleanupFileCount(deletable.count) + ' (' +
-    formatBytes(deletable.bytes) + ') from ' +
-    (manifest.source_root || 'the card') + '.';
-  const overlay = document.getElementById('card-cleanup-confirm');
-  overlay.classList.add('open');
-  overlay.onclick = (e) => { if (e.target === overlay) cardCleanupCloseConfirm(); };
-  if (cardCleanupState.confirmEscHandler) {
-    document.removeEventListener('keydown', cardCleanupState.confirmEscHandler);
-  }
-  cardCleanupState.confirmEscHandler = (e) => {
-    if (e.key === 'Escape') cardCleanupCloseConfirm();
-  };
-  document.addEventListener('keydown', cardCleanupState.confirmEscHandler);
-  document.body.style.overflow = 'hidden';
-  // Focus the dialog's first control (the close button), not the delete
-  // button — a stray Enter must not delete anything.
-  const firstAction = overlay.querySelector('button');
-  if (firstAction) firstAction.focus();
-}
-
-function cardCleanupCloseConfirm() {
-  document.getElementById('card-cleanup-confirm').classList.remove('open');
-  if (cardCleanupState.confirmEscHandler) {
-    document.removeEventListener('keydown', cardCleanupState.confirmEscHandler);
-    cardCleanupState.confirmEscHandler = null;
-  }
-  document.body.style.overflow = '';
-}
-
-async function cardCleanupConfirmDelete() {
-  const confirmBtn = document.getElementById('card-cleanup-confirm-btn');
-  confirmBtn.disabled = true;
-  try {
-    const resp = await fetch('/api/card-cleanup/delete', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ scan_job_id: cardCleanupState.scanJobId }),
-    });
-    const data = await resp.json();
-    cardCleanupCloseConfirm();
-    if (!resp.ok) {
-      if (resp.status === 404) {
-        // The manifest is gone, so the preview above no longer describes
-        // anything that can be deleted — take it down with the error.
-        cardCleanupState.scanJobId = null;
-        cardCleanupResetPreview();
-        cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
-      } else {
-        cardCleanupSetError(data.error || 'deletion failed to start');
-      }
-      return;
-    }
-    cardCleanupSetError('');
-    document.getElementById('card-cleanup-result').style.display = 'none';
-    document.getElementById('card-cleanup-delete-btn').disabled = true;
-    document.getElementById('card-cleanup-scan-btn').disabled = true;
-    cardCleanupWatchJob(data.job_id, 'delete', 'Starting deletion…');
-  } catch (e) {
-    cardCleanupCloseConfirm();
-    cardCleanupSetError(String(e.message || e));
-  } finally {
-    confirmBtn.disabled = false;
-  }
-}
-
-function cardCleanupRenderDeleteResult(result) {
-  const res = result || {};
-  const skipped = res.skipped || [];
-  const failed = res.failed || [];
-  // The job result bounds these lists to a sample; *_total carries the
-  // exact count (falls back to list length for pre-trim results).
-  const skippedTotal = (typeof res.skipped_total === 'number')
-    ? res.skipped_total : skipped.length;
-  const failedTotal = (typeof res.failed_total === 'number')
-    ? res.failed_total : failed.length;
-  const parts = ['Deleted ' + cardCleanupFileCount(res.deleted) +
-    ' (' + formatBytes(res.deleted_bytes) + ')'];
-  if (skippedTotal) {
-    parts.push(skippedTotal.toLocaleString() + ' skipped');
-  }
-  if (failedTotal) {
-    parts.push(failedTotal.toLocaleString() + ' failed');
-  }
-  if (res.cancelled) {
-    parts.push('Cancelled — ' + Number(res.remaining || 0).toLocaleString() +
-      ' files not yet processed.');
-  }
-  document.getElementById('card-cleanup-result').style.display = '';
-  document.getElementById('card-cleanup-result-summary').textContent =
-    parts.join(' · ');
-  const lines = [];
-  skipped.forEach((s) => {
-    lines.push('Skipped: ' + s.path + ' — ' + (s.reason || 'no reason given'));
-  });
-  if (skippedTotal > skipped.length) {
-    lines.push('…and ' + (skippedTotal - skipped.length).toLocaleString() +
-      ' more skipped files not listed here (the counts above are exact).');
-  }
-  failed.forEach((f) => {
-    lines.push('Failed: ' + f.path + ' — ' + (f.error || 'no error given'));
-  });
-  if (failedTotal > failed.length) {
-    lines.push('…and ' + (failedTotal - failed.length).toLocaleString() +
-      ' more failed files not listed here (the counts above are exact).');
-  }
-  const list = document.getElementById('card-cleanup-result-list');
-  if (lines.length) {
-    list.style.display = '';
-    cardCleanupFillList('card-cleanup-result-list', lines);
-  } else {
-    list.style.display = 'none';
-    list.innerHTML = '';
-  }
-  // The manifest describes files that are now gone, so the preview above
-  // is history. Say so instead of leaving a live-looking Delete button.
-  document.getElementById('card-cleanup-delete-btn').disabled = true;
-  document.getElementById('card-cleanup-delete-hint').textContent =
-    'These numbers describe the scan that ran before this deletion — ' +
-    'scan again to see what is still on the card.';
-}
-
-async function cardCleanupCancelJob() {
-  const jobId = cardCleanupState.jobId;
-  if (!jobId) return;
-  const btn = document.getElementById('card-cleanup-cancel-btn');
-  btn.disabled = true;
-  btn.textContent = 'Cancelling…';
-  try {
-    const resp = await fetch(
-      '/api/jobs/' + encodeURIComponent(jobId) + '/cancel', { method: 'POST' });
-    if (!resp.ok) {
-      const data = await resp.json().catch(() => ({}));
-      btn.disabled = false;
-      btn.textContent = 'Cancel';
-      cardCleanupSetError(data.error || 'Unable to cancel the job.');
-    }
-  } catch (e) {
-    btn.disabled = false;
-    btn.textContent = 'Cancel';
-    cardCleanupSetError(String(e.message || e));
-  }
+  const qs = params.toString();
+  window.location.href = '/card-cleanup' + (qs ? '?' + qs : '');
 }
 
 initImportPage();

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -158,6 +158,7 @@ GET          /api/workspaces/active/subject-types
 GET          /audit
 GET          /best-batch
 GET          /browse
+GET          /card-cleanup
 GET          /compare
 GET          /config-defaults.js
 GET          /cull

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -359,11 +359,48 @@ def test_scan_null_hash_status_kept_with_audit_remedy(db, tmp_path):
     assert "integrity audit" in kept[0]["reason"]
 
 
-def test_scan_failed_hash_status_kept_with_audit_remedy(db, tmp_path):
+def test_scan_failed_hash_status_kept_but_not_audit_remedy(db, tmp_path):
     # hash_status is a non-ok STRING (a prior verify run flagged the file),
     # not NULL — must be kept exactly like the null/unverified case, not
-    # mistaken for "ok" by a truthy/None-only check.
-    _archive_photo(db, tmp_path, hash_status="failed")
+    # mistaken for "ok" by a truthy/None-only check. Distinct from the
+    # NULL case: re-running verification would just reproduce the same
+    # bad verdict, so the reason must NOT point at the integrity audit
+    # (Codex P2 review) — the callout keys off that phrase and would
+    # otherwise ask the user to re-verify a file it can't help.
+    _archive_photo(db, tmp_path, hash_status="modified")
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    kept = _entries(result, "kept")
+    assert len(kept) == 1
+    assert "integrity audit" not in kept[0]["reason"]
+    assert "failed" in kept[0]["reason"]
+    assert "Audit page" in kept[0]["reason"]
+
+
+@pytest.mark.parametrize("bad_status", ["modified", "corrupt", "unreadable"])
+def test_scan_specific_failed_hash_statuses_all_kept_with_failed_reason(
+        db, tmp_path, bad_status):
+    # All three real failed-verdict values from verify_hashes should route
+    # to KEEP_ARCHIVE_HASH_FAILED, not KEEP_NOT_VERIFIED — the audit page
+    # is the remedy for each, not another verify run.
+    _archive_photo(db, tmp_path, hash_status=bad_status)
+    _card_file(tmp_path)
+    result = _scan(db, tmp_path)
+    kept = _entries(result, "kept")
+    assert len(kept) == 1
+    assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_HASH_FAILED
+
+
+def test_scan_mixed_null_and_failed_prefers_audit_remedy(db, tmp_path):
+    # Two archive rows share a card file's hash — one never checked, one
+    # already flagged. The NULL row is remediable by a verify run (its
+    # verdict could turn "ok"), so the reason must stay on the audit
+    # remedy; a failed row alongside it must not silently downgrade the
+    # message to "see the Audit page" and lose the offer to verify.
+    _archive_photo(db, tmp_path, name="IMG_A.NEF", content=b"raw-one",
+                   hash_status=None, folder="archive/2026/a")
+    _archive_photo(db, tmp_path, name="IMG_B.NEF", content=b"raw-one",
+                   hash_status="modified", folder="archive/2026/b")
     _card_file(tmp_path)
     result = _scan(db, tmp_path)
     kept = _entries(result, "kept")

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -424,3 +424,19 @@ def test_audit_callout_reason_stays_in_sync(app_and_db):
     assert matched in card_cleanup.KEEP_NOT_VERIFIED
     body = app.test_client().get("/card-cleanup").get_data(as_text=True)
     assert f"CARD_CLEANUP_AUDIT_REASON = '{matched}'" in body
+
+
+def test_hash_failed_callout_reason_stays_in_sync(app_and_db):
+    """The hash-failed callout has the same shape of coupling as the
+    audit callout (Codex P2 review): the page filters kept entries by a
+    tail of KEEP_ARCHIVE_HASH_FAILED. Pin both ends so a reword on either
+    side stops silently. Also assert the two literals do NOT overlap —
+    if they did, a KEEP_ARCHIVE_HASH_FAILED entry would count toward the
+    audit callout and get double-remediated."""
+    app, _ = app_and_db
+    matched = "see the Audit page"
+    assert matched in card_cleanup.KEEP_ARCHIVE_HASH_FAILED
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    assert f"CARD_CLEANUP_HASH_FAILED_REASON = '{matched}'" in body
+    assert matched not in card_cleanup.KEEP_NOT_VERIFIED
+    assert "run the integrity audit" not in card_cleanup.KEEP_ARCHIVE_HASH_FAILED

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -629,3 +629,61 @@ def test_start_audit_keeps_page_locked_on_ambiguous_start(app_and_db):
         "the JSON-parse catch on a 2xx response must direct the user to the "
         "Jobs page for the actual outcome"
     )
+
+
+def test_load_manifest_discards_stale_scan_response(app_and_db):
+    """Codex P2 review (commit 16a3f8e4): cardCleanupLoadManifest must
+    discard responses whose scan job id is no longer current.
+
+    Scenario: cardCleanupFinishJob unlocks the buttons and then awaits
+    cardCleanupLoadManifest() for scan #1. During that await a user can
+    change the source and start scan #2, which sets scanJobId to jobId2.
+    If scan #1's response then arrives it would (a) render scan #1's
+    source and totals over scan #2's state via cardCleanupRenderManifest
+    — including re-enabling the Delete button based on scan #1's
+    deletable count — while the delete POST uses cardCleanupState.
+    scanJobId, which is now jobId2, so the confirmation dialog would
+    advertise a set that does not match the manifest the destructive job
+    would operate on; or (b) on a 404, null out scanJobId and clobber
+    scan #2's identity; or (c) surface scan #1's fetch/parse error as if
+    scan #2 had failed.
+
+    Fix: capture scanJobId at request time and drop the response on both
+    the success and error paths when it has moved on. Pinning both paths
+    here so a refactor cannot quietly re-open either one.
+    """
+    app, _ = app_and_db
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    start = body.index("async function cardCleanupLoadManifest(")
+    end = body.index("function cardCleanupRenderManifest(", start)
+    section = body[start:end]
+    # The success path must run its stale-response check before ANY
+    # state mutation or render — both the 404 handler (which nulls
+    # scanJobId) and cardCleanupRenderManifest (which shows scan #1's
+    # totals and re-enables Delete based on them) would corrupt scan #2's
+    # state if reached with a stale response.
+    first_mutation_idx = min(
+        section.index("cardCleanupState.scanJobId = null"),
+        section.index("cardCleanupRenderManifest("),
+    )
+    pre_mutation = section[:first_mutation_idx]
+    assert "cardCleanupState.scanJobId !==" in pre_mutation, (
+        "cardCleanupLoadManifest must compare state.scanJobId against the "
+        "job id captured before the fetch, and return early on mismatch, "
+        "BEFORE touching state or rendering — otherwise a scan started "
+        "during the fetch will be overwritten by the stale response and "
+        "the Delete confirmation will advertise numbers that do not match "
+        "the manifest the delete POST would operate on"
+    )
+    # The error path (network failure, unreadable body, !resp.ok throw)
+    # must also discard on mismatch — a scan #2 in flight should not
+    # inherit scan #1's error banner as if it had failed itself.
+    catch_idx = section.index("} catch (e) {")
+    catch_body = section[catch_idx:]
+    assert "cardCleanupState.scanJobId !==" in catch_body, (
+        "the catch branch of cardCleanupLoadManifest must also check "
+        "state.scanJobId — a fetch or parse error on the stale scan #1 "
+        "response must not surface as an error message while scan #2 is "
+        "running, because it would misattribute the failure to the scan "
+        "the user is currently watching"
+    )

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -388,3 +388,27 @@ def test_endpoints_reject_non_object_json_body(app_and_db):
         resp = client.post(url, json=5)
         assert resp.status_code == 400, url
         assert "JSON object" in resp.get_json()["error"]
+
+
+def test_card_cleanup_page_renders(app_and_db):
+    # The flow lives on its own page now (spec:
+    # docs/superpowers/specs/2026-08-08-card-cleanup-page-design.md).
+    app, _ = app_and_db
+    resp = app.test_client().get("/card-cleanup")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "card-cleanup-section" in body
+    assert "card-cleanup-scan-btn" in body
+    # The integrity-audit affordance is part of the page, not the import page.
+    assert "card-cleanup-audit-btn" in body
+
+
+def test_import_page_links_to_card_cleanup_instead_of_hosting_it(app_and_db):
+    app, _ = app_and_db
+    resp = app.test_client().get("/import")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "card-cleanup-section" not in body
+    # The entry point stays: it now navigates to the dedicated page.
+    assert "btnFreeUpCardSpace" in body
+    assert "/card-cleanup" in body

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -495,18 +495,25 @@ def test_finish_audit_disables_delete_until_rescan(app_and_db):
 
 
 def test_confirm_delete_locks_page_before_post(app_and_db):
-    """Codex P2 review (commit 96137e3): cardCleanupConfirmDelete must set
-    the page-wide busy state *before* the POST /api/card-cleanup/delete
-    request is issued, not after the response arrives.
+    """Codex P2 reviews (commits 96137e3 and 012aec2c): cardCleanupConfirmDelete
+    must set the page-wide busy state *before* the POST /api/card-cleanup/delete
+    request is issued, and its failure paths must treat HTTP failures and
+    network errors differently.
 
-    The confirm dialog can be dismissed (backdrop click or Escape) while
-    the request is pending. If Scan and Verify remained enabled during
+    Ordering: the confirm dialog can be dismissed (backdrop click or Escape)
+    while the request is pending. If Scan and Verify remained enabled during
     that window, the user could kick off a second job whose watch would
     overwrite this delete's jobId — the exact orphan the single-busy-state
     owner exists to prevent, and one that could strand a destructive
-    deletion. Pinning the ordering here — busy set before the fetch, and
-    cleared on failure paths so buttons don't remain dead — so a refactor
-    can't quietly re-open the gap."""
+    deletion. Busy must be set before the fetch so a dismissal never opens
+    the gap.
+
+    Failure handling: an HTTP response proves whether the server queued the
+    delete, so !resp.ok can hand the buttons back. A `fetch` rejection is
+    ambiguous — the POST may have reached the server and started the
+    destructive job before the connection dropped — so the catch must NOT
+    unlock, and must direct the user to the Jobs page. Pinning both here so
+    a refactor can't quietly re-open the gap."""
     app, _ = app_and_db
     body = app.test_client().get("/card-cleanup").get_data(as_text=True)
     start = body.index("async function cardCleanupConfirmDelete(")
@@ -521,11 +528,34 @@ def test_confirm_delete_locks_page_before_post(app_and_db):
         "so a dialog dismissal during the pending request can't leave "
         "Scan/Verify live and race a second job into cardCleanupWatchJob"
     )
-    # Failure paths must release the lock — both the non-OK response branch
-    # and the network-error catch, so the user isn't stranded with a dead
-    # page after a definitive failure.
-    assert section.count("cardCleanupSetBusy(false)") >= 2, (
-        "both the !resp.ok branch and the catch block must call "
-        "cardCleanupSetBusy(false) to release the page-wide lock on "
-        "definitive failure"
+    # An HTTP response that proves nothing was queued (!resp.ok) must
+    # release the lock so the user isn't stranded with a dead page.
+    ok_branch_start = section.index("if (!resp.ok)")
+    ok_branch_end = section.index("cardCleanupWatchJob", ok_branch_start)
+    ok_branch = section[ok_branch_start:ok_branch_end]
+    assert "cardCleanupSetBusy(false)" in ok_branch, (
+        "the !resp.ok branch must call cardCleanupSetBusy(false) — the "
+        "server said the delete was not queued, so the page can safely hand "
+        "the buttons back"
+    )
+    # The catch branch is different: `fetch` rejects for network errors
+    # where the request may or may not have reached the server. If the
+    # server already queued the delete, the destructive job is running
+    # unseen — unlocking would let a second job overwrite this page's
+    # jobId (the exact orphan the single-busy-state owner exists to
+    # prevent). Codex P2 (commit 012aec2c) called this out: only unlock
+    # after an HTTP response proves no job was queued; treat network
+    # errors as unknown-running and direct the user to Jobs.
+    catch_start = section.index("} catch (e) {")
+    catch_end = section.index("} finally {", catch_start)
+    catch_body = section[catch_start:catch_end]
+    assert "cardCleanupSetBusy(false)" not in catch_body, (
+        "the network-error catch must NOT release the page lock — the "
+        "server may have queued the delete before the connection dropped, "
+        "and unlocking would let a second job race the destructive job"
+    )
+    assert "Jobs page" in catch_body, (
+        "the network-error catch must direct the user to the Jobs page so "
+        "they can find out whether the server queued the delete before the "
+        "connection dropped"
     )

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -559,3 +559,73 @@ def test_confirm_delete_locks_page_before_post(app_and_db):
         "they can find out whether the server queued the delete before the "
         "connection dropped"
     )
+
+
+def test_start_audit_keeps_page_locked_on_ambiguous_start(app_and_db):
+    """Codex P1 review (commit 5afcb0ba): cardCleanupStartAudit must not
+    release the page-wide busy lock on outcomes that don't prove whether the
+    server queued the verify-hashes job.
+
+    If the audit is silently running while Scan/Verify/Delete come back live,
+    a subsequent delete can race it. delete_verified() trusts the currently
+    committed hash_status plus archive size/mtime rather than re-hashing
+    archive bytes, so a row the audit is about to flip from `ok` to
+    modified/corrupt/unreadable could still qualify for deletion — removing
+    the good card copy of a file whose archive copy is silently rotting. Same
+    guarantee the delete-start path pins in test_confirm_delete_locks_page_
+    before_post; pinning both invariants here so a refactor can't quietly
+    re-open the gap."""
+    app, _ = app_and_db
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    start = body.index("async function cardCleanupStartAudit(")
+    end = body.index("function cardCleanupFinishAudit(", start)
+    section = body[start:end]
+    # An HTTP response that proves nothing was queued (!resp.ok) must
+    # release the lock so the user isn't stranded with a dead page.
+    ok_branch_start = section.index("if (!resp.ok)")
+    # The branch closes before the JSON re-parse below; scope to just that
+    # arm by ending at the trailing "return;" and its closing brace.
+    ok_branch_end = section.index("let data;", ok_branch_start)
+    ok_branch = section[ok_branch_start:ok_branch_end]
+    assert "cardCleanupSetBusy(false)" in ok_branch, (
+        "the !resp.ok branch must call cardCleanupSetBusy(false) — the "
+        "server said the verify-hashes job was not queued, so the page can "
+        "safely hand the buttons back"
+    )
+    # The network-error catch on the fetch itself must NOT unlock — the
+    # POST may have reached the server and started api_job_verify_hashes()
+    # before the connection dropped, and the delete path trusts hash_status
+    # in the DB rather than re-hashing archive bytes, so a concurrent delete
+    # could remove the good card copy of a file the audit is silently
+    # detecting as corrupt.
+    fetch_catch_start = section.index("resp = await fetch(")
+    fetch_catch_start = section.index("} catch (e) {", fetch_catch_start)
+    fetch_catch_end = section.index("if (!resp.ok)", fetch_catch_start)
+    fetch_catch_body = section[fetch_catch_start:fetch_catch_end]
+    assert "cardCleanupSetBusy(false)" not in fetch_catch_body, (
+        "the fetch-rejection catch on cardCleanupStartAudit must NOT release "
+        "the page lock — the POST may have reached the server and queued the "
+        "verify-hashes job before the connection dropped, and unlocking "
+        "would let a concurrent delete race the audit"
+    )
+    assert "Jobs page" in fetch_catch_body, (
+        "the fetch-rejection catch must direct the user to the Jobs page so "
+        "they can find out whether the server queued the verify-hashes job"
+    )
+    # The JSON-parse catch on the OK response is the second ambiguous
+    # outcome: a 2xx status means api_job_verify_hashes() returned, but if
+    # the body couldn't be decoded we can't be sure the job wasn't queued.
+    # Same reasoning — keep the lock, route to Jobs.
+    json_catch_start = section.index("data = await resp.json()")
+    json_catch_start = section.index("} catch (e) {", json_catch_start)
+    json_catch_end = section.index("cardCleanupWatchJob(", json_catch_start)
+    json_catch_body = section[json_catch_start:json_catch_end]
+    assert "cardCleanupSetBusy(false)" not in json_catch_body, (
+        "the JSON-parse catch on a 2xx response must NOT release the page "
+        "lock — the server returned OK, so api_job_verify_hashes() may have "
+        "queued the audit even though we can't read the response body"
+    )
+    assert "Jobs page" in json_catch_body, (
+        "the JSON-parse catch on a 2xx response must direct the user to the "
+        "Jobs page for the actual outcome"
+    )

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -412,3 +412,15 @@ def test_import_page_links_to_card_cleanup_instead_of_hosting_it(app_and_db):
     # The entry point stays: it now navigates to the dedicated page.
     assert "btnFreeUpCardSpace" in body
     assert "/card-cleanup" in body
+
+
+def test_audit_callout_reason_stays_in_sync(app_and_db):
+    """The page's audit callout counts kept entries by matching a tail of
+    KEEP_NOT_VERIFIED. That coupling is invisible from either side, so pin
+    both ends: the served page must carry the literal it matches on, and
+    the reason it matches must still contain it."""
+    app, _ = app_and_db
+    matched = "run the integrity audit"
+    assert matched in card_cleanup.KEEP_NOT_VERIFIED
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    assert f"CARD_CLEANUP_AUDIT_REASON = '{matched}'" in body

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -461,3 +461,34 @@ def test_hash_failed_callout_states_audit_workspace_scope(app_and_db):
     # drop the guidance the Codex P2 asked for.
     assert "Audit page shows flagged rows for the current workspace only" in body
     assert "switch to that workspace to find it there" in body
+
+
+def test_finish_audit_disables_delete_until_rescan(app_and_db):
+    """Codex P2 review (commit 1213fec): finishing or cancelling the
+    verify-hashes run must invalidate the preview's Delete affordance,
+    because verification can flip previously-ok rows to modified/corrupt/
+    unreadable — the confirmation dialog would then advertise stale file
+    and byte totals against a subset the user never agreed to. The audit
+    handler must both disable the Delete button and swap in a hint that
+    tells the user to re-scan (the button surfaced next to the audit
+    status). Pin the literal here so the guardrail can't be silently
+    reworded away."""
+    app, _ = app_and_db
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    finish = body.index("function cardCleanupFinishAudit(")
+    # Snap out a window around the handler body. The next function in the
+    # file is cardCleanupBindBucket; slice up to whichever declaration
+    # follows so this test does not accidentally match code elsewhere.
+    end = body.index("function cardCleanupBindBucket(", finish)
+    section = body[finish:end]
+    # The Delete button is disabled inside the handler, not just via the
+    # separate cardCleanupSetBusy(false) that ran first (which restores
+    # the pre-verify enabled state).
+    assert "deleteBtn.disabled = true" in section
+    # The user-facing hint that replaces whatever cardCleanupSetBusy
+    # restored — pinned verbatim so a reword can't drop the "re-scan
+    # first" instruction the Codex P2 asked for.
+    assert (
+        "Verification may have changed which files count as verified — "
+        "re-scan the card before deleting."
+    ) in section

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -440,3 +440,24 @@ def test_hash_failed_callout_reason_stays_in_sync(app_and_db):
     assert f"CARD_CLEANUP_HASH_FAILED_REASON = '{matched}'" in body
     assert matched not in card_cleanup.KEEP_NOT_VERIFIED
     assert "run the integrity audit" not in card_cleanup.KEEP_ARCHIVE_HASH_FAILED
+
+
+def test_hash_failed_callout_states_audit_workspace_scope(app_and_db):
+    """Second-order Codex P2 review: the audit remedy suggested by the
+    hash-failed callout is only reachable when the failed row is in the
+    active workspace, because Database.get_integrity_flagged() filters
+    to the active workspace but _load_catalog_by_hash() matches globally.
+    The callout must say so up front so the user does not click through
+    to an empty Audit page — mirroring the workspace-scope note added
+    to the verify-hashes callout for the same asymmetry."""
+    app, _ = app_and_db
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    # A dedicated hint element for the scope note, rendered inside the
+    # hash-failed callout container.
+    assert 'id="card-cleanup-hash-failed-scope"' in body
+    # The copy itself: names the current-workspace scope of the Audit
+    # page and tells the user how to reach a failed row in a different
+    # workspace's folders. Pinned literally so a reword does not quietly
+    # drop the guidance the Codex P2 asked for.
+    assert "Audit page shows flagged rows for the current workspace only" in body
+    assert "switch to that workspace to find it there" in body

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -492,3 +492,40 @@ def test_finish_audit_disables_delete_until_rescan(app_and_db):
         "Verification may have changed which files count as verified — "
         "re-scan the card before deleting."
     ) in section
+
+
+def test_confirm_delete_locks_page_before_post(app_and_db):
+    """Codex P2 review (commit 96137e3): cardCleanupConfirmDelete must set
+    the page-wide busy state *before* the POST /api/card-cleanup/delete
+    request is issued, not after the response arrives.
+
+    The confirm dialog can be dismissed (backdrop click or Escape) while
+    the request is pending. If Scan and Verify remained enabled during
+    that window, the user could kick off a second job whose watch would
+    overwrite this delete's jobId — the exact orphan the single-busy-state
+    owner exists to prevent, and one that could strand a destructive
+    deletion. Pinning the ordering here — busy set before the fetch, and
+    cleared on failure paths so buttons don't remain dead — so a refactor
+    can't quietly re-open the gap."""
+    app, _ = app_and_db
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    start = body.index("async function cardCleanupConfirmDelete(")
+    end = body.index("function cardCleanupRenderDeleteResult(", start)
+    section = body[start:end]
+    # Busy must be set BEFORE the fetch — locate both and require the
+    # setBusy call to come first.
+    fetch_idx = section.index("/api/card-cleanup/delete")
+    busy_true_idx = section.index("cardCleanupSetBusy(true")
+    assert busy_true_idx < fetch_idx, (
+        "cardCleanupSetBusy(true) must run before the delete POST is issued "
+        "so a dialog dismissal during the pending request can't leave "
+        "Scan/Verify live and race a second job into cardCleanupWatchJob"
+    )
+    # Failure paths must release the lock — both the non-OK response branch
+    # and the network-error catch, so the user isn't stranded with a dead
+    # page after a definitive failure.
+    assert section.count("cardCleanupSetBusy(false)") >= 2, (
+        "both the !resp.ok branch and the catch block must call "
+        "cardCleanupSetBusy(false) to release the page-wide lock on "
+        "definitive failure"
+    )

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -18397,7 +18397,7 @@ def test_count_classifier_runs_ignores_non_animal_detections(tmp_path):
 def test_all_nav_ids_covers_every_page():
     from db import ALL_NAV_IDS
     expected = {
-        "import",
+        "import", "card_cleanup",
         "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
         "misses", "highlights", "life_list", "browse", "edit", "map", "location_review", "variants",
         "dashboard", "storage", "audit", "move", "id_conflicts",

--- a/vireo/web/pages.py
+++ b/vireo/web/pages.py
@@ -32,6 +32,7 @@ _TEMPLATES = {
     "/misses": "misses.html",
     "/logs": "logs.html",
     "/import": "import.html",
+    "/card-cleanup": "card_cleanup.html",
     "/dashboard": "stats.html",
 }
 


### PR DESCRIPTION
## What

Implements docs/superpowers/specs/2026-08-08-card-cleanup-page-design.md,
the relocation follow-up to #1436.

- New standalone page `/card-cleanup` (navbar entry) holding the entire
  scan → preview → delete flow, moved from the import page with all
  user-facing copy byte-identical (confirmation dialog, incomplete-preview
  banner, summary states — verified by scripted comparison).
- New inline audit affordance: when kept files carry the "not verified by
  a checksummed import" reason, the page shows the exact count, explains
  the checksum gate, offers **Verify archive hashes** (the existing
  verify-hashes job, with progress and an honest result summary), warns
  about the SMB/VPN cost, and offers **Re-scan card** on completion.
  This closes the first-run dead end observed in production (5,523/5,523
  files kept with that reason and no path forward from the page).
- Import page trimmed back: the folder browser is byte-restored to its
  pre-feature form; the card-safety-pill button now deep-links to
  `/card-cleanup?source=<path>` (plus `others=` so the multi-source hint
  survives verbatim).
- One job at a time, visibly: a single busy-state owner disables
  scan/delete/verify buttons during any run (the Delete hint says why),
  preventing a mid-audit delete from hijacking the job watch.
- No backend changes to the card-cleanup endpoints; the page carries its
  own minimal single-select folder browser against the same /api/browse
  and /api/volumes endpoints (deliberate duplication per the spec).

## Tests

Feature suites: 88 passed (incl. new page-route, import-page-trim, and
audit-callout coupling tests). test_app.py + tests/test_workspaces.py:
558 passed, 1 failed — the known pre-existing machine-local exiftool
test. Route-contract snapshot regenerated (+1 line). node --check clean
on both changed templates; no duplicate ids on either rendered page;
ruff clean. Manual visual QA (both themes) pending, as with #1436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Card Cleanup page accessible from the navigation.
  - Supports folder selection, recursive scanning, progress tracking, previews, integrity audits, cancellation, and deletion.
  - Added warnings for incomplete scans and archive integrity issues.
  - Completed imports now link directly to Card Cleanup with source folders prefilled.

- **Bug Fixes**
  - Improved handling of failed, corrupt, modified, and unreadable archive verification results.
  - Prevented deletion when an audit requires rescanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->