### PR TITLE
Share folder browser across import and card cleanup

### DIFF
--- a/tests/e2e/test_card_cleanup.py
+++ b/tests/e2e/test_card_cleanup.py
@@ -1,0 +1,64 @@
+"""Browser coverage for the dedicated Card Cleanup page."""
+
+import re
+
+from playwright.sync_api import expect
+
+
+def test_card_cleanup_folder_browser_shows_recursive_photo_counts(
+    live_server, page,
+):
+    """The shared picker shows the same recursive counts as Import."""
+    url = live_server["url"]
+    page.goto(f"{url}/card-cleanup")
+    page.evaluate("window.pickDirectory = async () => null")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target === '/api/browse/photo-counts') {
+              const body = JSON.parse(init.body || '{}');
+              window.__cardFolderCountRequest = body;
+              return Promise.resolve(new Response(JSON.stringify({
+                counts: {
+                  '/tmp/card-a': 1,
+                  '/tmp/card-b': 1234,
+                  '/tmp/empty': 0,
+                },
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            if (target && target.indexOf('/api/browse') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                path: '/tmp',
+                dirs: [
+                  {name: 'card-a', path: '/tmp/card-a'},
+                  {name: 'card-b', path: '/tmp/card-b'},
+                  {name: 'empty', path: '/tmp/empty'},
+                ],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+    )
+
+    page.locator("[data-testid='card-cleanup-browse-btn']").click()
+
+    browser = page.locator("[data-testid='card-folder-browser']")
+    expect(browser).to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#folderBrowserTitle")).to_have_text(
+        "Select Card Folder"
+    )
+    badges = page.locator("#folderBrowserList .folder-browser-count")
+    expect(badges).to_have_count(3)
+    expect(badges.nth(0)).to_have_text("1 photo")
+    expect(badges.nth(1)).to_have_text("1,234 photos")
+    expect(badges.nth(2)).to_be_empty()
+    request = page.evaluate("window.__cardFolderCountRequest")
+    assert request["paths"] == [
+        "/tmp/card-a", "/tmp/card-b", "/tmp/empty",
+    ]
+    assert request["file_types"] == "both"

--- a/tests/e2e/test_card_cleanup.py
+++ b/tests/e2e/test_card_cleanup.py
@@ -47,7 +47,7 @@ def test_card_cleanup_folder_browser_shows_recursive_photo_counts(
 
     page.locator("[data-testid='card-cleanup-browse-btn']").click()
 
-    browser = page.locator("[data-testid='card-folder-browser']")
+    browser = page.locator("[data-testid='folder-browser']")
     expect(browser).to_have_class(re.compile(r"\bopen\b"))
     expect(page.locator("#folderBrowserTitle")).to_have_text(
         "Select Card Folder"

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -2142,7 +2142,7 @@ def test_import_browse_button_opens_folder_browser_fallback(live_server, page):
 
     page.locator("[data-testid='import-source-browse-btn']").click()
 
-    browser = page.locator("[data-testid='import-folder-browser']")
+    browser = page.locator("[data-testid='folder-browser']")
     expect(browser).to_have_class(re.compile(r"\bopen\b"))
     expect(page.locator("#folderBrowserTitle")).to_have_text("Select Source Folders")
     panel = browser.locator(".folder-browser-panel")
@@ -2431,7 +2431,7 @@ def test_import_menu_deep_link_opens_copy_mode_with_source_picker(live_server, p
 
     expect(page.locator("#modeCopy")).to_be_checked()
     expect(page.locator("#destCard")).to_be_visible()
-    expect(page.locator("[data-testid='import-folder-browser']")).to_have_class(
+    expect(page.locator("[data-testid='folder-browser']")).to_have_class(
         re.compile(r"\bopen\b"))
     expect(page.locator("#folderBrowserTitle")).to_have_text("Select Source Folders")
     # pick is a one-shot trigger: it must be stripped from the URL so a manual
@@ -2445,7 +2445,7 @@ def test_import_folder_browser_escape_closes_modal(live_server, page):
     page.evaluate("window.pickDirectory = async () => null")
 
     page.locator("[data-testid='import-source-browse-btn']").click()
-    browser = page.locator("[data-testid='import-folder-browser']")
+    browser = page.locator("[data-testid='folder-browser']")
     expect(browser).to_have_class(re.compile(r"\bopen\b"))
     expect(browser.locator(".folder-browser-close")).to_be_focused()
 
@@ -2524,7 +2524,7 @@ def test_import_destination_structure_hides_when_folder_browser_picks_destinatio
     expect(page.locator("#destStructure")).to_be_visible()
 
     page.locator("[data-testid='import-destination-browse-btn']").click()
-    expect(page.locator("[data-testid='import-folder-browser']")).to_have_class(
+    expect(page.locator("[data-testid='folder-browser']")).to_have_class(
         re.compile(r"\bopen\b"))
     page.locator("#folderBrowserSelectBtn").click()
 

--- a/vireo/static/vireo-folder-browser.css
+++ b/vireo/static/vireo-folder-browser.css
@@ -1,0 +1,57 @@
+.folder-browser-overlay {
+  display: none; position: fixed; inset: 0; z-index: 1001;
+  background: rgba(0, 0, 0, 0.45); align-items: center; justify-content: center;
+}
+.folder-browser-overlay.open { display: flex; }
+.folder-browser-panel {
+  width: min(720px, calc(100vw - 32px)); max-height: calc(100vh - 64px);
+  background: var(--bg-secondary); border: 1px solid var(--border-primary);
+  border-radius: 8px; box-shadow: 0 18px 60px rgba(0,0,0,0.35);
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.folder-browser-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 16px; border-bottom: 1px solid var(--border-primary);
+}
+.folder-browser-header h3 { margin: 0; }
+.folder-browser-close {
+  background: none; border: none; color: var(--text-secondary);
+  font-size: 22px; cursor: pointer;
+}
+.folder-browser-body {
+  padding: 12px 16px; display: flex; flex-direction: column;
+  gap: 10px; min-height: 0;
+}
+.folder-browser-shortcuts { display: flex; gap: 8px; flex-wrap: wrap; }
+.folder-browser-path {
+  font-size: 12px; color: var(--text-secondary); overflow-wrap: anywhere;
+}
+.folder-browser-list {
+  height: 320px; overflow: auto; border: 1px solid var(--border-primary);
+  border-radius: 6px; background: var(--bg-tertiary);
+}
+.folder-browser-item {
+  padding: 8px 10px; font-size: 12px; color: var(--text-primary);
+  cursor: pointer;
+  border-bottom: 1px solid color-mix(in srgb, var(--border-primary) 60%, transparent);
+  display: flex; align-items: center; gap: 8px;
+}
+.folder-browser-item:hover { background: var(--bg-hover, rgba(255,255,255,0.05)); }
+.folder-browser-item.selected {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+.folder-browser-item-name {
+  flex: 1; min-width: 0; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+.folder-browser-count {
+  color: var(--text-secondary); font-size: 11px;
+  font-variant-numeric: tabular-nums; flex-shrink: 0; white-space: nowrap;
+}
+.folder-browser-empty {
+  padding: 14px; font-size: 12px; color: var(--text-secondary);
+}
+.folder-browser-actions {
+  display: flex; gap: 8px; justify-content: flex-end;
+  padding: 12px 16px; border-top: 1px solid var(--border-primary);
+}

--- a/vireo/static/vireo-folder-browser.js
+++ b/vireo/static/vireo-folder-browser.js
@@ -1,0 +1,363 @@
+(function (global) {
+  'use strict';
+
+  function valueOf(option, fallback) {
+    if (typeof option === 'function') return option();
+    return option === undefined ? fallback : option;
+  }
+
+  function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, function (ch) {
+      return {
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+      }[ch];
+    });
+  }
+
+  function formatPhotoCount(value) {
+    var count = Number(value || 0);
+    return count.toLocaleString() + ' photo' + (count === 1 ? '' : 's');
+  }
+
+  function FolderBrowser(options) {
+    this.options = options || {};
+    this.overlay = document.getElementById(this.options.overlayId);
+    if (!this.overlay) {
+      throw new Error('Folder browser overlay not found: ' + this.options.overlayId);
+    }
+    this.title = this.overlay.querySelector('#folderBrowserTitle');
+    this.pathLabel = this.overlay.querySelector('#folderBrowserPath');
+    this.list = this.overlay.querySelector('#folderBrowserList');
+    this.selectionLabel = this.overlay.querySelector('#folderBrowserSelection');
+    this.selectButton = this.overlay.querySelector('#folderBrowserSelectBtn');
+    this.modeName = this.options.defaultMode || Object.keys(this.options.modes || {})[0];
+    this.path = '';
+    this.homePath = '';
+    this.seq = 0;
+    this.countsAbort = null;
+    this.countCache = {};
+    this.escHandler = null;
+    this.selectedPaths = [];
+    this.selectAnchorPath = '';
+    this._bindChrome();
+  }
+
+  Object.defineProperty(FolderBrowser.prototype, 'sequence', {
+    get: function () { return this.seq; },
+  });
+
+  FolderBrowser.prototype._mode = function () {
+    return (this.options.modes || {})[this.modeName] || {};
+  };
+
+  FolderBrowser.prototype._bindChrome = function () {
+    var self = this;
+    this.overlay.querySelectorAll('[data-folder-browser-action="close"]').forEach(
+      function (button) { button.addEventListener('click', function () { self.close(); }); }
+    );
+    this.overlay.querySelector('[data-folder-browser-path="home"]').addEventListener(
+      'click', function () { self.browse(null); }
+    );
+    this.overlay.querySelector('[data-folder-browser-path="pictures"]').addEventListener(
+      'click', function () { self.browse('__pictures__'); }
+    );
+    this.overlay.querySelector('[data-folder-browser-path="volumes"]').addEventListener(
+      'click', function () { self.browse('__volumes__'); }
+    );
+    this.selectButton.addEventListener('click', function () { self.confirm(); });
+  };
+
+  FolderBrowser.prototype.open = function (modeName, opts) {
+    if (!this.options.modes || !this.options.modes[modeName]) {
+      throw new Error('Unknown folder browser mode: ' + modeName);
+    }
+    this.modeName = modeName;
+    var mode = this._mode();
+    this.title.textContent = valueOf(mode.title, 'Select Folder');
+    this.selectedPaths = [];
+    this.selectAnchorPath = '';
+    this._updateSelection();
+    this.overlay.classList.add('open');
+    var self = this;
+    this.overlay.onclick = function (event) {
+      if (event.target === self.overlay) self.close();
+    };
+    if (this.escHandler) document.removeEventListener('keydown', this.escHandler);
+    this.escHandler = function (event) {
+      if (event.key === 'Escape') self.close();
+    };
+    document.addEventListener('keydown', this.escHandler);
+    document.body.style.overflow = 'hidden';
+    var firstAction = this.overlay.querySelector('button');
+    if (firstAction) firstAction.focus();
+    var startPath = valueOf(mode.startPath, '');
+    if (!(opts && opts.skipInitialBrowse)) this.browse(startPath || null);
+  };
+
+  FolderBrowser.prototype.close = function () {
+    this.overlay.classList.remove('open');
+    if (this.countsAbort) {
+      this.countsAbort.abort();
+      this.countsAbort = null;
+    }
+    if (this.escHandler) {
+      document.removeEventListener('keydown', this.escHandler);
+      this.escHandler = null;
+    }
+    document.body.style.overflow = '';
+  };
+
+  FolderBrowser.prototype._showBrowseError = function (message) {
+    this.pathLabel.textContent = message || 'Could not open folder.';
+    this.list.innerHTML = '<div class="folder-browser-empty">Could not open folder.</div>';
+    if (typeof this.options.onError === 'function') this.options.onError(message);
+  };
+
+  FolderBrowser.prototype.browse = async function (path) {
+    var seq = ++this.seq;
+    if (this.countsAbort) {
+      this.countsAbort.abort();
+      this.countsAbort = null;
+    }
+    this.path = '';
+    this.selectedPaths = [];
+    this.selectAnchorPath = '';
+    this._updateSelection();
+    this.selectButton.disabled = true;
+    this.pathLabel.textContent = 'Loading…';
+    this.list.innerHTML = '<div class="folder-browser-empty">Loading…</div>';
+
+    var url = '/api/browse';
+    if (path === '__pictures__') {
+      if (!this.homePath) {
+        try {
+          var homeResp = await fetch('/api/browse');
+          if (seq !== this.seq || !homeResp.ok) return;
+          var home = await homeResp.json();
+          this.homePath = home.path || '';
+        } catch (error) {
+          if (seq === this.seq) this._showBrowseError(String(error.message || error));
+          return;
+        }
+      }
+      url = '/api/browse?path=' + encodeURIComponent(this.homePath + '/Pictures');
+    } else if (path === '__volumes__') {
+      if (navigator.userAgent.indexOf('Mac') < 0) {
+        try {
+          var volumesResp = await fetch('/api/volumes');
+          if (seq !== this.seq || !volumesResp.ok) return;
+          var volumes = await volumesResp.json();
+          this.path = '';
+          this.render({path: '', dirs: volumes || []}, {syntheticRoot: true});
+        } catch (error) {
+          if (seq === this.seq) this._showBrowseError(String(error.message || error));
+        }
+        return;
+      }
+      url = '/api/browse?path=' + encodeURIComponent('/Volumes');
+    } else if (path) {
+      url = '/api/browse?path=' + encodeURIComponent(path);
+    }
+
+    try {
+      var response = await fetch(url);
+      if (seq !== this.seq) return;
+      if (!response.ok) {
+        var failure = await response.json().catch(function () { return {}; });
+        this._showBrowseError(failure.error || 'Could not open folder.');
+        return;
+      }
+      var data = await response.json();
+      if (seq !== this.seq) return;
+      this.path = data.path || '';
+      this.selectedPaths = [];
+      this.selectAnchorPath = '';
+      if (!path) this.homePath = this.path;
+      this.render(data);
+    } catch (error) {
+      if (seq === this.seq) this._showBrowseError(String(error.message || error));
+    }
+  };
+
+  FolderBrowser.prototype.render = function (data, opts) {
+    var mode = this._mode();
+    var multiple = !!mode.multiple;
+    var showCounts = !!mode.showCounts;
+    this.pathLabel.textContent = data.path || 'Volumes';
+    var dirs = data.dirs || [];
+    var html = '';
+    var syntheticRoot = opts && opts.syntheticRoot;
+    var parent = '';
+    if (data.path && data.path.indexOf('\\') !== -1) {
+      parent = data.path.replace(/[\\\/]?[^\\\/]+[\\\/]?$/, '') || data.path;
+      if (/^[A-Za-z]:$/.test(parent)) parent += '\\';
+    } else if (data.path) {
+      parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
+    }
+    if (data.path && data.path !== '/' && parent && parent !== data.path) {
+      html += '<div class="folder-browser-item" data-browse-path="' + escapeHtml(parent) + '" data-parent-link="1">' +
+        '<span class="folder-browser-item-name">&#128193; ..</span></div>';
+    }
+    dirs.forEach(function (dir) {
+      html += '<div class="folder-browser-item" data-browse-path="' + escapeHtml(dir.path) + '"' +
+        (multiple ? ' data-folder-path="' + escapeHtml(dir.path) + '"' : '') + '>' +
+        '<span class="folder-browser-item-name">&#128193; ' + escapeHtml(dir.name || dir.path) + '</span>' +
+        (showCounts ? '<span class="folder-browser-count" data-count-path="' + escapeHtml(dir.path) + '"></span>' : '') +
+        '</div>';
+    });
+    if (!html) {
+      html = '<div class="folder-browser-empty">' +
+        (syntheticRoot ? 'No volumes found.' : 'No subfolders.') + '</div>';
+    }
+    this.list.innerHTML = html;
+
+    var self = this;
+    this.list.onclick = function (event) {
+      var item = event.target.closest('.folder-browser-item[data-browse-path]');
+      if (!item) return;
+      if (item.getAttribute('data-parent-link') === '1' || !multiple) {
+        self.browse(item.getAttribute('data-browse-path'));
+        return;
+      }
+      self._selectItem(item, event);
+    };
+    this.list.ondblclick = multiple ? function (event) {
+      var item = event.target.closest('.folder-browser-item[data-browse-path]');
+      if (item && item.getAttribute('data-parent-link') !== '1') {
+        self.browse(item.getAttribute('data-browse-path'));
+      }
+    } : null;
+    this._updateSelection();
+    if (showCounts) this._refreshCounts(dirs, this.seq);
+  };
+
+  FolderBrowser.prototype._selectItem = function (item, event) {
+    var path = item.getAttribute('data-folder-path') || item.getAttribute('data-browse-path');
+    if (!path) return;
+    var items = Array.from(this.list.querySelectorAll('.folder-browser-item[data-folder-path]'));
+    var shift = event && event.shiftKey;
+    var toggle = event && (event.metaKey || event.ctrlKey);
+    if (shift && this.selectAnchorPath) {
+      var anchorIdx = items.findIndex(function (candidate) {
+        return candidate.getAttribute('data-folder-path') === this.selectAnchorPath;
+      }, this);
+      var clickIdx = items.findIndex(function (candidate) {
+        return candidate.getAttribute('data-folder-path') === path;
+      });
+      if (clickIdx === -1) return;
+      if (anchorIdx === -1) anchorIdx = clickIdx;
+      var lo = Math.min(anchorIdx, clickIdx);
+      var hi = Math.max(anchorIdx, clickIdx);
+      this.selectedPaths = items.slice(lo, hi + 1).map(function (candidate) {
+        return candidate.getAttribute('data-folder-path');
+      });
+    } else if (toggle) {
+      var idx = this.selectedPaths.indexOf(path);
+      if (idx === -1) this.selectedPaths.push(path);
+      else this.selectedPaths.splice(idx, 1);
+      this.selectAnchorPath = path;
+    } else {
+      this.selectedPaths = [path];
+      this.selectAnchorPath = path;
+    }
+    this._updateSelection();
+  };
+
+  FolderBrowser.prototype._updateSelection = function () {
+    var mode = this._mode();
+    var selected = {};
+    this.selectedPaths.forEach(function (path) { selected[path] = true; });
+    this.list.querySelectorAll('.folder-browser-item[data-folder-path]').forEach(function (item) {
+      item.classList.toggle('selected', !!selected[item.getAttribute('data-folder-path')]);
+    });
+    if (this.selectionLabel) {
+      if (mode.multiple && this.selectedPaths.length > 1) {
+        this.selectionLabel.textContent = this.selectedPaths.length + ' folders selected';
+      } else if (mode.multiple && this.selectedPaths.length === 1) {
+        this.selectionLabel.textContent = this.selectedPaths[0];
+      } else {
+        this.selectionLabel.textContent = '';
+      }
+    }
+    if (mode.multiple) {
+      this.selectButton.textContent = this.selectedPaths.length > 1
+        ? 'Add ' + this.selectedPaths.length + ' Folders'
+        : 'Add This Folder';
+      this.selectButton.disabled = !this.path && this.selectedPaths.length === 0;
+    } else {
+      this.selectButton.textContent = 'Select This Folder';
+      this.selectButton.disabled = !this.path;
+    }
+  };
+
+  FolderBrowser.prototype._countKey = function (path, fileTypes) {
+    var normalized = Array.isArray(fileTypes)
+      ? fileTypes.slice().sort().join(',')
+      : String(fileTypes || 'both');
+    return path + '\n' + normalized;
+  };
+
+  FolderBrowser.prototype._applyCount = function (path, count) {
+    if (!count) return;
+    this.list.querySelectorAll('.folder-browser-count').forEach(function (badge) {
+      if (badge.getAttribute('data-count-path') === path) {
+        badge.textContent = formatPhotoCount(count);
+      }
+    });
+  };
+
+  FolderBrowser.prototype._refreshCounts = async function (dirs, seq) {
+    if (!dirs.length || seq !== this.seq) return;
+    var fileTypes = valueOf(this._mode().fileTypes, 'both');
+    var uncached = [];
+    dirs.forEach(function (dir) {
+      var key = this._countKey(dir.path, fileTypes);
+      if (Object.prototype.hasOwnProperty.call(this.countCache, key)) {
+        this._applyCount(dir.path, this.countCache[key]);
+      } else {
+        uncached.push(dir.path);
+      }
+    }, this);
+    if (!uncached.length) return;
+
+    this.countsAbort = new AbortController();
+    try {
+      var response = await fetch('/api/browse/photo-counts', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({paths: uncached, file_types: fileTypes}),
+        signal: this.countsAbort.signal,
+      });
+      if (!response.ok || seq !== this.seq) return;
+      var data = await response.json();
+      if (seq !== this.seq) return;
+      var counts = data.counts || {};
+      Object.keys(counts).forEach(function (path) {
+        this.countCache[this._countKey(path, fileTypes)] = counts[path];
+        this._applyCount(path, counts[path]);
+      }, this);
+    } catch (error) {
+      if (error.name !== 'AbortError') { /* Counts are helpful but non-blocking. */ }
+    } finally {
+      if (seq === this.seq) this.countsAbort = null;
+    }
+  };
+
+  FolderBrowser.prototype.confirm = function () {
+    var mode = this._mode();
+    var selection;
+    if (mode.multiple) {
+      selection = this.selectedPaths.length
+        ? this.selectedPaths.slice()
+        : (this.path ? [this.path] : []);
+      if (!selection.length) return;
+    } else {
+      if (!this.path) return;
+      selection = this.path;
+    }
+    if (typeof mode.onSelect === 'function') mode.onSelect(selection);
+    this.close();
+  };
+
+  global.VireoFolderBrowser = FolderBrowser;
+})(window);

--- a/vireo/templates/_folder_browser.html
+++ b/vireo/templates/_folder_browser.html
@@ -1,0 +1,26 @@
+<div class="folder-browser-overlay" id="{{ folder_browser_overlay_id }}"
+     data-testid="{{ folder_browser_test_id }}">
+  <div class="folder-browser-panel" role="dialog" aria-modal="true"
+       aria-labelledby="folderBrowserTitle">
+    <div class="folder-browser-header">
+      <h3 id="folderBrowserTitle">Select Folder</h3>
+      <button class="folder-browser-close" type="button"
+              data-folder-browser-action="close">&times;</button>
+    </div>
+    <div class="folder-browser-body">
+      <div class="folder-browser-shortcuts">
+        <button class="btn" type="button" data-folder-browser-path="home">Home</button>
+        <button class="btn" type="button" data-folder-browser-path="pictures">Pictures</button>
+        <button class="btn" type="button" data-folder-browser-path="volumes">Volumes</button>
+      </div>
+      <div class="folder-browser-path" id="folderBrowserPath"></div>
+      <div class="folder-browser-list" id="folderBrowserList"></div>
+      <div class="folder-browser-path" id="folderBrowserSelection"></div>
+    </div>
+    <div class="folder-browser-actions">
+      <button class="btn" type="button" data-folder-browser-action="close">Cancel</button>
+      <button class="btn btn-primary" type="button" id="folderBrowserSelectBtn"
+              data-folder-browser-action="select">Select This Folder</button>
+    </div>
+  </div>
+</div>

--- a/vireo/templates/_folder_browser.html
+++ b/vireo/templates/_folder_browser.html
@@ -1,5 +1,5 @@
-<div class="folder-browser-overlay" id="{{ folder_browser_overlay_id }}"
-     data-testid="{{ folder_browser_test_id }}">
+<div class="folder-browser-overlay" id="folderBrowser"
+     data-testid="folder-browser">
   <div class="folder-browser-panel" role="dialog" aria-modal="true"
        aria-labelledby="folderBrowserTitle">
     <div class="folder-browser-header">

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -6,11 +6,11 @@
 <link rel="icon" type="image/png" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
 <link rel="stylesheet" href="/static/vireo-base.css">
+<link rel="stylesheet" href="/static/vireo-folder-browser.css">
 <title>Vireo - Card Cleanup</title>
 <style>
-/* Page CSS is a deliberate minimal copy of the import page's: this flow
-   moved off that page and has to keep looking like itself. Only the
-   classes this page actually uses were brought over. */
+/* Page-specific Card Cleanup layout. Shared folder-browser chrome lives in
+   vireo-folder-browser.css so Import and Cleanup cannot drift. */
 body { display: flex; flex-direction: column; height: 100vh; }
 .content { flex: 1; overflow-y: auto; padding: 20px; }
 .card-cleanup-wrap { max-width: 760px; margin: 0 auto; display: flex; flex-direction: column; gap: 16px; }
@@ -40,44 +40,6 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .progress-bar { height: 8px; background: var(--bg-tertiary); border-radius: 4px; overflow: hidden; }
 .progress-bar > div { height: 100%; background: var(--accent); width: 0; transition: width 0.2s; }
 .staging-details { margin: 8px 0 0 0; padding-left: 18px; font-size: 11px; color: var(--text-secondary); max-height: 120px; overflow: auto; }
-.folder-browser-overlay {
-  display: none; position: fixed; inset: 0; z-index: 1001;
-  background: rgba(0, 0, 0, 0.45); align-items: center; justify-content: center;
-}
-.folder-browser-overlay.open { display: flex; }
-.folder-browser-panel {
-  width: min(720px, calc(100vw - 32px)); max-height: calc(100vh - 64px);
-  background: var(--bg-secondary); border: 1px solid var(--border-primary);
-  border-radius: 8px; box-shadow: 0 18px 60px rgba(0,0,0,0.35);
-  display: flex; flex-direction: column; overflow: hidden;
-}
-.folder-browser-header {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 14px 16px; border-bottom: 1px solid var(--border-primary);
-}
-.folder-browser-header h3 { margin: 0; }
-.folder-browser-close { background: none; border: none; color: var(--text-secondary); font-size: 22px; cursor: pointer; }
-.folder-browser-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 10px; min-height: 0; }
-.folder-browser-shortcuts { display: flex; gap: 8px; flex-wrap: wrap; }
-.folder-browser-path { font-size: 12px; color: var(--text-secondary); overflow-wrap: anywhere; }
-.folder-browser-list {
-  height: 320px; overflow: auto; border: 1px solid var(--border-primary);
-  border-radius: 6px; background: var(--bg-tertiary);
-}
-.folder-browser-item {
-  padding: 8px 10px; font-size: 12px; color: var(--text-primary);
-  cursor: pointer; border-bottom: 1px solid color-mix(in srgb, var(--border-primary) 60%, transparent);
-  display: flex; align-items: center; gap: 8px;
-}
-.folder-browser-item:hover { background: var(--bg-hover, rgba(255,255,255,0.05)); }
-.folder-browser-item-name {
-  flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.folder-browser-empty { padding: 14px; font-size: 12px; color: var(--text-secondary); }
-.folder-browser-actions {
-  display: flex; gap: 8px; justify-content: flex-end;
-  padding: 12px 16px; border-top: 1px solid var(--border-primary);
-}
 .card-cleanup-bucket { margin-top: 6px; }
 .card-cleanup-bucket > summary { cursor: pointer; font-size: 12px; color: var(--text-primary); }
 /* Same callout shape as the import page's .managed-archive-callout, in
@@ -203,29 +165,9 @@ body { display: flex; flex-direction: column; height: 100vh; }
   </div>
 </div>
 
-<!-- Single-select folder browser: a minimal copy of the import page's,
-     kept to the one mode this page needs (pick one card folder). -->
-<div class="folder-browser-overlay" id="cardFolderBrowser" data-testid="card-folder-browser">
-  <div class="folder-browser-panel" role="dialog" aria-modal="true" aria-labelledby="folderBrowserTitle">
-    <div class="folder-browser-header">
-      <h3 id="folderBrowserTitle">Select Card Folder</h3>
-      <button class="folder-browser-close" type="button" onclick="closeCardFolderBrowser()">&times;</button>
-    </div>
-    <div class="folder-browser-body">
-      <div class="folder-browser-shortcuts">
-        <button class="btn" type="button" onclick="browseCardFolderTo(null)">Home</button>
-        <button class="btn" type="button" onclick="browseCardFolderTo('__pictures__')">Pictures</button>
-        <button class="btn" type="button" onclick="browseCardFolderTo('__volumes__')">Volumes</button>
-      </div>
-      <div class="folder-browser-path" id="folderBrowserPath"></div>
-      <div class="folder-browser-list" id="folderBrowserList"></div>
-    </div>
-    <div class="folder-browser-actions">
-      <button class="btn" type="button" onclick="closeCardFolderBrowser()">Cancel</button>
-      <button class="btn btn-primary" type="button" id="folderBrowserSelectBtn" onclick="selectCardBrowserFolder()">Select This Folder</button>
-    </div>
-  </div>
-</div>
+{% set folder_browser_overlay_id = 'cardFolderBrowser' %}
+{% set folder_browser_test_id = 'card-folder-browser' %}
+{% include '_folder_browser.html' %}
 
 <!-- Delete confirmation. Reuses the folder browser's overlay/panel classes:
      they are this page's only modal chrome, named after their first user. -->
@@ -254,6 +196,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
   </div>
 </div>
 
+<script src="/static/vireo-folder-browser.js"></script>
 <script>
 /* ---------- Free up card space ----------
    Deletes card files only where the archive copy is verified. Every count
@@ -329,12 +272,6 @@ function formatBytes(n) {
   return (i === 0 ? String(n) : n.toFixed(n >= 10 ? 1 : 2)) + ' ' + units[i];
 }
 
-function cardEscapeHtml(s) {
-  return String(s).replace(/[&<>"']/g, (ch) => ({
-    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
-  }[ch]));
-}
-
 function cardCleanupFileCount(n) {
   const count = Number(n || 0);
   return count.toLocaleString() + (count === 1 ? ' file' : ' files');
@@ -356,19 +293,33 @@ function cardCleanupSetError(msg, opts) {
   }
 }
 
-/* ---------- Single-select folder browser ----------
-   Minimal copy of the import page's browser: same /api/browse and
-   /api/volumes endpoints, one folder at a time, no photo counts. */
-let cardBrowserPath = '';
-let cardBrowserHomePath = '';
-let cardBrowserSeq = 0;
-let cardBrowserEscHandler = null;
+/* ---------- Shared single-select folder browser ---------- */
+const cardFolderBrowser = new VireoFolderBrowser({
+  overlayId: 'cardFolderBrowser',
+  defaultMode: 'card',
+  onError: (message) => cardCleanupSetError(message),
+  modes: {
+    card: {
+      title: 'Select Card Folder',
+      multiple: false,
+      showCounts: true,
+      // Cleanup considers every photo format Vireo imports, independent of
+      // the Import page's last RAW/JPEG filter selection.
+      fileTypes: 'both',
+      startPath: () =>
+        (document.getElementById('card-cleanup-source').value || '').trim(),
+      onSelect: (path) => {
+        document.getElementById('card-cleanup-source').value = path;
+      },
+    },
+  },
+});
 
 async function cardCleanupBrowse() {
   // Same shape as the import page's browseForSource(): native picker
   // when the desktop shell offers one, in-page browser otherwise.
   if (typeof pickDirectory === 'function') {
-    const seqBeforePicker = cardBrowserSeq;
+    const seqBeforePicker = cardFolderBrowser.sequence;
     const result = await pickDirectory('Select the card folder');
     if (result) {
       const path = Array.isArray(result) ? result[0] : result;
@@ -376,7 +327,7 @@ async function cardCleanupBrowse() {
       return;
     }
     if (typeof isTauri === 'function' && isTauri()) return;
-    if (cardBrowserSeq !== seqBeforePicker) {
+    if (cardFolderBrowser.sequence !== seqBeforePicker) {
       openCardFolderBrowser({ skipInitialBrowse: true });
       return;
     }
@@ -385,137 +336,19 @@ async function cardCleanupBrowse() {
 }
 
 function openCardFolderBrowser(opts = {}) {
-  const overlay = document.getElementById('cardFolderBrowser');
-  overlay.classList.add('open');
-  overlay.onclick = (e) => {
-    if (e.target === overlay) closeCardFolderBrowser();
-  };
-  if (cardBrowserEscHandler) {
-    document.removeEventListener('keydown', cardBrowserEscHandler);
-  }
-  cardBrowserEscHandler = (e) => {
-    if (e.key === 'Escape') closeCardFolderBrowser();
-  };
-  document.addEventListener('keydown', cardBrowserEscHandler);
-  document.body.style.overflow = 'hidden';
-  const firstAction = overlay.querySelector('button');
-  if (firstAction) firstAction.focus();
-  const startPath = (document.getElementById('card-cleanup-source').value || '').trim();
-  if (!opts.skipInitialBrowse) browseCardFolderTo(startPath || null);
+  cardFolderBrowser.open('card', opts);
 }
 
 function closeCardFolderBrowser() {
-  document.getElementById('cardFolderBrowser').classList.remove('open');
-  if (cardBrowserEscHandler) {
-    document.removeEventListener('keydown', cardBrowserEscHandler);
-    cardBrowserEscHandler = null;
-  }
-  document.body.style.overflow = '';
+  cardFolderBrowser.close();
 }
 
-async function browseCardFolderTo(path) {
-  const seq = ++cardBrowserSeq;
-  // Clear the stale selection while this async navigation is pending.
-  // Without this, clicking "Select This Folder" during a slow or failing
-  // fetch submits the previous folder instead of the one requested.
-  cardBrowserPath = '';
-  const selectBtn = document.getElementById('folderBrowserSelectBtn');
-  if (selectBtn) selectBtn.disabled = true;
-  document.getElementById('folderBrowserPath').textContent = 'Loading…';
-  document.getElementById('folderBrowserList').innerHTML =
-    '<div class="folder-browser-empty">Loading…</div>';
-  let url = '/api/browse';
-  if (path === '__pictures__') {
-    if (!cardBrowserHomePath) {
-      try {
-        const homeResp = await fetch('/api/browse');
-        if (seq !== cardBrowserSeq || !homeResp.ok) return;
-        const home = await homeResp.json();
-        cardBrowserHomePath = home.path || '';
-      } catch (e) {
-        return;
-      }
-    }
-    url = '/api/browse?path=' + encodeURIComponent(cardBrowserHomePath + '/Pictures');
-  } else if (path === '__volumes__') {
-    if (navigator.userAgent.indexOf('Mac') < 0) {
-      try {
-        const resp = await fetch('/api/volumes');
-        if (seq !== cardBrowserSeq || !resp.ok) return;
-        const volumes = await resp.json();
-        cardBrowserPath = '';
-        renderCardFolderBrowser({ path: '', dirs: volumes || [] }, { syntheticRoot: true });
-      } catch (e) { /* ignore */ }
-      return;
-    }
-    url = '/api/browse?path=' + encodeURIComponent('/Volumes');
-  } else if (path) {
-    url = '/api/browse?path=' + encodeURIComponent(path);
-  }
-
-  try {
-    const resp = await fetch(url);
-    if (seq !== cardBrowserSeq) return;
-    if (!resp.ok) {
-      const data = await resp.json().catch(() => ({}));
-      document.getElementById('folderBrowserPath').textContent =
-        data.error || 'Could not open folder.';
-      document.getElementById('folderBrowserList').innerHTML =
-        '<div class="folder-browser-empty">Could not open folder.</div>';
-      return;
-    }
-    const data = await resp.json();
-    cardBrowserPath = data.path || '';
-    if (!path) cardBrowserHomePath = cardBrowserPath;
-    renderCardFolderBrowser(data);
-  } catch (e) {
-    document.getElementById('folderBrowserPath').textContent = String(e.message || e);
-    document.getElementById('folderBrowserList').innerHTML =
-      '<div class="folder-browser-empty">Could not open folder.</div>';
-  }
-}
-
-function renderCardFolderBrowser(data, opts) {
-  document.getElementById('folderBrowserPath').textContent = data.path || 'Volumes';
-  const list = document.getElementById('folderBrowserList');
-  const dirs = data.dirs || [];
-  let html = '';
-  const syntheticRoot = opts && opts.syntheticRoot;
-  let parent = '';
-  if (data.path && data.path.indexOf('\\') !== -1) {
-    parent = data.path.replace(/[\\\/]?[^\\\/]+[\\\/]?$/, '') || data.path;
-    if (/^[A-Za-z]:$/.test(parent)) parent += '\\';
-  } else if (data.path) {
-    parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
-  }
-  if (data.path && data.path !== '/' && parent && parent !== data.path) {
-    html += '<div class="folder-browser-item" data-browse-path="' + cardEscapeHtml(parent) + '" data-parent-link="1">' +
-      '<span class="folder-browser-item-name">&#128193; ..</span></div>';
-  }
-  dirs.forEach((d) => {
-    html += '<div class="folder-browser-item" data-browse-path="' + cardEscapeHtml(d.path) + '">' +
-      '<span class="folder-browser-item-name">&#128193; ' + cardEscapeHtml(d.name || d.path) + '</span></div>';
-  });
-  if (!html) {
-    html = '<div class="folder-browser-empty">' +
-      (syntheticRoot ? 'No volumes found.' : 'No subfolders.') + '</div>';
-  }
-  list.innerHTML = html;
-  // Single-select: a click navigates into the folder, and the actions bar
-  // selects wherever you are standing.
-  list.onclick = (e) => {
-    const item = e.target.closest('.folder-browser-item[data-browse-path]');
-    if (!item) return;
-    browseCardFolderTo(item.getAttribute('data-browse-path'));
-  };
-  const selectBtn = document.getElementById('folderBrowserSelectBtn');
-  if (selectBtn) selectBtn.disabled = !cardBrowserPath;
+function browseCardFolderTo(path) {
+  return cardFolderBrowser.browse(path);
 }
 
 function selectCardBrowserFolder() {
-  if (!cardBrowserPath) return;
-  document.getElementById('card-cleanup-source').value = cardBrowserPath;
-  closeCardFolderBrowser();
+  cardFolderBrowser.confirm();
 }
 
 async function cardCleanupStartScan() {

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -165,8 +165,6 @@ body { display: flex; flex-direction: column; height: 100vh; }
   </div>
 </div>
 
-{% set folder_browser_overlay_id = 'cardFolderBrowser' %}
-{% set folder_browser_test_id = 'card-folder-browser' %}
 {% include '_folder_browser.html' %}
 
 <!-- Delete confirmation. Reuses the folder browser's overlay/panel classes:
@@ -295,7 +293,7 @@ function cardCleanupSetError(msg, opts) {
 
 /* ---------- Shared single-select folder browser ---------- */
 const cardFolderBrowser = new VireoFolderBrowser({
-  overlayId: 'cardFolderBrowser',
+  overlayId: 'folderBrowser',
   defaultMode: 'card',
   onError: (message) => cardCleanupSetError(message),
   modes: {

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -462,8 +462,6 @@ body { display: flex; flex-direction: column; height: 100vh; }
   </div>
 </div>
 
-{% set folder_browser_overlay_id = 'importFolderBrowser' %}
-{% set folder_browser_test_id = 'import-folder-browser' %}
 {% include '_folder_browser.html' %}
 
 <script src="/static/vireo-folder-browser.js"></script>
@@ -1330,7 +1328,7 @@ async function browseForDestination() {
 }
 
 const importFolderBrowser = new VireoFolderBrowser({
-  overlayId: 'importFolderBrowser',
+  overlayId: 'folderBrowser',
   defaultMode: 'source',
   onError: (message) => showError(message),
   modes: {

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -6,6 +6,7 @@
 <link rel="icon" type="image/png" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
 <link rel="stylesheet" href="/static/vireo-base.css">
+<link rel="stylesheet" href="/static/vireo-folder-browser.css">
 <title>Vireo - Import</title>
 <style>
 body { display: flex; flex-direction: column; height: 100vh; }
@@ -164,49 +165,6 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .staging-meta { font-size: 11px; color: var(--text-secondary); margin-top: 3px; }
 .staging-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
 .staging-details { margin: 8px 0 0 0; padding-left: 18px; font-size: 11px; color: var(--text-secondary); max-height: 120px; overflow: auto; }
-.folder-browser-overlay {
-  display: none; position: fixed; inset: 0; z-index: 1001;
-  background: rgba(0, 0, 0, 0.45); align-items: center; justify-content: center;
-}
-.folder-browser-overlay.open { display: flex; }
-.folder-browser-panel {
-  width: min(720px, calc(100vw - 32px)); max-height: calc(100vh - 64px);
-  background: var(--bg-secondary); border: 1px solid var(--border-primary);
-  border-radius: 8px; box-shadow: 0 18px 60px rgba(0,0,0,0.35);
-  display: flex; flex-direction: column; overflow: hidden;
-}
-.folder-browser-header {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 14px 16px; border-bottom: 1px solid var(--border-primary);
-}
-.folder-browser-header h3 { margin: 0; }
-.folder-browser-close { background: none; border: none; color: var(--text-secondary); font-size: 22px; cursor: pointer; }
-.folder-browser-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 10px; min-height: 0; }
-.folder-browser-shortcuts { display: flex; gap: 8px; flex-wrap: wrap; }
-.folder-browser-path { font-size: 12px; color: var(--text-secondary); overflow-wrap: anywhere; }
-.folder-browser-list {
-  height: 320px; overflow: auto; border: 1px solid var(--border-primary);
-  border-radius: 6px; background: var(--bg-tertiary);
-}
-.folder-browser-item {
-  padding: 8px 10px; font-size: 12px; color: var(--text-primary);
-  cursor: pointer; border-bottom: 1px solid color-mix(in srgb, var(--border-primary) 60%, transparent);
-  display: flex; align-items: center; gap: 8px;
-}
-.folder-browser-item:hover { background: var(--bg-hover, rgba(255,255,255,0.05)); }
-.folder-browser-item.selected { background: color-mix(in srgb, var(--accent) 15%, transparent); }
-.folder-browser-item-name {
-  flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.folder-browser-count {
-  color: var(--text-secondary); font-size: 11px; font-variant-numeric: tabular-nums;
-  flex-shrink: 0; white-space: nowrap;
-}
-.folder-browser-empty { padding: 14px; font-size: 12px; color: var(--text-secondary); }
-.folder-browser-actions {
-  display: flex; gap: 8px; justify-content: flex-end;
-  padding: 12px 16px; border-top: 1px solid var(--border-primary);
-}
 .import-tag-list { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
 .import-tag-chip {
   display: inline-flex; align-items: center; gap: 5px;
@@ -504,29 +462,11 @@ body { display: flex; flex-direction: column; height: 100vh; }
   </div>
 </div>
 
-<div class="folder-browser-overlay" id="importFolderBrowser" data-testid="import-folder-browser">
-  <div class="folder-browser-panel" role="dialog" aria-modal="true" aria-labelledby="folderBrowserTitle">
-    <div class="folder-browser-header">
-      <h3 id="folderBrowserTitle">Select Folder</h3>
-      <button class="folder-browser-close" type="button" onclick="closeImportFolderBrowser()">&times;</button>
-    </div>
-    <div class="folder-browser-body">
-      <div class="folder-browser-shortcuts">
-        <button class="btn" type="button" onclick="browseImportFolderTo(null)">Home</button>
-        <button class="btn" type="button" onclick="browseImportFolderTo('__pictures__')">Pictures</button>
-        <button class="btn" type="button" onclick="browseImportFolderTo('__volumes__')">Volumes</button>
-      </div>
-      <div class="folder-browser-path" id="folderBrowserPath"></div>
-      <div class="folder-browser-list" id="folderBrowserList"></div>
-      <div class="folder-browser-path" id="folderBrowserSelection"></div>
-    </div>
-    <div class="folder-browser-actions">
-      <button class="btn" type="button" onclick="closeImportFolderBrowser()">Cancel</button>
-      <button class="btn btn-primary" type="button" id="folderBrowserSelectBtn" onclick="selectImportBrowserFolder()">Select This Folder</button>
-    </div>
-  </div>
-</div>
+{% set folder_browser_overlay_id = 'importFolderBrowser' %}
+{% set folder_browser_test_id = 'import-folder-browser' %}
+{% include '_folder_browser.html' %}
 
+<script src="/static/vireo-folder-browser.js"></script>
 <script>
 /* Import page: adds folders in place or copies them to an archive, renders
    live progress from the job's SSE stream, and only shows safe-to-format
@@ -540,15 +480,6 @@ let cardCleanupImportSources = [];
 let stagingResultsByPath = {};
 let sourceCounts = {};
 let sourceCountRequestSeq = 0;
-let browserMode = 'source';
-let browserPath = '';
-let browserHomePath = '';
-let browserSeq = 0;
-let browserCountsAbort = null;
-let browserCountCache = {};
-let browserEscHandler = null;
-let browserSelectedPaths = [];
-let browserSelectAnchorPath = '';
 let activeImportMode = 'in_place';
 let importRemoteTargets = [];
 let importRsyncAvailable = false;
@@ -1215,16 +1146,6 @@ async function loadImportRemoteTargets() {
   updateAfterMoveUI();
 }
 
-function importEscapeHtml(s) {
-  return String(s).replace(/[&<>"']/g, (ch) => ({
-    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
-  }[ch]));
-}
-
-function importEscapeAttr(s) {
-  return importEscapeHtml(s);
-}
-
 function renderSources() {
   const list = document.getElementById('sourceList');
   list.innerHTML = '';
@@ -1367,7 +1288,7 @@ function addSource() {
 
 async function browseForSource() {
   if (typeof pickDirectory === 'function') {
-    const seqBeforePicker = browserSeq;
+    const seqBeforePicker = importFolderBrowser.sequence;
     const result = await pickDirectory('Select source folders', { multiple: true });
     if (result) {
       const paths = Array.isArray(result) ? result : [result];
@@ -1375,7 +1296,7 @@ async function browseForSource() {
       return;
     }
     if (typeof isTauri === 'function' && isTauri()) return;
-    if (browserSeq !== seqBeforePicker) {
+    if (importFolderBrowser.sequence !== seqBeforePicker) {
       openImportFolderBrowser('source', { skipInitialBrowse: true });
       return;
     }
@@ -1385,7 +1306,7 @@ async function browseForSource() {
 
 async function browseForDestination() {
   if (typeof pickDirectory === 'function') {
-    const seqBeforePicker = browserSeq;
+    const seqBeforePicker = importFolderBrowser.sequence;
     const result = await pickDirectory('Select archive folder');
     if (result) {
       const path = Array.isArray(result) ? result[0] : result;
@@ -1400,7 +1321,7 @@ async function browseForDestination() {
       return;
     }
     if (typeof isTauri === 'function' && isTauri()) return;
-    if (browserSeq !== seqBeforePicker) {
+    if (importFolderBrowser.sequence !== seqBeforePicker) {
       openImportFolderBrowser('destination', { skipInitialBrowse: true });
       return;
     }
@@ -1408,290 +1329,50 @@ async function browseForDestination() {
   openImportFolderBrowser('destination');
 }
 
+const importFolderBrowser = new VireoFolderBrowser({
+  overlayId: 'importFolderBrowser',
+  defaultMode: 'source',
+  onError: (message) => showError(message),
+  modes: {
+    source: {
+      title: 'Select Source Folders',
+      multiple: true,
+      showCounts: true,
+      fileTypes: () => selectedSourceCountOptions().file_types,
+      startPath: '',
+      onSelect: (paths) => paths.forEach(addSourcePath),
+    },
+    destination: {
+      title: 'Select Destination Folder',
+      multiple: false,
+      showCounts: false,
+      startPath: () => (document.getElementById('destInput').value || '').trim(),
+      onSelect: (path) => {
+        const destination = document.getElementById('destInput');
+        destination.value = path;
+        // Notify destination-preview listeners exactly like a manual edit.
+        destination.dispatchEvent(new Event('input', { bubbles: true }));
+      },
+    },
+  },
+});
+
+// Compatibility wrappers keep existing inline callers, deep-link behavior,
+// and browser-level tests stable while all behavior lives in the shared module.
 function openImportFolderBrowser(mode, opts = {}) {
-  browserMode = mode === 'destination' ? 'destination' : 'source';
-  const overlay = document.getElementById('importFolderBrowser');
-  document.getElementById('folderBrowserTitle').textContent =
-    browserMode === 'source' ? 'Select Source Folders' : 'Select Destination Folder';
-  browserSelectedPaths = [];
-  browserSelectAnchorPath = '';
-  updateImportBrowserSelection();
-  overlay.classList.add('open');
-  overlay.onclick = (e) => {
-    if (e.target === overlay) closeImportFolderBrowser();
-  };
-  if (browserEscHandler) document.removeEventListener('keydown', browserEscHandler);
-  browserEscHandler = (e) => {
-    if (e.key === 'Escape') closeImportFolderBrowser();
-  };
-  document.addEventListener('keydown', browserEscHandler);
-  document.body.style.overflow = 'hidden';
-  const firstAction = overlay.querySelector('button');
-  if (firstAction) firstAction.focus();
-  const startPath = browserMode === 'destination'
-    ? (document.getElementById('destInput').value || '').trim()
-    : '';
-  if (!opts.skipInitialBrowse) browseImportFolderTo(startPath || null);
+  importFolderBrowser.open(mode === 'destination' ? 'destination' : 'source', opts);
 }
 
 function closeImportFolderBrowser() {
-  document.getElementById('importFolderBrowser').classList.remove('open');
-  if (browserCountsAbort) {
-    browserCountsAbort.abort();
-    browserCountsAbort = null;
-  }
-  if (browserEscHandler) {
-    document.removeEventListener('keydown', browserEscHandler);
-    browserEscHandler = null;
-  }
-  document.body.style.overflow = '';
+  importFolderBrowser.close();
 }
 
-async function browseImportFolderTo(path) {
-  const seq = ++browserSeq;
-  if (browserCountsAbort) {
-    browserCountsAbort.abort();
-    browserCountsAbort = null;
-  }
-  // Clear stale selection while this async navigation is pending. Without
-  // this, clicking "Select This Folder" during a slow or failing fetch
-  // submits the previous folder instead of the one the user requested —
-  // both on modal open and mid-session navigation.
-  browserPath = '';
-  browserSelectedPaths = [];
-  browserSelectAnchorPath = '';
-  updateImportBrowserSelection();
-  const selectBtn = document.getElementById('folderBrowserSelectBtn');
-  if (selectBtn) selectBtn.disabled = true;
-  document.getElementById('folderBrowserPath').textContent = 'Loading…';
-  document.getElementById('folderBrowserList').innerHTML =
-    '<div class="folder-browser-empty">Loading…</div>';
-  let url = '/api/browse';
-  if (path === '__pictures__') {
-    if (!browserHomePath) {
-      try {
-        const homeResp = await fetch('/api/browse');
-        if (seq !== browserSeq || !homeResp.ok) return;
-        const home = await homeResp.json();
-        browserHomePath = home.path || '';
-      } catch (e) {
-        return;
-      }
-    }
-    url = '/api/browse?path=' + encodeURIComponent(browserHomePath + '/Pictures');
-  } else if (path === '__volumes__') {
-    if (navigator.userAgent.indexOf('Mac') < 0) {
-      try {
-        const resp = await fetch('/api/volumes');
-        if (seq !== browserSeq || !resp.ok) return;
-        const volumes = await resp.json();
-        browserPath = '';
-        renderImportFolderBrowser({ path: '', dirs: volumes || [] }, { syntheticRoot: true });
-      } catch (e) { /* ignore */ }
-      return;
-    }
-    url = '/api/browse?path=' + encodeURIComponent('/Volumes');
-  } else if (path) {
-    url = '/api/browse?path=' + encodeURIComponent(path);
-  }
-
-  try {
-    const resp = await fetch(url);
-    if (seq !== browserSeq) return;
-    if (!resp.ok) {
-      const data = await resp.json().catch(() => ({}));
-      showError(data.error || 'Could not open folder.');
-      return;
-    }
-    const data = await resp.json();
-    browserPath = data.path || '';
-    browserSelectedPaths = [];
-    browserSelectAnchorPath = '';
-    if (!path) browserHomePath = browserPath;
-    renderImportFolderBrowser(data);
-  } catch (e) {
-    showError(String(e.message || e));
-  }
-}
-
-function renderImportFolderBrowser(data, opts) {
-  document.getElementById('folderBrowserPath').textContent = data.path || 'Volumes';
-  const list = document.getElementById('folderBrowserList');
-  const dirs = data.dirs || [];
-  let html = '';
-  const syntheticRoot = opts && opts.syntheticRoot;
-  let parent = '';
-  if (data.path && data.path.indexOf('\\') !== -1) {
-    parent = data.path.replace(/[\\\/]?[^\\\/]+[\\\/]?$/, '') || data.path;
-    if (/^[A-Za-z]:$/.test(parent)) parent += '\\';
-  } else if (data.path) {
-    parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
-  }
-  if (data.path && data.path !== '/' && parent && parent !== data.path) {
-    html += '<div class="folder-browser-item" data-browse-path="' + importEscapeAttr(parent) + '" data-parent-link="1">' +
-      '<span class="folder-browser-item-name">&#128193; ..</span></div>';
-  }
-  dirs.forEach((d) => {
-    html += '<div class="folder-browser-item" data-browse-path="' + importEscapeAttr(d.path) + '" data-folder-path="' + importEscapeAttr(d.path) + '">' +
-      '<span class="folder-browser-item-name">&#128193; ' + importEscapeHtml(d.name || d.path) + '</span>' +
-      '<span class="folder-browser-count" data-count-path="' + importEscapeAttr(d.path) + '"></span></div>';
-  });
-  if (!html) {
-    html = '<div class="folder-browser-empty">' +
-      (syntheticRoot ? 'No volumes found.' : 'No subfolders.') + '</div>';
-  }
-  list.innerHTML = html;
-  list.onclick = (e) => {
-    const item = e.target.closest('.folder-browser-item[data-browse-path]');
-    if (!item) return;
-    if (item.getAttribute('data-parent-link') === '1' || browserMode === 'destination') {
-      browseImportFolderTo(item.getAttribute('data-browse-path'));
-      return;
-    }
-    selectImportBrowserListItem(item, e);
-  };
-  list.ondblclick = (e) => {
-    const item = e.target.closest('.folder-browser-item[data-browse-path]');
-    if (item && item.getAttribute('data-parent-link') !== '1') {
-      browseImportFolderTo(item.getAttribute('data-browse-path'));
-    }
-  };
-  updateImportBrowserSelection();
-  if (browserMode === 'source') refreshImportBrowserCounts(dirs, browserSeq);
-}
-
-function importBrowserCountKey(path, fileTypes) {
-  const normalized = Array.isArray(fileTypes)
-    ? fileTypes.slice().sort().join(',')
-    : String(fileTypes || 'both');
-  return path + '\n' + normalized;
-}
-
-function applyImportBrowserCount(path, count) {
-  if (!count) return;
-  document.querySelectorAll('#folderBrowserList .folder-browser-count').forEach((badge) => {
-    if (badge.getAttribute('data-count-path') === path) {
-      badge.textContent = formatPhotoCount(count);
-    }
-  });
-}
-
-async function refreshImportBrowserCounts(dirs, seq) {
-  if (!dirs.length || seq !== browserSeq) return;
-  const fileTypes = selectedSourceCountOptions().file_types;
-  const uncached = [];
-  dirs.forEach((dir) => {
-    const key = importBrowserCountKey(dir.path, fileTypes);
-    if (Object.prototype.hasOwnProperty.call(browserCountCache, key)) {
-      applyImportBrowserCount(dir.path, browserCountCache[key]);
-    } else {
-      uncached.push(dir.path);
-    }
-  });
-  if (!uncached.length) return;
-
-  browserCountsAbort = new AbortController();
-  try {
-    const resp = await fetch('/api/browse/photo-counts', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ paths: uncached, file_types: fileTypes }),
-      signal: browserCountsAbort.signal,
-    });
-    if (!resp.ok || seq !== browserSeq) return;
-    const data = await resp.json();
-    if (seq !== browserSeq) return;
-    const counts = data.counts || {};
-    Object.keys(counts).forEach((path) => {
-      browserCountCache[importBrowserCountKey(path, fileTypes)] = counts[path];
-      applyImportBrowserCount(path, counts[path]);
-    });
-  } catch (e) {
-    if (e.name !== 'AbortError') { /* Counts are helpful but non-blocking. */ }
-  } finally {
-    if (seq === browserSeq) browserCountsAbort = null;
-  }
-}
-
-function selectImportBrowserListItem(item, event) {
-  const path = item.getAttribute('data-folder-path') || item.getAttribute('data-browse-path');
-  if (!path) return;
-  const items = Array.from(document.querySelectorAll('#folderBrowserList .folder-browser-item[data-folder-path]'));
-  const shift = event && event.shiftKey;
-  const toggle = event && (event.metaKey || event.ctrlKey);
-
-  if (shift && browserSelectAnchorPath) {
-    let anchorIdx = items.findIndex((el) => el.getAttribute('data-folder-path') === browserSelectAnchorPath);
-    const clickIdx = items.findIndex((el) => el.getAttribute('data-folder-path') === path);
-    if (clickIdx === -1) return;
-    if (anchorIdx === -1) anchorIdx = clickIdx;
-    const lo = Math.min(anchorIdx, clickIdx);
-    const hi = Math.max(anchorIdx, clickIdx);
-    browserSelectedPaths = items.slice(lo, hi + 1).map((el) => el.getAttribute('data-folder-path'));
-  } else if (toggle) {
-    const idx = browserSelectedPaths.indexOf(path);
-    if (idx === -1) browserSelectedPaths.push(path);
-    else browserSelectedPaths.splice(idx, 1);
-    browserSelectAnchorPath = path;
-  } else {
-    browserSelectedPaths = [path];
-    browserSelectAnchorPath = path;
-  }
-  updateImportBrowserSelection();
-}
-
-function updateImportBrowserSelection() {
-  const selected = {};
-  browserSelectedPaths.forEach((path) => { selected[path] = true; });
-  document.querySelectorAll('#folderBrowserList .folder-browser-item[data-folder-path]').forEach((item) => {
-    item.classList.toggle('selected', !!selected[item.getAttribute('data-folder-path')]);
-  });
-
-  const selection = document.getElementById('folderBrowserSelection');
-  if (selection) {
-    if (browserMode === 'source' && browserSelectedPaths.length > 1) {
-      selection.textContent = browserSelectedPaths.length + ' folders selected';
-    } else if (browserMode === 'source' && browserSelectedPaths.length === 1) {
-      selection.textContent = browserSelectedPaths[0];
-    } else {
-      selection.textContent = '';
-    }
-  }
-
-  const selectBtn = document.getElementById('folderBrowserSelectBtn');
-  if (selectBtn) {
-    if (browserMode === 'source') {
-      selectBtn.textContent = browserSelectedPaths.length > 1
-        ? 'Add ' + browserSelectedPaths.length + ' Folders'
-        : 'Add This Folder';
-      // Volumes root renders with browserPath = '' but selectable drive rows.
-      // Enable submission whenever the user has picked at least one, so
-      // multi-select from the Volumes shortcut is reachable.
-      selectBtn.disabled = !browserPath && browserSelectedPaths.length === 0;
-    } else {
-      selectBtn.textContent = 'Select This Folder';
-      selectBtn.disabled = !browserPath;
-    }
-  }
+function browseImportFolderTo(path) {
+  return importFolderBrowser.browse(path);
 }
 
 function selectImportBrowserFolder() {
-  if (browserMode === 'destination') {
-    if (!browserPath) return;
-    const destination = document.getElementById('destInput');
-    destination.value = browserPath;
-    // Notify destInput listeners (dest-structure invalidation, NAS-move
-    // row) exactly like a manual edit would — matches
-    // selectRecentDestination().
-    destination.dispatchEvent(new Event('input', { bubbles: true }));
-  } else {
-    const paths = browserSelectedPaths.length
-      ? browserSelectedPaths
-      : (browserPath ? [browserPath] : []);
-    if (!paths.length) return;
-    paths.forEach(addSourcePath);
-  }
-  closeImportFolderBrowser();
+  importFolderBrowser.confirm();
 }
 
 // Populate the After Import dropdown from the saved-process library. Keeps

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -403,6 +403,24 @@ def test_card_cleanup_page_renders(app_and_db):
     assert "card-cleanup-audit-btn" in body
 
 
+def test_import_and_card_cleanup_share_folder_browser(app_and_db):
+    """Both pages use one browser implementation, partial, and stylesheet.
+
+    This pins the architectural reason for the refactor: count rendering and
+    navigation fixes must land once rather than drift between template copies.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    import_body = client.get("/import").get_data(as_text=True)
+    cleanup_body = client.get("/card-cleanup").get_data(as_text=True)
+    for body in (import_body, cleanup_body):
+        assert '/static/vireo-folder-browser.js' in body
+        assert '/static/vireo-folder-browser.css' in body
+        assert 'data-folder-browser-action="select"' in body
+    assert client.get("/static/vireo-folder-browser.js").status_code == 200
+    assert client.get("/static/vireo-folder-browser.css").status_code == 200
+
+
 def test_import_page_links_to_card_cleanup_instead_of_hosting_it(app_and_db):
     app, _ = app_and_db
     resp = app.test_client().get("/import")


### PR DESCRIPTION
## Summary

- extract the Import folder picker into shared JavaScript, CSS, and template partials
- use the shared picker in Card Cleanup so folders display recursive photo counts
- preserve Import multi-select and destination-selection behavior while sharing navigation and count loading
- add API/template regression coverage and Card Cleanup browser coverage

## Testing

- `python -m pytest tests/e2e/test_import_page.py tests/e2e/test_card_cleanup.py -q` (115 passed)
- `python -m pytest vireo/tests/test_card_cleanup_api.py -q` (26 passed)
- `python -m pytest vireo/tests/test_app.py -k browse_photo_counts vireo/tests/test_build_static.py -q` (6 passed)
- `ruff check tests/e2e/test_card_cleanup.py vireo/tests/test_card_cleanup_api.py`
- `node --check vireo/static/vireo-folder-browser.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared folder browser for importing and Card Cleanup.
  * Supports folder navigation, Home/Pictures/Volumes shortcuts, photo counts, single- and multi-folder selection, and range selection.
  * Added loading, error, empty-state, keyboard, and overlay dismissal support.
  * Import and Card Cleanup now use consistent folder-selection experiences.

* **Tests**
  * Added coverage for folder navigation, counts, filters, selections, and shared browser assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->