### PR TITLE
Scope card cleanup verification to matching files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to Vireo are documented in this file.
   updater, and uninstall-preservation gates before publication.
 
 ### Fixed
+- Freeing card space now verifies only archive copies that match the selected
+  card instead of re-hashing the entire workspace, refreshes the preview
+  automatically, and reads each card file only once at deletion.
 - Opening a catalog that was already migrated by a newer Vireo (for example
   after reinstalling an older build) now shows clear "update Vireo to open
   this catalog" guidance instead of a crash — and no longer suggests moving

--- a/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
@@ -293,13 +293,20 @@ photo) are both deletable — the rule is content-based, not one-to-one.
 
 ### Delete job
 
-`POST /api/card-cleanup/delete` with `{scan_job_id}` starts
-`card_cleanup_delete`. It loads the manifest file written by the scan and
-refuses to start if the scan job is missing, unfinished, or cancelled, if
-the manifest file is gone (expired), or if its deletable bucket is empty.
-Only one delete job per scan manifest may run at a time. Because the
-manifest lives on disk, delete-after-restart works: the endpoint validates
-the scan job against `job_history` when it is no longer in memory.
+`POST /api/card-cleanup/delete` with `{scan_job_id, manifest_revision}`
+starts `card_cleanup_delete`. `manifest_revision` is the integer revision
+the client last rendered (from the manifest's `revision` field); a
+targeted verify job atomically bumps this after each run, so a mismatch
+means the on-disk preview no longer matches what the user confirmed.
+The endpoint responds `409 manifest_revision_mismatch` in that case so
+the UI can drop the user back into a "reload the preview" state rather
+than sweep in newly-promoted files the user never saw. It otherwise
+loads the manifest file written by the scan and refuses to start if the
+scan job is missing, unfinished, or cancelled, if the manifest file is
+gone (expired), or if its deletable bucket is empty. Only one delete
+job per scan manifest may run at a time. Because the manifest lives on
+disk, delete-after-restart works: the endpoint validates the scan job
+against `job_history` when it is no longer in memory.
 
 For each **deletable** manifest entry, immediately before deletion:
 
@@ -352,11 +359,18 @@ they exist only for the preview.
   matching, previously-unchecked archive copies and atomically refreshes the
   scan manifest. Returns the job id; 409 if verification or deletion for the
   same manifest is already running.
-- `POST /api/card-cleanup/delete` — body `{scan_job_id}`. Returns the job
-  id. 409 if a delete for that manifest is already running; 400 for an
-  unfinished/cancelled scan or a manifest that fails load-time validation
-  (corrupt, wrong schema, entries outside the source root); 404 for an
-  unknown scan job, a pruned manifest file, or a manifest older than 7
+- `POST /api/card-cleanup/delete` — body
+  `{scan_job_id, manifest_revision: int}`. Returns the job id. 400 if
+  `manifest_revision` is missing or not an integer (bools are rejected
+  explicitly — `isinstance(True, int)` is truthy). 409
+  `manifest_revision_mismatch` when the on-disk manifest carries a
+  different revision than the client confirmed (a verify run has since
+  refreshed the preview); the UI reloads and asks the user to
+  re-confirm. Otherwise 409 if a delete for that manifest is already
+  running; 400 for an unfinished/cancelled scan or a manifest that
+  fails load-time validation (corrupt, wrong schema, entries outside
+  the source root); 404 for an unknown scan job, a pruned manifest
+  file, or a manifest older than 7
   days (age is checked at request time, not only at prune time), with
   "re-scan the card" copy.
 - Progress and results ride the existing job endpoints (stream, status,

--- a/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
@@ -173,9 +173,11 @@ verified files** button opens a confirmation dialog that states plainly:
 - Deletion is permanent — memory cards have no trash.
 - After deletion, the archive holds the only copy of these photos.
 - What "verified" means: each file's archive copy passed a checksum check
-  (at import, targeted cleanup verification, or integrity audit) and is
-  confirmed unchanged since by size and timestamp; the card copy itself is
-  re-checksummed at the moment of deletion. Archive bytes are not re-downloaded.
+  (at import, targeted cleanup verification, or integrity audit) and its
+  current size and modification time still match the `file_size` /
+  `file_mtime` baseline the catalog recorded when the checksum was
+  written; the card copy itself is re-checksummed at the moment of
+  deletion. Archive bytes are not re-downloaded.
 
 Confirming starts the **delete** job with live per-file progress. The final
 summary reports exact counts: deleted, kept, skipped-because-changed, and

--- a/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
@@ -11,7 +11,7 @@ manifests); awaiting maintainer sign-off before implementation planning
 card) only after verifying, per file and at deletion time, that the card
 file's bytes match a hash that was checksum-verified into the archive and
 that the archive copy is confirmed unchanged since that verification by
-metadata (see "Safety invariant" for the exact guarantee). Two new job
+metadata (see "Safety invariant" for the exact guarantee). Three new job
 types plus an import-page UI section. No changes to the import pipeline
 itself.
 
@@ -173,9 +173,9 @@ verified files** button opens a confirmation dialog that states plainly:
 - Deletion is permanent — memory cards have no trash.
 - After deletion, the archive holds the only copy of these photos.
 - What "verified" means: each file's archive copy passed a checksum check
-  (at import or integrity audit) and is confirmed unchanged since by size
-  and timestamp; the card copy itself is re-checksummed at the moment of
-  deletion. Archive bytes are not re-downloaded.
+  (at import, targeted cleanup verification, or integrity audit) and is
+  confirmed unchanged since by size and timestamp; the card copy itself is
+  re-checksummed at the moment of deletion. Archive bytes are not re-downloaded.
 
 Confirming starts the **delete** job with live per-file progress. The final
 summary reports exact counts: deleted, kept, skipped-because-changed, and
@@ -237,9 +237,24 @@ changed since verification (size/mtime off baseline), only catalog copy is
 inside the selected source tree, unreadable on card. Photos cataloged by an archive *scan*
 rather than a verified import have `file_hash` but NULL `hash_status`, so
 whole scan-cataloged archives land in this bucket — safely conservative,
-but the keep-reason copy must point at the remedy ("not verified by a
-checksummed import — run the integrity audit") so the tool doesn't read as
-broken.
+but the keep-reason copy offers targeted verification of the matching
+archive copies so the tool does not read as broken or force a full-library
+audit.
+
+### Targeted archive-verification job
+
+`POST /api/card-cleanup/verify` with `{scan_job_id}` reads only archive
+rows needed by that preview's `KEEP_NOT_VERIFIED` entries. It groups card
+entries by content hash, tries unchecked archive rows until one viable copy
+matches, and stops after the first success for that hash. Unrelated archive
+files and redundant copies are not read; duplicate card files with the same
+content share one archive read. Successful rows receive `hash_status =
+'ok'` and a fresh size/mtime baseline.
+
+The job atomically reclassifies the existing manifest after each completed
+or cancelled run. Because it only promotes previously-unverified rows and
+never re-audits existing `ok` rows, the page can reload the preview directly
+without hashing the card again. Delete-time checks remain authoritative.
 
 **Manifest storage and lifecycle.** The manifest — a header with the
 resolved source root (so the delete job's overlap guard travels with the
@@ -286,32 +301,35 @@ the scan job against `job_history` when it is no longer in memory.
 
 For each **deletable** manifest entry, immediately before deletion:
 
-1. **Card gate (stat, then re-hash)** — re-`stat` the card file; if size
+1. **Card metadata gate** — re-`stat` the card file; if size
    or `mtime_ns` differs from the manifest, **skip** (cheap pre-check).
-   Then re-hash the card file and require the hash to equal the manifest
+2. **Archive gate 1, then card hash** — require a currently qualifying
+   archive row before doing the full card read. Then hash the card file once
+   and require the hash to equal the manifest
    hash — size+mtime alone cannot detect a swapped card or a same-size
-   replacement, especially with FAT/exFAT timestamp granularity. The card
-   is local, so this second read is fast. Any mismatch → **skipped**, with
-   reason. New files are simply absent from the manifest, so the user can
-   keep shooting between scan and delete.
-2. **Archive gate (re-validated now, not trusted from the scan)** —
+   replacement, especially with FAT/exFAT timestamp granularity. Any
+   mismatch → **skipped**, with reason. New files are simply absent from the
+   manifest, so the user can keep shooting between scan and delete.
+3. **Archive gate 2 (re-validated after the card read)** —
    re-query `photos WHERE file_hash = ?` and require at least one row to
    pass the qualifying test from the safety invariant: `hash_status =
    'ok'`, path outside the source tree and not `samefile` with the card
    file, fresh archive `stat` exactly matching the cataloged size/mtime
    baseline. If the mount is down, the file was deleted from the archive,
    or the baseline no longer matches, the card file is **skipped**, not
-   deleted. The scan-time check only made the preview honest; this one is
-   the guarantee.
-3. **Delete** — `os.remove`. Per-file errors (read-only card, vanished
+   deleted. Running the archive check on both sides of the one full card
+   read prevents either side's verdict from going stale during the other's
+   slow I/O without reading every card file twice.
+4. **Delete** — `os.remove`. Per-file errors (read-only card, vanished
    file) are recorded as **failed** with the OS error; the job continues.
 
 Catalog *row* lookups for duplicate card files sharing a hash may be
 cached within the run; the archive **stat may not** — it must be repeated
 immediately before every individual removal, because a cached stat could
 authorize deleting the second duplicate after the archive vanished
-following the first. One SMB stat round-trip per removal; archive bytes
-are never re-read — see the safety invariant for the explicit tradeoff.
+following the first. Two lightweight archive metadata gates run per removal;
+archive bytes are never re-read — see the safety invariant for the explicit
+tradeoff.
 
 Progress is per-file over SSE. Cancellation stops at a file boundary;
 already-deleted files stay deleted and the summary honestly reports
@@ -328,6 +346,10 @@ they exist only for the preview.
   equals, contains, or lies inside any cataloged folder root under the
   overlap guard's containment rules — the guard's fail-fast half. Returns
   the job id.
+- `POST /api/card-cleanup/verify` — body `{scan_job_id}`. Verifies only
+  matching, previously-unchecked archive copies and atomically refreshes the
+  scan manifest. Returns the job id; 409 if verification or deletion for the
+  same manifest is already running.
 - `POST /api/card-cleanup/delete` — body `{scan_job_id}`. Returns the job
   id. 409 if a delete for that manifest is already running; 400 for an
   unfinished/cancelled scan or a manifest that fails load-time validation
@@ -338,7 +360,7 @@ they exist only for the preview.
 - Progress and results ride the existing job endpoints (stream, status,
   history).
 
-Both jobs are global (photos and their hashes are global, not
+All three jobs are global (photos and their hashes are global, not
 workspace-scoped), matching how the catalog works.
 
 ### Error handling
@@ -365,6 +387,9 @@ Unit tests with temp directories (no real card or SMB mount):
 - Scan candidate set equals `discover_source_files` output on the same
   tree (filter-parity test, so the two predicates cannot drift).
 - Hash match but `hash_status` ≠ `'ok'` → kept.
+- Targeted verification reads only matching archive rows, stops after one
+  verified copy per unique hash, and atomically promotes every matching card
+  entry without a second card scan.
 - Hash match but archive file missing, or size/mtime off the cataloged
   baseline → kept.
 - Overlap: scan of a source equal to / containing / inside a cataloged

--- a/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-card-cleanup-design.md
@@ -366,8 +366,8 @@ they exist only for the preview.
   `manifest_revision_mismatch` when the on-disk manifest carries a
   different revision than the client confirmed (a verify run has since
   refreshed the preview); the UI reloads and asks the user to
-  re-confirm. Otherwise 409 if a delete for that manifest is already
-  running; 400 for an unfinished/cancelled scan or a manifest that
+  re-confirm. Otherwise 409 if verification or deletion for that manifest
+  is already running; 400 for an unfinished/cancelled scan or a manifest that
   fails load-time validation (corrupt, wrong schema, entries outside
   the source root); 404 for an unknown scan job, a pruned manifest
   file, or a manifest older than 7

--- a/docs/superpowers/specs/2026-08-08-card-cleanup-page-design.md
+++ b/docs/superpowers/specs/2026-08-08-card-cleanup-page-design.md
@@ -2,12 +2,13 @@
 
 **Date:** 2026-08-08
 **Status:** Approved in discussion with maintainer (relocation follow-up to
-PR #1436); lightweight spec — the feature's behavior is unchanged and
-governed by `2026-08-07-card-cleanup-design.md`.
+PR #1436); amended 2026-08-11 to replace the workspace-wide audit affordance
+with targeted matching-copy verification. Runtime behavior is governed by
+`2026-08-07-card-cleanup-design.md`.
 **Scope:** Move the "Free up card space" UI from a collapsed section on the
 import page to a dedicated page with a navbar entry; add an inline
-integrity-audit affordance; keep the post-import entry point as a link.
-No backend behavior changes to scan/delete.
+targeted-verification affordance; keep the post-import entry point as a link.
+Scan/delete behavior remains governed by the parent design.
 
 ## Problem
 
@@ -40,17 +41,13 @@ this reason).
    refactor of import.html: the parent PR's reviewers accepted mirrored
    code at this scale, and un-inlining import.html's browser is exactly
    the kind of unrelated refactor the parent spec declined.
-3. **Inline audit affordance.** When the rendered preview's kept bucket
-   contains the `KEEP_NOT_VERIFIED` reason ("not verified by a checksummed
-   import — run the integrity audit"), show a callout above the buckets:
-   how many kept files carry that reason, one sentence explaining that
-   the archive copies must be checksum-verified before deletion is
-   allowed, a **Verify archive hashes** button that starts the existing
-   `verify-hashes` job (`POST /api/jobs/verify-hashes`) with the page's
-   standard progress rendering, and — on completion — a **Re-scan card**
-   affordance. Include the SMB cost warning: verification re-reads
-   archive files; on a VPN'd mount this is slow, best run close to the
-   NAS. No new backend endpoints.
+3. **Inline targeted-verification affordance.** When the rendered preview's
+   kept bucket contains `KEEP_NOT_VERIFIED`, show how many card files and
+   unique hashes need verification. **Verify matching archive copies** calls
+   `POST /api/card-cleanup/verify` for this scan. It reads at most one viable
+   archive copy per unique pending hash, never unrelated workspace files,
+   then reloads the atomically refreshed manifest. No second card scan is
+   required.
 4. **Navbar**: add "Card cleanup" to `_navbar.html` in the tools/pages
    list (match existing nav idiom and ordering conventions).
 5. **Import page**: remove the moved section and its JS; keep the
@@ -59,8 +56,9 @@ this reason).
    its source input from the `source` query parameter. Multi-source
    imports pass the first source; the new page keeps the existing
    "remaining sources" hint behavior.
-6. **No API changes.** Scan/delete/manifest endpoints, job types, and
-   manifest format are untouched.
+6. **Scoped API addition.** The verify endpoint and `card-cleanup-verify`
+   job are tied to a completed scan manifest and cannot overlap verification
+   or deletion for that manifest.
 
 ## Testing
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6335,6 +6335,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # missing-originals timer fire during verification would
         # double the I/O on those slow volumes.
         "verify-hashes",
+        # Card cleanup reads only archive copies that match one card, but
+        # those reads still hit the same NAS/SMB trees.
+        "card-cleanup-verify",
         # The startup working-copy backfill job walks the same source
         # trees and additionally performs RAW decode + JPEG encode
         # work per file, so overlapping it with an automatic Missing
@@ -20004,6 +20007,88 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), status=e.http_status)
         return jsonify(manifest)
 
+    @app.route("/api/card-cleanup/verify", methods=["POST"])
+    def api_card_cleanup_verify():
+        """Verify only archive copies needed by a cleanup preview.
+
+        Unlike the workspace-wide integrity audit, this reads at most one
+        viable archive copy per distinct pending card hash and refreshes the
+        existing manifest when it finishes.
+        """
+        body = request.get_json(silent=True) or {}
+        if not isinstance(body, dict):
+            return json_error("request body must be a JSON object")
+        scan_job_id = body.get("scan_job_id")
+        if not scan_job_id or not isinstance(scan_job_id, str):
+            return json_error("scan_job_id required")
+
+        db = _get_db()
+        runner = app._job_runner
+        active_ws = db._active_workspace_id
+        scan_job = runner.get(scan_job_id)
+        if scan_job is None:
+            row = db.conn.execute(
+                "SELECT type, status FROM job_history WHERE id = ?",
+                (scan_job_id,)).fetchone()
+            scan_job = dict(row) if row is not None else None
+        if scan_job is None or scan_job.get("type") != "card-cleanup-scan":
+            return json_error("unknown scan job", status=404)
+        if scan_job.get("status") in ("queued", "running"):
+            return json_error("scan still running — wait for it to finish")
+        if scan_job.get("status") != "completed":
+            return json_error("scan did not complete — re-scan the card")
+
+        for job in runner.list_jobs():
+            if (job.get("type") in
+                    ("card-cleanup-verify", "card-cleanup-delete")
+                    and job.get("status") in ("queued", "running")
+                    and (job.get("config") or {}).get("scan_job_id")
+                    == scan_job_id):
+                return json_error(
+                    "verification or deletion for this scan is already "
+                    "running", status=409)
+
+        card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
+        try:
+            manifest = card_cleanup.load_manifest(
+                card_cleanup_dir, scan_job_id)
+        except card_cleanup.ManifestError as e:
+            return json_error(str(e), status=e.http_status)
+        if not any(
+            entry.get("bucket") == "kept"
+            and entry.get("reason") == card_cleanup.KEEP_NOT_VERIFIED
+            and entry.get("hash")
+            for entry in manifest["entries"]
+        ):
+            return json_error("nothing needs archive verification")
+
+        def work(job):
+            thread_db = Database(db_path)
+            try:
+                if active_ws is not None:
+                    thread_db.set_active_workspace(active_ws)
+
+                def progress_cb(current, total, filename):
+                    runner.push_event(job["id"], "progress", {
+                        "current": current, "total": total,
+                        "current_file": filename,
+                        "phase": "Verifying matching archive copies",
+                    })
+
+                return card_cleanup.verify_manifest_archives(
+                    thread_db, manifest, card_cleanup_dir,
+                    progress_cb=progress_cb,
+                    should_cancel=lambda: runner.is_cancelled(job["id"]),
+                )
+            finally:
+                thread_db.close()
+
+        job_id = runner.start(
+            "card-cleanup-verify", work,
+            config={"scan_job_id": scan_job_id},
+            workspace_id=active_ws)
+        return jsonify({"job_id": job_id})
+
     @app.route("/api/card-cleanup/delete", methods=["POST"])
     def api_card_cleanup_delete():
         """Delete the deletable bucket of a scan's manifest.
@@ -20047,12 +20132,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # simultaneous POSTs is likewise acceptable: the gates make a
         # double-delete skip, not double-fire.)
         for j in runner.list_jobs():
-            if (j.get("type") == "card-cleanup-delete"
+            if (j.get("type") in
+                    ("card-cleanup-delete", "card-cleanup-verify")
                     and j.get("status") in ("queued", "running")
                     and (j.get("config") or {}).get("scan_job_id")
                     == scan_job_id):
                 return json_error(
-                    "a delete for this scan is already running", status=409)
+                    "verification or deletion for this scan is already "
+                    "running", status=409)
         card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
         try:
             manifest = card_cleanup.load_manifest(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -20085,48 +20085,55 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return err
 
         card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
-        try:
-            manifest = card_cleanup.load_manifest(
-                card_cleanup_dir, scan_job_id)
-        except card_cleanup.ManifestError as e:
-            return json_error(str(e), status=e.http_status)
-        if not any(
-            entry.get("bucket") == "kept"
-            and entry.get("reason") == card_cleanup.KEEP_NOT_VERIFIED
-            and entry.get("hash")
-            for entry in manifest["entries"]
-        ):
-            return json_error("nothing needs archive verification")
 
-        def work(job):
-            thread_db = Database(db_path)
-            try:
-                if active_ws is not None:
-                    thread_db.set_active_workspace(active_ws)
-
-                def progress_cb(current, total, filename):
-                    runner.push_event(job["id"], "progress", {
-                        "current": current, "total": total,
-                        "current_file": filename,
-                        "phase": "Verifying matching archive copies",
-                    })
-
-                return card_cleanup.verify_manifest_archives(
-                    thread_db, manifest, card_cleanup_dir,
-                    progress_cb=progress_cb,
-                    should_cancel=lambda: runner.is_cancelled(job["id"]),
-                )
-            finally:
-                thread_db.close()
-
-        # Atomic conflict-check + start (Codex P1): without the lock,
-        # two concurrent verify POSTs can both pass the conflict check
-        # and both launch a worker that rewrites the same manifest.
+        # Codex P1: load the manifest INSIDE the lock, after the conflict
+        # check passes. Loading it before we hold the lock captures a
+        # snapshot that a concurrent verify can outdate before our worker
+        # starts: if request A loads revision N, releases, then request B
+        # runs to completion and writes revision N+1, A can still enter
+        # the lock (B is no longer registered), pass the conflict check,
+        # and hand its stale revision-N manifest to verify_manifest_
+        # archives — which bumps to N+1 and writes it, clobbering B's
+        # promotions with entries the user never saw promoted.
         with _CARD_CLEANUP_JOB_LOCK:
             conflict = _card_cleanup_job_conflict_response(
                 runner, scan_job_id)
             if conflict is not None:
                 return conflict
+            try:
+                manifest = card_cleanup.load_manifest(
+                    card_cleanup_dir, scan_job_id)
+            except card_cleanup.ManifestError as e:
+                return json_error(str(e), status=e.http_status)
+            if not any(
+                entry.get("bucket") == "kept"
+                and entry.get("reason") == card_cleanup.KEEP_NOT_VERIFIED
+                and entry.get("hash")
+                for entry in manifest["entries"]
+            ):
+                return json_error("nothing needs archive verification")
+
+            def work(job):
+                thread_db = Database(db_path)
+                try:
+                    if active_ws is not None:
+                        thread_db.set_active_workspace(active_ws)
+
+                    def progress_cb(current, total, filename):
+                        runner.push_event(job["id"], "progress", {
+                            "current": current, "total": total,
+                            "current_file": filename,
+                            "phase": "Verifying matching archive copies",
+                        })
+
+                    return card_cleanup.verify_manifest_archives(
+                        thread_db, manifest, card_cleanup_dir,
+                        progress_cb=progress_cb,
+                        should_cancel=lambda: runner.is_cancelled(job["id"]),
+                    )
+                finally:
+                    thread_db.close()
+
             job_id = runner.start(
                 "card-cleanup-verify", work,
                 config={"scan_job_id": scan_job_id},

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -130,6 +130,15 @@ log = logging.getLogger(__name__)
 # and leave the process in the wrong mode mid-probe.
 _WIN_ERROR_MODE_LOCK = threading.Lock()
 
+# Serializes the "no other card-cleanup verify/delete is running for this
+# scan" check with the runner.start() that follows it. list_jobs() +
+# runner.start() are separately atomic, but the gap between them let two
+# concurrent verify or delete POSTs both see "nothing running" and both
+# launch a worker — a race Codex flagged on PR 1453. Holding this lock
+# across the check AND the registration collapses that gap; the second
+# request now sees the first's just-registered job and returns 409.
+_CARD_CLEANUP_JOB_LOCK = threading.Lock()
+
 # A Leaflet marker is substantially heavier than its JSON source row. Keep a
 # hard ceiling as a final safety net for very large libraries; the Map UI
 # clearly reports truncation and lets users narrow the shared filters.
@@ -20007,6 +20016,51 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), status=e.http_status)
         return jsonify(manifest)
 
+    def _resolve_completed_card_cleanup_scan(db, runner, scan_job_id):
+        """Look up a card-cleanup-scan job, live runner first then
+        job_history, and return (scan_job, error_response). Either the
+        job is completed and the caller may proceed, or ``error_response``
+        is a ready-to-return :func:`json_error` for the bad states.
+
+        Shared by the verify and delete endpoints so their
+        scan-resolution rules can't drift.
+        """
+        scan_job = runner.get(scan_job_id)
+        if scan_job is None:
+            row = db.conn.execute(
+                "SELECT type, status FROM job_history WHERE id = ?",
+                (scan_job_id,)).fetchone()
+            scan_job = dict(row) if row is not None else None
+        if scan_job is None or scan_job.get("type") != "card-cleanup-scan":
+            return None, json_error("unknown scan job", status=404)
+        if scan_job.get("status") in ("queued", "running"):
+            # Mid-flight, not a dead end: telling the user to re-scan
+            # here would throw away a scan that is about to succeed.
+            return None, json_error(
+                "scan still running — wait for it to finish")
+        if scan_job.get("status") != "completed":
+            return None, json_error(
+                "scan did not complete — re-scan the card")
+        return scan_job, None
+
+    def _card_cleanup_job_conflict_response(runner, scan_job_id):
+        """Return a 409 :func:`json_error` when a verify or delete for
+        this scan is already queued or running, else ``None``. Callers
+        MUST hold ``_CARD_CLEANUP_JOB_LOCK`` across both this call and
+        the following ``runner.start()`` so a second POST cannot slip in
+        during the gap and register its own worker.
+        """
+        for j in runner.list_jobs():
+            if (j.get("type") in
+                    ("card-cleanup-verify", "card-cleanup-delete")
+                    and j.get("status") in ("queued", "running")
+                    and (j.get("config") or {}).get("scan_job_id")
+                    == scan_job_id):
+                return json_error(
+                    "verification or deletion for this scan is already "
+                    "running", status=409)
+        return None
+
     @app.route("/api/card-cleanup/verify", methods=["POST"])
     def api_card_cleanup_verify():
         """Verify only archive copies needed by a cleanup preview.
@@ -20025,28 +20079,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         runner = app._job_runner
         active_ws = db._active_workspace_id
-        scan_job = runner.get(scan_job_id)
-        if scan_job is None:
-            row = db.conn.execute(
-                "SELECT type, status FROM job_history WHERE id = ?",
-                (scan_job_id,)).fetchone()
-            scan_job = dict(row) if row is not None else None
-        if scan_job is None or scan_job.get("type") != "card-cleanup-scan":
-            return json_error("unknown scan job", status=404)
-        if scan_job.get("status") in ("queued", "running"):
-            return json_error("scan still running — wait for it to finish")
-        if scan_job.get("status") != "completed":
-            return json_error("scan did not complete — re-scan the card")
-
-        for job in runner.list_jobs():
-            if (job.get("type") in
-                    ("card-cleanup-verify", "card-cleanup-delete")
-                    and job.get("status") in ("queued", "running")
-                    and (job.get("config") or {}).get("scan_job_id")
-                    == scan_job_id):
-                return json_error(
-                    "verification or deletion for this scan is already "
-                    "running", status=409)
+        _scan_job, err = _resolve_completed_card_cleanup_scan(
+            db, runner, scan_job_id)
+        if err is not None:
+            return err
 
         card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
         try:
@@ -20083,10 +20119,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             finally:
                 thread_db.close()
 
-        job_id = runner.start(
-            "card-cleanup-verify", work,
-            config={"scan_job_id": scan_job_id},
-            workspace_id=active_ws)
+        # Atomic conflict-check + start (Codex P1): without the lock,
+        # two concurrent verify POSTs can both pass the conflict check
+        # and both launch a worker that rewrites the same manifest.
+        with _CARD_CLEANUP_JOB_LOCK:
+            conflict = _card_cleanup_job_conflict_response(
+                runner, scan_job_id)
+            if conflict is not None:
+                return conflict
+            job_id = runner.start(
+                "card-cleanup-verify", work,
+                config={"scan_job_id": scan_job_id},
+                workspace_id=active_ws)
         return jsonify({"job_id": job_id})
 
     @app.route("/api/card-cleanup/delete", methods=["POST"])
@@ -20111,41 +20155,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         runner = app._job_runner
         active_ws = db._active_workspace_id
 
-        scan_job = runner.get(scan_job_id)
-        if scan_job is None:
-            row = db.conn.execute(
-                "SELECT type, status FROM job_history WHERE id = ?",
-                (scan_job_id,)).fetchone()
-            scan_job = dict(row) if row is not None else None
-        if scan_job is None or scan_job.get("type") != "card-cleanup-scan":
-            return json_error("unknown scan job", status=404)
-        if scan_job.get("status") in ("queued", "running"):
-            # Mid-flight, not a dead end: telling the user to re-scan here
-            # would throw away a scan that is about to succeed.
-            return json_error("scan still running — wait for it to finish")
-        if scan_job.get("status") != "completed":
-            return json_error("scan did not complete — re-scan the card")
-        # One delete AT A TIME per manifest — this guards concurrency,
-        # not repetition: after a delete finishes, the manifest still
-        # loads and a second delete may start (its per-file gates skip
-        # everything already gone). (A TOCTOU race between two
-        # simultaneous POSTs is likewise acceptable: the gates make a
-        # double-delete skip, not double-fire.)
-        for j in runner.list_jobs():
-            if (j.get("type") in
-                    ("card-cleanup-delete", "card-cleanup-verify")
-                    and j.get("status") in ("queued", "running")
-                    and (j.get("config") or {}).get("scan_job_id")
-                    == scan_job_id):
-                return json_error(
-                    "verification or deletion for this scan is already "
-                    "running", status=409)
+        _scan_job, err = _resolve_completed_card_cleanup_scan(
+            db, runner, scan_job_id)
+        if err is not None:
+            return err
+        # Codex P1: the client must send the manifest revision it
+        # confirmed. If a verify has run since that confirmation, the
+        # on-disk manifest carries a newer revision and its deletable
+        # set may include files the user never saw — reject rather than
+        # sweep them in silently. Checked AFTER the scan-job resolution
+        # so an unknown scan still surfaces as 404 rather than a body
+        # complaint.
+        manifest_revision = body.get("manifest_revision")
+        if (not isinstance(manifest_revision, int)
+                or isinstance(manifest_revision, bool)):
+            return json_error("manifest_revision required")
         card_cleanup_dir = app.config["CARD_CLEANUP_DIR"]
         try:
             manifest = card_cleanup.load_manifest(
                 card_cleanup_dir, scan_job_id)
         except card_cleanup.ManifestError as e:
             return json_error(str(e), status=e.http_status)
+        loaded_revision = int(manifest.get(
+            "revision", card_cleanup.INITIAL_MANIFEST_REVISION))
+        if loaded_revision != manifest_revision:
+            # Explicit code so the UI can distinguish this from generic
+            # 409s and drop the user back into a "reload the preview
+            # before deleting" state.
+            return json_error(
+                "the preview has changed since you confirmed it — "
+                "reload the page to review the updated totals before "
+                "deleting.",
+                status=409,
+                code="manifest_revision_mismatch",
+            )
         if not any(e.get("bucket") == "deletable"
                    for e in manifest["entries"]):
             return json_error("nothing to delete — no verified files")
@@ -20183,10 +20226,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             finally:
                 thread_db.close()
 
-        job_id = runner.start(
-            "card-cleanup-delete", work,
-            config={"scan_job_id": scan_job_id},
-            workspace_id=active_ws)
+        # Atomic conflict-check + start (Codex P1): pair with the same
+        # lock the verify endpoint uses so a verify POST can't slip in
+        # between our check and our registration and start writing a
+        # new manifest under this delete.
+        with _CARD_CLEANUP_JOB_LOCK:
+            conflict = _card_cleanup_job_conflict_response(
+                runner, scan_job_id)
+            if conflict is not None:
+                return conflict
+            job_id = runner.start(
+                "card-cleanup-delete", work,
+                config={"scan_job_id": scan_job_id},
+                workspace_id=active_ws)
         return jsonify({"job_id": job_id})
 
     @app.route("/api/audit/resolve", methods=["POST"])

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -577,10 +577,29 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             finally:
                 os.close(archive_fd)
 
+            # Codex P1: the pinned fd's fstat describes the object we
+            # actually hashed, but an atomic replace under the same
+            # name during compute_fd_hash would leave that fd pointing
+            # at the old (now-unlinked) inode. before/after fstat then
+            # still match, and after_real == archive_real, but the
+            # pathname now resolves to a fresh object. A replacement
+            # that preserves size+mtime could then pass qualify_rows
+            # later and let the card copy be deleted against an
+            # archive whose bytes we never read. Re-stat the pathname
+            # and require its dev/inode still match the fd's — a
+            # mismatch means the successor is a different file.
+            try:
+                after_path_st = os.stat(archive_path)
+            except (OSError, ValueError):
+                after_path_st = None
+
             # Do not certify a pathname that moved or changed while it was
             # being read.  A later retry can verify the stable object.
             if (after_real != archive_real
                     or contains_check(after_real)
+                    or after_path_st is None
+                    or (after_path_st.st_dev, after_path_st.st_ino)
+                    != (after.st_dev, after.st_ino)
                     or (before.st_dev, before.st_ino, before.st_size,
                         before.st_mtime_ns)
                     != (after.st_dev, after.st_ino, after.st_size,

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -439,6 +439,31 @@ def _load_catalog_by_hash(db):
     return by_hash
 
 
+def _card_gate_promotion_block(entry):
+    """Return a SKIP_* reason if the card file no longer matches the
+    manifest baseline in a way delete_verified would refuse; return
+    ``None`` when promotion is safe to attempt or the check cannot make
+    a firm judgment (missing path / transient OSError). Deliberately
+    parallels the cheap card-side gates at the top of
+    ``delete_verified``.
+    """
+    path = entry.get("path")
+    if not path:
+        return None
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return None
+    if stat_mod.S_ISLNK(st.st_mode):
+        return SKIP_SYMLINK
+    if not stat_mod.S_ISREG(st.st_mode):
+        return SKIP_NOT_REGULAR
+    if (st.st_size != entry.get("size")
+            or st.st_mtime_ns != entry.get("mtime_ns")):
+        return SKIP_CHANGED
+    return None
+
+
 def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                              should_cancel=None):
     """Verify only archive copies needed by one card-cleanup preview.
@@ -740,6 +765,24 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
     for expected_hash, card_entries in pending_by_hash.items():
         rows = fetch_rows_by_hash(db, expected_hash)
         for entry in card_entries:
+            # Codex P2 (follow-up 3): qualify_rows only inspects catalog
+            # rows — it cannot see that this card file has been replaced,
+            # resized, or turned into a symlink since the scan. Promoting
+            # a changed pending entry to the deletable bucket would let
+            # its bytes land in the refreshed totals the user confirms,
+            # even though delete_verified would later skip it
+            # (SKIP_CHANGED / SKIP_SYMLINK / SKIP_NOT_REGULAR) and
+            # actually unlink nothing. Reproduce the delete-time card
+            # gates here so promotion honors the same baseline. Content
+            # drift (bytes changed with size + mtime intact) still lands
+            # in delete_verified's full-hash pass — repeating that here
+            # would defeat the point of scoped verification.
+            promote_block = _card_gate_promotion_block(entry)
+            if promote_block is not None:
+                entry["bucket"] = "kept"
+                entry["reason"] = promote_block
+                entry.pop("archive_path", None)
+                continue
             archive_path, reason = qualify_rows(
                 rows, source_root, entry["path"], contains_check)
             if archive_path is not None:

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -857,8 +857,35 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 # infinite verify loop (qualify_rows keeps returning
                 # KEEP_NOT_VERIFIED off the still-NULL alias rows).
                 # Adopt the terminal inside-source reason instead.
+                #
+                # Codex P2 (follow-up 2): the inside-source override
+                # must not mask a persisted external integrity failure.
+                # When a hash has one same-source alias row (still NULL,
+                # inside-source terminal) AND at least one external row
+                # that was hashed and persisted as corrupt/modified/
+                # unreadable in a prior pass, qualify_rows still returns
+                # KEEP_NOT_VERIFIED (the alias remains NULL and wins
+                # priority), and this hash lands in
+                # terminal_inside_source_hashes on the run that only
+                # sees the alias. Surfacing KEEP_INSIDE_SOURCE here
+                # would tell the user "no independent archive exists"
+                # even though the catalog has one — one that failed —
+                # and hide the Audit-page remedy the failed row needs.
+                # Persisted check-failed statuses only ever belong to
+                # external rows: every inside-source / same-as-card gate
+                # in the verify loop short-circuits with continue and
+                # never calls update_photo_hash_check, so any non-None,
+                # non-"ok" hash_status here is definitionally external.
                 if expected_hash in terminal_inside_source_hashes:
-                    entry["reason"] = KEEP_INSIDE_SOURCE
+                    has_persisted_external_failure = any(
+                        row["hash_status"] in (
+                            "corrupt", "modified", "unreadable")
+                        for row in rows
+                    )
+                    if has_persisted_external_failure:
+                        entry["reason"] = KEEP_ARCHIVE_HASH_FAILED
+                    else:
+                        entry["reason"] = KEEP_INSIDE_SOURCE
                 else:
                     entry["reason"] = KEEP_NOT_VERIFIED
             elif reason == KEEP_ARCHIVE_HASH_FAILED:

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -656,6 +656,18 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 entry.pop("reason", None)
                 stats["unblocked_files"] += 1
                 stats["unblocked_bytes"] += entry.get("size", 0)
+            elif reason == KEEP_NOT_VERIFIED:
+                # Codex P2: qualify_rows saw a viable unchecked row
+                # after our attempt, so verify still has a lever here.
+                # Overwriting with this run's transient
+                # KEEP_ARCHIVE_UNREACHABLE/CHANGED would push the entry
+                # out of the KEEP_NOT_VERIFIED bucket that the verify
+                # endpoint's pending-reason filter and the UI callout
+                # key off; once the NAS mount returns or the file
+                # settles, targeted verification would then report
+                # "nothing needs checking" until the user re-scans the
+                # card. Keep the entry in the retry-eligible bucket.
+                entry["reason"] = KEEP_NOT_VERIFIED
             elif expected_hash in failure_reasons:
                 entry["reason"] = failure_reasons[expected_hash]
             else:

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -419,7 +419,8 @@ def qualify_rows(rows, source_root_real, card_path, contains_check=None):
 
 
 _ROWS_BY_HASH_SQL = """
-    SELECT p.id, p.filename, p.file_size, p.file_mtime, p.hash_status,
+    SELECT p.id, p.folder_id, p.filename, p.file_size, p.file_mtime,
+           p.hash_status,
            f.path AS folder_path
     FROM photos p LEFT JOIN folders f ON f.id = p.folder_id
     WHERE p.file_hash = ?
@@ -428,6 +429,35 @@ _ROWS_BY_HASH_SQL = """
 
 def fetch_rows_by_hash(db, file_hash):
     return db.conn.execute(_ROWS_BY_HASH_SQL, (file_hash,)).fetchall()
+
+
+def _record_unchecked_hash_verdict(db, row, expected_hash, status,
+                                   file_size=None, file_mtime=None):
+    """Persist a scoped-verification verdict only for the row we read.
+
+    Hashing can take long enough for a concurrent catalog refresh to replace
+    or repurpose the photo row.  Binding the update to its original identity,
+    baseline, hash, and unchecked state prevents the old descriptor's digest
+    from certifying (or flagging) that newer row.
+    """
+    now = datetime.now().isoformat()
+    assignments = "hash_status = ?, hash_checked_at = ?"
+    values = [status, now]
+    if file_size is not None and file_mtime is not None:
+        assignments += ", file_size = ?, file_mtime = ?"
+        values.extend([file_size, file_mtime])
+    values.extend([
+        row["id"], expected_hash, row["folder_id"], row["filename"],
+        row["file_size"], row["file_mtime"],
+    ])
+    cursor = db.conn.execute(
+        f"UPDATE photos SET {assignments} "
+        "WHERE id = ? AND file_hash = ? AND hash_status IS NULL "
+        "AND folder_id IS ? AND filename = ? "
+        "AND file_size IS ? AND file_mtime IS ?",
+        values,
+    )
+    return cursor.rowcount == 1
 
 
 def _load_catalog_by_hash(db):
@@ -570,18 +600,12 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
         "unblocked_files": 0, "unblocked_bytes": 0,
     }
     failure_reasons = {}
-    # Codex P2: hashes whose ONLY unchecked catalog rows turned out to be
-    # aliases/hardlinks of the card file itself, or whose cataloged
-    # archive path resolves inside the current source. Those rows stay
-    # NULL-status (they neither read as usable archives nor pass a
-    # persistable failure verdict), so qualify_rows' next pass would
-    # again see saw_never_checked=True and return KEEP_NOT_VERIFIED,
-    # trapping the entry in an infinite verify retry — every click reads
-    # nothing new and shows the same "audit hasn't run" callout. Track
-    # the terminal signal here and let reclassification adopt it below
-    # so the callout finally explains what is actually true: no
-    # independent archive copy exists.
-    terminal_inside_source_hashes = set()
+    # qualify_rows deliberately prioritizes any NULL-status row so a viable
+    # independent copy remains retryable. Once this run establishes that no
+    # such copy remains, however, a NULL same-file/source alias must not mask
+    # either the terminal "inside source" result or a failed independent
+    # archive. Record that final reason for the refresh below.
+    terminal_reasons = {}
 
     for i, (expected_hash, card_entries) in enumerate(pending):
         if should_cancel is not None and should_cancel():
@@ -598,23 +622,21 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
         unchecked = [row for row in rows if row["hash_status"] is None]
         outcome_reason = KEEP_ARCHIVE_UNREACHABLE
         verified = False
-        # Codex P2 (see terminal_inside_source_hashes above): stays True
-        # only if every unchecked row we processed ended with an inside-
-        # source verdict AND left the row NULL in the DB. A single row
-        # that was persisted (unreadable / modified / corrupt), came back
-        # transiently unreachable, or changed under us flips this off —
-        # qualify_rows' next pass will then have a real lever (either a
-        # persisted verdict it can surface, or a still-NULL row a retry
-        # can still try), so we must not overwrite its KEEP_NOT_VERIFIED
-        # verdict.
-        all_unchecked_inside_source = bool(unchecked)
+        saw_inside_source_alias = False
+        saw_terminal_failure = any(
+            row["hash_status"] not in (None, "ok") for row in rows
+        )
+        saw_retryable_external = False
         for row in unchecked:
             folder_path = row["folder_path"]
             if not folder_path:
-                db.update_photo_hash_check(
-                    row["id"], "unreadable", commit=False)
-                stats["unreadable"] += 1
-                all_unchecked_inside_source = False
+                if _record_unchecked_hash_verdict(
+                        db, row, expected_hash, "unreadable"):
+                    stats["unreadable"] += 1
+                    saw_terminal_failure = True
+                else:
+                    outcome_reason = KEEP_ARCHIVE_CHANGED
+                    saw_retryable_external = True
                 continue
             archive_path = os.path.join(folder_path, row["filename"])
             try:
@@ -629,10 +651,11 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 # verify retry.
                 stats["unreadable"] += 1
                 outcome_reason = KEEP_ARCHIVE_UNREACHABLE
-                all_unchecked_inside_source = False
+                saw_retryable_external = True
                 continue
             if contains_check(archive_real):
                 outcome_reason = KEEP_INSIDE_SOURCE
+                saw_inside_source_alias = True
                 continue
             # CodeRabbit: pin the checked object via a descriptor rather
             # than re-opening the pathname. A concurrent rename that swaps
@@ -657,7 +680,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 # we actually reached but could not read.
                 stats["unreadable"] += 1
                 outcome_reason = KEEP_ARCHIVE_UNREACHABLE
-                all_unchecked_inside_source = False
+                saw_retryable_external = True
                 continue
             try:
                 try:
@@ -678,11 +701,14 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     # verdict, hiding the failure and stripping the
                     # Audit-page guidance the UI shows for
                     # KEEP_ARCHIVE_HASH_FAILED.
-                    db.update_photo_hash_check(
-                        row["id"], "unreadable", commit=False)
-                    stats["unreadable"] += 1
-                    outcome_reason = KEEP_ARCHIVE_HASH_FAILED
-                    all_unchecked_inside_source = False
+                    if _record_unchecked_hash_verdict(
+                            db, row, expected_hash, "unreadable"):
+                        stats["unreadable"] += 1
+                        outcome_reason = KEEP_ARCHIVE_HASH_FAILED
+                        saw_terminal_failure = True
+                    else:
+                        outcome_reason = KEEP_ARCHIVE_CHANGED
+                        saw_retryable_external = True
                     continue
                 if not stat_mod.S_ISREG(before.st_mode):
                     # The object is present but is a directory/FIFO/
@@ -692,11 +718,14 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     # a subsequent audit is the right remedy.
                     #
                     # Codex P2 (follow-up): see the fstat branch above.
-                    db.update_photo_hash_check(
-                        row["id"], "unreadable", commit=False)
-                    stats["unreadable"] += 1
-                    outcome_reason = KEEP_ARCHIVE_HASH_FAILED
-                    all_unchecked_inside_source = False
+                    if _record_unchecked_hash_verdict(
+                            db, row, expected_hash, "unreadable"):
+                        stats["unreadable"] += 1
+                        outcome_reason = KEEP_ARCHIVE_HASH_FAILED
+                        saw_terminal_failure = True
+                    else:
+                        outcome_reason = KEEP_ARCHIVE_CHANGED
+                        saw_retryable_external = True
                     continue
 
                 # An outside-path hardlink to a card file is not a second
@@ -714,6 +743,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                         break
                 if same_as_card:
                     outcome_reason = KEEP_INSIDE_SOURCE
+                    saw_inside_source_alias = True
                     continue
 
                 try:
@@ -727,11 +757,14 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     # promotion loop does not override qualify_rows'
                     # KEEP_ARCHIVE_HASH_FAILED with the initial
                     # KEEP_ARCHIVE_UNREACHABLE.
-                    db.update_photo_hash_check(
-                        row["id"], "unreadable", commit=False)
-                    stats["unreadable"] += 1
-                    outcome_reason = KEEP_ARCHIVE_HASH_FAILED
-                    all_unchecked_inside_source = False
+                    if _record_unchecked_hash_verdict(
+                            db, row, expected_hash, "unreadable"):
+                        stats["unreadable"] += 1
+                        outcome_reason = KEEP_ARCHIVE_HASH_FAILED
+                        saw_terminal_failure = True
+                    else:
+                        outcome_reason = KEEP_ARCHIVE_CHANGED
+                        saw_retryable_external = True
                     continue
                 stats["archive_files_read"] += 1
             finally:
@@ -765,20 +798,19 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     != (after.st_dev, after.st_ino, after.st_size,
                         after.st_mtime_ns)):
                 outcome_reason = KEEP_ARCHIVE_CHANGED
-                all_unchecked_inside_source = False
+                saw_retryable_external = True
                 continue
 
             if actual_hash == expected_hash:
-                now = datetime.now().isoformat()
-                db.conn.execute(
-                    "UPDATE photos SET hash_status = 'ok', "
-                    "hash_checked_at = ?, file_size = ?, file_mtime = ? "
-                    "WHERE id = ?",
-                    (now, after.st_size, after.st_mtime, row["id"]),
-                )
-                stats["verified"] += 1
-                verified = True
-                break
+                if _record_unchecked_hash_verdict(
+                        db, row, expected_hash, "ok",
+                        file_size=after.st_size, file_mtime=after.st_mtime):
+                    stats["verified"] += 1
+                    verified = True
+                    break
+                outcome_reason = KEEP_ARCHIVE_CHANGED
+                saw_retryable_external = True
+                continue
 
             db_mtime = row["file_mtime"]
             if (db_mtime is not None
@@ -786,17 +818,25 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 status = "modified"
             else:
                 status = "corrupt"
-            db.update_photo_hash_check(row["id"], status, commit=False)
-            stats[status] += 1
-            outcome_reason = KEEP_ARCHIVE_HASH_FAILED
-            all_unchecked_inside_source = False
+            if _record_unchecked_hash_verdict(
+                    db, row, expected_hash, status):
+                stats[status] += 1
+                outcome_reason = KEEP_ARCHIVE_HASH_FAILED
+                saw_terminal_failure = True
+            else:
+                outcome_reason = KEEP_ARCHIVE_CHANGED
+                saw_retryable_external = True
 
         db.conn.commit()
         stats["hashes_processed"] += 1
         if not verified:
             failure_reasons[expected_hash] = outcome_reason
-            if all_unchecked_inside_source:
-                terminal_inside_source_hashes.add(expected_hash)
+            if not saw_retryable_external:
+                if saw_terminal_failure:
+                    terminal_reasons[expected_hash] = (
+                        KEEP_ARCHIVE_HASH_FAILED)
+                elif saw_inside_source_alias:
+                    terminal_reasons[expected_hash] = KEEP_INSIDE_SOURCE
 
     # Only previously-unverified entries can change here.  Existing
     # deletable rows are not re-audited or invalidated by this scoped job.
@@ -857,37 +897,8 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 # infinite verify loop (qualify_rows keeps returning
                 # KEEP_NOT_VERIFIED off the still-NULL alias rows).
                 # Adopt the terminal inside-source reason instead.
-                #
-                # Codex P2 (follow-up 2): the inside-source override
-                # must not mask a persisted external integrity failure.
-                # When a hash has one same-source alias row (still NULL,
-                # inside-source terminal) AND at least one external row
-                # that was hashed and persisted as corrupt/modified/
-                # unreadable in a prior pass, qualify_rows still returns
-                # KEEP_NOT_VERIFIED (the alias remains NULL and wins
-                # priority), and this hash lands in
-                # terminal_inside_source_hashes on the run that only
-                # sees the alias. Surfacing KEEP_INSIDE_SOURCE here
-                # would tell the user "no independent archive exists"
-                # even though the catalog has one — one that failed —
-                # and hide the Audit-page remedy the failed row needs.
-                # Persisted check-failed statuses only ever belong to
-                # external rows: every inside-source / same-as-card gate
-                # in the verify loop short-circuits with continue and
-                # never calls update_photo_hash_check, so any non-None,
-                # non-"ok" hash_status here is definitionally external.
-                if expected_hash in terminal_inside_source_hashes:
-                    has_persisted_external_failure = any(
-                        row["hash_status"] in (
-                            "corrupt", "modified", "unreadable")
-                        for row in rows
-                    )
-                    if has_persisted_external_failure:
-                        entry["reason"] = KEEP_ARCHIVE_HASH_FAILED
-                    else:
-                        entry["reason"] = KEEP_INSIDE_SOURCE
-                else:
-                    entry["reason"] = KEEP_NOT_VERIFIED
+                entry["reason"] = terminal_reasons.get(
+                    expected_hash, KEEP_NOT_VERIFIED)
             elif reason == KEEP_ARCHIVE_HASH_FAILED:
                 # A reached row whose fstat/read failed was persisted as
                 # unreadable. That terminal catalog verdict must win over a

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -452,6 +452,35 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
     """
     source_root = manifest["source_root"]
     contains_check = path_guard.make_case_folded_check(source_root)
+
+    # Codex P2: a prior delete_verified run on this scan unlinks card
+    # files but never rewrites the manifest, so its deletable entries
+    # sit here even though their card paths are gone. If we left them
+    # in, the totals recomputed below would still credit their bytes
+    # to the deletable bucket and the refreshed UI would re-enable
+    # Delete asking the user to confirm counts that include files
+    # already deleted from the card. Drop entries whose card path is
+    # gone; a transient stat error (mount hiccup, EACCES) preserves
+    # the entry so a NAS blip cannot shrink the preview.
+    surviving = []
+    for entry in manifest["entries"]:
+        if entry.get("bucket") != "deletable":
+            surviving.append(entry)
+            continue
+        path = entry.get("path")
+        if not path:
+            surviving.append(entry)
+            continue
+        try:
+            os.lstat(path)
+        except FileNotFoundError:
+            continue
+        except OSError:
+            surviving.append(entry)
+        else:
+            surviving.append(entry)
+    manifest["entries"] = surviving
+
     pending_by_hash = {}
     for entry in manifest["entries"]:
         if (entry.get("bucket") == "kept"

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -180,6 +180,13 @@ def load_manifest(manifest_dir, scan_job_id,
     if (not isinstance(manifest, dict)
             or manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION):
         raise ManifestError("manifest schema not recognized — re-scan the card")
+    revision = manifest.get("revision", INITIAL_MANIFEST_REVISION)
+    if (isinstance(revision, bool) or not isinstance(revision, int)
+            or revision < INITIAL_MANIFEST_REVISION):
+        raise ManifestError("manifest revision invalid — re-scan the card")
+    # Normalize pre-revision manifests at the read boundary so every caller
+    # sees the same initial value, including the API response and verify job.
+    manifest["revision"] = revision
     source_root = manifest.get("source_root")
     if not source_root or not os.path.isabs(str(source_root)):
         raise ManifestError("manifest missing source root — re-scan the card")
@@ -452,6 +459,8 @@ def _card_gate_promotion_block(entry):
         return None
     try:
         st = os.lstat(path)
+    except FileNotFoundError:
+        return SKIP_ALREADY_GONE
     except OSError:
         return None
     if stat_mod.S_ISLNK(st.st_mode):
@@ -762,6 +771,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
 
     # Only previously-unverified entries can change here.  Existing
     # deletable rows are not re-audited or invalidated by this scoped job.
+    missing_pending_entry_ids = set()
     for expected_hash, card_entries in pending_by_hash.items():
         rows = fetch_rows_by_hash(db, expected_hash)
         for entry in card_entries:
@@ -778,6 +788,12 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             # in delete_verified's full-hash pass — repeating that here
             # would defeat the point of scoped verification.
             promote_block = _card_gate_promotion_block(entry)
+            if promote_block == SKIP_ALREADY_GONE:
+                # A prior delete or external removal means this file no
+                # longer exists on the card. Do not retain its historical
+                # bytes in the refreshed kept totals.
+                missing_pending_entry_ids.add(id(entry))
+                continue
             if promote_block is not None:
                 entry["bucket"] = "kept"
                 entry["reason"] = promote_block
@@ -816,10 +832,22 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     entry["reason"] = KEEP_INSIDE_SOURCE
                 else:
                     entry["reason"] = KEEP_NOT_VERIFIED
+            elif reason == KEEP_ARCHIVE_HASH_FAILED:
+                # A reached row whose fstat/read failed was persisted as
+                # unreadable. That terminal catalog verdict must win over a
+                # transient run-local fallback so the preview offers the
+                # Audit remedy instead of neither retry nor repair guidance.
+                entry["reason"] = reason
             elif expected_hash in failure_reasons:
                 entry["reason"] = failure_reasons[expected_hash]
             else:
                 entry["reason"] = reason
+
+    if missing_pending_entry_ids:
+        manifest["entries"] = [
+            entry for entry in manifest["entries"]
+            if id(entry) not in missing_pending_entry_ids
+        ]
 
     totals = {
         "deletable": {"count": 0, "bytes": 0},

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -241,14 +241,10 @@ def load_manifest(manifest_dir, scan_job_id,
 
 
 KEEP_NOT_IN_CATALOG = "not in catalog — not imported yet"
-# The card-cleanup page keys its "Verify archive hashes" callout off this
-# reason: card_cleanup.html matches the tail "run the integrity audit" in
-# each kept entry to count the files an audit would unblock. Reword this
-# and the callout silently stops appearing — change both together, and
-# test_audit_callout_reason_stays_in_sync guards the pair.
-KEEP_NOT_VERIFIED = (
-    "not verified by a checksummed import — run the integrity audit"
-)
+# The card-cleanup page keys its scoped verification callout off this exact
+# reason.  It intentionally does not send users through the workspace-wide
+# integrity audit.
+KEEP_NOT_VERIFIED = "archive copy has not been checksum-verified"
 # Codex P2: distinguished from KEEP_NOT_VERIFIED so the callout does NOT
 # offer to re-verify these — the archive rows have already been checked
 # and the verdict was modified/corrupt/unreadable. Re-running verify
@@ -386,7 +382,7 @@ def qualify_rows(rows, source_root_real, card_path, contains_check=None):
 
 
 _ROWS_BY_HASH_SQL = """
-    SELECT p.filename, p.file_size, p.file_mtime, p.hash_status,
+    SELECT p.id, p.filename, p.file_size, p.file_mtime, p.hash_status,
            f.path AS folder_path
     FROM photos p LEFT JOIN folders f ON f.id = p.folder_id
     WHERE p.file_hash = ?
@@ -411,6 +407,181 @@ def _load_catalog_by_hash(db):
     for row in rows:
         by_hash.setdefault(row["file_hash"], []).append(row)
     return by_hash
+
+
+def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
+                             should_cancel=None):
+    """Verify only archive copies needed by one card-cleanup preview.
+
+    One viable archive row is read per distinct pending content hash.  A
+    successful row is enough to authorize every matching card entry; unrelated
+    workspace photos and redundant archive copies are not read.  The manifest
+    is then atomically refreshed so the existing preview can be used without a
+    second card scan.  Destructive-time card and archive gates remain in
+    ``delete_verified``.
+    """
+    source_root = manifest["source_root"]
+    contains_check = path_guard.make_case_folded_check(source_root)
+    pending_by_hash = {}
+    for entry in manifest["entries"]:
+        if (entry.get("bucket") == "kept"
+                and entry.get("reason") == KEEP_NOT_VERIFIED
+                and entry.get("hash")):
+            pending_by_hash.setdefault(entry["hash"], []).append(entry)
+
+    pending = list(pending_by_hash.items())
+    stats = {
+        "hashes_total": len(pending), "hashes_processed": 0,
+        "archive_files_read": 0, "verified": 0,
+        "modified": 0, "corrupt": 0, "unreadable": 0,
+        "cancelled": False, "remaining": 0,
+        "unblocked_files": 0, "unblocked_bytes": 0,
+    }
+    failure_reasons = {}
+
+    for i, (expected_hash, card_entries) in enumerate(pending):
+        if should_cancel is not None and should_cancel():
+            stats["cancelled"] = True
+            stats["remaining"] = len(pending) - i
+            break
+        if progress_cb is not None:
+            progress_cb(
+                i + 1, len(pending),
+                os.path.basename(card_entries[0]["path"]),
+            )
+
+        rows = fetch_rows_by_hash(db, expected_hash)
+        unchecked = [row for row in rows if row["hash_status"] is None]
+        outcome_reason = KEEP_ARCHIVE_UNREACHABLE
+        verified = False
+        for row in unchecked:
+            folder_path = row["folder_path"]
+            if not folder_path:
+                db.update_photo_hash_check(
+                    row["id"], "unreadable", commit=False)
+                stats["unreadable"] += 1
+                continue
+            archive_path = os.path.join(folder_path, row["filename"])
+            try:
+                archive_real = os.path.realpath(archive_path)
+            except (OSError, ValueError):
+                db.update_photo_hash_check(
+                    row["id"], "unreadable", commit=False)
+                stats["unreadable"] += 1
+                continue
+            if contains_check(archive_real):
+                outcome_reason = KEEP_INSIDE_SOURCE
+                continue
+            try:
+                before = os.stat(archive_path)
+            except (OSError, ValueError):
+                db.update_photo_hash_check(
+                    row["id"], "unreadable", commit=False)
+                stats["unreadable"] += 1
+                continue
+            if not stat_mod.S_ISREG(before.st_mode):
+                db.update_photo_hash_check(
+                    row["id"], "unreadable", commit=False)
+                stats["unreadable"] += 1
+                continue
+
+            # An outside-path hardlink to a card file is not a second copy.
+            same_as_card = False
+            for entry in card_entries:
+                try:
+                    card_st = os.stat(entry["path"])
+                except OSError:
+                    continue
+                if ((before.st_dev, before.st_ino)
+                        == (card_st.st_dev, card_st.st_ino)):
+                    same_as_card = True
+                    break
+            if same_as_card:
+                outcome_reason = KEEP_INSIDE_SOURCE
+                continue
+
+            try:
+                actual_hash = compute_file_hash(archive_path)
+                after = os.stat(archive_path)
+                after_real = os.path.realpath(archive_path)
+            except (OSError, ValueError):
+                db.update_photo_hash_check(
+                    row["id"], "unreadable", commit=False)
+                stats["unreadable"] += 1
+                continue
+            stats["archive_files_read"] += 1
+
+            # Do not certify a pathname that moved or changed while it was
+            # being read.  A later retry can verify the stable object.
+            if (after_real != archive_real
+                    or contains_check(after_real)
+                    or (before.st_dev, before.st_ino, before.st_size,
+                        before.st_mtime_ns)
+                    != (after.st_dev, after.st_ino, after.st_size,
+                        after.st_mtime_ns)):
+                outcome_reason = KEEP_ARCHIVE_CHANGED
+                continue
+
+            if actual_hash == expected_hash:
+                now = datetime.now().isoformat()
+                db.conn.execute(
+                    "UPDATE photos SET hash_status = 'ok', "
+                    "hash_checked_at = ?, file_size = ?, file_mtime = ? "
+                    "WHERE id = ?",
+                    (now, after.st_size, after.st_mtime, row["id"]),
+                )
+                stats["verified"] += 1
+                verified = True
+                break
+
+            db_mtime = row["file_mtime"]
+            if (db_mtime is not None
+                    and abs(after.st_mtime - db_mtime) > 1.0):
+                status = "modified"
+            else:
+                status = "corrupt"
+            db.update_photo_hash_check(row["id"], status, commit=False)
+            stats[status] += 1
+            outcome_reason = KEEP_ARCHIVE_HASH_FAILED
+
+        db.conn.commit()
+        stats["hashes_processed"] += 1
+        if not verified:
+            failure_reasons[expected_hash] = outcome_reason
+
+    # Only previously-unverified entries can change here.  Existing
+    # deletable rows are not re-audited or invalidated by this scoped job.
+    for expected_hash, card_entries in pending_by_hash.items():
+        rows = fetch_rows_by_hash(db, expected_hash)
+        for entry in card_entries:
+            archive_path, reason = qualify_rows(
+                rows, source_root, entry["path"], contains_check)
+            if archive_path is not None:
+                entry["bucket"] = "deletable"
+                entry["archive_path"] = archive_path
+                entry.pop("reason", None)
+                stats["unblocked_files"] += 1
+                stats["unblocked_bytes"] += entry.get("size", 0)
+            elif expected_hash in failure_reasons:
+                entry["reason"] = failure_reasons[expected_hash]
+            else:
+                entry["reason"] = reason
+
+    totals = {
+        "deletable": {"count": 0, "bytes": 0},
+        "kept": {"count": 0, "bytes": 0},
+        "ignored": {"count": 0},
+    }
+    for entry in manifest["entries"]:
+        bucket = entry.get("bucket")
+        if bucket == "ignored":
+            totals["ignored"]["count"] += 1
+        elif bucket in ("deletable", "kept"):
+            totals[bucket]["count"] += 1
+            totals[bucket]["bytes"] += entry.get("size", 0)
+    manifest["totals"] = totals
+    write_manifest(manifest_dir, manifest)
+    return stats
 
 
 def scan_card(db, source, recursive, manifest_dir, scan_job_id,
@@ -565,54 +736,42 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_CHANGED})
             continue
-        try:
-            initial_hash = compute_file_hash(path)
-        except OSError as e:
-            summary["failed"].append({"path": path, "error": str(e)})
-            continue
-        if initial_hash != entry["hash"]:
-            summary["skipped"].append(
-                {"path": path, "reason": SKIP_CONTENT_CHANGED})
-            continue
-        # Archive gate 1: fresh rows, fresh stat. Early fail if the
-        # archive is unreachable or has lost the verified copy — spares
-        # the second full-file read below.
+        # Archive gate 1 is deliberately before the only full card read.
+        # It cheaply rejects an archive that is already unavailable.  The
+        # same archive test runs again after hashing, so neither side's
+        # verdict can go stale during the other side's potentially slow I/O.
         archive_path, reason = qualify_rows(
-            fetch_rows_by_hash(db, initial_hash), source_root_real, path,
+            fetch_rows_by_hash(db, entry["hash"]), source_root_real, path,
             contains_check)
         if archive_path is None:
             summary["skipped"].append({"path": path, "reason": reason})
             continue
-        # Final card re-hash (Codex P1 review): the archive gate above
-        # can take SMB-round-trip time. A same-inode in-place rewrite that
-        # preserves size and forces mtime back to the manifest value (FAT
-        # is 2s-granular; a camera reusing a filename in that window is
-        # the realistic case) passes every metadata check but hashes to
-        # different bytes than the ones we authorized.
+
+        # One full card read, after the first archive round trip.  This
+        # catches ordinary changes plus same-size/same-mtime replacements;
+        # putting it here preserves that protection without reading every
+        # card file twice.
         try:
-            final_hash = compute_file_hash(path)
+            current_hash = compute_file_hash(path)
         except OSError as e:
             summary["failed"].append({"path": path, "error": str(e)})
             continue
-        if final_hash != entry["hash"]:
+        if current_hash != entry["hash"]:
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_CONTENT_CHANGED})
             continue
-        # Archive gate 2 (Codex P1): the final hash reads the whole file
-        # and can take seconds. If the archive dies (unmount, SMB drop,
-        # sync process rewriting it) during that window, gate 1's
-        # authorization is stale — deleting the card copy would destroy
-        # the only remaining copy. Re-verify freshness immediately
-        # before the unlink so an authorized archive is the LAST thing
-        # checked, not the first.
+
+        # Archive gate 2 makes the archive the last full-copy condition
+        # checked before unlink.  If it disappears while the card is being
+        # read, deletion is skipped.
         archive_path, reason = qualify_rows(
-            fetch_rows_by_hash(db, final_hash), source_root_real, path,
+            fetch_rows_by_hash(db, current_hash), source_root_real, path,
             contains_check)
         if archive_path is None:
             summary["skipped"].append({"path": path, "reason": reason})
             continue
         # Path gate (Codex P1): a parent directory swapped for a symlink
-        # DURING the final hash can redirect this pathname to a
+        # DURING the card hash can redirect this pathname to a
         # byte-identical file outside the scanned source — bytes hash
         # identically, both archive gates pass, but os.remove would
         # unlink the external file. Both containment and the final

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -473,6 +473,13 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
     # Content-changed-but-metadata-matching is still caught by
     # delete_verified's own hash pass — expensive re-hashing here
     # would defeat the point of scoped verification.
+    #
+    # Codex P2 (follow-up 2): dropping a changed-but-still-present
+    # card entry hid a file that still exists on the card, so the
+    # kept-list and totals undercounted what would remain after
+    # deletion. Reclassify those entries into the kept bucket with
+    # the corresponding SKIP_* reason instead; only a confirmed-
+    # absent path (FileNotFoundError above) leaves the manifest.
     surviving = []
     for entry in manifest["entries"]:
         if entry.get("bucket") != "deletable":
@@ -489,11 +496,19 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
         except OSError:
             surviving.append(entry)
             continue
-        if (stat_mod.S_ISLNK(st.st_mode)
-                or not stat_mod.S_ISREG(st.st_mode)
-                or st.st_size != entry.get("size")
+        if stat_mod.S_ISLNK(st.st_mode):
+            reclassify_reason = SKIP_SYMLINK
+        elif not stat_mod.S_ISREG(st.st_mode):
+            reclassify_reason = SKIP_NOT_REGULAR
+        elif (st.st_size != entry.get("size")
                 or st.st_mtime_ns != entry.get("mtime_ns")):
+            reclassify_reason = SKIP_CHANGED
+        else:
+            surviving.append(entry)
             continue
+        entry["bucket"] = "kept"
+        entry["reason"] = reclassify_reason
+        entry.pop("archive_path", None)
         surviving.append(entry)
     manifest["entries"] = surviving
 

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -44,6 +44,15 @@ INITIAL_MANIFEST_REVISION = 1
 # a FIFO the same way, so a plain O_RDONLY there is safe.
 O_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
 
+# Codex P1: os.open on Windows defaults to text mode. compute_fd_hash
+# reads through os.read, and the CRT would translate CRLF↔LF and treat
+# Ctrl-Z (0x1A) as EOF in text mode — producing a different digest from
+# compute_file_hash's "rb" open for any RAW/JPEG file containing those
+# bytes. Scoped verification would then flag valid archives as corrupt,
+# and delete_verified's identical card-file open would skip valid
+# deletions. O_BINARY is a POSIX no-op (getattr fallback).
+O_BINARY = getattr(os, "O_BINARY", 0)
+
 
 class ManifestError(Exception):
     """Manifest missing, expired, or failing validation.
@@ -511,7 +520,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             # cannot slip a different object under us.
             try:
                 archive_fd = os.open(
-                    archive_path, os.O_RDONLY | O_NONBLOCK)
+                    archive_path, os.O_RDONLY | O_NONBLOCK | O_BINARY)
             except (OSError, ValueError):
                 # Same rationale as the realpath branch above (Codex
                 # P2): a stat that can't see the file — the common
@@ -854,7 +863,7 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         # fstat then re-proves regular-file + dev/inode identity against
         # the scanned baseline before any bytes are read.
         try:
-            card_fd = os.open(path, os.O_RDONLY | O_NONBLOCK)
+            card_fd = os.open(path, os.O_RDONLY | O_NONBLOCK | O_BINARY)
         except FileNotFoundError:
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_ALREADY_GONE})

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -514,9 +514,23 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
     # deletion. Reclassify those entries into the kept bucket with
     # the corresponding SKIP_* reason instead; only a confirmed-
     # absent path (FileNotFoundError above) leaves the manifest.
+    #
+    # Codex P2 (follow-up 3): pending KEEP_NOT_VERIFIED entries were
+    # never revalidated here, so a pending card file removed after
+    # the scan stayed in the refreshed manifest with its original
+    # byte count credited to the kept bucket — the preview then
+    # claimed a nonexistent file would remain on the card. Handle
+    # confirmed-absent card paths the same way for pending entries;
+    # transient OSErrors still preserve the entry so a mount blip
+    # cannot shrink the preview, and still-present pending entries
+    # keep flowing through the promotion loop below (which applies
+    # the delete-time gates via _card_gate_promotion_block).
     surviving = []
     for entry in manifest["entries"]:
-        if entry.get("bucket") != "deletable":
+        bucket = entry.get("bucket")
+        is_pending = (bucket == "kept"
+                      and entry.get("reason") == KEEP_NOT_VERIFIED)
+        if bucket != "deletable" and not is_pending:
             surviving.append(entry)
             continue
         path = entry.get("path")
@@ -528,6 +542,13 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
         except FileNotFoundError:
             continue
         except OSError:
+            surviving.append(entry)
+            continue
+        if bucket != "deletable":
+            # Pending entry is still present. Leave changed/type-
+            # mismatch reclassification to the promotion loop's
+            # _card_gate_promotion_block so the gate decision stays
+            # in one place.
             surviving.append(entry)
             continue
         if stat_mod.S_ISLNK(st.st_mode):
@@ -660,9 +681,20 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     # itself). Treat as reached-but-unreadable rather
                     # than unreachable; the fd itself would have
                     # failed at open() in the mount-down case.
+                    #
+                    # Codex P2 (follow-up): outcome_reason must match
+                    # what qualify_rows will return for the row we
+                    # just persisted as 'unreadable' — KEEP_ARCHIVE_
+                    # HASH_FAILED. Leaving it at the initial KEEP_
+                    # ARCHIVE_UNREACHABLE lets the promotion-loop
+                    # override downgrade qualify_rows' terminal
+                    # verdict, hiding the failure and stripping the
+                    # Audit-page guidance the UI shows for
+                    # KEEP_ARCHIVE_HASH_FAILED.
                     db.update_photo_hash_check(
                         row["id"], "unreadable", commit=False)
                     stats["unreadable"] += 1
+                    outcome_reason = KEEP_ARCHIVE_HASH_FAILED
                     all_unchecked_inside_source = False
                     continue
                 if not stat_mod.S_ISREG(before.st_mode):
@@ -671,9 +703,12 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     # "unreachable" (we reached it), just not something
                     # we can hash. Marking unreadable is intentional;
                     # a subsequent audit is the right remedy.
+                    #
+                    # Codex P2 (follow-up): see the fstat branch above.
                     db.update_photo_hash_check(
                         row["id"], "unreadable", commit=False)
                     stats["unreadable"] += 1
+                    outcome_reason = KEEP_ARCHIVE_HASH_FAILED
                     all_unchecked_inside_source = False
                     continue
 
@@ -699,9 +734,16 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     after = os.fstat(archive_fd)
                     after_real = os.path.realpath(archive_path)
                 except (OSError, ValueError):
+                    # Codex P2 (follow-up): see the earlier fstat
+                    # branch — outcome_reason must reflect the
+                    # persisted 'unreadable' verdict so the
+                    # promotion loop does not override qualify_rows'
+                    # KEEP_ARCHIVE_HASH_FAILED with the initial
+                    # KEEP_ARCHIVE_UNREACHABLE.
                     db.update_photo_hash_check(
                         row["id"], "unreadable", commit=False)
                     stats["unreadable"] += 1
+                    outcome_reason = KEEP_ARCHIVE_HASH_FAILED
                     all_unchecked_inside_source = False
                     continue
                 stats["archive_files_read"] += 1

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -480,9 +480,15 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             try:
                 archive_real = os.path.realpath(archive_path)
             except (OSError, ValueError):
-                db.update_photo_hash_check(
-                    row["id"], "unreadable", commit=False)
+                # Codex P2: keep hash_status NULL when we can't even
+                # reach the archive path. Marking unreadable here is
+                # permanent — after a transiently-down mount comes
+                # back, a re-scan would classify the row as a prior
+                # integrity failure and route users to the
+                # workspace-wide Audit page instead of a targeted
+                # verify retry.
                 stats["unreadable"] += 1
+                outcome_reason = KEEP_ARCHIVE_UNREACHABLE
                 continue
             if contains_check(archive_real):
                 outcome_reason = KEEP_INSIDE_SOURCE
@@ -501,19 +507,35 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 archive_fd = os.open(
                     archive_path, os.O_RDONLY | os.O_NONBLOCK)
             except (OSError, ValueError):
-                db.update_photo_hash_check(
-                    row["id"], "unreadable", commit=False)
+                # Same rationale as the realpath branch above (Codex
+                # P2): a stat that can't see the file — the common
+                # symptom of a disconnected NAS mount — means the
+                # archive is unreachable, not corrupt. Leave the row
+                # unchecked so targeted verification can retry once
+                # the mount returns; reserve 'unreadable' for files
+                # we actually reached but could not read.
                 stats["unreadable"] += 1
+                outcome_reason = KEEP_ARCHIVE_UNREACHABLE
                 continue
             try:
                 try:
                     before = os.fstat(archive_fd)
                 except OSError:
+                    # We opened the object but immediately failed to
+                    # stat it (extremely rare — a race on the mount
+                    # itself). Treat as reached-but-unreadable rather
+                    # than unreachable; the fd itself would have
+                    # failed at open() in the mount-down case.
                     db.update_photo_hash_check(
                         row["id"], "unreadable", commit=False)
                     stats["unreadable"] += 1
                     continue
                 if not stat_mod.S_ISREG(before.st_mode):
+                    # The object is present but is a directory/FIFO/
+                    # device swapped in on top of the path — not
+                    # "unreachable" (we reached it), just not something
+                    # we can hash. Marking unreadable is intentional;
+                    # a subsequent audit is the right remedy.
                     db.update_photo_hash_check(
                         row["id"], "unreadable", commit=False)
                     stats["unreadable"] += 1

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -515,22 +515,16 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
     # the corresponding SKIP_* reason instead; only a confirmed-
     # absent path (FileNotFoundError above) leaves the manifest.
     #
-    # Codex P2 (follow-up 3): pending KEEP_NOT_VERIFIED entries were
-    # never revalidated here, so a pending card file removed after
-    # the scan stayed in the refreshed manifest with its original
-    # byte count credited to the kept bucket — the preview then
-    # claimed a nonexistent file would remain on the card. Handle
-    # confirmed-absent card paths the same way for pending entries;
-    # transient OSErrors still preserve the entry so a mount blip
-    # cannot shrink the preview, and still-present pending entries
-    # keep flowing through the promotion loop below (which applies
-    # the delete-time gates via _card_gate_promotion_block).
+    # Pending entries with a removed card file are handled in the
+    # promotion loop below via _card_gate_promotion_block's
+    # SKIP_ALREADY_GONE path, which lets scoped verify still hash
+    # the archive and refresh the catalog row before dropping the
+    # entry from the manifest. Keeping that dispatch in one place
+    # (rather than short-circuiting here) preserves the DB-refresh
+    # side effect other card scans keyed off the same hash rely on.
     surviving = []
     for entry in manifest["entries"]:
-        bucket = entry.get("bucket")
-        is_pending = (bucket == "kept"
-                      and entry.get("reason") == KEEP_NOT_VERIFIED)
-        if bucket != "deletable" and not is_pending:
+        if entry.get("bucket") != "deletable":
             surviving.append(entry)
             continue
         path = entry.get("path")
@@ -542,13 +536,6 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
         except FileNotFoundError:
             continue
         except OSError:
-            surviving.append(entry)
-            continue
-        if bucket != "deletable":
-            # Pending entry is still present. Leave changed/type-
-            # mismatch reclassification to the promotion loop's
-            # _card_gate_promotion_block so the gate decision stays
-            # in one place.
             surviving.append(entry)
             continue
         if stat_mod.S_ISLNK(st.st_mode):

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -28,10 +28,15 @@ from image_loader import (
     safe_iter_dir,
     safe_scan_walk,
 )
-from scanner import compute_file_hash
+from scanner import compute_fd_hash, compute_file_hash
 
 MANIFEST_SCHEMA_VERSION = 1
 MANIFEST_MAX_AGE_DAYS = 7
+# Bumped whenever the manifest is rewritten (scan or verify). The delete
+# endpoint requires the client's confirmed revision to match — a verify
+# that runs between the confirmation and the delete POST would otherwise
+# let deletion sweep newly-promoted files the user never saw.
+INITIAL_MANIFEST_REVISION = 1
 
 
 class ManifestError(Exception):
@@ -293,9 +298,18 @@ def qualify_rows(rows, source_root_real, card_path, contains_check=None):
     # non-NULL, non-"ok" status (modified/corrupt/unreadable) have already
     # been verified; re-running verification reproduces the same verdict
     # and the remedy lives on the Audit page, so those rows fall back to
-    # KEEP_ARCHIVE_HASH_FAILED instead. A specific reason from an "ok"
-    # row that failed a later gate (unreachable / changed / inside source)
-    # still wins over both — that's the closest-to-success signal we have.
+    # KEEP_ARCHIVE_HASH_FAILED instead.
+    #
+    # Priority (also Codex P2): a specific reason from an "ok" row that
+    # failed a later gate USED TO win over KEEP_NOT_VERIFIED, but that hid
+    # entries whose unchecked sibling row could still be verified.
+    # KEEP_NOT_VERIFIED now takes precedence whenever we saw a
+    # never-checked row that verify could still try — the unchecked row
+    # might have a different archive path that clears the same gate.
+    # verify_manifest_archives itself does not persist a bad verdict when
+    # the archive fails a gate before hashing, so trying it is free of
+    # side effects; the ok-row's specific reason is only preferred when
+    # no unchecked row is available to give verify a fresh attempt.
     saw_never_checked = False
     saw_check_failed = False
     reason = None
@@ -363,15 +377,16 @@ def qualify_rows(rows, source_root_real, card_path, contains_check=None):
             reason = KEEP_INSIDE_SOURCE
             continue
         return archive_path, None
-    if reason is None:
-        # No "ok" row got as far as a specific rejection — fall back to
-        # the most accurate blame for what's on file. NULL wins the tie:
-        # a mix of never-checked and check-failed rows is still remediable
-        # by an audit (a never-checked row could turn "ok" and unlock the
-        # file), whereas the failed rows are just extra failed rows.
-        if saw_never_checked:
-            reason = KEEP_NOT_VERIFIED
-        elif saw_check_failed:
+    # NULL-hash-status wins over a specific ok-row reason (Codex P2): the
+    # unchecked row is verify's next lever, so the entry must land in the
+    # KEEP_NOT_VERIFIED bucket the callout keys off. Otherwise the reason
+    # already reflects the closest-to-success signal we have, and
+    # KEEP_ARCHIVE_HASH_FAILED only surfaces when no ok row spoke up and
+    # only check-failed rows remain.
+    if saw_never_checked:
+        reason = KEEP_NOT_VERIFIED
+    elif reason is None:
+        if saw_check_failed:
             reason = KEEP_ARCHIVE_HASH_FAILED
         else:
             # No non-ok rows and no ok row got a specific reason — the
@@ -472,44 +487,67 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             if contains_check(archive_real):
                 outcome_reason = KEEP_INSIDE_SOURCE
                 continue
+            # CodeRabbit: pin the checked object via a descriptor rather
+            # than re-opening the pathname. A concurrent rename that swaps
+            # the archive for a FIFO between our S_ISREG check and the
+            # hash-open would leave compute_file_hash blocking forever
+            # inside open() — cancellation is checked only at file
+            # boundaries, so the verify worker would hang. Opening with
+            # O_NONBLOCK bypasses the FIFO-open block; fstat then rejects
+            # anything that is not a regular file, and every subsequent
+            # read/stat operates on this pinned fd so a later rename
+            # cannot slip a different object under us.
             try:
-                before = os.stat(archive_path)
+                archive_fd = os.open(
+                    archive_path, os.O_RDONLY | os.O_NONBLOCK)
             except (OSError, ValueError):
                 db.update_photo_hash_check(
                     row["id"], "unreadable", commit=False)
                 stats["unreadable"] += 1
                 continue
-            if not stat_mod.S_ISREG(before.st_mode):
-                db.update_photo_hash_check(
-                    row["id"], "unreadable", commit=False)
-                stats["unreadable"] += 1
-                continue
-
-            # An outside-path hardlink to a card file is not a second copy.
-            same_as_card = False
-            for entry in card_entries:
+            try:
                 try:
-                    card_st = os.stat(entry["path"])
+                    before = os.fstat(archive_fd)
                 except OSError:
+                    db.update_photo_hash_check(
+                        row["id"], "unreadable", commit=False)
+                    stats["unreadable"] += 1
                     continue
-                if ((before.st_dev, before.st_ino)
-                        == (card_st.st_dev, card_st.st_ino)):
-                    same_as_card = True
-                    break
-            if same_as_card:
-                outcome_reason = KEEP_INSIDE_SOURCE
-                continue
+                if not stat_mod.S_ISREG(before.st_mode):
+                    db.update_photo_hash_check(
+                        row["id"], "unreadable", commit=False)
+                    stats["unreadable"] += 1
+                    continue
 
-            try:
-                actual_hash = compute_file_hash(archive_path)
-                after = os.stat(archive_path)
-                after_real = os.path.realpath(archive_path)
-            except (OSError, ValueError):
-                db.update_photo_hash_check(
-                    row["id"], "unreadable", commit=False)
-                stats["unreadable"] += 1
-                continue
-            stats["archive_files_read"] += 1
+                # An outside-path hardlink to a card file is not a second
+                # copy.  Compare against the fd's dev/inode — the same
+                # object every later step here operates on.
+                same_as_card = False
+                for entry in card_entries:
+                    try:
+                        card_st = os.stat(entry["path"])
+                    except OSError:
+                        continue
+                    if ((before.st_dev, before.st_ino)
+                            == (card_st.st_dev, card_st.st_ino)):
+                        same_as_card = True
+                        break
+                if same_as_card:
+                    outcome_reason = KEEP_INSIDE_SOURCE
+                    continue
+
+                try:
+                    actual_hash = compute_fd_hash(archive_fd)
+                    after = os.fstat(archive_fd)
+                    after_real = os.path.realpath(archive_path)
+                except (OSError, ValueError):
+                    db.update_photo_hash_check(
+                        row["id"], "unreadable", commit=False)
+                    stats["unreadable"] += 1
+                    continue
+                stats["archive_files_read"] += 1
+            finally:
+                os.close(archive_fd)
 
             # Do not certify a pathname that moved or changed while it was
             # being read.  A later retry can verify the stable object.
@@ -580,6 +618,13 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             totals[bucket]["count"] += 1
             totals[bucket]["bytes"] += entry.get("size", 0)
     manifest["totals"] = totals
+    # Bump before write: the delete endpoint's revision check compares
+    # against whatever is on disk, so the new manifest must carry a fresh
+    # number the moment it lands. Missing on old manifests (pre-revision
+    # schema) is treated as the initial revision — the next write is the
+    # first observable change.
+    manifest["revision"] = int(
+        manifest.get("revision", INITIAL_MANIFEST_REVISION)) + 1
     write_manifest(manifest_dir, manifest)
     return stats
 
@@ -656,6 +701,7 @@ def scan_card(db, source, recursive, manifest_dir, scan_job_id,
         "entries": entries,
         "walk_errors": walk_errors,
         "totals": totals,
+        "revision": INITIAL_MANIFEST_REVISION,
     }
     write_manifest(manifest_dir, manifest)
     # Job-result flag only — deliberately NOT part of the persisted
@@ -751,11 +797,47 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         # catches ordinary changes plus same-size/same-mtime replacements;
         # putting it here preserves that protection without reading every
         # card file twice.
+        #
+        # CodeRabbit: hash the descriptor we open here rather than
+        # re-opening the pathname. A rename that swaps the card file for
+        # a FIFO after the S_ISREG check on ``st`` but before
+        # compute_file_hash would leave the worker blocking inside
+        # open() — cancellation is checked at file boundaries only, so
+        # the delete job hangs. O_NONBLOCK survives the FIFO open;
+        # fstat then re-proves regular-file + dev/inode identity against
+        # the scanned baseline before any bytes are read.
         try:
-            current_hash = compute_file_hash(path)
+            card_fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        except FileNotFoundError:
+            summary["skipped"].append(
+                {"path": path, "reason": SKIP_ALREADY_GONE})
+            continue
         except OSError as e:
             summary["failed"].append({"path": path, "error": str(e)})
             continue
+        try:
+            try:
+                fst = os.fstat(card_fd)
+            except OSError as e:
+                summary["failed"].append({"path": path, "error": str(e)})
+                continue
+            if not stat_mod.S_ISREG(fst.st_mode):
+                summary["skipped"].append(
+                    {"path": path, "reason": SKIP_NOT_REGULAR})
+                continue
+            if ((fst.st_dev, fst.st_ino) != (st.st_dev, st.st_ino)
+                    or fst.st_size != entry["size"]
+                    or fst.st_mtime_ns != entry["mtime_ns"]):
+                summary["skipped"].append(
+                    {"path": path, "reason": SKIP_CHANGED})
+                continue
+            try:
+                current_hash = compute_fd_hash(card_fd)
+            except OSError as e:
+                summary["failed"].append({"path": path, "error": str(e)})
+                continue
+        finally:
+            os.close(card_fd)
         if current_hash != entry["hash"]:
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_CONTENT_CHANGED})

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -462,6 +462,17 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
     # already deleted from the card. Drop entries whose card path is
     # gone; a transient stat error (mount hiccup, EACCES) preserves
     # the entry so a NAS blip cannot shrink the preview.
+    #
+    # Codex P2 (follow-up): the FileNotFoundError-only check misses
+    # files delete_verified skipped for size/mtime/type mismatches
+    # (SKIP_CHANGED / SKIP_NOT_REGULAR / SKIP_SYMLINK). lstat still
+    # succeeds for those files, so the stale entry would stay in the
+    # deletable bucket, inflate totals, and re-enable Delete for a
+    # count the delete-time gates will refuse. Mirror the cheap gates
+    # here so the refreshed preview matches what delete would accept.
+    # Content-changed-but-metadata-matching is still caught by
+    # delete_verified's own hash pass — expensive re-hashing here
+    # would defeat the point of scoped verification.
     surviving = []
     for entry in manifest["entries"]:
         if entry.get("bucket") != "deletable":
@@ -472,13 +483,18 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             surviving.append(entry)
             continue
         try:
-            os.lstat(path)
+            st = os.lstat(path)
         except FileNotFoundError:
             continue
         except OSError:
             surviving.append(entry)
-        else:
-            surviving.append(entry)
+            continue
+        if (stat_mod.S_ISLNK(st.st_mode)
+                or not stat_mod.S_ISREG(st.st_mode)
+                or st.st_size != entry.get("size")
+                or st.st_mtime_ns != entry.get("mtime_ns")):
+            continue
+        surviving.append(entry)
     manifest["entries"] = surviving
 
     pending_by_hash = {}
@@ -497,6 +513,18 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
         "unblocked_files": 0, "unblocked_bytes": 0,
     }
     failure_reasons = {}
+    # Codex P2: hashes whose ONLY unchecked catalog rows turned out to be
+    # aliases/hardlinks of the card file itself, or whose cataloged
+    # archive path resolves inside the current source. Those rows stay
+    # NULL-status (they neither read as usable archives nor pass a
+    # persistable failure verdict), so qualify_rows' next pass would
+    # again see saw_never_checked=True and return KEEP_NOT_VERIFIED,
+    # trapping the entry in an infinite verify retry — every click reads
+    # nothing new and shows the same "audit hasn't run" callout. Track
+    # the terminal signal here and let reclassification adopt it below
+    # so the callout finally explains what is actually true: no
+    # independent archive copy exists.
+    terminal_inside_source_hashes = set()
 
     for i, (expected_hash, card_entries) in enumerate(pending):
         if should_cancel is not None and should_cancel():
@@ -513,12 +541,23 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
         unchecked = [row for row in rows if row["hash_status"] is None]
         outcome_reason = KEEP_ARCHIVE_UNREACHABLE
         verified = False
+        # Codex P2 (see terminal_inside_source_hashes above): stays True
+        # only if every unchecked row we processed ended with an inside-
+        # source verdict AND left the row NULL in the DB. A single row
+        # that was persisted (unreadable / modified / corrupt), came back
+        # transiently unreachable, or changed under us flips this off —
+        # qualify_rows' next pass will then have a real lever (either a
+        # persisted verdict it can surface, or a still-NULL row a retry
+        # can still try), so we must not overwrite its KEEP_NOT_VERIFIED
+        # verdict.
+        all_unchecked_inside_source = bool(unchecked)
         for row in unchecked:
             folder_path = row["folder_path"]
             if not folder_path:
                 db.update_photo_hash_check(
                     row["id"], "unreadable", commit=False)
                 stats["unreadable"] += 1
+                all_unchecked_inside_source = False
                 continue
             archive_path = os.path.join(folder_path, row["filename"])
             try:
@@ -533,6 +572,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 # verify retry.
                 stats["unreadable"] += 1
                 outcome_reason = KEEP_ARCHIVE_UNREACHABLE
+                all_unchecked_inside_source = False
                 continue
             if contains_check(archive_real):
                 outcome_reason = KEEP_INSIDE_SOURCE
@@ -560,6 +600,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 # we actually reached but could not read.
                 stats["unreadable"] += 1
                 outcome_reason = KEEP_ARCHIVE_UNREACHABLE
+                all_unchecked_inside_source = False
                 continue
             try:
                 try:
@@ -573,6 +614,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     db.update_photo_hash_check(
                         row["id"], "unreadable", commit=False)
                     stats["unreadable"] += 1
+                    all_unchecked_inside_source = False
                     continue
                 if not stat_mod.S_ISREG(before.st_mode):
                     # The object is present but is a directory/FIFO/
@@ -583,6 +625,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     db.update_photo_hash_check(
                         row["id"], "unreadable", commit=False)
                     stats["unreadable"] += 1
+                    all_unchecked_inside_source = False
                     continue
 
                 # An outside-path hardlink to a card file is not a second
@@ -610,6 +653,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     db.update_photo_hash_check(
                         row["id"], "unreadable", commit=False)
                     stats["unreadable"] += 1
+                    all_unchecked_inside_source = False
                     continue
                 stats["archive_files_read"] += 1
             finally:
@@ -643,6 +687,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                     != (after.st_dev, after.st_ino, after.st_size,
                         after.st_mtime_ns)):
                 outcome_reason = KEEP_ARCHIVE_CHANGED
+                all_unchecked_inside_source = False
                 continue
 
             if actual_hash == expected_hash:
@@ -666,11 +711,14 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             db.update_photo_hash_check(row["id"], status, commit=False)
             stats[status] += 1
             outcome_reason = KEEP_ARCHIVE_HASH_FAILED
+            all_unchecked_inside_source = False
 
         db.conn.commit()
         stats["hashes_processed"] += 1
         if not verified:
             failure_reasons[expected_hash] = outcome_reason
+            if all_unchecked_inside_source:
+                terminal_inside_source_hashes.add(expected_hash)
 
     # Only previously-unverified entries can change here.  Existing
     # deletable rows are not re-audited or invalidated by this scoped job.
@@ -696,7 +744,20 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
                 # settles, targeted verification would then report
                 # "nothing needs checking" until the user re-scans the
                 # card. Keep the entry in the retry-eligible bucket.
-                entry["reason"] = KEEP_NOT_VERIFIED
+                #
+                # Codex P2 (follow-up): the exception is when this
+                # run proved every unchecked row for the hash is a
+                # same-source alias / hardlink of the card file — no
+                # independent archive copy exists, so there IS no
+                # future retry that can change the outcome. Preserving
+                # KEEP_NOT_VERIFIED there traps the entry in an
+                # infinite verify loop (qualify_rows keeps returning
+                # KEEP_NOT_VERIFIED off the still-NULL alias rows).
+                # Adopt the terminal inside-source reason instead.
+                if expected_hash in terminal_inside_source_hashes:
+                    entry["reason"] = KEEP_INSIDE_SOURCE
+                else:
+                    entry["reason"] = KEEP_NOT_VERIFIED
             elif expected_hash in failure_reasons:
                 entry["reason"] = failure_reasons[expected_hash]
             else:

--- a/vireo/card_cleanup.py
+++ b/vireo/card_cleanup.py
@@ -38,6 +38,12 @@ MANIFEST_MAX_AGE_DAYS = 7
 # let deletion sweep newly-promoted files the user never saw.
 INITIAL_MANIFEST_REVISION = 1
 
+# O_NONBLOCK doesn't exist on Windows; fall back to 0 (a no-op flag) so
+# the open call succeeds. The FIFO-open block this flag defends against
+# is a POSIX concern — Windows can't be tricked into open() blocking on
+# a FIFO the same way, so a plain O_RDONLY there is safe.
+O_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
+
 
 class ManifestError(Exception):
     """Manifest missing, expired, or failing validation.
@@ -505,7 +511,7 @@ def verify_manifest_archives(db, manifest, manifest_dir, progress_cb=None,
             # cannot slip a different object under us.
             try:
                 archive_fd = os.open(
-                    archive_path, os.O_RDONLY | os.O_NONBLOCK)
+                    archive_path, os.O_RDONLY | O_NONBLOCK)
             except (OSError, ValueError):
                 # Same rationale as the realpath branch above (Codex
                 # P2): a stat that can't see the file — the common
@@ -829,7 +835,7 @@ def delete_verified(db, manifest, progress_cb=None, should_cancel=None):
         # fstat then re-proves regular-file + dev/inode identity against
         # the scanned baseline before any bytes are read.
         try:
-            card_fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+            card_fd = os.open(path, os.O_RDONLY | O_NONBLOCK)
         except FileNotFoundError:
             summary["skipped"].append(
                 {"path": path, "reason": SKIP_ALREADY_GONE})

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -114,6 +114,25 @@ def compute_file_hash(file_path, chunk_size=65536):
     return h.hexdigest()
 
 
+def compute_fd_hash(fd, chunk_size=65536):
+    """Compute SHA-256 hash of the object referred to by ``fd``.
+
+    Reading from the descriptor rather than re-opening the pathname keeps
+    a concurrent rename from substituting a FIFO or other blocking object
+    behind us — the caller pins the object with ``os.open`` + ``fstat``,
+    and this function only ever hashes whatever that descriptor already
+    refers to. Does NOT seek: pass a freshly-opened descriptor, or the
+    hash covers only the bytes past the current file offset.
+    """
+    h = hashlib.sha256()
+    while True:
+        chunk = os.read(fd, chunk_size)
+        if not chunk:
+            break
+        h.update(chunk)
+    return h.hexdigest()
+
+
 def _compute_file_features(path_str):
     """Compute (phash, file_hash) for one image.
 

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -114,21 +114,18 @@ body { display: flex; flex-direction: column; height: 100vh; }
           </details>
         </div>
         <div class="hint" id="card-cleanup-scanned-root" style="margin-bottom:6px;"></div>
-        <!-- Shown only when the scan's own kept reasons say the integrity
-             audit is what is missing. -->
-        <div class="card-cleanup-audit" id="card-cleanup-audit" style="display:none;">
-          <div id="card-cleanup-audit-text"></div>
-          <span class="hint" id="card-cleanup-audit-cost"></span>
-          <span class="hint" id="card-cleanup-audit-scope-note"
-                style="display:none;"></span>
+        <!-- Shown only when matching archive rows have never had their
+             bytes verified.  This check is scoped to the current card. -->
+        <div class="card-cleanup-audit" id="card-cleanup-verify" style="display:none;">
+          <div id="card-cleanup-verify-text"></div>
+          <span class="hint" id="card-cleanup-verify-cost"></span>
           <div class="row" style="margin-top:8px;margin-bottom:0;">
-            <button class="btn btn-primary" type="button" id="card-cleanup-audit-btn"
-                    onclick="cardCleanupStartAudit()">Verify archive hashes</button>
-            <button class="btn" type="button" id="card-cleanup-audit-rescan-btn"
-                    style="display:none;" onclick="cardCleanupStartScan()">Re-scan card</button>
+            <button class="btn btn-primary" type="button" id="card-cleanup-verify-btn"
+                    onclick="cardCleanupStartVerification()">Verify matching archive copies</button>
           </div>
-          <div class="hint" id="card-cleanup-audit-status" style="margin-top:6px;"></div>
         </div>
+        <div class="hint" id="card-cleanup-verify-result"
+             style="display:none;margin:8px 0;"></div>
         <!-- Shown when kept entries are held back because their archive
              copies failed a prior integrity check. Distinct from the
              audit callout above: re-running verify would just reproduce
@@ -183,7 +180,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <ul class="card-cleanup-confirm-list">
         <li>Deletion is permanent — memory cards have no trash.</li>
         <li>After deletion, the archive holds the only copy of these photos.</li>
-        <li>What "verified" means: each file's archive copy passed a checksum check (at import or integrity audit) and is confirmed unchanged since by size and timestamp; the card copy itself is re-checksummed at the moment of deletion. Archive bytes are not re-downloaded.</li>
+        <li>What "verified" means: each file's archive copy passed a checksum check (at import, here, or in the integrity audit) and is confirmed unchanged since by size and timestamp; the card copy itself is re-checksummed at the moment of deletion. Archive bytes are not re-downloaded.</li>
       </ul>
     </div>
     <div class="folder-browser-actions">
@@ -210,7 +207,6 @@ const cardCleanupState = {
   listsRendered: {},    // bucket -> true once its <li>s are in the DOM
   confirmEscHandler: null,
   busyRestore: null,    // delete button/hint state saved while a job runs
-  auditCompleted: false, // a verify-hashes run finished during this page visit
 };
 
 /* Exactly one job at a time. Starting a second one while this page is
@@ -223,7 +219,7 @@ const cardCleanupState = {
 function cardCleanupSetBusy(running, opts) {
   const scanBtn = document.getElementById('card-cleanup-scan-btn');
   const deleteBtn = document.getElementById('card-cleanup-delete-btn');
-  const auditBtn = document.getElementById('card-cleanup-audit-btn');
+  const verifyBtn = document.getElementById('card-cleanup-verify-btn');
   const deleteHint = document.getElementById('card-cleanup-delete-hint');
   if (running) {
     // Whether Delete may be pressed depends on the manifest (and on
@@ -236,7 +232,7 @@ function cardCleanupSetBusy(running, opts) {
       };
     }
     scanBtn.disabled = true;
-    auditBtn.disabled = true;
+    verifyBtn.disabled = true;
     deleteBtn.disabled = true;
     if (opts && opts.deleteHint) deleteHint.textContent = opts.deleteHint;
     return;
@@ -244,20 +240,20 @@ function cardCleanupSetBusy(running, opts) {
   const restore = cardCleanupState.busyRestore;
   cardCleanupState.busyRestore = null;
   scanBtn.disabled = false;
-  auditBtn.disabled = false;
+  verifyBtn.disabled = false;
+  if (opts && opts.keepDeleteState) return;
   if (restore) {
     deleteBtn.disabled = restore.deleteDisabled;
     deleteHint.textContent = restore.deleteHint;
   }
 }
 
-// The manifest reason that this page's audit callout answers. Mirrors
-// card_cleanup.KEEP_NOT_VERIFIED — matched on the distinctive tail so a
-// reason with extra detail appended still counts.
-const CARD_CLEANUP_AUDIT_REASON = 'run the integrity audit';
+// Mirrors card_cleanup.KEEP_NOT_VERIFIED exactly.  Exact matching avoids
+// offering verification for rows that already failed a previous check.
+const CARD_CLEANUP_VERIFY_REASON = 'archive copy has not been checksum-verified';
 // The manifest reason that this page's hash-failed callout answers.
 // Mirrors card_cleanup.KEEP_ARCHIVE_HASH_FAILED — kept distinct from
-// CARD_CLEANUP_AUDIT_REASON so a check-failed row cannot pretend to be a
+// CARD_CLEANUP_VERIFY_REASON so a check-failed row cannot pretend to be a
 // never-checked one and get double-counted (or vice versa). Same tail
 // match as above; test_hash_failed_callout_reason_stays_in_sync pins it.
 const CARD_CLEANUP_HASH_FAILED_REASON = 'see the Audit page';
@@ -474,11 +470,11 @@ async function cardCleanupFinishJob(jobId, kind) {
   cardCleanupState.jobId = null;
   document.getElementById('card-cleanup-cancel-btn').style.display = 'none';
   document.getElementById('card-cleanup-progress').style.display = 'none';
-  // Buttons come back first; the per-kind branches below then overwrite
-  // the Delete button and its hint with what this run's outcome means.
-  cardCleanupSetBusy(false);
   const status = job && job.status;
   const jobError = job && (job.errors || [])[0];
+  // A verification completion owns the page until its refreshed manifest
+  // is rendered; otherwise Delete could briefly advertise the old totals.
+  if (kind !== 'verify') cardCleanupSetBusy(false);
   if (kind === 'scan') {
     if (status === 'completed') {
       await cardCleanupLoadManifest();
@@ -496,8 +492,8 @@ async function cardCleanupFinishJob(jobId, kind) {
     }
     return;
   }
-  if (kind === 'audit') {
-    cardCleanupFinishAudit(job, status, jobError);
+  if (kind === 'verify') {
+    await cardCleanupFinishVerification(job, status, jobError);
     return;
   }
   // Delete: the per-file outcome lives in the job result, so a job that
@@ -536,13 +532,15 @@ async function cardCleanupLoadManifest() {
     if (resp.status === 404) {
       cardCleanupState.scanJobId = null;
       cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
-      return;
+      return false;
     }
     if (!resp.ok) throw new Error(data.error || 'the preview could not be loaded');
     cardCleanupRenderManifest(data);
+    return true;
   } catch (e) {
     if (cardCleanupState.scanJobId !== requestedScanJobId) return;
     cardCleanupSetError(String(e.message || e));
+    return false;
   }
 }
 
@@ -588,7 +586,7 @@ function cardCleanupRenderManifest(manifest) {
     cardCleanupFileCount(ignored.count) +
     ' ignored (not photo files Vireo imports)';
 
-  cardCleanupRenderAuditCallout(manifest);
+  cardCleanupRenderVerificationCallout(manifest);
   cardCleanupRenderHashFailedCallout(manifest);
 
   cardCleanupBindBucket('deletable', 'card-cleanup-deletable-details',
@@ -609,48 +607,36 @@ function cardCleanupRenderManifest(manifest) {
   document.getElementById('card-cleanup-preview').style.display = '';
 }
 
-/* ---------- Integrity-audit affordance ----------
-   The scan itself tells us when the archive audit is the missing step:
-   every kept entry whose reason is KEEP_NOT_VERIFIED. The count below is
-   those entries, not an estimate. */
-function cardCleanupAuditPendingCount(manifest) {
+/* ---------- Card-scoped archive verification ---------- */
+function cardCleanupVerificationPendingCount(manifest) {
   return (manifest.entries || []).filter(entry =>
     entry.bucket === 'kept'
-    && String(entry.reason || '').indexOf(CARD_CLEANUP_AUDIT_REASON) !== -1
+    && entry.reason === CARD_CLEANUP_VERIFY_REASON
   ).length;
 }
 
-function cardCleanupRenderAuditCallout(manifest) {
-  const callout = document.getElementById('card-cleanup-audit');
-  const pending = cardCleanupAuditPendingCount(manifest);
+function cardCleanupRenderVerificationCallout(manifest) {
+  const callout = document.getElementById('card-cleanup-verify');
+  const pending = cardCleanupVerificationPendingCount(manifest);
   if (!pending) {
     callout.style.display = 'none';
     return;
   }
-  document.getElementById('card-cleanup-audit-text').textContent =
+  const uniqueHashes = new Set((manifest.entries || [])
+    .filter(entry => entry.bucket === 'kept'
+      && entry.reason === CARD_CLEANUP_VERIFY_REASON && entry.hash)
+    .map(entry => entry.hash)).size;
+  document.getElementById('card-cleanup-verify-text').textContent =
     cardCleanupFileCount(pending) +
     (pending === 1 ? ' is' : ' are') +
-    ' kept only because the archive ' +
-    'copy has never been checksum-verified. Vireo will not delete a card ' +
-    'file until its archive copy passes a checksum check, and the ' +
-    'integrity audit is what performs that check.';
-  // Scope honesty (Codex P2 review): the card scan matches photos across
-  // ALL workspaces, but the verify-hashes job covers only the folders in
-  // the CURRENT workspace. If some of these files' archive copies live
-  // in another workspace's folders, verifying here will not touch them —
-  // say so up front, and cardCleanupRenderStillUnverifiedHint says it
-  // again, specifically, when a post-audit re-scan proves it happened.
-  document.getElementById('card-cleanup-audit-cost').textContent =
-    'Verifying re-reads and re-checksums every archive file in the ' +
-    'current workspace, not just these — over a VPN’d network mount ' +
-    'that is slow, so it is best run on a machine close to the NAS. ' +
-    'Archive copies that belong to a different workspace are not ' +
-    'covered; switch to that workspace to verify them.';
-  cardCleanupRenderStillUnverifiedHint(pending);
-  document.getElementById('card-cleanup-audit-btn').style.display = '';
-  document.getElementById('card-cleanup-audit-btn').disabled = false;
-  document.getElementById('card-cleanup-audit-rescan-btn').style.display = 'none';
-  document.getElementById('card-cleanup-audit-status').textContent = '';
+    ' kept only because the matching archive copy has never been ' +
+    'checksum-verified.';
+  document.getElementById('card-cleanup-verify-cost').textContent =
+    'This reads only the matching archive ' +
+    (uniqueHashes === 1 ? 'copy' : uniqueHashes.toLocaleString() + ' copies') +
+    ' needed by this card. Unrelated archive files are not touched, and ' +
+    'duplicate files on the card share one check.';
+  document.getElementById('card-cleanup-verify-btn').disabled = false;
   callout.style.display = '';
 }
 
@@ -693,63 +679,28 @@ function cardCleanupRenderHashFailedCallout(manifest) {
   callout.style.display = '';
 }
 
-/* After a verification has run, files still pending on the next scan are
-   exactly the ones verification could not reach — most likely archive
-   copies in folders that belong to a different workspace (the scan
-   matches globally; verify-hashes covers only the current workspace's
-   folders). Say that specifically instead of letting the callout loop. */
-function cardCleanupRenderStillUnverifiedHint(pending) {
-  const note = document.getElementById('card-cleanup-audit-scope-note');
-  if (!cardCleanupState.auditCompleted || !pending) {
-    note.style.display = 'none';
-    note.textContent = '';
-    return;
-  }
-  note.textContent =
-    'Still unverified after the last verification run: these files’ ' +
-    'archive copies were not covered by it — most likely they belong to ' +
-    'folders in a different workspace (or the run was cancelled before ' +
-    'reaching them). Switch to the workspace that holds those folders ' +
-    'and verify there, then re-scan here.';
-  note.style.display = 'block';
-}
-
-async function cardCleanupStartAudit() {
+async function cardCleanupStartVerification() {
   if (cardCleanupState.jobId) return;  // a run is already streaming
-  // Verification changes what counts as verified, so the preview's Delete
-  // button describes a state that is being rewritten underneath it. Say
-  // that where the Delete button is, not only up here.
   cardCleanupSetBusy(true, {
     deleteHint: 'Verification is running — deletion is available when it ' +
       'finishes.',
   });
-  document.getElementById('card-cleanup-audit-rescan-btn').style.display = 'none';
-  document.getElementById('card-cleanup-audit-status').textContent = '';
+  const resultEl = document.getElementById('card-cleanup-verify-result');
+  resultEl.style.display = 'none';
+  resultEl.textContent = '';
   cardCleanupSetError('');
-  // Failure handling here mirrors cardCleanupConfirmDelete (Codex P1 review
-  // on commit 5afcb0ba). Only a definitive HTTP response proves whether the
-  // server queued the audit — an fetch rejection or an unreadable body
-  // could mean api_job_verify_hashes() is already running. If the page
-  // unlocked in that gap, delete_verified() would trust the currently
-  // committed hash_status plus archive size/mtime rather than re-hashing
-  // archive bytes, so a concurrent delete could qualify a row on its old
-  // `ok` verdict while the audit is flipping it to modified/corrupt/
-  // unreadable — and remove the good card copy. Keep Scan/Verify/Delete
-  // disabled on any ambiguous outcome and send the user to Jobs, only
-  // unlocking when the server proves nothing was queued.
   let resp;
   try {
-    resp = await fetch('/api/jobs/verify-hashes', {
+    resp = await fetch('/api/card-cleanup/verify', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: '{}',
+      body: JSON.stringify({scan_job_id: cardCleanupState.scanJobId}),
     });
   } catch (e) {
     cardCleanupSetError(
       'The verify request never got a response, so we cannot tell whether ' +
-      'the server queued the audit. Check the Jobs page for a verify-hashes ' +
-      'job that started around now, then reload this page to work with the ' +
-      'card again. (' + String(e.message || e) + ')');
+      'the server queued it. Check the Jobs page for a card-cleanup-verify ' +
+      'job, then reload this page. (' + String(e.message || e) + ')');
     return;
   }
   if (!resp.ok) {
@@ -768,71 +719,46 @@ async function cardCleanupStartAudit() {
   try {
     data = await resp.json();
   } catch (e) {
-    // 2xx response, unreadable body: the audit may already be running.
-    // Same reasoning as the network catch above — keep the page locked and
-    // route the user to Jobs rather than freeing the destructive path.
     cardCleanupSetError(
       'The verify request returned OK but its response could not be read, ' +
-      'so the audit may already be running. Check the Jobs page for a ' +
-      'verify-hashes job that started around now, then reload this page to ' +
-      'work with the card again. (' + String(e.message || e) + ')');
+      'so verification may already be running. Check the Jobs page for a ' +
+      'card-cleanup-verify job, then reload this page. (' +
+      String(e.message || e) + ')');
     return;
   }
-  cardCleanupWatchJob(data.job_id, 'audit', 'Starting hash verification…');
+  cardCleanupWatchJob(data.job_id, 'verify', 'Starting matching-copy verification…');
 }
 
-// The buttons are already re-enabled by cardCleanupSetBusy(false) in
-// cardCleanupFinishJob's cleanup; this only reports what the run found.
-// Verification can flip previously-ok rows to modified/corrupt/unreadable,
-// so the preview's deletable count/bytes may no longer describe what a
-// deletion would actually touch. Disable Delete until the user takes the
-// re-scan surfaced below — the backend re-checks and skips invalid rows,
-// but the confirmation dialog would still show stale totals against a
-// valid subset the user never agreed to.
-function cardCleanupFinishAudit(job, status, jobError) {
-  const statusEl = document.getElementById('card-cleanup-audit-status');
-  if (status === 'completed' || status === 'cancelled') {
-    // Lets the next re-scan's callout explain files that verification
-    // could not have covered (other workspaces' folders).
-    cardCleanupState.auditCompleted = true;
+async function cardCleanupFinishVerification(job, status, jobError) {
+  const resultEl = document.getElementById('card-cleanup-verify-result');
+  let refreshed = false;
+  if ((status === 'completed' || status === 'cancelled')
+      && cardCleanupState.scanJobId) {
+    refreshed = await cardCleanupLoadManifest();
   }
-  const deleteBtn = document.getElementById('card-cleanup-delete-btn');
-  deleteBtn.disabled = true;
-  document.getElementById('card-cleanup-delete-hint').textContent
-    = 'Verification may have changed which files count as verified — re-scan the card before deleting.';
+  cardCleanupSetBusy(false, {keepDeleteState: refreshed});
+  resultEl.style.display = '';
   if (status === 'completed' && job && job.result) {
     const r = job.result;
     const problems = (r.modified || 0) + (r.corrupt || 0) + (r.unreadable || 0);
-    const parts = [cardCleanupFileCount(r.checked) + ' checked'];
-    if (r.baselined) {
-      parts.push(Number(r.baselined).toLocaleString() +
-        ' baselined (no prior hash)');
-    }
-    if (r.missing) {
-      parts.push(Number(r.missing).toLocaleString() +
-        ' missing (see the Audit page)');
-    }
-    parts.push(problems
-      ? problems.toLocaleString() + ' problems found (see the Audit page)'
-      : 'no problems');
-    if (r.cancelled) parts.push('cancelled before the whole archive was read');
-    statusEl.textContent = parts.join(' · ') +
-      '. The preview above is from the earlier scan — re-scan the card to ' +
-      'see what is verified now.';
+    const parts = [Number(r.archive_files_read || 0).toLocaleString() +
+      ' matching archive ' + ((r.archive_files_read || 0) === 1 ? 'file' : 'files') +
+      ' read'];
+    parts.push(cardCleanupFileCount(r.unblocked_files || 0) + ' now ready to delete');
+    if (problems) parts.push(problems.toLocaleString() + ' could not be verified');
+    resultEl.textContent = parts.join(' · ') + '. Preview updated.';
   } else if (status === 'cancelled') {
-    statusEl.textContent =
-      'Verification cancelled — the files it had already checked keep ' +
-      'their new verdicts; the rest are unchanged.';
+    resultEl.textContent =
+      'Verification cancelled — completed checks were kept and the preview was updated.';
   } else if (status) {
-    statusEl.textContent = 'Verification ' + status +
+    resultEl.textContent = 'Verification ' + status +
       (jobError ? ': ' + jobError : '.') +
       ' Check the Jobs page for what it managed to check.';
   } else {
-    statusEl.textContent =
+    resultEl.textContent =
       'The verification is still running but this page lost track of it — ' +
       'check the Jobs page.';
   }
-  document.getElementById('card-cleanup-audit-rescan-btn').style.display = '';
 }
 
 // Bucket lists run to thousands of rows, so build them the first time the
@@ -887,7 +813,8 @@ function cardCleanupResetPreview() {
   cardCleanupState.listsRendered = {};
   document.getElementById('card-cleanup-preview').style.display = 'none';
   document.getElementById('card-cleanup-incomplete').style.display = 'none';
-  document.getElementById('card-cleanup-audit').style.display = 'none';
+  document.getElementById('card-cleanup-verify').style.display = 'none';
+  document.getElementById('card-cleanup-verify-result').style.display = 'none';
   document.getElementById('card-cleanup-hash-failed').style.display = 'none';
   const deleteBtn = document.getElementById('card-cleanup-delete-btn');
   deleteBtn.disabled = true;

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -528,7 +528,7 @@ async function cardCleanupLoadManifest() {
     const resp = await fetch('/api/card-cleanup/' +
       encodeURIComponent(requestedScanJobId) + '/manifest');
     const data = await resp.json();
-    if (cardCleanupState.scanJobId !== requestedScanJobId) return;
+    if (cardCleanupState.scanJobId !== requestedScanJobId) return false;
     if (resp.status === 404) {
       cardCleanupState.scanJobId = null;
       cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
@@ -538,7 +538,11 @@ async function cardCleanupLoadManifest() {
     cardCleanupRenderManifest(data);
     return true;
   } catch (e) {
-    if (cardCleanupState.scanJobId !== requestedScanJobId) return;
+    // CodeRabbit: preserve the boolean return contract on the
+    // stale-scan ownership check too. Returning undefined here would be
+    // read as "not refreshed" by the caller, which happens to be
+    // correct — but only by accident. State it.
+    if (cardCleanupState.scanJobId !== requestedScanJobId) return false;
     cardCleanupSetError(String(e.message || e));
     return false;
   }
@@ -609,9 +613,14 @@ function cardCleanupRenderManifest(manifest) {
 
 /* ---------- Card-scoped archive verification ---------- */
 function cardCleanupVerificationPendingCount(manifest) {
+  // CodeRabbit: match verify_manifest_archives' filter — it groups
+  // pending work by entry.hash and silently drops hashless entries, so
+  // counting them here made the callout advertise a pending count
+  // while `reads only the matching archive 0 copies` sat below it.
   return (manifest.entries || []).filter(entry =>
     entry.bucket === 'kept'
     && entry.reason === CARD_CLEANUP_VERIFY_REASON
+    && entry.hash
   ).length;
 }
 
@@ -743,7 +752,15 @@ async function cardCleanupFinishVerification(job, status, jobError) {
   if (attemptedReload) {
     refreshed = await cardCleanupLoadManifest();
   }
-  cardCleanupSetBusy(false, {keepDeleteState: refreshed});
+  // Codex P1: any completed/cancelled verification renders the
+  // pre-verification Delete state stale. Do NOT let cardCleanupSetBusy
+  // restore that state — a successful reload has already re-rendered
+  // Delete via cardCleanupRenderManifest, and a failed reload needs it
+  // locked. Restoring the busyRestore snapshot in between would flicker
+  // Delete back to "enabled with old counts" for the microsecond
+  // between this call and the manual disable below, and Codex flagged
+  // the whole window as a P1 risk on this PR.
+  cardCleanupSetBusy(false, {keepDeleteState: attemptedReload || refreshed});
   if (attemptedReload && !refreshed) {
     // Verification finished but the manifest reload failed or returned
     // an unreadable response, so the on-disk deletable set may now
@@ -916,11 +933,21 @@ async function cardCleanupConfirmDelete() {
   cardCleanupSetBusy(true, {
     deleteHint: 'Deletion is starting…',
   });
+  // Codex P1: send the manifest revision we confirmed against. If a
+  // verify has landed since (and rewritten the manifest with a fresh
+  // revision), the server rejects this POST rather than deleting the
+  // newly-promoted files the user never saw. Missing revision on an old
+  // manifest is treated as INITIAL_MANIFEST_REVISION on the server side.
+  const confirmedRevision =
+    cardCleanupState.manifest && cardCleanupState.manifest.revision;
   try {
     const resp = await fetch('/api/card-cleanup/delete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ scan_job_id: cardCleanupState.scanJobId }),
+      body: JSON.stringify({
+        scan_job_id: cardCleanupState.scanJobId,
+        manifest_revision: confirmedRevision,
+      }),
     });
     const data = await resp.json();
     cardCleanupCloseConfirm();
@@ -933,6 +960,14 @@ async function cardCleanupConfirmDelete() {
         cardCleanupState.scanJobId = null;
         cardCleanupResetPreview();
         cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
+      } else if (data && data.code === 'manifest_revision_mismatch') {
+        // Reload the on-disk manifest so the preview and Delete button
+        // reflect what would actually be deleted next; the totals the
+        // user just confirmed no longer exist on the server.
+        cardCleanupSetError(data.error ||
+          'The preview changed since you confirmed it — review the ' +
+          'updated totals before deleting.');
+        cardCleanupLoadManifest();
       } else {
         cardCleanupSetError(data.error || 'deletion failed to start');
       }

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -616,7 +616,7 @@ function cardCleanupVerificationPendingCount(manifest) {
   // CodeRabbit: match verify_manifest_archives' filter — it groups
   // pending work by entry.hash and silently drops hashless entries, so
   // counting them here made the callout advertise a pending count
-  // while `reads only the matching archive 0 copies` sat below it.
+  // while the cost message below said zero archives would be read.
   return (manifest.entries || []).filter(entry =>
     entry.bucket === 'kept'
     && entry.reason === CARD_CLEANUP_VERIFY_REASON
@@ -640,11 +640,23 @@ function cardCleanupRenderVerificationCallout(manifest) {
     (pending === 1 ? ' is' : ' are') +
     ' kept only because the matching archive copy has never been ' +
     'checksum-verified.';
+  // Codex P2 (r3761960414): the cost message used to promise "reads N
+  // matching copies" where N = number of unique pending hashes. But
+  // verify_manifest_archives iterates every unchecked archive row for a
+  // hash until one hashes cleanly, so a hash with several corrupt or
+  // stale candidates can drive multiple full-file reads even though the
+  // unique-hash count is one. Say "at least one per pending hash" and
+  // name the retry condition explicitly, so the wording matches what
+  // the verify job may actually do.
   document.getElementById('card-cleanup-verify-cost').textContent =
-    'This reads only the matching archive ' +
-    (uniqueHashes === 1 ? 'copy' : uniqueHashes.toLocaleString() + ' copies') +
-    ' needed by this card. Unrelated archive files are not touched, and ' +
-    'duplicate files on the card share one check.';
+    'This reads matching archive files this card needs — at least one ' +
+    'per ' +
+    (uniqueHashes === 1
+      ? 'pending hash'
+      : uniqueHashes.toLocaleString() + ' pending hashes') +
+    ', with additional reads if a candidate turns out to be corrupt or ' +
+    'stale. Unrelated archive files are not touched, and duplicate ' +
+    'files on the card share one check.';
   document.getElementById('card-cleanup-verify-btn').disabled = false;
   callout.style.display = '';
 }

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -959,11 +959,10 @@ async function cardCleanupConfirmDelete() {
     const data = await resp.json();
     cardCleanupCloseConfirm();
     if (!resp.ok) {
-      // Nothing was queued — hand the buttons back before showing the error.
-      cardCleanupSetBusy(false);
       if (resp.status === 404) {
         // The manifest is gone, so the preview above no longer describes
         // anything that can be deleted — take it down with the error.
+        cardCleanupSetBusy(false);
         cardCleanupState.scanJobId = null;
         cardCleanupResetPreview();
         cardCleanupSetError('Preview expired — re-scan the card.', { rescan: true });
@@ -974,8 +973,34 @@ async function cardCleanupConfirmDelete() {
         cardCleanupSetError(data.error ||
           'The preview changed since you confirmed it — review the ' +
           'updated totals before deleting.');
-        cardCleanupLoadManifest();
+        // Codex P1 review: await the reload before releasing the busy
+        // state. The previous flow called cardCleanupSetBusy(false)
+        // first and then kicked cardCleanupLoadManifest() off as
+        // fire-and-forget, so Scan/Verify/Delete were re-enabled in
+        // the gap before the response landed. A user who reopened
+        // the confirm dialog during that gap saw the pre-mismatch
+        // totals; once the reload swapped cardCleanupState.manifest
+        // for the fresh one, confirming would send the new revision
+        // and the server would accept deletion of the newly promoted
+        // set that never appeared in the dialog. Awaiting the reload
+        // with the page still locked closes the window. On success,
+        // cardCleanupRenderManifest has already set Delete's disabled
+        // state and hint from the fresh totals, so keepDeleteState
+        // preserves them across the unlock. On failure the render
+        // never ran, so explicitly disable Delete and clear the
+        // stale "Deletion is starting…" hint — a stale preview must
+        // not be able to authorize a deletion.
+        const reloaded = await cardCleanupLoadManifest();
+        cardCleanupSetBusy(false, { keepDeleteState: true });
+        if (!reloaded) {
+          const deleteBtn = document.getElementById('card-cleanup-delete-btn');
+          deleteBtn.disabled = true;
+          document.getElementById('card-cleanup-delete-hint').textContent =
+            'Reload the page or scan again before deleting — the ' +
+            'preview could not be refreshed after the revision changed.';
+        }
       } else {
+        cardCleanupSetBusy(false);
         cardCleanupSetError(data.error || 'deletion failed to start');
       }
       return;

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -936,10 +936,17 @@ async function cardCleanupConfirmDelete() {
   // Codex P1: send the manifest revision we confirmed against. If a
   // verify has landed since (and rewritten the manifest with a fresh
   // revision), the server rejects this POST rather than deleting the
-  // newly-promoted files the user never saw. Missing revision on an old
-  // manifest is treated as INITIAL_MANIFEST_REVISION on the server side.
+  // newly-promoted files the user never saw.
+  //
+  // Codex P2: pre-revision manifests (saved before this branch landed)
+  // have no `revision` key. Sending undefined would make JSON.stringify
+  // drop `manifest_revision` from the body, and the endpoint rejects a
+  // missing key with 400 rather than treating it as the initial
+  // revision — leaving every carried-over preview undeletable. Match
+  // what the server already does when it loads a manifest without a
+  // revision: default to INITIAL_MANIFEST_REVISION (1).
   const confirmedRevision =
-    cardCleanupState.manifest && cardCleanupState.manifest.revision;
+    (cardCleanupState.manifest && cardCleanupState.manifest.revision) || 1;
   try {
     const resp = await fetch('/api/card-cleanup/delete', {
       method: 'POST',

--- a/vireo/templates/card_cleanup.html
+++ b/vireo/templates/card_cleanup.html
@@ -731,12 +731,32 @@ async function cardCleanupStartVerification() {
 
 async function cardCleanupFinishVerification(job, status, jobError) {
   const resultEl = document.getElementById('card-cleanup-verify-result');
+  // Codex P1 (this commit): a completed or cancelled verification may
+  // have promoted files, so the pre-verification Delete state is stale
+  // until the refreshed manifest lands. Track both whether we tried to
+  // reload and whether it succeeded; the "Preview updated" copy and
+  // the Delete lock both depend on that success.
+  const attemptedReload =
+    (status === 'completed' || status === 'cancelled')
+    && !!cardCleanupState.scanJobId;
   let refreshed = false;
-  if ((status === 'completed' || status === 'cancelled')
-      && cardCleanupState.scanJobId) {
+  if (attemptedReload) {
     refreshed = await cardCleanupLoadManifest();
   }
   cardCleanupSetBusy(false, {keepDeleteState: refreshed});
+  if (attemptedReload && !refreshed) {
+    // Verification finished but the manifest reload failed or returned
+    // an unreadable response, so the on-disk deletable set may now
+    // exceed what the pre-verification preview advertises. Keep Delete
+    // locked and require a successful reload or re-scan before it can
+    // fire — the user would otherwise confirm the old totals while the
+    // server deletes the freshly-promoted files too.
+    const deleteBtn = document.getElementById('card-cleanup-delete-btn');
+    deleteBtn.disabled = true;
+    document.getElementById('card-cleanup-delete-hint').textContent =
+      'Verification finished but the updated preview could not be loaded ' +
+      '— reload the page or scan again before deleting.';
+  }
   resultEl.style.display = '';
   if (status === 'completed' && job && job.result) {
     const r = job.result;
@@ -746,10 +766,20 @@ async function cardCleanupFinishVerification(job, status, jobError) {
       ' read'];
     parts.push(cardCleanupFileCount(r.unblocked_files || 0) + ' now ready to delete');
     if (problems) parts.push(problems.toLocaleString() + ' could not be verified');
-    resultEl.textContent = parts.join(' · ') + '. Preview updated.';
+    // Only claim the preview was updated once the refreshed manifest
+    // has actually rendered — the counts above come from the job result,
+    // not from the preview, so a failed reload would leave a stale
+    // preview under a "Preview updated" line.
+    resultEl.textContent = parts.join(' · ') +
+      (refreshed
+        ? '. Preview updated.'
+        : '. The updated preview could not be loaded — reload the page ' +
+          'or scan again before deleting.');
   } else if (status === 'cancelled') {
-    resultEl.textContent =
-      'Verification cancelled — completed checks were kept and the preview was updated.';
+    resultEl.textContent = refreshed
+      ? 'Verification cancelled — completed checks were kept and the preview was updated.'
+      : 'Verification cancelled but the updated preview could not be loaded ' +
+        '— reload the page or scan again before deleting.';
   } else if (status) {
     resultEl.textContent = 'Verification ' + status +
       (jobError ? ': ' + jobError : '.') +

--- a/vireo/tests/contracts/routes.txt
+++ b/vireo/tests/contracts/routes.txt
@@ -227,6 +227,7 @@ POST         /api/browse/photo-counts
 POST         /api/capture-time/preview
 POST         /api/card-cleanup/delete
 POST         /api/card-cleanup/scan
+POST         /api/card-cleanup/verify
 POST         /api/collections
 POST         /api/collections/<int:collection_id>/add-photos
 POST         /api/collections/<int:collection_id>/duplicate

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -348,7 +348,7 @@ def test_scan_uncataloged_file_kept(db, tmp_path):
     assert len(kept) == 1 and "not in catalog" in kept[0]["reason"]
 
 
-def test_scan_null_hash_status_kept_with_audit_remedy(db, tmp_path):
+def test_scan_null_hash_status_kept_with_scoped_verify_remedy(db, tmp_path):
     # Scan-cataloged archives: file_hash set, hash_status NULL. Kept —
     # and the reason must point at the remedy, or the tool reads broken.
     _archive_photo(db, tmp_path, hash_status=None)
@@ -356,7 +356,7 @@ def test_scan_null_hash_status_kept_with_audit_remedy(db, tmp_path):
     result = _scan(db, tmp_path)
     kept = _entries(result, "kept")
     assert len(kept) == 1
-    assert "integrity audit" in kept[0]["reason"]
+    assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
 
 
 def test_scan_failed_hash_status_kept_but_not_audit_remedy(db, tmp_path):
@@ -391,7 +391,7 @@ def test_scan_specific_failed_hash_statuses_all_kept_with_failed_reason(
     assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_HASH_FAILED
 
 
-def test_scan_mixed_null_and_failed_prefers_audit_remedy(db, tmp_path):
+def test_scan_mixed_null_and_failed_prefers_verify_remedy(db, tmp_path):
     # Two archive rows share a card file's hash — one never checked, one
     # already flagged. The NULL row is remediable by a verify run (its
     # verdict could turn "ok"), so the reason must stay on the audit
@@ -405,7 +405,89 @@ def test_scan_mixed_null_and_failed_prefers_audit_remedy(db, tmp_path):
     result = _scan(db, tmp_path)
     kept = _entries(result, "kept")
     assert len(kept) == 1
-    assert "integrity audit" in kept[0]["reason"]
+    assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
+
+
+def test_scoped_verify_reads_only_matching_archive_and_refreshes_manifest(
+        db, tmp_path, monkeypatch):
+    archive_file, pid = _archive_photo(db, tmp_path, hash_status=None)
+    unrelated, unrelated_pid = _archive_photo(
+        db, tmp_path, name="OTHER.NEF", content=b"other",
+        hash_status=None, folder="archive/other")
+    _card_file(tmp_path)
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 0
+
+    manifest_dir = str(tmp_path / "manifests")
+    manifest = load_manifest(manifest_dir, "scan-1")
+    calls = []
+    real_hash = card_cleanup.compute_file_hash
+
+    def counting_hash(path, *args, **kwargs):
+        calls.append(str(path))
+        return real_hash(path, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup, "compute_file_hash", counting_hash)
+    result = card_cleanup.verify_manifest_archives(
+        db, manifest, manifest_dir)
+
+    assert calls == [str(archive_file)]
+    assert str(unrelated) not in calls
+    assert result["archive_files_read"] == 1
+    assert result["unblocked_files"] == 1
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["totals"]["deletable"]["count"] == 1
+    assert _entries(refreshed, "deletable")[0]["archive_path"] == str(
+        archive_file)
+    statuses = {
+        row["id"]: row["hash_status"]
+        for row in db.conn.execute(
+            "SELECT id, hash_status FROM photos WHERE id IN (?, ?)",
+            (pid, unrelated_pid),
+        )
+    }
+    assert statuses == {pid: "ok", unrelated_pid: None}
+
+
+def test_scoped_verify_hashes_duplicate_card_content_once(db, tmp_path):
+    _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path, name="IMG_0001.NEF")
+    _card_file(tmp_path, name="IMG_0002.NEF")
+    _scan(db, tmp_path)
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+    assert result["hashes_total"] == 1
+    assert result["archive_files_read"] == 1
+    assert result["unblocked_files"] == 2
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["totals"]["deletable"]["count"] == 2
+
+
+def test_scoped_verify_mismatch_stays_kept_and_records_failed_verdict(
+        db, tmp_path):
+    archive_file, pid = _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    _scan(db, tmp_path)
+    original_mtime = os.stat(archive_file).st_mtime_ns
+    archive_file.write_bytes(b"NEW-ONE")  # same size as b"raw-one"
+    os.utime(archive_file, ns=(original_mtime, original_mtime))
+
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    assert result["verified"] == 0
+    assert result["corrupt"] == 1
+    assert result["unblocked_files"] == 0
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["totals"]["deletable"]["count"] == 0
+    assert _entries(refreshed, "kept")[0]["reason"] == (
+        card_cleanup.KEEP_ARCHIVE_HASH_FAILED)
+    status = db.conn.execute(
+        "SELECT hash_status FROM photos WHERE id = ?", (pid,)
+    ).fetchone()["hash_status"]
+    assert status == "corrupt"
 
 
 def test_scan_archive_file_missing_kept(db, tmp_path):
@@ -828,14 +910,9 @@ def test_delete_skips_file_replaced_during_archive_gate(db, tmp_path):
 
 
 def test_delete_skips_inplace_rewrite_during_archive_gate(db, tmp_path):
-    # Final-rehash gate (Codex P1 follow-up): the initial delete-time hash
-    # runs BEFORE the potentially slow archive gate. If the file is
-    # rewritten in place during the archive gate — same inode (open/write
-    # preserves it), same size, mtime forced back to the manifest value
-    # (FAT is 2s-granular; a camera reusing a filename in that window is
-    # the realistic case) — every metadata gate passes but the bytes at
-    # unlink time are not the ones we authorized. Only a rehash right
-    # before os.remove can catch this.
+    # The card hash runs after archive gate 1. If the file is rewritten in
+    # place during that potentially slow gate — same inode, size, and mtime
+    # — the single content read still catches it.
     _archive_photo(db, tmp_path)
     card = _card_file(tmp_path)  # content b"raw-one", 7 bytes
     scan = _scan(db, tmp_path)
@@ -859,8 +936,8 @@ def test_delete_skips_inplace_rewrite_during_archive_gate(db, tmp_path):
     with unittest.mock.patch.object(
             card_cleanup, "fetch_rows_by_hash", fetch_then_inplace_rewrite):
         summary = card_cleanup.delete_verified(db, manifest)
-    # Inode preserved: metadata gates would have passed. Only the final
-    # rehash can catch the swap — assert both the outcome and the reason.
+    # Inode preserved: metadata gates would have passed. The content hash
+    # catches the swap — assert both the outcome and the reason.
     assert os.stat(card).st_ino == original_ino
     assert summary["deleted"] == 0
     assert len(summary["skipped"]) == 1
@@ -1026,8 +1103,8 @@ def test_delete_skips_when_card_path_becomes_fifo_post_scan(
     assert stat.S_ISFIFO(os.lstat(card).st_mode)
 
 
-def test_delete_skips_when_archive_dies_during_final_hash(db, tmp_path):
-    # Codex P1: gate 1 authorizes, then the final card re-hash reads the
+def test_delete_skips_when_archive_dies_during_card_hash(db, tmp_path):
+    # Gate 1 authorizes, then the single card hash reads the
     # whole file (seconds on real photos). If the archive vanishes during
     # that hash, gate 1's authorization is stale. A second archive gate
     # immediately before os.remove must catch the death — otherwise the
@@ -1040,19 +1117,15 @@ def test_delete_skips_when_archive_dies_during_final_hash(db, tmp_path):
     real_hash = card_cleanup.compute_file_hash
     hash_calls = []
 
-    def hash_kill_archive_before_final(path, *a, **kw):
-        # Two hash calls per candidate in delete_verified: initial (fast
-        # reject) and final (right before unlink). Simulate the archive
-        # dying during the final call by unlinking it just before this
-        # invocation returns.
+    def hash_kill_archive(path, *a, **kw):
         hash_calls.append(str(path))
         result = real_hash(path, *a, **kw)
-        if len(hash_calls) == 2:
+        if len(hash_calls) == 1:
             os.unlink(archive_file)
         return result
 
     with unittest.mock.patch.object(
-            card_cleanup, "compute_file_hash", hash_kill_archive_before_final):
+            card_cleanup, "compute_file_hash", hash_kill_archive):
         summary = card_cleanup.delete_verified(db, manifest)
     assert summary["deleted"] == 0
     assert card.exists()
@@ -1060,7 +1133,7 @@ def test_delete_skips_when_archive_dies_during_final_hash(db, tmp_path):
     assert "archive" in summary["skipped"][0]["reason"]
 
 
-def test_delete_skips_when_parent_redirected_during_final_hash(db, tmp_path):
+def test_delete_skips_when_parent_redirected_during_card_hash(db, tmp_path):
     # Codex P1: after both archive gate 1 and gate 2 authorize, if the
     # parent directory is swapped for a symlink to a byte-identical
     # external copy during the final hash, every content gate still
@@ -1085,11 +1158,9 @@ def test_delete_skips_when_parent_redirected_during_final_hash(db, tmp_path):
     def hash_then_swap_parent(path, *a, **kw):
         hash_calls.append(str(path))
         result = real_hash(path, *a, **kw)
-        if len(hash_calls) == 2:
-            # Second hash call is the FINAL rehash. Swap the parent
-            # directory for a symlink to `outside` after the read has
-            # already committed to card bytes but before containment
-            # is re-verified.
+        if len(hash_calls) == 1:
+            # Swap the parent for a symlink after the single card read has
+            # committed to bytes but before containment is re-verified.
             dcim = tmp_path / "card" / "DCIM"
             shutil.rmtree(dcim)
             try:
@@ -1106,6 +1177,24 @@ def test_delete_skips_when_parent_redirected_during_final_hash(db, tmp_path):
     assert "no longer resolves inside" in summary["skipped"][0]["reason"]
     # The decoy — the only file behind the redirected path — must survive.
     assert decoy.exists() and decoy.read_bytes() == b"raw-one"
+
+
+def test_delete_hashes_each_card_file_once(db, tmp_path, monkeypatch):
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    _scan(db, tmp_path)
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    calls = []
+    real_hash = card_cleanup.compute_file_hash
+
+    def counting_hash(path, *args, **kwargs):
+        calls.append(str(path))
+        return real_hash(path, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup, "compute_file_hash", counting_hash)
+    summary = card_cleanup.delete_verified(db, manifest)
+    assert summary["deleted"] == 1
+    assert calls == [str(card)]
 
 
 def test_qualify_binds_containment_to_statted_object(db, tmp_path, monkeypatch):

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -1027,6 +1027,172 @@ def test_scoped_verify_keeps_pending_when_alias_and_transient_row_coexist(
     assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
 
 
+def test_scoped_verify_drops_pending_kept_entries_whose_card_files_are_gone(
+        db, tmp_path):
+    # Codex P2 (follow-up): the deletable pre-pass already drops
+    # confirmed-absent card files, but pending KEEP_NOT_VERIFIED
+    # entries were never revalidated the same way. If a pending card
+    # file is removed after the scan, the previous code kept the
+    # entry with its original byte count credited to the "kept"
+    # bucket; the refreshed preview then claimed a nonexistent file
+    # would remain on the card. The absent entry must be dropped so
+    # the totals match what is actually on disk.
+    #
+    # Pair with a second pending file that has a viable archive so
+    # verify actually does something and the missing entry is the
+    # only kept survivor difference we're measuring.
+    archive_gone, _ = _archive_photo(
+        db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
+        hash_status=None)
+    archive_kept, _ = _archive_photo(
+        db, tmp_path, name="IMG_0002.NEF", content=b"raw-two",
+        hash_status=None, folder="archive/2026/2026-08-02")
+    gone_card = _card_file(
+        tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+    _card_file(tmp_path, name="IMG_0002.NEF", content=b"raw-two")
+
+    scan = _scan(db, tmp_path)
+    kept = _entries(scan, "kept")
+    assert sorted(e["path"] for e in kept) == sorted([
+        str(gone_card),
+        str(tmp_path / "card" / "DCIM" / "IMG_0002.NEF"),
+    ])
+    assert all(e["reason"] == card_cleanup.KEEP_NOT_VERIFIED for e in kept)
+
+    # Simulate the card file getting removed after the scan (for
+    # example, ejected and re-inserted, or the user deleted it
+    # directly from the card in another tool).
+    os.unlink(gone_card)
+
+    manifest_dir = str(tmp_path / "manifests")
+    manifest_before = load_manifest(manifest_dir, "scan-1")
+    revision_before = int(manifest_before.get(
+        "revision", card_cleanup.INITIAL_MANIFEST_REVISION))
+
+    card_cleanup.verify_manifest_archives(
+        db, manifest_before, manifest_dir)
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    # The IMG_0002 pending entry promoted to deletable. The gone-card
+    # entry did NOT survive as a kept-with-original-bytes row.
+    kept = _entries(refreshed, "kept")
+    assert kept == [], (
+        "Confirmed-absent pending entries must leave the manifest so "
+        "the refreshed totals do not claim a nonexistent file will "
+        "remain on the card."
+    )
+    deletable = _entries(refreshed, "deletable")
+    assert [e["path"] for e in deletable] == [
+        str(tmp_path / "card" / "DCIM" / "IMG_0002.NEF")]
+    assert refreshed["totals"]["kept"]["count"] == 0
+    assert refreshed["totals"]["kept"]["bytes"] == 0
+    assert refreshed["totals"]["deletable"]["count"] == 1
+    assert refreshed["totals"]["deletable"]["bytes"] == len(b"raw-two")
+    # Revision still bumps so any confirmation against the pre-verify
+    # manifest is rejected by the delete endpoint's freshness gate.
+    assert int(refreshed["revision"]) == revision_before + 1
+
+
+def test_scoped_verify_keeps_pending_entry_when_lstat_error_is_transient(
+        db, tmp_path, monkeypatch):
+    # Companion to the drop test: a transient lstat error on a
+    # pending card file (mount blip, EACCES) is NOT proof the file is
+    # gone. Dropping the entry would shrink the preview during an
+    # ordinary hiccup and — worse — make a still-eligible file
+    # invisible until the next scan. Pair the transient lstat with a
+    # transient archive-open failure so the archive-side verify keeps
+    # the entry in the KEEP_NOT_VERIFIED bucket (rather than
+    # promoting it via qualify_rows, which uses os.stat and is not
+    # affected by an os.lstat monkeypatch); this isolates that the
+    # pre-pass itself preserves the entry.
+    archive_file, _ = _archive_photo(db, tmp_path, hash_status=None)
+    card_file = _card_file(tmp_path)
+    _scan(db, tmp_path)
+
+    real_lstat = os.lstat
+    real_open = os.open
+    card_str = str(card_file)
+    archive_str = str(archive_file)
+
+    def flaky_lstat(path, *args, **kwargs):
+        if str(path) == card_str:
+            raise OSError(13, "permission denied")
+        return real_lstat(path, *args, **kwargs)
+
+    def flaky_open(path, *args, **kwargs):
+        if str(path) == archive_str:
+            raise OSError(2, "mount is down")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup.os, "lstat", flaky_lstat)
+    monkeypatch.setattr(card_cleanup.os, "open", flaky_open)
+
+    manifest_dir = str(tmp_path / "manifests")
+    card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    kept = _entries(refreshed, "kept")
+    # The transient lstat did NOT drop the pending entry from the
+    # manifest — it survived the pre-pass, and with the archive
+    # transiently unreachable it stays retry-eligible.
+    assert [e["path"] for e in kept] == [card_str]
+    assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
+
+
+def test_scoped_verify_records_hash_failed_when_open_fd_hash_fails(
+        db, tmp_path, monkeypatch):
+    # Codex P2: when os.open on the archive path succeeds but the
+    # subsequent fd read (compute_fd_hash / fstat / realpath) fails,
+    # the DB row is persisted as hash_status='unreadable' — a
+    # permanent verdict. qualify_rows returns KEEP_ARCHIVE_HASH_FAILED
+    # for that persisted row on the next pass. The scoped-verify
+    # promotion-loop override used to replace that verdict with the
+    # run's outcome_reason, still initialized to
+    # KEEP_ARCHIVE_UNREACHABLE, hiding the failure from the refreshed
+    # preview. The UI shows the retry affordance for
+    # KEEP_ARCHIVE_UNREACHABLE and the Audit-page guidance only for
+    # KEEP_ARCHIVE_HASH_FAILED, so the mismatched reason misroutes
+    # the user. outcome_reason must match the persisted verdict.
+    _, pid = _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    _scan(db, tmp_path)
+
+    def failing_compute(fd, *args, **kwargs):
+        # Simulate a mid-read failure on the pinned archive fd.
+        raise OSError(5, "input/output error")
+
+    monkeypatch.setattr(card_cleanup, "compute_fd_hash", failing_compute)
+
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    # The row was reached (os.open succeeded), so this counts as
+    # unreadable, not verified.
+    assert result["unreadable"] == 1
+    assert result["verified"] == 0
+    assert result["unblocked_files"] == 0
+
+    # The DB row must be persisted as 'unreadable' — permanent.
+    status = db.conn.execute(
+        "SELECT hash_status FROM photos WHERE id = ?", (pid,)
+    ).fetchone()["hash_status"]
+    assert status == "unreadable"
+
+    # The manifest reason must match qualify_rows' terminal verdict
+    # for a persisted-unreadable row: KEEP_ARCHIVE_HASH_FAILED, NOT
+    # the run's initial KEEP_ARCHIVE_UNREACHABLE. This is the signal
+    # the UI keys off to point users at the Audit page.
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    kept = _entries(refreshed, "kept")
+    assert len(kept) == 1
+    assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_HASH_FAILED
+    # And it must not have been overridden back to unreachable
+    # (which would incorrectly offer a retry).
+    assert kept[0]["reason"] != card_cleanup.KEEP_ARCHIVE_UNREACHABLE
+
+
 def test_scan_archive_file_missing_kept(db, tmp_path):
     archive_file, _ = _archive_photo(db, tmp_path)
     _card_file(tmp_path)

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -731,6 +731,152 @@ def test_scoped_verify_keeps_deletable_entry_when_lstat_error_is_transient(
     assert [e["path"] for e in _entries(refreshed, "deletable")] == [card_str]
 
 
+def test_scoped_verify_drops_deletable_entry_when_card_file_type_changed(
+        db, tmp_path):
+    # Codex P2: a prior delete_verified run skipped the file because its
+    # type (or size, or mtime) no longer matched the scanned baseline —
+    # SKIP_NOT_REGULAR / SKIP_SYMLINK / SKIP_CHANGED. lstat still
+    # succeeds, so the FileNotFoundError-only gone-file check retained
+    # the entry, inflating the refreshed deletable totals with bytes the
+    # delete gates will refuse. Mirror the delete-time gates here so
+    # scoped verify's revised preview matches what delete would accept.
+    archive_file, _ = _archive_photo(
+        db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
+        hash_status="ok")
+    _archive_photo(
+        db, tmp_path, name="IMG_0002.NEF", content=b"raw-two",
+        hash_status=None, folder="archive/2026/2026-08-02")
+    swapped_card = _card_file(
+        tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+    _card_file(tmp_path, name="IMG_0002.NEF", content=b"raw-two")
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    assert scan["totals"]["kept"]["count"] == 1
+
+    # Simulate the SKIP_CHANGED delete-time skip: same size, different
+    # mtime_ns. delete_verified would refuse to unlink; scoped verify
+    # must not re-enable Delete for these bytes.
+    os.utime(swapped_card, ns=(0, 0))
+
+    manifest_dir = str(tmp_path / "manifests")
+    card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    deletable = _entries(refreshed, "deletable")
+    assert [e["path"] for e in deletable] == [
+        str(tmp_path / "card" / "DCIM" / "IMG_0002.NEF")]
+    assert refreshed["totals"]["deletable"]["count"] == 1
+    assert refreshed["totals"]["deletable"]["bytes"] == len(b"raw-two")
+
+
+def test_scoped_verify_terminal_alias_promotes_to_inside_source(
+        db, tmp_path):
+    # Codex P2: the only unchecked catalog row for a card file is a
+    # hardlink (or alt-mount alias) of the card file itself. The initial
+    # scan classifies the entry as KEEP_NOT_VERIFIED because
+    # qualify_rows skips NULL-status rows before the same-file check.
+    # Scoped verify then detects the alias via the fd's dev+inode and
+    # sets its outcome_reason to KEEP_INSIDE_SOURCE, but does not
+    # persist a verdict on the DB row — the row stays NULL. Without a
+    # terminal override, qualify_rows would return KEEP_NOT_VERIFIED
+    # again on the next click, trapping the entry in an infinite retry
+    # loop with the "audit hasn't run" callout. The refreshed manifest
+    # must adopt KEEP_INSIDE_SOURCE so the user sees the real story:
+    # no independent archive copy exists.
+    card = _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+    folder_path = tmp_path / "archive" / "2026"
+    folder_path.mkdir(parents=True)
+    alias = folder_path / "IMG_0001.NEF"
+    try:
+        os.link(card, alias)
+    except (OSError, NotImplementedError):
+        pytest.skip("hardlinks unsupported on this filesystem")
+    st = os.stat(alias)
+    fid = db.add_folder(str(folder_path))
+    db.add_photo(
+        folder_id=fid, filename="IMG_0001.NEF", extension=".NEF",
+        file_size=st.st_size, file_mtime=st.st_mtime,
+        file_hash=_sha(str(alias)),
+    )
+    # NULL hash_status: the alias row was cataloged but never audited.
+
+    scan = _scan(db, tmp_path)
+    kept = _entries(scan, "kept")
+    assert len(kept) == 1
+    assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
+
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+    assert result["verified"] == 0
+    assert result["unblocked_files"] == 0
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    kept = _entries(refreshed, "kept")
+    assert [e["path"] for e in kept] == [str(card)]
+    assert kept[0]["reason"] == card_cleanup.KEEP_INSIDE_SOURCE
+    # And the retry-eligible bucket is empty — the verify endpoint
+    # would tell the user "nothing needs checking" without the loop.
+    pending = [e for e in refreshed["entries"]
+               if e.get("reason") == card_cleanup.KEEP_NOT_VERIFIED]
+    assert pending == []
+
+
+def test_scoped_verify_keeps_pending_when_alias_and_transient_row_coexist(
+        db, tmp_path):
+    # Guard the terminal-alias override against overreach: when a hash
+    # has one unchecked alias row AND one unchecked transient-failure
+    # row (e.g. the real archive's mount is momentarily down), the
+    # entry must stay retry-eligible. A future click after the mount
+    # returns has a real lever — the transient row can still succeed.
+    card = _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+    # Alias row (hardlink into the card, NULL hash_status).
+    alias_folder = tmp_path / "archive" / "alias"
+    alias_folder.mkdir(parents=True)
+    alias = alias_folder / "IMG_0001.NEF"
+    try:
+        os.link(card, alias)
+    except (OSError, NotImplementedError):
+        pytest.skip("hardlinks unsupported on this filesystem")
+    alias_st = os.stat(alias)
+    alias_fid = db.add_folder(str(alias_folder))
+    db.add_photo(
+        folder_id=alias_fid, filename="IMG_0001.NEF", extension=".NEF",
+        file_size=alias_st.st_size, file_mtime=alias_st.st_mtime,
+        file_hash=_sha(str(alias)),
+    )
+    # Real independent archive row (NULL hash_status), but the file is
+    # deleted so scoped verify sees KEEP_ARCHIVE_UNREACHABLE — the same
+    # shape as a mount that comes back later.
+    real_folder = tmp_path / "archive" / "2026"
+    real_folder.mkdir(parents=True)
+    real_archive = real_folder / "IMG_0001.NEF"
+    real_archive.write_bytes(b"raw-one")
+    real_st = os.stat(real_archive)
+    real_fid = db.add_folder(str(real_folder))
+    db.add_photo(
+        folder_id=real_fid, filename="IMG_0001.NEF", extension=".NEF",
+        file_size=real_st.st_size, file_mtime=real_st.st_mtime,
+        file_hash=_sha(str(real_archive)),
+    )
+    os.unlink(real_archive)
+
+    scan = _scan(db, tmp_path)
+    assert _entries(scan, "kept")[0]["reason"] == \
+        card_cleanup.KEEP_NOT_VERIFIED
+
+    manifest_dir = str(tmp_path / "manifests")
+    card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    kept = _entries(refreshed, "kept")
+    # Retry-eligible: KEEP_NOT_VERIFIED wins because the real row still
+    # gives verify a lever once its mount returns.
+    assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
+
+
 def test_scan_archive_file_missing_kept(db, tmp_path):
     archive_file, _ = _archive_photo(db, tmp_path)
     _card_file(tmp_path)

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -532,10 +532,53 @@ def test_scoped_verify_unreachable_archive_keeps_row_unchecked(
     ).fetchone()["hash_status"]
     assert status is None
 
+    # Codex P2: the manifest reason must ALSO stay in the
+    # KEEP_NOT_VERIFIED bucket the verify endpoint/UI's
+    # pending-reason filter keys off. Overwriting with this run's
+    # transient KEEP_ARCHIVE_UNREACHABLE would let a later verify report
+    # "nothing needs checking" once the mount returns, forcing the user
+    # to re-scan the card even though the DB row is still eligible.
     refreshed = load_manifest(manifest_dir, "scan-1")
     kept = _entries(refreshed, "kept")
     assert len(kept) == 1
-    assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_UNREACHABLE
+    assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
+
+
+def test_scoped_verify_retry_after_transient_failure_unblocks(
+        db, tmp_path, monkeypatch):
+    # Codex P2 end-to-end: the first verify run hits a transient
+    # os.open failure (mount down); the row must remain retry-eligible
+    # so that a second verify run, once the mount is back, actually
+    # promotes the entry to deletable without a fresh card scan.
+    archive_file, pid = _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    _scan(db, tmp_path)
+    manifest_dir = str(tmp_path / "manifests")
+
+    real_open = os.open
+    archive_str = str(archive_file)
+    down = {"active": True}
+
+    def flaky_open(path, *args, **kwargs):
+        if down["active"] and str(path) == archive_str:
+            raise OSError(2, "mount is down")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup.os, "open", flaky_open)
+    card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+    kept_first = _entries(load_manifest(manifest_dir, "scan-1"), "kept")
+    assert len(kept_first) == 1
+    assert kept_first[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
+
+    down["active"] = False
+    retry = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    assert retry["verified"] == 1
+    assert retry["unblocked_files"] == 1
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["totals"]["deletable"]["count"] == 1
 
 
 def test_scoped_verify_rejects_atomic_replace_during_hash(
@@ -590,9 +633,13 @@ def test_scoped_verify_rejects_atomic_replace_during_hash(
     assert status is None
     refreshed = load_manifest(manifest_dir, "scan-1")
     assert refreshed["totals"]["deletable"]["count"] == 0
+    # Codex P2: the DB row is still unchecked (verify did not persist a
+    # verdict), so the manifest must stay in the KEEP_NOT_VERIFIED
+    # bucket — a targeted retry after the file settles is the correct
+    # next lever, not "archive changed" which would look terminal.
     assert (
         _entries(refreshed, "kept")[0]["reason"]
-        == card_cleanup.KEEP_ARCHIVE_CHANGED
+        == card_cleanup.KEEP_NOT_VERIFIED
     )
 
 

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -43,6 +43,16 @@ def test_write_then_load_roundtrip(tmp_path):
     write_manifest(mdir, _manifest(tmp_path))
     loaded = load_manifest(mdir, "scan-1")
     assert loaded["scan_job_id"] == "scan-1"
+    assert loaded["revision"] == card_cleanup.INITIAL_MANIFEST_REVISION
+
+
+@pytest.mark.parametrize("revision", [True, False, 0, -1, "1", 1.5])
+def test_load_rejects_invalid_manifest_revision(tmp_path, revision):
+    (tmp_path / "card").mkdir()
+    mdir = str(tmp_path / "manifests")
+    write_manifest(mdir, _manifest(tmp_path, revision=revision))
+    with pytest.raises(ManifestError, match="revision invalid"):
+        load_manifest(mdir, "scan-1")
 
 
 def test_write_is_atomic_no_leftover_tmp(tmp_path):
@@ -582,6 +592,60 @@ def test_scoped_verify_retry_after_transient_failure_unblocks(
     assert refreshed["totals"]["deletable"]["count"] == 1
 
 
+def test_scoped_verify_preserves_persisted_unreadable_reason(
+        db, tmp_path, monkeypatch):
+    archive_file, pid = _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    _scan(db, tmp_path)
+    real_hash = card_cleanup.compute_fd_hash
+
+    def fail_archive_read(fd, *args, **kwargs):
+        if os.fstat(fd).st_ino == os.stat(archive_file).st_ino:
+            raise OSError("archive read failed")
+        return real_hash(fd, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup, "compute_fd_hash", fail_archive_read)
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    assert result["unreadable"] == 1
+    status = db.conn.execute(
+        "SELECT hash_status FROM photos WHERE id = ?", (pid,)
+    ).fetchone()["hash_status"]
+    assert status == "unreadable"
+    kept = _entries(load_manifest(manifest_dir, "scan-1"), "kept")
+    assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_HASH_FAILED
+
+
+def test_scoped_verify_nonblocking_open_rejects_fifo_swap(
+        db, tmp_path, monkeypatch):
+    if not hasattr(os, "mkfifo") or not card_cleanup.O_NONBLOCK:
+        pytest.skip("non-blocking FIFOs unsupported on this platform")
+    archive_file, _ = _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    _scan(db, tmp_path)
+    real_open = os.open
+    opened_flags = []
+
+    def swap_then_open(path, flags, *args, **kwargs):
+        if str(path) == str(archive_file) and not opened_flags:
+            opened_flags.append(flags)
+            os.unlink(archive_file)
+            os.mkfifo(archive_file)
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup.os, "open", swap_then_open)
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    assert opened_flags[0] & card_cleanup.O_NONBLOCK
+    assert result["archive_files_read"] == 0
+    assert result["unreadable"] == 1
+    assert stat.S_ISFIFO(os.lstat(archive_file).st_mode)
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="POSIX-only race: Windows locks files opened via os.open, so "
@@ -835,6 +899,25 @@ def test_scoped_verify_gates_pending_entry_before_promotion(
     assert "archive_path" not in kept[0]
     assert refreshed["totals"]["kept"]["count"] == 1
     assert refreshed["totals"]["kept"]["bytes"] == len(b"raw-one")
+
+
+def test_scoped_verify_drops_missing_pending_entry(db, tmp_path):
+    _archive_photo(db, tmp_path, hash_status=None)
+    card = _card_file(tmp_path)
+    scan = _scan(db, tmp_path)
+    assert _entries(scan, "kept")[0]["reason"] == (
+        card_cleanup.KEEP_NOT_VERIFIED)
+    os.unlink(card)
+
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    assert result["verified"] == 1
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["entries"] == []
+    assert refreshed["totals"]["deletable"] == {"count": 0, "bytes": 0}
+    assert refreshed["totals"]["kept"] == {"count": 0, "bytes": 0}
 
 
 def test_scoped_verify_terminal_alias_promotes_to_inside_source(
@@ -1590,6 +1673,35 @@ def test_delete_skips_when_card_path_becomes_fifo_post_scan(
     assert len(summary["skipped"]) == 1
     assert summary["skipped"][0]["reason"] == card_cleanup.SKIP_NOT_REGULAR
     # The FIFO is left untouched — the tool refused to operate on it.
+    assert stat.S_ISFIFO(os.lstat(card).st_mode)
+
+
+def test_delete_nonblocking_open_rejects_fifo_swap_after_lstat(
+        db, tmp_path, monkeypatch):
+    if not hasattr(os, "mkfifo") or not card_cleanup.O_NONBLOCK:
+        pytest.skip("non-blocking FIFOs unsupported on this platform")
+    _archive_photo(db, tmp_path)
+    card = _card_file(tmp_path)
+    _scan(db, tmp_path)
+    manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
+    real_open = os.open
+    opened_flags = []
+
+    def swap_then_open(path, flags, *args, **kwargs):
+        if str(path) == str(card) and not opened_flags:
+            opened_flags.append(flags)
+            os.unlink(card)
+            os.mkfifo(card)
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup.os, "open", swap_then_open)
+    summary = card_cleanup.delete_verified(db, manifest)
+
+    assert opened_flags[0] & card_cleanup.O_NONBLOCK
+    assert summary["deleted"] == 0
+    assert summary["skipped"] == [{
+        "path": str(card), "reason": card_cleanup.SKIP_NOT_REGULAR,
+    }]
     assert stat.S_ISFIFO(os.lstat(card).st_mode)
 
 

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -731,7 +731,7 @@ def test_scoped_verify_keeps_deletable_entry_when_lstat_error_is_transient(
     assert [e["path"] for e in _entries(refreshed, "deletable")] == [card_str]
 
 
-def test_scoped_verify_drops_deletable_entry_when_card_file_type_changed(
+def test_scoped_verify_reclassifies_changed_deletable_entry_as_kept(
         db, tmp_path):
     # Codex P2: a prior delete_verified run skipped the file because its
     # type (or size, or mtime) no longer matched the scanned baseline —
@@ -740,6 +740,12 @@ def test_scoped_verify_drops_deletable_entry_when_card_file_type_changed(
     # the entry, inflating the refreshed deletable totals with bytes the
     # delete gates will refuse. Mirror the delete-time gates here so
     # scoped verify's revised preview matches what delete would accept.
+    #
+    # Codex P2 (follow-up 2): the file is still on the card, so dropping
+    # the entry entirely undercounted the kept list and the totals hid a
+    # file that will remain after deletion. Reclassify into the kept
+    # bucket with SKIP_CHANGED instead; only confirmed-absent paths
+    # should leave the manifest.
     archive_file, _ = _archive_photo(
         db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
         hash_status="ok")
@@ -768,6 +774,16 @@ def test_scoped_verify_drops_deletable_entry_when_card_file_type_changed(
         str(tmp_path / "card" / "DCIM" / "IMG_0002.NEF")]
     assert refreshed["totals"]["deletable"]["count"] == 1
     assert refreshed["totals"]["deletable"]["bytes"] == len(b"raw-two")
+    # Changed card file is now kept (reclassified, not dropped).
+    # IMG_0002.NEF, originally kept with KEEP_NOT_VERIFIED, is
+    # promoted to deletable by the verify pass, so IMG_0001.NEF is the
+    # sole kept entry after verify.
+    kept = _entries(refreshed, "kept")
+    assert [e["path"] for e in kept] == [str(swapped_card)]
+    assert kept[0]["reason"] == card_cleanup.SKIP_CHANGED
+    assert "archive_path" not in kept[0]
+    assert refreshed["totals"]["kept"]["count"] == 1
+    assert refreshed["totals"]["kept"]["bytes"] == len(b"raw-one")
 
 
 def test_scoped_verify_terminal_alias_promotes_to_inside_source(

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -538,6 +538,64 @@ def test_scoped_verify_unreachable_archive_keeps_row_unchecked(
     assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_UNREACHABLE
 
 
+def test_scoped_verify_rejects_atomic_replace_during_hash(
+        db, tmp_path, monkeypatch):
+    # Codex P1: while compute_fd_hash reads the pinned archive fd, a
+    # sync/backup tool can atomically replace archive_path with a
+    # different file under the same name. The fd's fstat still describes
+    # the old (now unlinked) inode, so before/after fstat match — but the
+    # bytes we then trust as authoritative for the archive no longer live
+    # at that name. Certifying the row would let qualify_rows accept the
+    # replacement later (same size+mtime is enough) and delete the card
+    # copy against an archive we never actually saw. Row must stay
+    # unchecked so a targeted re-verify can settle it once the file is
+    # stable.
+    archive_file, pid = _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    _scan(db, tmp_path)
+
+    archive_str = str(archive_file)
+    real_hash = card_cleanup.compute_fd_hash
+    swapped = {"done": False}
+
+    def swap_then_hash(fd, *a, **kw):
+        result = real_hash(fd, *a, **kw)
+        if not swapped["done"] and os.fstat(fd).st_ino == os.stat(
+                archive_str).st_ino:
+            replacement = tmp_path / "replacement.NEF"
+            # Same size + mtime as the original — a naïve later
+            # qualify_rows stat would otherwise accept it.
+            replacement.write_bytes(b"raw-one")
+            original_st = os.stat(archive_str)
+            os.utime(
+                replacement,
+                ns=(original_st.st_atime_ns, original_st.st_mtime_ns),
+            )
+            os.replace(str(replacement), archive_str)
+            swapped["done"] = True
+        return result
+
+    monkeypatch.setattr(card_cleanup, "compute_fd_hash", swap_then_hash)
+
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    assert swapped["done"]
+    assert result["verified"] == 0
+    assert result["unblocked_files"] == 0
+    status = db.conn.execute(
+        "SELECT hash_status FROM photos WHERE id = ?", (pid,)
+    ).fetchone()["hash_status"]
+    assert status is None
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["totals"]["deletable"]["count"] == 0
+    assert (
+        _entries(refreshed, "kept")[0]["reason"]
+        == card_cleanup.KEEP_ARCHIVE_CHANGED
+    )
+
+
 def test_scan_archive_file_missing_kept(db, tmp_path):
     archive_file, _ = _archive_photo(db, tmp_path)
     _card_file(tmp_path)

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -786,6 +786,57 @@ def test_scoped_verify_reclassifies_changed_deletable_entry_as_kept(
     assert refreshed["totals"]["kept"]["bytes"] == len(b"raw-one")
 
 
+def test_scoped_verify_gates_pending_entry_before_promotion(
+        db, tmp_path):
+    # Codex P2 (follow-up 3): the deletable-entry pre-pass revalidates
+    # the card file against the manifest baseline before the promotion
+    # loop, but pending kept entries (KEEP_NOT_VERIFIED) went straight
+    # into qualify_rows — which only inspects catalog rows and cannot
+    # see that the card file has been replaced/resized/turned into a
+    # symlink since the scan. delete_verified would reject the changed
+    # file (SKIP_CHANGED / SKIP_SYMLINK / SKIP_NOT_REGULAR), so the
+    # refreshed preview must not credit its bytes to the deletable
+    # totals or re-enable Delete for it. Applying the same gates to
+    # KEEP_NOT_VERIFIED entries reclassifies the changed file as kept
+    # with the appropriate SKIP_* reason before qualify_rows sees it.
+    archive_file, _ = _archive_photo(
+        db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
+        hash_status=None)
+    card = _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+
+    scan = _scan(db, tmp_path)
+    # The unchecked archive row keeps the card entry pending.
+    assert scan["totals"]["deletable"]["count"] == 0
+    kept = _entries(scan, "kept")
+    assert len(kept) == 1
+    assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
+    assert kept[0]["path"] == str(card)
+
+    # Simulate the SKIP_CHANGED delete-time skip: same size, different
+    # mtime_ns. Archive hash still verifies fine, so qualify_rows would
+    # happily promote — but delete_verified would refuse to unlink.
+    os.utime(card, ns=(0, 0))
+
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+    # The archive still verified successfully; the pending entry just
+    # did not get promoted.
+    assert result["verified"] == 1
+    assert result["unblocked_files"] == 0
+    assert result["unblocked_bytes"] == 0
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["totals"]["deletable"]["count"] == 0
+    assert refreshed["totals"]["deletable"]["bytes"] == 0
+    kept = _entries(refreshed, "kept")
+    assert [e["path"] for e in kept] == [str(card)]
+    assert kept[0]["reason"] == card_cleanup.SKIP_CHANGED
+    assert "archive_path" not in kept[0]
+    assert refreshed["totals"]["kept"]["count"] == 1
+    assert refreshed["totals"]["kept"]["bytes"] == len(b"raw-one")
+
+
 def test_scoped_verify_terminal_alias_promotes_to_inside_source(
         db, tmp_path):
     # Codex P2: the only unchecked catalog row for a card file is a

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -5,6 +5,7 @@ docs/superpowers/specs/2026-08-07-card-cleanup-design.md
 import os
 import shutil
 import stat
+import sys
 import unittest.mock
 from datetime import UTC, datetime, timedelta
 
@@ -581,6 +582,13 @@ def test_scoped_verify_retry_after_transient_failure_unblocks(
     assert refreshed["totals"]["deletable"]["count"] == 1
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only race: Windows locks files opened via os.open, so "
+    "os.replace() against the archive path fails inside the wrapper "
+    "before the swap can complete. The race this test simulates cannot "
+    "occur on Windows in the first place.",
+)
 def test_scoped_verify_rejects_atomic_replace_during_hash(
         db, tmp_path, monkeypatch):
     # Codex P1: while compute_fd_hash reads the pinned archive fd, a
@@ -1406,6 +1414,13 @@ def test_delete_skips_when_archive_dies_during_card_hash(db, tmp_path):
     assert "archive" in summary["skipped"][0]["reason"]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only race: Windows cannot rmtree a directory that "
+    "contains an open file, so the parent-directory swap inside the "
+    "wrapper fails before the containment recheck runs. The race this "
+    "test simulates cannot occur on Windows in the first place.",
+)
 def test_delete_skips_when_parent_redirected_during_card_hash(db, tmp_path):
     # Codex P1: after both archive gate 1 and gate 2 authorize, if the
     # parent directory is swapped for a symlink to a byte-identical

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -1102,6 +1102,90 @@ def test_scoped_verify_terminal_alias_does_not_mask_persisted_external_failure(
     assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_HASH_FAILED
 
 
+def test_scoped_verify_surfaces_new_failed_archive_beside_unchecked_alias(
+        db, tmp_path):
+    """A failure persisted in this run also outranks a NULL alias."""
+    card = _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+    expected_hash = _sha(str(card))
+
+    alias_folder = tmp_path / "archive" / "alias-current"
+    alias_folder.mkdir(parents=True)
+    alias = alias_folder / "IMG_0001.NEF"
+    try:
+        os.link(card, alias)
+    except (OSError, NotImplementedError):
+        pytest.skip("hardlinks unsupported on this filesystem")
+    alias_st = os.stat(alias)
+    alias_fid = db.add_folder(str(alias_folder))
+    alias_pid = db.add_photo(
+        folder_id=alias_fid, filename=alias.name, extension=".NEF",
+        file_size=alias_st.st_size, file_mtime=alias_st.st_mtime,
+        file_hash=expected_hash,
+    )
+
+    failed_folder = tmp_path / "archive" / "independent"
+    failed_folder.mkdir(parents=True)
+    failed_archive = failed_folder / "IMG_0001.NEF"
+    failed_archive.write_bytes(b"bad-copy")
+    failed_st = os.stat(failed_archive)
+    failed_fid = db.add_folder(str(failed_folder))
+    failed_pid = db.add_photo(
+        folder_id=failed_fid, filename=failed_archive.name, extension=".NEF",
+        file_size=failed_st.st_size, file_mtime=failed_st.st_mtime,
+        file_hash=expected_hash,
+    )
+
+    _scan(db, tmp_path)
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    assert result["corrupt"] == 1
+    statuses = {
+        row["id"]: row["hash_status"]
+        for row in db.conn.execute(
+            "SELECT id, hash_status FROM photos WHERE id IN (?, ?)",
+            (alias_pid, failed_pid),
+        )
+    }
+    assert statuses == {alias_pid: None, failed_pid: "corrupt"}
+    kept = _entries(load_manifest(manifest_dir, "scan-1"), "kept")
+    assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_HASH_FAILED
+
+
+def test_scoped_verify_does_not_certify_repurposed_catalog_row(
+        db, tmp_path, monkeypatch):
+    archive_file, pid = _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    _scan(db, tmp_path)
+    real_hash = card_cleanup.compute_fd_hash
+
+    def repurpose_row_while_hashing(fd, *args, **kwargs):
+        result = real_hash(fd, *args, **kwargs)
+        if os.fstat(fd).st_ino == os.stat(archive_file).st_ino:
+            db.conn.execute(
+                "UPDATE photos SET filename = ? WHERE id = ?",
+                ("REUSED.NEF", pid),
+            )
+        return result
+
+    monkeypatch.setattr(
+        card_cleanup, "compute_fd_hash", repurpose_row_while_hashing)
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    row = db.conn.execute(
+        "SELECT filename, hash_status FROM photos WHERE id = ?", (pid,)
+    ).fetchone()
+    assert row["filename"] == "REUSED.NEF"
+    assert row["hash_status"] is None
+    assert result["verified"] == 0
+    assert result["unblocked_files"] == 0
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["totals"]["deletable"]["count"] == 0
+
+
 def test_scoped_verify_drops_pending_kept_entries_whose_card_files_are_gone(
         db, tmp_path):
     # Codex P2 (follow-up): the deletable pre-pass already drops

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -1027,6 +1027,81 @@ def test_scoped_verify_keeps_pending_when_alias_and_transient_row_coexist(
     assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
 
 
+def test_scoped_verify_terminal_alias_does_not_mask_persisted_external_failure(
+        db, tmp_path):
+    # Codex P2: a hash with one same-source alias row (still NULL) and
+    # one external row already persisted as corrupt (from an earlier
+    # verify pass) hits an edge case in the terminal-alias override.
+    # This run only processes the alias — the external row is no longer
+    # unchecked — so scoped verify records the alias as terminally
+    # inside-source and adds the hash to terminal_inside_source_hashes.
+    # qualify_rows then still returns KEEP_NOT_VERIFIED (the alias's
+    # NULL row wins priority over the corrupt row's KEEP_ARCHIVE_HASH_
+    # FAILED). Without this fix, the reclassification pass would
+    # overwrite that to KEEP_INSIDE_SOURCE and tell the user "no
+    # independent archive copy exists", hiding the corrupt external
+    # archive and the Audit-page remedy it needs. The refreshed
+    # manifest must surface KEEP_ARCHIVE_HASH_FAILED instead: the
+    # external failure was cataloged, and the Audit page — not
+    # another verify click — is the remedy.
+    card = _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+
+    # External archive row that was hashed as corrupt in an earlier
+    # pass. Store the row without a real file on disk so this run's
+    # verify loop cannot revisit it; hash_status = "corrupt" makes it
+    # non-unchecked so it never enters the scoped verify's unchecked
+    # list. The row remains visible to qualify_rows and to the
+    # reclassification's row scan.
+    external_folder = tmp_path / "archive" / "2026"
+    external_folder.mkdir(parents=True)
+    external_fid = db.add_folder(str(external_folder))
+    external_pid = db.add_photo(
+        folder_id=external_fid, filename="IMG_0001.NEF", extension=".NEF",
+        file_size=len(b"raw-one"), file_mtime=1000.0,
+        file_hash=_sha(str(card)),
+    )
+    db.update_photo_hash_check(external_pid, "corrupt")
+
+    # Alias row: a hardlink into the card file itself. Still NULL —
+    # never audited. Scoped verify will detect it as same-as-card via
+    # the fd's dev/inode and leave it NULL.
+    alias_folder = tmp_path / "archive" / "alias"
+    alias_folder.mkdir(parents=True)
+    alias = alias_folder / "IMG_0001.NEF"
+    try:
+        os.link(card, alias)
+    except (OSError, NotImplementedError):
+        pytest.skip("hardlinks unsupported on this filesystem")
+    alias_st = os.stat(alias)
+    alias_fid = db.add_folder(str(alias_folder))
+    db.add_photo(
+        folder_id=alias_fid, filename="IMG_0001.NEF", extension=".NEF",
+        file_size=alias_st.st_size, file_mtime=alias_st.st_mtime,
+        file_hash=_sha(str(alias)),
+    )
+
+    scan = _scan(db, tmp_path)
+    kept = _entries(scan, "kept")
+    assert len(kept) == 1
+    # Initial scan: the alias's NULL status makes KEEP_NOT_VERIFIED the
+    # winning reason via qualify_rows' priority order.
+    assert kept[0]["reason"] == card_cleanup.KEEP_NOT_VERIFIED
+
+    manifest_dir = str(tmp_path / "manifests")
+    card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    kept = _entries(refreshed, "kept")
+    assert len(kept) == 1
+    # Not KEEP_INSIDE_SOURCE (which would tell the user no independent
+    # archive exists — false; one is cataloged) and not
+    # KEEP_NOT_VERIFIED (another verify click would find nothing new to
+    # do since the only remaining NULL row is a same-source alias).
+    # The correct surface is the terminal external verdict.
+    assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_HASH_FAILED
+
+
 def test_scoped_verify_drops_pending_kept_entries_whose_card_files_are_gone(
         db, tmp_path):
     # Codex P2 (follow-up): the deletable pre-pass already drops

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -420,19 +420,22 @@ def test_scoped_verify_reads_only_matching_archive_and_refreshes_manifest(
 
     manifest_dir = str(tmp_path / "manifests")
     manifest = load_manifest(manifest_dir, "scan-1")
-    calls = []
-    real_hash = card_cleanup.compute_file_hash
+    # verify_manifest_archives hashes a pinned descriptor now (CodeRabbit
+    # TOCTOU fix), so callers no longer name the path. Correlate hashed
+    # descriptors back to files via fstat inode.
+    hashed_inodes = []
+    real_hash = card_cleanup.compute_fd_hash
 
-    def counting_hash(path, *args, **kwargs):
-        calls.append(str(path))
-        return real_hash(path, *args, **kwargs)
+    def track(fd, *a, **kw):
+        hashed_inodes.append(os.fstat(fd).st_ino)
+        return real_hash(fd, *a, **kw)
 
-    monkeypatch.setattr(card_cleanup, "compute_file_hash", counting_hash)
+    monkeypatch.setattr(card_cleanup, "compute_fd_hash", track)
     result = card_cleanup.verify_manifest_archives(
         db, manifest, manifest_dir)
 
-    assert calls == [str(archive_file)]
-    assert str(unrelated) not in calls
+    assert hashed_inodes == [os.stat(archive_file).st_ino]
+    assert os.stat(unrelated).st_ino not in hashed_inodes
     assert result["archive_files_read"] == 1
     assert result["unblocked_files"] == 1
     refreshed = load_manifest(manifest_dir, "scan-1")
@@ -639,6 +642,35 @@ def test_qualify_rows_null_archive_stat_baseline_keeps(db, tmp_path):
         rows, source_root_real, str(card))
     assert archive_path is None
     assert reason == card_cleanup.KEEP_ARCHIVE_CHANGED
+
+
+def test_qualify_rows_prefers_verify_remedy_over_ok_row_specific_reason(
+        db, tmp_path):
+    """Codex P2: an ok archive row that fails a later gate (missing
+    file, changed size/mtime, etc.) used to set the specific reason
+    verbatim, which then hid rows that still had an unchecked sibling
+    verify could try. Ensure the never-checked sibling wins so the
+    card-cleanup callout offers to verify it."""
+    archive_file, _ = _archive_photo(db, tmp_path)
+    source_root_real = os.path.realpath(str(tmp_path / "card"))
+    card = _card_file(tmp_path)
+    # Row A is 'ok' but its archive file is missing on disk — the row
+    # itself would raise KEEP_ARCHIVE_UNREACHABLE via the ok-path stat
+    # failure. Row B is a never-checked sibling that verify could still
+    # try; its presence must promote the reason to KEEP_NOT_VERIFIED.
+    rows = [
+        {"filename": "GONE.NEF",
+         "file_size": 7, "file_mtime": 0.0,
+         "hash_status": "ok",
+         "folder_path": str(tmp_path / "archive_missing")},
+        {"filename": os.path.basename(str(archive_file)),
+         "file_size": None, "file_mtime": None,
+         "hash_status": None,
+         "folder_path": os.path.dirname(str(archive_file))},
+    ]
+    _, reason = card_cleanup.qualify_rows(
+        rows, source_root_real, str(card))
+    assert reason == card_cleanup.KEEP_NOT_VERIFIED
 
 
 def test_qualify_rows_missing_card_file_unreadable(db, tmp_path):
@@ -1078,21 +1110,28 @@ def test_delete_skips_when_card_path_becomes_fifo_post_scan(
         pytest.skip("mkfifo unsupported on this filesystem")
     os.utime(card, ns=(entry["mtime_ns"], entry["mtime_ns"]))
 
-    # compute_file_hash on a FIFO would block on open indefinitely. Prove
-    # the gate rejects the replacement BEFORE any hash call happens.
+    # compute_file_hash / compute_fd_hash on a FIFO would block on read
+    # indefinitely. Prove the gate rejects the replacement BEFORE any
+    # hash call happens. Both hash entry points are patched — the delete
+    # path uses compute_fd_hash after the CodeRabbit TOCTOU fix, but
+    # guarding both keeps future regressions from silently slipping the
+    # bad object through.
     hash_calls = []
     real_hash = card_cleanup.compute_file_hash
+    real_fd_hash = card_cleanup.compute_fd_hash
 
-    def guarded_hash(path, *a, **kw):
-        hash_calls.append(path)
+    def guarded_hash(*a, **kw):
+        hash_calls.append(a)
         raise AssertionError(
-            "compute_file_hash must not be called on a non-regular replacement")
+            "hash function must not be called on a non-regular replacement")
 
     monkeypatch.setattr(card_cleanup, "compute_file_hash", guarded_hash)
+    monkeypatch.setattr(card_cleanup, "compute_fd_hash", guarded_hash)
     try:
         summary = card_cleanup.delete_verified(db, manifest)
     finally:
         monkeypatch.setattr(card_cleanup, "compute_file_hash", real_hash)
+        monkeypatch.setattr(card_cleanup, "compute_fd_hash", real_fd_hash)
 
     assert hash_calls == []
     assert summary["deleted"] == 0
@@ -1114,18 +1153,22 @@ def test_delete_skips_when_archive_dies_during_card_hash(db, tmp_path):
     scan = _scan(db, tmp_path)
     assert scan["totals"]["deletable"]["count"] == 1
     manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
-    real_hash = card_cleanup.compute_file_hash
+    # delete_verified reads the card via compute_fd_hash on a pinned
+    # descriptor (CodeRabbit TOCTOU fix), so intercept that instead of
+    # compute_file_hash. Kill the archive during the single card hash to
+    # prove gate 2 catches the death before os.remove.
+    real_hash = card_cleanup.compute_fd_hash
     hash_calls = []
 
-    def hash_kill_archive(path, *a, **kw):
-        hash_calls.append(str(path))
-        result = real_hash(path, *a, **kw)
+    def hash_kill_archive(fd, *a, **kw):
+        hash_calls.append(fd)
+        result = real_hash(fd, *a, **kw)
         if len(hash_calls) == 1:
             os.unlink(archive_file)
         return result
 
     with unittest.mock.patch.object(
-            card_cleanup, "compute_file_hash", hash_kill_archive):
+            card_cleanup, "compute_fd_hash", hash_kill_archive):
         summary = card_cleanup.delete_verified(db, manifest)
     assert summary["deleted"] == 0
     assert card.exists()
@@ -1152,12 +1195,15 @@ def test_delete_skips_when_parent_redirected_during_card_hash(db, tmp_path):
     decoy.write_bytes(b"raw-one")
     os.utime(decoy, ns=(entry["mtime_ns"], entry["mtime_ns"]))
 
-    real_hash = card_cleanup.compute_file_hash
+    # Same intent as above: delete_verified now reads the card via
+    # compute_fd_hash (CodeRabbit TOCTOU fix), so hook that entry point
+    # to run the parent-directory swap during the pinned-fd hash.
+    real_hash = card_cleanup.compute_fd_hash
     hash_calls = []
 
-    def hash_then_swap_parent(path, *a, **kw):
-        hash_calls.append(str(path))
-        result = real_hash(path, *a, **kw)
+    def hash_then_swap_parent(fd, *a, **kw):
+        hash_calls.append(fd)
+        result = real_hash(fd, *a, **kw)
         if len(hash_calls) == 1:
             # Swap the parent for a symlink after the single card read has
             # committed to bytes but before containment is re-verified.
@@ -1170,7 +1216,7 @@ def test_delete_skips_when_parent_redirected_during_card_hash(db, tmp_path):
         return result
 
     with unittest.mock.patch.object(
-            card_cleanup, "compute_file_hash", hash_then_swap_parent):
+            card_cleanup, "compute_fd_hash", hash_then_swap_parent):
         summary = card_cleanup.delete_verified(db, manifest)
     assert summary["deleted"] == 0
     assert len(summary["skipped"]) == 1
@@ -1182,19 +1228,23 @@ def test_delete_skips_when_parent_redirected_during_card_hash(db, tmp_path):
 def test_delete_hashes_each_card_file_once(db, tmp_path, monkeypatch):
     _archive_photo(db, tmp_path)
     card = _card_file(tmp_path)
+    card_inode = os.stat(card).st_ino
     _scan(db, tmp_path)
     manifest = load_manifest(str(tmp_path / "manifests"), "scan-1")
-    calls = []
-    real_hash = card_cleanup.compute_file_hash
+    # delete_verified hashes the card via compute_fd_hash on a pinned
+    # descriptor (CodeRabbit TOCTOU fix). Correlate fds back to the card
+    # by inode so this assertion still says "one read per card file".
+    hashed_inodes = []
+    real_hash = card_cleanup.compute_fd_hash
 
-    def counting_hash(path, *args, **kwargs):
-        calls.append(str(path))
-        return real_hash(path, *args, **kwargs)
+    def counting_hash(fd, *args, **kwargs):
+        hashed_inodes.append(os.fstat(fd).st_ino)
+        return real_hash(fd, *args, **kwargs)
 
-    monkeypatch.setattr(card_cleanup, "compute_file_hash", counting_hash)
+    monkeypatch.setattr(card_cleanup, "compute_fd_hash", counting_hash)
     summary = card_cleanup.delete_verified(db, manifest)
     assert summary["deleted"] == 1
-    assert calls == [str(card)]
+    assert hashed_inodes == [card_inode]
 
 
 def test_qualify_binds_containment_to_statted_object(db, tmp_path, monkeypatch):

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -493,6 +493,51 @@ def test_scoped_verify_mismatch_stays_kept_and_records_failed_verdict(
     assert status == "corrupt"
 
 
+def test_scoped_verify_unreachable_archive_keeps_row_unchecked(
+        db, tmp_path, monkeypatch):
+    # Codex P2: a transiently unreachable archive (NAS mount down) must
+    # not permanently downgrade the row from unchecked → unreadable, or
+    # a later re-scan would classify it as a prior integrity failure
+    # (KEEP_ARCHIVE_HASH_FAILED) and route the user to the workspace-wide
+    # Audit page instead of retrying targeted verification.
+    archive_file, pid = _archive_photo(db, tmp_path, hash_status=None)
+    _card_file(tmp_path)
+    _scan(db, tmp_path)
+
+    # verify_manifest_archives opens the archive fd first (CodeRabbit's
+    # descriptor-pinning fix), so a downed-mount symptom surfaces as an
+    # os.open failure on the archive path.
+    real_open = os.open
+    archive_str = str(archive_file)
+
+    def failing_open(path, *args, **kwargs):
+        if str(path) == archive_str:
+            raise OSError(2, "mount is down")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup.os, "open", failing_open)
+
+    manifest_dir = str(tmp_path / "manifests")
+    result = card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    assert result["unreadable"] == 1
+    assert result["verified"] == 0
+    assert result["unblocked_files"] == 0
+
+    # DB row must remain NULL so a later scan-after-remount re-issues
+    # KEEP_NOT_VERIFIED, not KEEP_ARCHIVE_HASH_FAILED.
+    status = db.conn.execute(
+        "SELECT hash_status FROM photos WHERE id = ?", (pid,)
+    ).fetchone()["hash_status"]
+    assert status is None
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    kept = _entries(refreshed, "kept")
+    assert len(kept) == 1
+    assert kept[0]["reason"] == card_cleanup.KEEP_ARCHIVE_UNREACHABLE
+
+
 def test_scan_archive_file_missing_kept(db, tmp_path):
     archive_file, _ = _archive_photo(db, tmp_path)
     _card_file(tmp_path)

--- a/vireo/tests/test_card_cleanup.py
+++ b/vireo/tests/test_card_cleanup.py
@@ -643,6 +643,86 @@ def test_scoped_verify_rejects_atomic_replace_during_hash(
     )
 
 
+def test_scoped_verify_drops_deletable_entries_whose_card_files_are_gone(
+        db, tmp_path):
+    # Codex P2: delete_verified unlinks card files but never rewrites the
+    # manifest, so a subsequent scoped-verify run sees stale deletable
+    # entries whose card paths no longer exist. The recomputed totals
+    # must not credit those bytes to the deletable bucket — otherwise
+    # the refreshed UI re-enables Delete asking the user to confirm
+    # counts that include files already gone from the card, and the
+    # revision bump would let a delete request sweep past the freshness
+    # guard.
+    already_deleted, _ = _archive_photo(
+        db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
+        hash_status="ok")
+    _archive_photo(
+        db, tmp_path, name="IMG_0002.NEF", content=b"raw-two",
+        hash_status=None, folder="archive/2026/2026-08-02")
+    gone_card = _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+    _card_file(tmp_path, name="IMG_0002.NEF", content=b"raw-two")
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+    assert scan["totals"]["kept"]["count"] == 1
+
+    # Simulate a prior delete_verified run: the card file was unlinked
+    # but the manifest still lists it as deletable.
+    os.unlink(gone_card)
+
+    manifest_dir = str(tmp_path / "manifests")
+    manifest_before = load_manifest(manifest_dir, "scan-1")
+    revision_before = int(manifest_before.get(
+        "revision", card_cleanup.INITIAL_MANIFEST_REVISION))
+
+    card_cleanup.verify_manifest_archives(
+        db, manifest_before, manifest_dir)
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    deletable = _entries(refreshed, "deletable")
+    # Only the newly-verified file is deletable; the already-gone one
+    # was dropped rather than counted.
+    assert [e["path"] for e in deletable] == [
+        str(tmp_path / "card" / "DCIM" / "IMG_0002.NEF")]
+    assert refreshed["totals"]["deletable"]["count"] == 1
+    assert refreshed["totals"]["deletable"]["bytes"] == len(b"raw-two")
+    # The revision still bumps so a stale confirmation for the pre-verify
+    # manifest is rejected by the delete endpoint's freshness gate.
+    assert int(refreshed["revision"]) == revision_before + 1
+
+
+def test_scoped_verify_keeps_deletable_entry_when_lstat_error_is_transient(
+        db, tmp_path, monkeypatch):
+    # Companion to the drop test: a transient lstat error (mount blip,
+    # EACCES) is NOT proof the card file is gone. Dropping the entry on
+    # any OSError would shrink the preview during an ordinary hiccup.
+    # Preserve the entry so the next scoped verify — or the next delete
+    # gate — gets the real answer.
+    archive_file, _ = _archive_photo(
+        db, tmp_path, name="IMG_0001.NEF", content=b"raw-one",
+        hash_status="ok")
+    card_file = _card_file(tmp_path, name="IMG_0001.NEF", content=b"raw-one")
+    scan = _scan(db, tmp_path)
+    assert scan["totals"]["deletable"]["count"] == 1
+
+    real_lstat = os.lstat
+    card_str = str(card_file)
+
+    def flaky_lstat(path, *args, **kwargs):
+        if str(path) == card_str:
+            raise OSError(13, "permission denied")
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(card_cleanup.os, "lstat", flaky_lstat)
+
+    manifest_dir = str(tmp_path / "manifests")
+    card_cleanup.verify_manifest_archives(
+        db, load_manifest(manifest_dir, "scan-1"), manifest_dir)
+
+    refreshed = load_manifest(manifest_dir, "scan-1")
+    assert refreshed["totals"]["deletable"]["count"] == 1
+    assert [e["path"] for e in _entries(refreshed, "deletable")] == [card_str]
+
+
 def test_scan_archive_file_missing_kept(db, tmp_path):
     archive_file, _ = _archive_photo(db, tmp_path)
     _card_file(tmp_path)

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -868,6 +868,84 @@ def test_confirm_delete_defaults_manifest_revision_for_pre_upgrade_manifests(
     )
 
 
+def test_confirm_delete_awaits_manifest_reload_on_revision_mismatch(
+        app_and_db):
+    """Codex P1 review: cardCleanupConfirmDelete must keep the page locked
+    until the post-mismatch manifest reload finishes.
+
+    When /api/card-cleanup/delete returns 409 manifest_revision_mismatch
+    the on-disk manifest has already moved past the revision the user
+    just confirmed against — a concurrent verify (from another tab or
+    another client) promoted new files. The page must reload the fresh
+    manifest so the preview and Delete button describe what would
+    actually be deleted next.
+
+    The prior flow ran cardCleanupSetBusy(false) first (re-enabling
+    Delete against the pre-mismatch cardCleanupState.manifest), then
+    kicked cardCleanupLoadManifest() off as fire-and-forget. In the
+    gap before the reload landed a user could reopen the confirm
+    dialog with the old totals; once the reload swapped the manifest,
+    confirming would send the new revision and the server would accept
+    deletion of the newly promoted files that never appeared in the
+    dialog.
+
+    Pin the closed gap: the mismatch branch must await
+    cardCleanupLoadManifest, keep the busy state during the await,
+    unlock with keepDeleteState so the freshly rendered Delete state
+    survives, and explicitly disable Delete on reload failure so a
+    stale preview cannot authorize a deletion.
+    """
+    app, _ = app_and_db
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    start = body.index("async function cardCleanupConfirmDelete(")
+    end = body.index("function cardCleanupRenderDeleteResult(", start)
+    section = body[start:end]
+    # Locate the mismatch branch.
+    branch_start = section.index("manifest_revision_mismatch")
+    branch_end = section.index("} else {", branch_start)
+    branch = section[branch_start:branch_end]
+    # The reload must be awaited, not fire-and-forget.
+    assert "await cardCleanupLoadManifest()" in branch, (
+        "the manifest_revision_mismatch branch must await "
+        "cardCleanupLoadManifest — a fire-and-forget reload lets the "
+        "user reopen the confirm dialog against the pre-mismatch "
+        "manifest in the gap before the response lands, and the "
+        "next confirmation sends the new revision the server will "
+        "accept for the newly promoted set"
+    )
+    # The unlock must run AFTER the await and must use keepDeleteState
+    # so the freshly rendered Delete state is not overwritten by
+    # busyRestore.
+    reload_idx = branch.index("await cardCleanupLoadManifest()")
+    unlock_idx = branch.index("cardCleanupSetBusy(false", reload_idx)
+    assert unlock_idx > reload_idx, (
+        "cardCleanupSetBusy(false, …) must run after awaiting the "
+        "reload — otherwise the page unlocks before the fresh manifest "
+        "has replaced the pre-mismatch state and the race the P1 fix "
+        "closes reopens"
+    )
+    assert "keepDeleteState: true" in branch[unlock_idx:], (
+        "the post-reload cardCleanupSetBusy(false, …) must pass "
+        "keepDeleteState so busyRestore does not overwrite the "
+        "Delete-button state that cardCleanupRenderManifest just set "
+        "from the fresh totals"
+    )
+    # The failure path must explicitly disable Delete — busyRestore
+    # was skipped and the render never ran, so Delete would still
+    # carry setBusy(true)'s disabled=true; pinning the explicit disable
+    # here so a future refactor cannot leave it dangling.
+    assert "deleteBtn.disabled = true" in branch, (
+        "the reload-failure branch must explicitly disable the Delete "
+        "button — a stale preview must not be able to authorize a "
+        "deletion when the fresh manifest could not be loaded"
+    )
+    # And it must tell the user why Delete is off and how to recover.
+    assert "Reload the page or scan again before deleting" in branch, (
+        "the reload-failure hint must direct the user to reload or "
+        "scan again before deletion is possible"
+    )
+
+
 def test_start_verification_keeps_page_locked_on_ambiguous_start(app_and_db):
     """An ambiguous POST outcome must not unlock deletion while the scoped
     verification job may be refreshing the manifest."""

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -127,7 +127,9 @@ def test_scan_then_manifest_then_delete_end_to_end(app_and_db, tmp_path):
     assert manifest["totals"]["deletable"]["count"] == 1
 
     delete_resp = client.post(
-        "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+        "/api/card-cleanup/delete",
+        json={"scan_job_id": scan_job_id,
+              "manifest_revision": manifest["revision"]})
     assert delete_resp.status_code == 200
     delete_job_id = delete_resp.get_json()["job_id"]
     _wait_for_job(client, delete_job_id)
@@ -170,7 +172,8 @@ def test_scoped_verify_endpoint_promotes_preview_without_global_audit(
     after = client.get(
         f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
     assert after["totals"]["deletable"]["count"] == 1
-    assert after["entries"][0]["archive_path"] == str(archive_file)
+    deletable = [e for e in after["entries"] if e["bucket"] == "deletable"]
+    assert [e["archive_path"] for e in deletable] == [str(archive_file)]
     assert unrelated.exists()
     unrelated_status = db.conn.execute(
         "SELECT hash_status FROM photos WHERE id = ?", (unrelated_pid,)
@@ -275,8 +278,12 @@ def test_delete_after_restart_uses_history_and_disk_manifest(
     )
     db.conn.commit()
 
+    manifest = client.get(
+        "/api/card-cleanup/scan-r/manifest").get_json()
     delete_resp = client.post(
-        "/api/card-cleanup/delete", json={"scan_job_id": "scan-r"})
+        "/api/card-cleanup/delete",
+        json={"scan_job_id": "scan-r",
+              "manifest_revision": manifest["revision"]})
     assert delete_resp.status_code == 200
     delete_job_id = delete_resp.get_json()["job_id"]
     _wait_for_job(client, delete_job_id)
@@ -307,7 +314,9 @@ def test_delete_expired_manifest_404(app_and_db, tmp_path):
         json.dump(manifest, f)
 
     delete_resp = client.post(
-        "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+        "/api/card-cleanup/delete",
+        json={"scan_job_id": scan_job_id,
+              "manifest_revision": manifest["revision"]})
     assert delete_resp.status_code == 404
     assert "re-scan" in delete_resp.get_json()["error"]
 
@@ -338,12 +347,16 @@ def test_delete_concurrent_delete_409(app_and_db, tmp_path, monkeypatch):
 
     monkeypatch.setattr(
         card_cleanup, "delete_verified", blocking_delete_verified)
+    manifest = client.get(
+        f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
     # Bound before the try so a failure on the first POST surfaces as
     # itself, not as a NameError raised from the finally drain.
     job1_id = None
     try:
         resp1 = client.post(
-            "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+            "/api/card-cleanup/delete",
+            json={"scan_job_id": scan_job_id,
+                  "manifest_revision": manifest["revision"]})
         assert resp1.status_code == 200
         job1_id = resp1.get_json()["job_id"]
         assert started.wait(timeout=15)
@@ -360,7 +373,9 @@ def test_delete_concurrent_delete_409(app_and_db, tmp_path, monkeypatch):
         assert _running()
 
         resp2 = client.post(
-            "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+            "/api/card-cleanup/delete",
+            json={"scan_job_id": scan_job_id,
+                  "manifest_revision": manifest["revision"]})
         assert resp2.status_code == 409
     finally:
         release.set()
@@ -411,14 +426,109 @@ def test_delete_result_carries_exact_totals(app_and_db, tmp_path):
                        json={"source": str(tmp_path / "card")})
     scan_job_id = resp.get_json()["job_id"]
     _wait_for_job(client, scan_job_id)
+    manifest = client.get(
+        f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
     resp = client.post("/api/card-cleanup/delete",
-                       json={"scan_job_id": scan_job_id})
+                       json={"scan_job_id": scan_job_id,
+                             "manifest_revision": manifest["revision"]})
     job_id = resp.get_json()["job_id"]
     _wait_for_job(client, job_id)
     result = client.get(f"/api/jobs/{job_id}").get_json()["result"]
     assert result["skipped_total"] == len(result["skipped"]) == 0
     assert result["failed_total"] == len(result["failed"]) == 0
     assert result["deleted"] == 1
+
+
+def test_scan_manifest_carries_initial_revision(app_and_db, tmp_path):
+    """Codex P1: the first manifest a scan writes must carry
+    INITIAL_MANIFEST_REVISION so the delete endpoint's revision check
+    has something concrete to compare against on the very first pass."""
+    app, db = app_and_db
+    client = app.test_client()
+    _make_verified_pair(db, tmp_path)
+    resp = client.post("/api/card-cleanup/scan",
+                       json={"source": str(tmp_path / "card")})
+    scan_job_id = resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+    manifest = client.get(
+        f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
+    assert manifest["revision"] == card_cleanup.INITIAL_MANIFEST_REVISION
+
+
+def test_verify_bumps_manifest_revision(app_and_db, tmp_path):
+    """Codex P1: a completed verify must land a fresh revision so any
+    still-open confirmation from before the verify fails the delete-side
+    revision check instead of quietly deleting newly-promoted files."""
+    app, db = app_and_db
+    client = app.test_client()
+    _archive_photo(db, tmp_path)
+    db.conn.execute(
+        "UPDATE photos SET hash_status = NULL, hash_checked_at = NULL")
+    db.conn.commit()
+    _card_file(tmp_path)
+    scan_resp = client.post(
+        "/api/card-cleanup/scan", json={"source": str(tmp_path / "card")})
+    scan_job_id = scan_resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+
+    before = client.get(
+        f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
+    verify_resp = client.post(
+        "/api/card-cleanup/verify", json={"scan_job_id": scan_job_id})
+    _wait_for_job(client, verify_resp.get_json()["job_id"])
+    after = client.get(
+        f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
+    assert after["revision"] == before["revision"] + 1
+
+
+def test_delete_rejects_missing_manifest_revision(app_and_db, tmp_path):
+    """The revision check is required on any completed scan.  A body
+    that omits it must 400 rather than defaulting silently."""
+    app, db = app_and_db
+    client = app.test_client()
+    _make_verified_pair(db, tmp_path)
+    scan_resp = client.post(
+        "/api/card-cleanup/scan", json={"source": str(tmp_path / "card")})
+    scan_job_id = scan_resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+    resp = client.post(
+        "/api/card-cleanup/delete", json={"scan_job_id": scan_job_id})
+    assert resp.status_code == 400
+    assert "manifest_revision" in resp.get_json()["error"]
+
+
+def test_delete_rejects_stale_manifest_revision_after_verify(
+        app_and_db, tmp_path):
+    """Codex P1: a delete that confirms an older revision after verify
+    has rewritten the manifest must be rejected with a distinguishable
+    code so the UI can hand the user back to the refreshed preview."""
+    app, db = app_and_db
+    client = app.test_client()
+    _archive_photo(db, tmp_path)
+    db.conn.execute(
+        "UPDATE photos SET hash_status = NULL, hash_checked_at = NULL")
+    db.conn.commit()
+    _card_file(tmp_path)
+    scan_resp = client.post(
+        "/api/card-cleanup/scan", json={"source": str(tmp_path / "card")})
+    scan_job_id = scan_resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+    stale = client.get(
+        f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
+    stale_revision = stale["revision"]
+
+    # Verify promotes the unchecked archive row and bumps the revision.
+    verify_resp = client.post(
+        "/api/card-cleanup/verify", json={"scan_job_id": scan_job_id})
+    _wait_for_job(client, verify_resp.get_json()["job_id"])
+
+    resp = client.post(
+        "/api/card-cleanup/delete",
+        json={"scan_job_id": scan_job_id,
+              "manifest_revision": stale_revision})
+    assert resp.status_code == 409
+    body = resp.get_json()
+    assert body["code"] == "manifest_revision_mismatch"
 
 
 def test_endpoints_reject_non_object_json_body(app_and_db):
@@ -533,7 +643,11 @@ def test_finish_scoped_verification_refreshes_preview_without_rescan(
     assert "await cardCleanupLoadManifest()" in section
     assert section.index("await cardCleanupLoadManifest()") < section.index(
         "cardCleanupSetBusy(false")
-    assert "keepDeleteState: refreshed" in section
+    # After the Codex P1 flicker fix, keepDeleteState is truthy for any
+    # completed/cancelled verification so cardCleanupSetBusy never
+    # restores the pre-verification Delete snapshot — success re-renders
+    # via cardCleanupLoadManifest, failure explicitly disables below.
+    assert "keepDeleteState: attemptedReload || refreshed" in section
     assert "re-scan the card before deleting" not in section
 
 

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -136,6 +136,48 @@ def test_scan_then_manifest_then_delete_end_to_end(app_and_db, tmp_path):
     assert archive_file.exists()
 
 
+def test_scoped_verify_endpoint_promotes_preview_without_global_audit(
+        app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    archive_file, pid = _archive_photo(db, tmp_path)
+    unrelated, unrelated_pid = _archive_photo(
+        db, tmp_path, name="OTHER.NEF", content=b"other",
+        folder="archive/other")
+    db.conn.execute(
+        "UPDATE photos SET hash_status = NULL, hash_checked_at = NULL "
+        "WHERE id IN (?, ?)", (pid, unrelated_pid))
+    db.conn.commit()
+    _card_file(tmp_path)
+
+    scan_resp = client.post(
+        "/api/card-cleanup/scan", json={"source": str(tmp_path / "card")})
+    scan_job_id = scan_resp.get_json()["job_id"]
+    _wait_for_job(client, scan_job_id)
+    before = client.get(
+        f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
+    assert before["totals"]["deletable"]["count"] == 0
+
+    verify_resp = client.post(
+        "/api/card-cleanup/verify", json={"scan_job_id": scan_job_id})
+    assert verify_resp.status_code == 200
+    verify_job_id = verify_resp.get_json()["job_id"]
+    job = _wait_for_job(client, verify_job_id)
+    assert job["type"] == "card-cleanup-verify"
+    assert job["result"]["archive_files_read"] == 1
+    assert job["result"]["unblocked_files"] == 1
+
+    after = client.get(
+        f"/api/card-cleanup/{scan_job_id}/manifest").get_json()
+    assert after["totals"]["deletable"]["count"] == 1
+    assert after["entries"][0]["archive_path"] == str(archive_file)
+    assert unrelated.exists()
+    unrelated_status = db.conn.execute(
+        "SELECT hash_status FROM photos WHERE id = ?", (unrelated_pid,)
+    ).fetchone()["hash_status"]
+    assert unrelated_status is None
+
+
 def test_scan_job_result_carries_totals_not_entries(app_and_db, tmp_path):
     """Spec: the scan job's RESULT carries only bucket totals, resolved
     source root, and the manifest path — never the (potentially
@@ -384,7 +426,8 @@ def test_endpoints_reject_non_object_json_body(app_and_db):
     # endpoints must 400, not 500 on body.get.
     app, _ = app_and_db
     client = app.test_client()
-    for url in ("/api/card-cleanup/scan", "/api/card-cleanup/delete"):
+    for url in ("/api/card-cleanup/scan", "/api/card-cleanup/verify",
+                "/api/card-cleanup/delete"):
         resp = client.post(url, json=5)
         assert resp.status_code == 400, url
         assert "JSON object" in resp.get_json()["error"]
@@ -399,8 +442,7 @@ def test_card_cleanup_page_renders(app_and_db):
     body = resp.get_data(as_text=True)
     assert "card-cleanup-section" in body
     assert "card-cleanup-scan-btn" in body
-    # The integrity-audit affordance is part of the page, not the import page.
-    assert "card-cleanup-audit-btn" in body
+    assert "card-cleanup-verify-btn" in body
 
 
 def test_import_and_card_cleanup_share_folder_browser(app_and_db):
@@ -432,16 +474,14 @@ def test_import_page_links_to_card_cleanup_instead_of_hosting_it(app_and_db):
     assert "/card-cleanup" in body
 
 
-def test_audit_callout_reason_stays_in_sync(app_and_db):
-    """The page's audit callout counts kept entries by matching a tail of
-    KEEP_NOT_VERIFIED. That coupling is invisible from either side, so pin
-    both ends: the served page must carry the literal it matches on, and
-    the reason it matches must still contain it."""
+def test_verification_callout_reason_stays_in_sync(app_and_db):
+    """The scoped verification callout and backend reason stay coupled."""
     app, _ = app_and_db
-    matched = "run the integrity audit"
-    assert matched in card_cleanup.KEEP_NOT_VERIFIED
+    matched = card_cleanup.KEEP_NOT_VERIFIED
     body = app.test_client().get("/card-cleanup").get_data(as_text=True)
-    assert f"CARD_CLEANUP_AUDIT_REASON = '{matched}'" in body
+    assert f"CARD_CLEANUP_VERIFY_REASON = '{matched}'" in body
+    assert "/api/card-cleanup/verify" in body
+    assert "/api/jobs/verify-hashes" not in body
 
 
 def test_hash_failed_callout_reason_stays_in_sync(app_and_db):
@@ -481,35 +521,20 @@ def test_hash_failed_callout_states_audit_workspace_scope(app_and_db):
     assert "switch to that workspace to find it there" in body
 
 
-def test_finish_audit_disables_delete_until_rescan(app_and_db):
-    """Codex P2 review (commit 1213fec): finishing or cancelling the
-    verify-hashes run must invalidate the preview's Delete affordance,
-    because verification can flip previously-ok rows to modified/corrupt/
-    unreadable — the confirmation dialog would then advertise stale file
-    and byte totals against a subset the user never agreed to. The audit
-    handler must both disable the Delete button and swap in a hint that
-    tells the user to re-scan (the button surfaced next to the audit
-    status). Pin the literal here so the guardrail can't be silently
-    reworded away."""
+def test_finish_scoped_verification_refreshes_preview_without_rescan(
+        app_and_db):
+    """Scoped verification only promotes pending rows, so it can atomically
+    refresh the existing manifest instead of forcing another card scan."""
     app, _ = app_and_db
     body = app.test_client().get("/card-cleanup").get_data(as_text=True)
-    finish = body.index("function cardCleanupFinishAudit(")
-    # Snap out a window around the handler body. The next function in the
-    # file is cardCleanupBindBucket; slice up to whichever declaration
-    # follows so this test does not accidentally match code elsewhere.
+    finish = body.index("async function cardCleanupFinishVerification(")
     end = body.index("function cardCleanupBindBucket(", finish)
     section = body[finish:end]
-    # The Delete button is disabled inside the handler, not just via the
-    # separate cardCleanupSetBusy(false) that ran first (which restores
-    # the pre-verify enabled state).
-    assert "deleteBtn.disabled = true" in section
-    # The user-facing hint that replaces whatever cardCleanupSetBusy
-    # restored — pinned verbatim so a reword can't drop the "re-scan
-    # first" instruction the Codex P2 asked for.
-    assert (
-        "Verification may have changed which files count as verified — "
-        "re-scan the card before deleting."
-    ) in section
+    assert "await cardCleanupLoadManifest()" in section
+    assert section.index("await cardCleanupLoadManifest()") < section.index(
+        "cardCleanupSetBusy(false")
+    assert "keepDeleteState: refreshed" in section
+    assert "re-scan the card before deleting" not in section
 
 
 def test_confirm_delete_locks_page_before_post(app_and_db):
@@ -579,24 +604,13 @@ def test_confirm_delete_locks_page_before_post(app_and_db):
     )
 
 
-def test_start_audit_keeps_page_locked_on_ambiguous_start(app_and_db):
-    """Codex P1 review (commit 5afcb0ba): cardCleanupStartAudit must not
-    release the page-wide busy lock on outcomes that don't prove whether the
-    server queued the verify-hashes job.
-
-    If the audit is silently running while Scan/Verify/Delete come back live,
-    a subsequent delete can race it. delete_verified() trusts the currently
-    committed hash_status plus archive size/mtime rather than re-hashing
-    archive bytes, so a row the audit is about to flip from `ok` to
-    modified/corrupt/unreadable could still qualify for deletion — removing
-    the good card copy of a file whose archive copy is silently rotting. Same
-    guarantee the delete-start path pins in test_confirm_delete_locks_page_
-    before_post; pinning both invariants here so a refactor can't quietly
-    re-open the gap."""
+def test_start_verification_keeps_page_locked_on_ambiguous_start(app_and_db):
+    """An ambiguous POST outcome must not unlock deletion while the scoped
+    verification job may be refreshing the manifest."""
     app, _ = app_and_db
     body = app.test_client().get("/card-cleanup").get_data(as_text=True)
-    start = body.index("async function cardCleanupStartAudit(")
-    end = body.index("function cardCleanupFinishAudit(", start)
+    start = body.index("async function cardCleanupStartVerification(")
+    end = body.index("async function cardCleanupFinishVerification(", start)
     section = body[start:end]
     # An HTTP response that proves nothing was queued (!resp.ok) must
     # release the lock so the user isn't stranded with a dead page.
@@ -607,31 +621,23 @@ def test_start_audit_keeps_page_locked_on_ambiguous_start(app_and_db):
     ok_branch = section[ok_branch_start:ok_branch_end]
     assert "cardCleanupSetBusy(false)" in ok_branch, (
         "the !resp.ok branch must call cardCleanupSetBusy(false) — the "
-        "server said the verify-hashes job was not queued, so the page can "
+        "server said the verification job was not queued, so the page can "
         "safely hand the buttons back"
     )
-    # The network-error catch on the fetch itself must NOT unlock — the
-    # POST may have reached the server and started api_job_verify_hashes()
-    # before the connection dropped, and the delete path trusts hash_status
-    # in the DB rather than re-hashing archive bytes, so a concurrent delete
-    # could remove the good card copy of a file the audit is silently
-    # detecting as corrupt.
     fetch_catch_start = section.index("resp = await fetch(")
     fetch_catch_start = section.index("} catch (e) {", fetch_catch_start)
     fetch_catch_end = section.index("if (!resp.ok)", fetch_catch_start)
     fetch_catch_body = section[fetch_catch_start:fetch_catch_end]
     assert "cardCleanupSetBusy(false)" not in fetch_catch_body, (
-        "the fetch-rejection catch on cardCleanupStartAudit must NOT release "
-        "the page lock — the POST may have reached the server and queued the "
-        "verify-hashes job before the connection dropped, and unlocking "
-        "would let a concurrent delete race the audit"
+        "the fetch-rejection catch must not unlock a possibly running "
+        "verification job"
     )
     assert "Jobs page" in fetch_catch_body, (
         "the fetch-rejection catch must direct the user to the Jobs page so "
-        "they can find out whether the server queued the verify-hashes job"
+        "they can find out whether verification was queued"
     )
     # The JSON-parse catch on the OK response is the second ambiguous
-    # outcome: a 2xx status means api_job_verify_hashes() returned, but if
+    # outcome: a 2xx status means the endpoint returned, but if
     # the body couldn't be decoded we can't be sure the job wasn't queued.
     # Same reasoning — keep the lock, route to Jobs.
     json_catch_start = section.index("data = await resp.json()")
@@ -640,8 +646,7 @@ def test_start_audit_keeps_page_locked_on_ambiguous_start(app_and_db):
     json_catch_body = section[json_catch_start:json_catch_end]
     assert "cardCleanupSetBusy(false)" not in json_catch_body, (
         "the JSON-parse catch on a 2xx response must NOT release the page "
-        "lock — the server returned OK, so api_job_verify_hashes() may have "
-        "queued the audit even though we can't read the response body"
+        "lock — the server returned OK, so verification may be running"
     )
     assert "Jobs page" in json_catch_body, (
         "the JSON-parse catch on a 2xx response must direct the user to the "

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -481,6 +481,56 @@ def test_verify_bumps_manifest_revision(app_and_db, tmp_path):
     assert after["revision"] == before["revision"] + 1
 
 
+def test_verify_endpoint_loads_manifest_inside_cleanup_job_lock():
+    """Codex P1 (commit ad9375db): the verify endpoint must load the
+    manifest INSIDE the ``_CARD_CLEANUP_JOB_LOCK`` critical section, not
+    before it.
+
+    Race: request A loads revision N, releases before taking the lock,
+    then request B runs to completion and writes revision N+1. If A
+    then enters the lock (B is no longer registered as running), passes
+    the conflict check, and hands its stale revision-N manifest to
+    verify_manifest_archives, the worker bumps to N+1 and writes it —
+    silently clobbering B's promotions with entries the user never saw
+    promoted. The conflict check alone does NOT close this window
+    because the check catches only queued/running jobs, and A can enter
+    the lock after B has finished.
+
+    Load-inside-lock closes the window: every verify starts from the
+    manifest that the previous verify's write landed. Pinning this via
+    source inspection because reproducing the race in a functional test
+    would need scheduler hooks we do not have; a future refactor that
+    quietly hoists load_manifest above the ``with`` block would
+    reintroduce the exact bug this commit fixed.
+    """
+    import inspect
+
+    import app as app_module
+
+    src = inspect.getsource(app_module.create_app)
+    start = src.index("def api_card_cleanup_verify(")
+    end = src.index("def api_card_cleanup_delete(", start)
+    verify_src = src[start:end]
+
+    lock_idx = verify_src.index("with _CARD_CLEANUP_JOB_LOCK")
+    load_idx = verify_src.index("card_cleanup.load_manifest(")
+    conflict_idx = verify_src.index(
+        "_card_cleanup_job_conflict_response(")
+    start_idx = verify_src.index("runner.start(")
+
+    assert lock_idx < conflict_idx < load_idx < start_idx, (
+        "api_card_cleanup_verify must run these steps IN ORDER inside "
+        "the _CARD_CLEANUP_JOB_LOCK critical section: (1) take the "
+        "lock, (2) call _card_cleanup_job_conflict_response, (3) load "
+        "the manifest, (4) runner.start. Hoisting load_manifest above "
+        "the `with` block reopens the load-before-lock window Codex "
+        "P1 called out at commit ad9375db: a verify can enter after "
+        "another verify has completed, see no conflict, and hand a "
+        "stale snapshot to verify_manifest_archives that clobbers the "
+        "just-landed revision."
+    )
+
+
 def test_delete_rejects_missing_manifest_revision(app_and_db, tmp_path):
     """The revision check is required on any completed scan.  A body
     that omits it must 400 rather than defaulting silently."""
@@ -779,6 +829,42 @@ def test_confirm_delete_locks_page_before_post(app_and_db):
         "the network-error catch must direct the user to the Jobs page so "
         "they can find out whether the server queued the delete before the "
         "connection dropped"
+    )
+
+
+def test_confirm_delete_defaults_manifest_revision_for_pre_upgrade_manifests(
+        app_and_db):
+    """Codex P2 (commit ad9375db): cardCleanupConfirmDelete must send a
+    concrete manifest_revision even when the loaded manifest has no
+    revision key.
+
+    A manifest saved before the revision schema landed has no ``revision``
+    property. If the client reads it as ``undefined``, JSON.stringify
+    drops the key from the request body, and the server rejects a missing
+    manifest_revision with 400 required — making every carried-over
+    preview undeletable. The server treats a missing on-disk revision as
+    ``INITIAL_MANIFEST_REVISION`` (1), so the client must default to the
+    same value to keep the two sides in sync.
+    """
+    app, _ = app_and_db
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    start = body.index("async function cardCleanupConfirmDelete(")
+    end = body.index("function cardCleanupRenderDeleteResult(", start)
+    section = body[start:end]
+    # Locate the confirmedRevision assignment and require a truthy
+    # fallback to 1 so an undefined/absent manifest.revision does not
+    # silently drop the key from the request body.
+    rev_idx = section.index("const confirmedRevision")
+    body_idx = section.index("manifest_revision:", rev_idx)
+    rev_expr = section[rev_idx:body_idx]
+    assert "|| 1" in rev_expr, (
+        "cardCleanupConfirmDelete must default confirmedRevision to 1 "
+        "(INITIAL_MANIFEST_REVISION) when cardCleanupState.manifest.revision "
+        "is undefined — sending undefined here would omit manifest_revision "
+        "from JSON.stringify and the delete endpoint would reject a "
+        "pre-upgrade manifest that has no revision key with 400 required, "
+        "even though the server treats a missing on-disk revision as the "
+        "initial revision on load"
     )
 
 

--- a/vireo/tests/test_card_cleanup_api.py
+++ b/vireo/tests/test_card_cleanup_api.py
@@ -537,6 +537,70 @@ def test_finish_scoped_verification_refreshes_preview_without_rescan(
     assert "re-scan the card before deleting" not in section
 
 
+def test_finish_scoped_verification_locks_delete_when_manifest_reload_fails(
+        app_and_db):
+    """Codex P1 review: if verification finishes but the refreshed manifest
+    cannot be loaded, keep Delete disabled and require a reload or re-scan.
+
+    Verification can promote kept rows to deletable. When it does, the
+    pre-verification Delete state understates what is now on disk: a
+    click would confirm the old totals while /api/card-cleanup/delete
+    operates on the freshly-promoted set too. The prior implementation
+    called cardCleanupSetBusy(false, {keepDeleteState: false}) on reload
+    failure, which restored the pre-verification busyRestore snapshot —
+    including Delete enabled with the old count. It also unconditionally
+    told the user "Preview updated" on a completed status even when the
+    updated preview never rendered.
+
+    Pin the recovered behaviour so a future refactor cannot silently
+    re-open the gap: on the failure branch the Delete button must be
+    explicitly disabled with a hint that directs the user to reload or
+    scan again, and the "Preview updated" copy must be gated on the
+    reload succeeding.
+    """
+    app, _ = app_and_db
+    body = app.test_client().get("/card-cleanup").get_data(as_text=True)
+    finish = body.index("async function cardCleanupFinishVerification(")
+    end = body.index("function cardCleanupBindBucket(", finish)
+    section = body[finish:end]
+    # The failure branch must explicitly force Delete off — a plain
+    # setBusy(false) restore is not enough because busyRestore holds the
+    # pre-verification Delete state (possibly enabled with stale counts).
+    assert "deleteBtn.disabled = true" in section, (
+        "cardCleanupFinishVerification must explicitly disable Delete "
+        "when the post-verification manifest reload fails; otherwise the "
+        "pre-verification Delete state (possibly enabled with stale "
+        "counts) is what the user sees"
+    )
+    # The delete-hint must tell the user why Delete is off and how to
+    # recover (reload / re-scan). Match the actionable phrase.
+    assert "reload the page or scan again before deleting" in section, (
+        "the delete hint must direct the user to reload or scan again "
+        "before deletion is possible after a failed manifest reload"
+    )
+    # The "Preview updated" copy must only appear on the refreshed
+    # branch — pin the conditional so a rewrite cannot drop back to the
+    # unconditional message that was misleading before this fix.
+    completed_start = section.index("if (status === 'completed'")
+    completed_end = section.index("else if (status === 'cancelled')", completed_start)
+    completed_block = section[completed_start:completed_end]
+    assert "refreshed" in completed_block and "Preview updated" in completed_block, (
+        "the completed-status branch must gate 'Preview updated' on the "
+        "refreshed flag so the message is only shown after the reload "
+        "actually rendered the new manifest"
+    )
+    # The cancelled branch must also gate its "preview was updated" copy
+    # on the same flag.
+    cancelled_start = section.index("else if (status === 'cancelled')")
+    cancelled_end = section.index("else if (status)", cancelled_start)
+    cancelled_block = section[cancelled_start:cancelled_end]
+    assert "refreshed" in cancelled_block, (
+        "the cancelled-status branch must gate its 'preview was updated' "
+        "copy on the refreshed flag so a failed reload after cancel does "
+        "not still claim the preview reflects the completed checks"
+    )
+
+
 def test_confirm_delete_locks_page_before_post(app_and_db):
     """Codex P2 reviews (commits 96137e3 and 012aec2c): cardCleanupConfirmDelete
     must set the page-wide busy state *before* the POST /api/card-cleanup/delete


### PR DESCRIPTION
The card cleanup flow now verifies only archive copies matching the selected card, rather than re-hashing the entire workspace. It atomically refreshes the existing preview, deduplicates checks by content hash, and leaves unrelated archive files untouched. Deletion now reads each card file once while retaining fresh archive checks around that read and all existing mutation and overlap guards. Validation: 94 focused unit, API, and browser tests pass, along with the missing-originals heavy-job regression, Ruff, JavaScript syntax, and diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added targeted archive verification for card cleanup, checking only matching archive copies.
  - Added progress, cancellation, and completion reporting for verification jobs.
  - Cleanup previews now refresh automatically with updated manifests and file status details.

- **Bug Fixes**
  - Improved deletion safety with archive rechecks and protection against outdated previews.
  - Prevented overlapping or stale verification and deletion operations.
  - Reduced unnecessary card-file reads during deletion.
  - Improved handling of unavailable, changed, corrupt, or unreadable archive copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->