### PR TITLE
Fix new-images snapshot startup blocked by readiness

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -4207,6 +4207,36 @@ def test_snapshot_mode_hides_selection_and_says_what_it_will_import(
     expect(page.locator("#modeInPlace")).to_be_disabled()
 
 
+def test_snapshot_mode_loads_while_import_readiness_is_slow(
+        live_server, page):
+    """A metadata-repair count must not hold a captured import hostage.
+
+    Snapshot activation only needs the frozen list and its preview.  Import
+    readiness is independent advisory work and can take minutes on a large
+    catalog, so the captured count and controls must render while that request
+    is still in flight.
+    """
+    page.goto(f"{live_server['url']}/import")  # warm the app before routing
+    _stub_snapshot_import(page, _files(1))
+
+    def readiness(route):
+        # Never fulfill: model a catalog-wide metadata check that is still
+        # running while the snapshot endpoints answer normally.
+        pass
+
+    page.route("**/api/import/readiness", readiness)
+    page.goto(
+        f"{live_server['url']}/import?new_images=42",
+        wait_until="domcontentloaded",
+    )
+
+    expect(page.locator("#newImagesImportSource")).to_contain_text(
+        "1 newly detected image",
+    )
+    expect(page.locator("#modeInPlace")).to_be_disabled()
+    expect(page.locator("#importPreviewGrid")).to_be_visible()
+
+
 def test_snapshot_mode_withholds_selection_even_if_the_mode_radio_flips(
         live_server, page):
     """importSelectionEnabled()'s snapshot clause is not decoration.

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -4346,7 +4346,11 @@ async function initImportPage() {
   // target request afterward used to leave the destination picker with only
   // its static local-path option for the entire scan.
   loadImportRemoteTargets();
-  await loadImportReadiness();
+  // Metadata readiness is advisory startup work: the import endpoint still
+  // verifies ExifTool when a job starts, and loadImportReadiness() owns the
+  // eventual form-gate update.  Do not hold snapshot deep links (or the rest
+  // of the wizard) behind a catalog-wide repair count that can take minutes.
+  loadImportReadiness();
   // Native menu deep link: File > Import Folder... routes here as
   // /import?mode=copy&pick=source so it lands in Copy-to-archive with the
   // source picker open, while File > Import Photos... gets the page


### PR DESCRIPTION
## Summary

Stop Import-page startup from awaiting the advisory metadata-readiness request, allowing captured new-image snapshots and the rest of the wizard to load while a catalog-wide repair count is still running.

The root cause was `initImportPage()` serializing snapshot activation behind `/api/import/readiness`, which can take longer than the banner flow's UI timeout on a busy or large catalog.

Add an E2E regression that keeps readiness pending and verifies the captured image count, locked in-place mode, and preview still render.

## Validation

- `pytest -q tests/e2e/test_new_images_pipeline.py --browser chromium`
- `pytest -q tests/e2e/test_import_page.py tests/e2e/test_new_images_pipeline.py --browser chromium -k 'snapshot or readiness or new_images_banner'`
- `ruff check tests/e2e/test_import_page.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Import pages now load and display snapshot images and captured item counts without waiting for catalog readiness.
  * Deep links and other import-page content remain responsive while readiness information is still loading.

* **Tests**
  * Added coverage confirming snapshot-mode imports render correctly when readiness checks are delayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->